### PR TITLE
PEP 287: fix typo in word frangible

### DIFF
--- a/pep-0287.txt
+++ b/pep-0287.txt
@@ -554,7 +554,7 @@ Questions & Answers
 
        Abstract
 
-           This PEP proposes adding frungible doodads [1] to the core.
+           This PEP proposes adding frangible doodads [1] to the core.
            It extends PEP 9876 [2] via the BCA [3] mechanism.
 
        ...
@@ -576,7 +576,7 @@ Questions & Answers
        Abstract
        ========
 
-       This PEP proposes adding `frungible doodads`_ to the core.  It
+       This PEP proposes adding `frangible doodads`_ to the core.  It
        extends PEP 9876 [#pep9876]_ via the BCA [#]_ mechanism.
 
        ...
@@ -584,7 +584,7 @@ Questions & Answers
        References & Footnotes
        ======================
 
-       .. _frungible doodads: http://www.example.org/
+       .. _frangible doodads: http://www.example.org/
 
        .. [#pep9876] PEP 9876, Let's Hope We Never Get Here
 
@@ -599,7 +599,7 @@ Questions & Answers
    explicitly (in citation form), another tree transform could be
    used.
 
-   URL references can be named ("frungible doodads"), and can be
+   URL references can be named ("frangible doodads"), and can be
    referenced from multiple places in the document without additional
    definitions.  When converted to HTML, references will be replaced
    with inline hyperlinks (HTML <a> tags).  The two footnotes are


### PR DESCRIPTION
Spelling `frungible` changed to `frangible`.