### PR TITLE
[WIP] PEP 484: use package_data to distribute stubs

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -1611,22 +1611,15 @@ Note that if the user decides to use the "latest" available source
 package, using the "latest" stub files should generally also work if
 they're updated often.
 
-Third-party stub packages can use any location for stub storage.  Type
-checkers should search for them using PYTHONPATH.  A default fallback
-directory that is always checked is ``shared/typehints/python3.5/`` (or
-3.6, etc.).  Since there can only be one package installed for a given
-Python version per environment, no additional versioning is performed
-under that directory (just like bare directory installs by ``pip`` in
-site-packages).  Stub file package authors might use the following
-snippet in ``setup.py``::
+Third-party stub packages can use any location for stub storage. Type
+checkers should search for them using PYTHONPATH. Stub file package
+authors might use the following snippet in ``setup.py``::
 
   ...
-  data_files=[
-      (
-          'shared/typehints/python{}.{}'.format(*sys.version_info[:2]),
-          pathlib.Path(SRC_PATH).glob('**/*.pyi'),
-      ),
-  ],
+  package_data={
+      SRC_PATH: [str(p.relative_to(SRC_PATH))
+                 for p in pathlib.Path(SRC_PATH).glob('**/*.pyi')],
+  },
   ...
 
 The Typeshed Repo


### PR DESCRIPTION
See [mypy#1895](https://github.com/python/mypy/pull/1895).

Change location for finding stubs from having a fixed location as `shared/typehints/python*` to having the stubs being directly in the module (`package_data` instead of `data_files`). Having this will tight types annotations to code rather than to repository, which IMO is good, that also remove the need to have a tree outside of `/usr/lib/python*/site-packages`, with version done by hand.

The type checker would still have to look in `PYTHONPATH` to find a suitable type definition but, as the loaded module what found in it, we don't need to check elsewhere.