### PR TITLE
PEP8: Dictionary values should have an extra indent

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -121,6 +121,51 @@ Optional::
       var_one, var_two,
       var_three, var_four)
 
+For dictionaries there is an extra rule. When placing a dictionary key on a new
+line an additional hanging indent should be added. This is so it is easy to
+differentiate between keys and values.
+
+Yes::
+
+    # Keys aligned with opening delimiter, values have an extra indent.
+    mydict = {'firstkey':
+                  'a very very very very very long value',
+              'secondkey': 'a short value',
+              'thirdkey': 'a very very very'
+                  ' long value that continues on the next line'
+                  ' and even on the line after that.',
+    }
+
+    # Keys with one and values with two levels of hanging indents.
+    mydict = {
+        'firstkey':
+            'a very very very very very long value',
+        'secondkey': 'a short value',
+        'thirdkey': 'a very very very'
+            ' long value that continues on the next line'
+            ' and even on the line after that.',
+    }
+
+    # Continuing value indented to column where the value starts.
+    mydict = {
+        'thirdkey': 'a very very very'
+                    ' long value that continues on the next line'
+                    ' and even on the line after that.',
+    }
+
+
+No::
+
+    # Keys and values indented in the same way.
+    mydict = {'firstkey':
+              'a very very very very very long value',
+              'secondkey': 'a short value',
+              'thirdkey': 'a very very very'
+              ' long value that continues on the next line',
+              ' and even on the line after that.'
+    }
+
+
 .. _`multiline if-statements`:
 
 When the conditional part of an ``if``-statement is long enough to require


### PR DESCRIPTION
This adds a new indenting rule to PEP8 to make it easy to differentiate between
keys and values of dictionaries. This was already shortly discussed in the
python-ideas mailinglist:
https://mail.python.org/pipermail/python-ideas/2016-October/042753.html