### PR TITLE
'Fix typo: wich -> which'

### DIFF
--- a/pep-0345.txt
+++ b/pep-0345.txt
@@ -436,7 +436,7 @@ Some Examples:
 - ``Requires-Dist: zope.interface (3.1.0)``: any version that starts with
   3.1.0, excluding post or pre-releases. Since that particular project doesn't
   use more than 3 digits, it also means "only the 3.1.0 release".
-- ``Requires-Python: 3``: Any Python 3 version, no matter wich one, excluding
+- ``Requires-Python: 3``: Any Python 3 version, no matter which one, excluding
   post or pre-releases.
 - ``Requires-Python: >=2.6,<3``: Any version of Python 2.6 or 2.7, including
   post releases of 2.6, pre and post releases of 2.7. It excludes pre releases


### PR DESCRIPTION
---

In pep 345; I could have changed it into [a witch](https://www.youtube.com/watch?v=zrzMhU_4m-g) but I think it was not the intent.