### PR TITLE
Update pep 345 to reference pep 440 that supersede pep 386.

### DIFF
--- a/pep-0345.txt
+++ b/pep-0345.txt
@@ -68,7 +68,7 @@ Version
 :::::::
 
 A string containing the distribution's version number.  This
-field  must be in the format specified in PEP 386.
+field  must be in the format specified in PEP 440.
 
 Example::
 
@@ -371,7 +371,7 @@ parentheses.
 
 Because they refer to non-Python software releases, version numbers
 for this field are **not** required to conform to the format
-specified in PEP 386:  they should correspond to the
+specified in PEP 440:  they should correspond to the
 version scheme used by the external dependency.
 
 Notice that there's is no particular rule on the strings to be used.
@@ -406,7 +406,7 @@ Any number of conditional operators can be specified, e.g.
 the string ">1.0, !=1.3.4, <2.0" is a legal version declaration.
 The comma (",") is equivalent to the **and** operator.
 
-Each version number must be in the format specified in PEP 386.
+Each version number must be in the format specified in PEP 440.
 
 When a version is provided, it always includes all versions that
 starts with the same value. For example, the "2.5" version of Python


### PR DESCRIPTION
Pep 386 - "Changing the version comparison module in Distutils" has been
replaced by Pep 440 - "Version Identification and Dependency
Specification"

Pep 345 still refer to pep 386, I suppose it is meant to reference pep
440 now.

--- 

The only "gotcha" is that pep 345 says that `Requires-Python = 3` is valid: 

> Requires-Python: 3 : Any Python 3 version, no matter wich one, excluding post or pre-releases.

That it must comply to the version specifiers:

> Version numbers must be in the format specified in Version Specifiers .

Which should match pep 386, now superseded by 440, in which `3` alone is not valid. 

So peps are contradicting themselves.