### PR TITLE
Fix typo in PEP 492

### DIFF
--- a/pep-0492.txt
+++ b/pep-0492.txt
@@ -673,7 +673,7 @@ coroutines::
 
     @asyncio.coroutine
     def useful():
-        asyncio.sleep(1) # this will do noting without 'yield from'
+        asyncio.sleep(1) # this will do nothing without 'yield from'
 
 For debugging this kind of mistakes there is a special debug mode in
 asyncio, in which ``@coroutine`` decorator wraps all functions with a


### PR DESCRIPTION
`noting` -> `nothing`