### PR TITLE
Fix quotation in PEP-0505

### DIFF
--- a/pep-0505.txt
+++ b/pep-0505.txt
@@ -1010,7 +1010,7 @@ Finally, observe that short circuiting adjacent operators is not at all the same
 If ``user`` is not ``None``, then ``user.first_name`` is evaluated. If
 ``user.first_name`` evaluates to ``None``, then ``user.first_name.upper()`` is
 an error! In English, this expression says, "``user`` is optional but if it has
-a value, then it must have a ``first_name``, too.""
+a value, then it must have a ``first_name``, too."
 
 If ``first_name`` is supposed to be optional attribute, then the expression must
 make that explicit::


### PR DESCRIPTION
While reading through PEP-0505 I noticed that the quotation which is explaining the None-aware expression in English was closing the quote using two double quotes.