### PR TITLE
Add data-requires-python attribute to file links (PEP 503)

### DIFF
--- a/pep-0503.txt
+++ b/pep-0503.txt
@@ -96,6 +96,13 @@ In addition to the above, the following constraints are placed on the API:
   a value of either ``true`` or ``false`` to indicate whether or not there is a
   GPG signature. Repositories that do this **SHOULD** include it on every link.
 
+* A repository **MAY** include a ``data-requires-python`` attribute on a file
+  link. This exposes the *Requires-Python* metadata field, specified in PEP 345,
+  for the corresponding release. Where this is present, installer tools
+  **SHOULD** ignore the download when installing to a Python version that
+  doesn't satisfy the requirement. For example::
+
+      <a href="..." data-requires-python=">=3">...</a>
 
 Normalized Names
 ----------------

--- a/pep-0503.txt
+++ b/pep-0503.txt
@@ -102,7 +102,10 @@ In addition to the above, the following constraints are placed on the API:
   **SHOULD** ignore the download when installing to a Python version that
   doesn't satisfy the requirement. For example::
 
-      <a href="..." data-requires-python=">=3">...</a>
+      <a href="..." data-requires-python="&gt;=3">...</a>
+
+  In the attribute value, < and > have to be HTML encoded as ``&lt;`` and
+  ``&gt;``, respectively.
 
 Normalized Names
 ----------------

--- a/pep-0503.txt
+++ b/pep-0503.txt
@@ -118,6 +118,11 @@ can be implemented in Python with the ``re`` module::
    def normalize(name):
        return re.sub(r"[-_.]+", "-", name).lower()
 
+Changes
+-------
+
+* The optional ``data-requires-python`` attribute was added in July 2016.
+
 
 Copyright
 =========


### PR DESCRIPTION
This was suggested by @dstufft in pypa/pip#3847