### PR TITLE
Google's python frame change isn't years old

### DIFF
--- a/pep-0523.txt
+++ b/pep-0523.txt
@@ -270,9 +270,8 @@ skipping information that ``sys.settrace()`` normally provides and
 even go as far as to dynamically rewrite bytecode prior to execution
 to inject e.g. breakpoints in the bytecode.
 
-It also turns out that Google has provided a very similar API
-internally for years. It has been used for performant debugging
-purposes.
+It also turns out that Google provides a very similar API
+internally. It has been used for performant debugging purposes.
 
 
 Implementation


### PR DESCRIPTION
I think this was a misunderstanding on someone's part. It's fairly new.