### PR TITLE
Update pep-0042.txt

### DIFF
--- a/pep-0042.txt
+++ b/pep-0042.txt
@@ -79,6 +79,13 @@ Core Language / Builtins
   pass bindings for free variables to eval when a code object with
   free variables is passed. http://www.python.org/sf/443866
 
+* It would be useful to allow a "mapreduce" comprehension - basically 
+  a list-comprehension that allows you to update some internal variable
+  in the loop.  Eg: A neural network forward pass: 
+  `activations = [u=np.maximum(0, u.dot(w)+b) for w, b in zip(ws, bs) from u=x]`
+  An exponentially decaying average:
+  `lowpass_sig = [u = u*0.9 + s for s in signal from u=0]`
+
 Standard Library
 ================
 

--- a/pep-0042.txt
+++ b/pep-0042.txt
@@ -83,8 +83,8 @@ Core Language / Builtins
   a list-comprehension that allows you to update some internal variable
   in the loop.  Eg: A neural network forward pass: 
   `activations = [u=np.maximum(0, u.dot(w)+b) for w, b in zip(ws, bs) from u=x]`
-  An exponentially decaying average:
-  `lowpass_sig = [u = u*0.9 + s for s in signal from u=0]`
+  An exponential moving average:
+  `lowpass_sig = [u = u*0.9 + s*0.1 for s in signal from u=0]`
 
 Standard Library
 ================


### PR DESCRIPTION
Suggest a "mapreduce" comprehension:

`lowpass_sig = [u = u*0.9 + s*0.1 for s in signal from u = 0]`

This arose from [this StackOverflow post](http://stackoverflow.com/questions/39688133/cleanest-way-to-combine-reduce-and-map-in-python/), which revealed there's no compact way to do this in python now.