### PR TITLE
Added whitespace peeve for before attribute access

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -504,6 +504,12 @@ Avoid extraneous whitespace in the following situations:
       Yes: dct['key'] = lst[index]
       No:  dct ['key'] = lst [index]
 
+- Immediately before the dot that starts an attribute access or
+  function / method call::
+
+      Yes: dct.items()
+      No:  dct    .items()
+
 - More than one space around an assignment (or other) operator to
   align it with another.
 


### PR DESCRIPTION
This missing advice came up on https://github.com/PyCQA/pycodestyle/issues/553.