### PR TITLE
Strongly prefer reStructuredText.

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -368,7 +368,7 @@ optional and are described below.  All other headers are required. ::
     Status: <Draft | Active | Accepted | Deferred | Rejected |
              Withdrawn | Final | Superseded>
     Type: <Standards Track | Informational | Process>
-  * Content-Type: <text/plain | text/x-rst>
+  * Content-Type: <text/x-rst | text/plain>
   * Requires: <pep numbers>
     Created: <date created on, in dd-mmm-yyyy format>
   * Python-Version: <version number>
@@ -421,8 +421,9 @@ Informational, or Process.
 The format of a PEP is specified with a Content-Type header.  The
 acceptable values are "text/plain" for plaintext PEPs (see PEP 9 [3]_)
 and "text/x-rst" for reStructuredText PEPs (see PEP 12 [4]_).
-Plaintext ("text/plain") is the default if no Content-Type header is
-present.
+reStructuredText is strongly preferred, but for backwards
+compatibility plain text is currently still the default if no
+Content-Type header is present.
 
 The Created header records the date that the PEP was assigned a
 number, while Post-History is used to record the dates of when new


### PR DESCRIPTION
We can't immediately change the default when there's no `Content-Type` but we should deprecate it and strongly prefer reStructuredText.  There's also #4 to consider.