### PR TITLE
Trigger self-deploy for fork, on <self>/gh-pages branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ before_install:
     - pip install docutils
 script:
     - make
+after_success:
+    - bash .travis/travis.sh

--- a/.travis/travis.sh
+++ b/.travis/travis.sh
@@ -1,0 +1,97 @@
+MASTER_REPO='python/peps'
+
+authenticate(){
+        echo "unpacking private ssh_key";
+        echo $1 | base64 -d > ~/.ssh/github_deploy ;
+        echo -e "Host github.com\n\tHostName github.com\n\tUser git\n\tIdentityFile ~/.ssh/github_deploy\n" >> ~/.ssh/config
+        chmod 600 ~/.ssh/github_deploy
+        eval `ssh-agent -s`
+        ssh-add ~/.ssh/github_deploy
+}
+
+should_deploy(){
+    if [[ $TRAVIS_PULL_REQUEST == false
+          && $TRAVIS_REPO_SLUG == $MASTER_REPO
+          && $TRAVIS_BRANCH == 'master' ]]; then
+          echo 'Should deploy'
+          return 0 # bash, 0 is true
+    fi
+
+    if [[ $TRAVIS_PULL_REQUEST == false
+          && $TRAVIS_REPO_SLUG != $MASTER_REPO
+          && $TRAVIS_BRANCH != 'master'
+          && $TRAVIS_BRANCH != 'gh-pages' ]]; then
+          echo 'Should deploy'
+          return 0 #bash 0 is true
+    fi
+    return 1 # bash 1 is false
+}
+
+deploy_dir(){
+    if [[ $TRAVIS_PULL_REQUEST == false
+          && $TRAVIS_REPO_SLUG == $MASTER_REPO
+          && $TRAVIS_BRANCH == 'master' ]] ;then
+          echo "."
+          return 0
+    fi
+
+    if [[ $TRAVIS_PULL_REQUEST == false
+          && $TRAVIS_REPO_SLUG != $MASTER_REPO
+          && $TRAVIS_BRANCH != 'master'
+          && $TRAVIS_BRANCH != 'gh-pages' ]] ;then
+          echo "$TRAVIS_BRANCH"
+          return 0
+    fi
+
+    echo "there-is-a-bug-this-should-not-happen"
+    echo "$TRAVIS_PULL_REQUEST -- $TRAVIS_REPO_SLUG!=$MASTER_REPO -- $TRAVIS_BRANCH"
+}
+
+if [ -z ${DEPLOY_KEY+x} ]; then 
+    echo "DEPLOY_KEY is unset";
+    echo "if you want to automatically deploy on you GH Pages"
+    echo "Generate a pair of key for youfork/pep, base64 encode it"
+    echo "and set is as a private ENV variable on travis named DEPLOY_KEY"
+else 
+    if should_deploy; 
+      then
+        authenticate $DEPLOY_KEY
+        ORIGIN="ssh://github.com/$TRAVIS_REPO_SLUG"
+        git clone $ORIGIN deploy
+        echo 'cd deploy'
+        cd deploy
+
+        DEPLOY_DIR=$(deploy_dir)
+
+        echo '=== configuring git for push ==='
+
+        git config --global user.email "travis-ci@travis.ci"
+        git config --global user.name "TravisCI BOT"
+        git checkout -b gh-pages
+        git config --global push.default simple
+        git reset --hard origin/gh-pages
+        
+
+        mkdir -p $DEPLOY_DIR
+        rm -rf $DEPLOY_DIR/*
+
+
+        cp -v $HOME/build/$TRAVIS_REPO_SLUG/*.html $DEPLOY_DIR
+        cp -v $HOME/build/$TRAVIS_REPO_SLUG/*.css $DEPLOY_DIR
+
+        echo '===== git add .  ===='
+        git add -A $DEPLOY_DIR
+        
+        echo '===== git status  ===='
+        git status
+
+        git commit -am"deploy of branch $BRANCH"
+        git push origin gh-pages:gh-pages
+
+        echo '==========================='
+        echo $(echo $TRAVIS_REPO_SLUG | sed -e 's/\//.github.io\//')"/$DEPLOY_DIR/pep-0000.html"
+        echo '==========================='
+    else
+        echo "No trying to deploy to gh-pages"
+    fi 
+fi

--- a/README.rst
+++ b/README.rst
@@ -32,3 +32,32 @@ your source code should be in ``pep-0999.txt`` and the HTML will be
 generated to ``pep-0999.html`` by the command ``make pep-0999.html``.
 The default Make target generates HTML for all PEPs.  If you don't have
 Make, use the ``pep2html.py`` script.
+
+
+Auto generating the HTML version of Peps from your Pull requests 
+================================================================
+
+Once you have forked this repository:
+
+- Enable travis build for your forks:
+  - go to https://travis-ci.org/profile/$your_user_name
+  - Click `Sync Account`
+  - find `$your_username/peps` and enable it.
+
+- Generate a public/private ssh key pair:
+  - `$ ssh-keygen -b 2048 -t rsa -f ssh_pair_ghpages_deploy_peps -q -N ""`
+
+- head to `https://travis-ci.org/$your_user_name/peps/settings` and add a hidden environment variable with:
+  - the name `DEPLOY_KEY`
+  - the content of `$ cat ssh_pair_ghpages_deploy_peps | base64`
+
+- head to `https://github.com/$your_user_name/peps/settings/keys`
+  and add a deploy key with the content of `$ cat ssh_pair_ghpages_deploy_peps.pub`
+
+
+Now every time you push on `$your_username/peps`, a build of the current branch
+should be available after a few minutes at
+https://yourusername.github.io/peps/${branch-name}/.
+
+
+


### PR DESCRIPTION
If the current repository is python/peps:
 - build only on master.
 - deploy to root of gh-pages, meaning that peps should be visible at:
    `https://python.github.io/peps/` (CNAMe can be added later to be
    accessible from `peps.python.org`

If the current repository is **not** `python/peps`:
 - build unless the branch is `master` or `gh-pages` (we want to avoid
   recursion right?)
 - deploy to `<username>.github.io/peps/<branchname>/`

This try to deploy only if `DEPLOY_KEY`is set.

--- 
Take 2 on #17 

@brettcannon said in #17:

> Save auto-deploy for a separate PR. I have no issue with Travis zipping up the built PEPs as a build artifact that people can download to view post-CI if they want to see what the rendered version.

The problem is that the code to do it have to be in `python/peps` otherwise it requires people to modify their `.travis.yml` for every PR, which you obviously don't want to merge. 
And uploading a zip needs credentials as well. Pushing back on Gh-Pages seem the simpler as it also allow to see the rendered version with need to download-zip, unpack, and test locally (which you can't do on phones) 


