### PR TITLE
Build with Travis, including users PRs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+# http://travis-ci.org/#!/ipython/ipython
+language: python
+python:
+    - 3.5
+before_install:
+    - pip install docutils
+script:
+    - make


### PR DESCRIPTION
Prompted by https://github.com/python/peps/issues/5 (Set up Travis to build the peps) and https://github.com/python/peps/pull/16#issuecomment-226974669 : 

> (in this case we need to pull the branch locally and build the HTML version of the file) 

I was wondering if I could setup Travis to auto build all my Pull requests, and push them on my  gh-pages without committing my (encrypted) ssh key to this repo. And make that (relatively) simple for anyone to have the same functionality.

So this is my attempt at doing it. 

Once something similar is into the main repo, then any user "just" have to 
 - set-up a secret `DEPLOY_KEY` env variable  on **Travis** 
 - upload a corresponding public key as a **Deploy Key** on  **GitHub**
 - activate `Travis`.

That's it.

Now every branch they push get deploy on `<username>.github.io/<fork-name>/<branch-name>/` 

( I suspect this could be partly automatized with the travis gem, but not an expert.)

I'm aware it will likely need some extra work once  https://github.com/python/peps/pull/15 is in.

That should allow – at least for regular contributor – to automatically have a rendered version of the modification they request to be pulled in.

Sidenote, it can't be done on each PR for obvious security reason. The only way would be to ask knight-who-says-ni to do it, but that would still be potentially dangerous. 

And see my autodeployed version : https://carreau.github.io/peps/travis/pep-0000.html
and the [travis build which deployed it](https://travis-ci.org/Carreau/peps/builds/138675967).