### PR TITLE
correct "p3yk" typos  - redux

### DIFF
--- a/pep-3107.txt
+++ b/pep-3107.txt
@@ -235,7 +235,7 @@ The ``Parameter`` object may change or other changes may be warranted.
 Implementation
 ==============
 
-A reference implementation has been checked into the p3yk branch
+A reference implementation has been checked into the py3k branch
 as revision 53170 [#implementation]_.
 
 

--- a/pep-3107.txt
+++ b/pep-3107.txt
@@ -235,8 +235,8 @@ The ``Parameter`` object may change or other changes may be warranted.
 Implementation
 ==============
 
-A reference implementation has been checked into the py3k branch
-as revision 53170 [#implementation]_.
+A reference implementation has been checked into the py3k (formerly 
+"p3yk") branch as revision 53170 [#implementation]_.
 
 
 Rejected Proposals

--- a/pep-3110.txt
+++ b/pep-3110.txt
@@ -129,7 +129,7 @@ gets translated to (in Python 2.5 terms) ::
             del N
     ...
 
-An implementation has already been checked into the p3yk branch
+An implementation has already been checked into the py3k branch
 [#translation-checkin]_.
 
 
@@ -283,10 +283,10 @@ References
    http://mail.python.org/pipermail/python-3000/2007-January/005604.html
    
 .. [#r53342]
-   http://svn.python.org/view/python/branches/p3yk/?view=rev&rev=53342
+   http://svn.python.org/view/python/branches/py3k/?view=rev&rev=53342
    
 .. [#r53349]
-   http://svn.python.org/view/python/branches/p3yk/?view=rev&rev=53349
+   http://svn.python.org/view/python/branches/py3k/?view=rev&rev=53349
    
 .. [#r55446]
    http://svn.python.org/view/python/trunk/?view=rev&rev=55446

--- a/pep-3110.txt
+++ b/pep-3110.txt
@@ -129,8 +129,8 @@ gets translated to (in Python 2.5 terms) ::
             del N
     ...
 
-An implementation has already been checked into the py3k branch
-[#translation-checkin]_.
+An implementation has already been checked into the py3k (formerly 
+"p3yk") branch [#translation-checkin]_.
 
 
 Compatibility Issues
@@ -283,10 +283,10 @@ References
    http://mail.python.org/pipermail/python-3000/2007-January/005604.html
    
 .. [#r53342]
-   http://svn.python.org/view/python/branches/py3k/?view=rev&rev=53342
+   http://svn.python.org/view?view=revision&revision=53342
    
 .. [#r53349]
-   http://svn.python.org/view/python/branches/py3k/?view=rev&rev=53349
+   http://svn.python.org/view?view=revision&revision=53349
    
 .. [#r55446]
    http://svn.python.org/view/python/trunk/?view=rev&rev=55446


### PR DESCRIPTION
Changes based on discussion in rejected pull request #86. URLs to svn branches changed to revision-only. Text acknowledges the branch was originally named "p3yk" before being renamed to "py3k", to prevent future suggestions to correct it.