### PR TITLE
PEP 484: Allow annotating first argument of instance and class methods

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -108,7 +108,7 @@ comment should be treated as having no annotations.
 It is recommended but not required that checked functions have
 annotations for all arguments and the return type.  For a checked
 function, the default annotation for arguments and for the return type
-is ``Any``.  An exception is that the first argument of instance and
+is ``Any``.  An exception is the first argument of instance and
 class methods. If it is not annotated, then it is assumed to have the
 type of the containing class for instance methods, and a type object
 type corresponding to the containing class object for class methods.
@@ -1128,7 +1128,7 @@ does not need to be annotated, and it is assumed to have the
 type of the containing class for instance methods, and a type object
 type corresponding to the containing class object for class methods.
 In addition, the first argument in an instance method can be annotated
-with a type variable. In this case the return type uses the same
+with a type variable. In this case the return type may use the same
 type variable, thus making that method a generic function. For example::
 
   T = TypeVar('T', bound='Copyable')
@@ -1153,21 +1153,7 @@ of the first argument::
 
 Note that some type checkers may apply restrictions on this use, such as
 requiring an appropriate upper bound for the type variable used
-(see examples). Also this use case should not be confused with the use
-of type variables in methods of generic classes. Compare::
-
-  T = TypeVar('T')
-  class Num(Generic[T]):
-      def __init__(self, val: T) -> None: ...
-      def __add__(self, other: 'Num[T]') -> 'Num[T]': ...
-  Num(1) + Num(3.14) # Rejected by type checker
-
-  N = TypeVar('N', bound='Float')
-  class Float:
-      def __init__(self, val) -> None: ...
-      def __add__(self: N, other: N) -> N: ...
-  class Int(Float): ...
-  Int(1) + Float(3.14) # OK, the inferred value of T is Float
+(see examples).
 
 
 Version and platform checking

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -1145,6 +1145,7 @@ of the first argument::
 
   T = TypeVar('T', bound='C')
   class C:
+      @classmethod
       def factory(cls: Type[T]) -> T:
           # make a new instance of cls
 

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -109,7 +109,7 @@ It is recommended but not required that checked functions have
 annotations for all arguments and the return type.  For a checked
 function, the default annotation for arguments and for the return type
 is ``Any``.  An exception is that the first argument of instance and
-class methods does not need to be annotated; it is assumed to have the
+class methods. If it is not annotated, then it is assumed to have the
 type of the containing class for instance methods, and a type object
 type corresponding to the containing class object for class methods.
 For example, in class ``A`` the first argument of an instance method
@@ -1118,6 +1118,56 @@ subtype of ``Type[Base]``::
   def new_pro_user(pro_user_class: Type[ProUser]):
       user = new_user(pro_user_class)  # OK
       ...
+
+
+Annotating instance and class methods
+-------------------------------------
+
+In most cases the first argument of class and instance methods
+does not need to be annotated, and it is assumed to have the
+type of the containing class for instance methods, and a type object
+type corresponding to the containing class object for class methods.
+In addition, the first argument in an instance method can be annotated
+with a type variable. In this case the return type uses the same
+type variable, thus making that method a generic function. For example::
+
+  T = TypeVar('T', bound='Copyable')
+  class Copyable:
+      def copy(self: T) -> T:
+          # return a copy of self
+
+  class C(Copyable): ...
+  c = C()
+  c2 = c.copy()  # type here should be C
+
+The same applies to class methods using ``Type[]`` in an annotation
+of the first argument::
+
+  T = TypeVar('T', bound='C')
+  class C:
+      def factory(cls: Type[T]) -> T:
+          # make a new instance of cls
+
+  class D(C): ...
+  d = D.factory()  # type here should be D
+
+Note that some type checkers may apply restrictions on this use, such as
+requiring an appropriate upper bound for the type variable used
+(see examples). Also this use case should not be confused with the use
+of type variables in methods of generic classes. Compare::
+
+  T = TypeVar('T')
+  class Num(Generic[T]):
+      def __init__(self, val: T) -> None: ...
+      def __add__(self, other: 'Num[T]') -> 'Num[T]': ...
+  Num(1) + Num(3.14) # Rejected by type checker
+
+  N = TypeVar('N', bound='Float')
+  class Float:
+      def __init__(self, val) -> None: ...
+      def __add__(self: N, other: N) -> N: ...
+  class Int(Float): ...
+  Int(1) + Float(3.14) # OK, the inferred value of T is Float
 
 
 Version and platform checking


### PR DESCRIPTION
Fixes https://github.com/python/typing/issues/271 and https://github.com/python/mypy/issues/1212

@JukkaL @gvanrossum 
Please review.

@JukkaL The third example works in mypy (with appropriate function bodies), Guido wants to double check that mypy could be patched so that first two examples also work.
