### PR TITLE
correct "p3yk" typos

### DIFF
--- a/pep-3107.txt
+++ b/pep-3107.txt
@@ -235,7 +235,7 @@ The ``Parameter`` object may change or other changes may be warranted.
 Implementation
 ==============
 
-A reference implementation has been checked into the p3yk branch
+A reference implementation has been checked into the py3k branch
 as revision 53170 [#implementation]_.
 
 

--- a/pep-3110.txt
+++ b/pep-3110.txt
@@ -129,7 +129,7 @@ gets translated to (in Python 2.5 terms) ::
             del N
     ...
 
-An implementation has already been checked into the p3yk branch
+An implementation has already been checked into the py3k branch
 [#translation-checkin]_.
 
 
@@ -283,10 +283,10 @@ References
    http://mail.python.org/pipermail/python-3000/2007-January/005604.html
    
 .. [#r53342]
-   http://svn.python.org/view/python/branches/p3yk/?view=rev&rev=53342
+   http://svn.python.org/view/python/branches/py3k/?view=rev&rev=53342
    
 .. [#r53349]
-   http://svn.python.org/view/python/branches/p3yk/?view=rev&rev=53349
+   http://svn.python.org/view/python/branches/py3k/?view=rev&rev=53349
    
 .. [#r55446]
    http://svn.python.org/view/python/trunk/?view=rev&rev=55446


### PR DESCRIPTION
Replacing "p3yk" typo with "py3k".  Surprisingly, a web search reveals that this typo occurs many times.