### PR TITLE
PEP 484: Add a note that misplaced type comments are errors for typecheckers

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -2027,6 +2027,17 @@ Notes:
     def add(a, b):  # type: (int, int) -> int
         return a + b
 
+- Misplaced type comment will be flagged as errors by a type checker.
+  If necessary, such comments could be commented twice. For example::
+
+    def f():
+        '''Docstring'''
+        # type: () -> None # Error!
+
+    def g():
+        '''Docstring'''
+        # # type: () -> None # This is OK
+
 
 Rejected Alternatives
 =====================

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -2027,7 +2027,7 @@ Notes:
     def add(a, b):  # type: (int, int) -> int
         return a + b
 
-- Misplaced type comment will be flagged as errors by a type checker.
+- Misplaced type comments will be flagged as errors by a type checker.
   If necessary, such comments could be commented twice. For example::
 
     def f():


### PR DESCRIPTION
Fixes https://github.com/python/typing/issues/210
@gvanrossum @ddfisher This behaviour with ``--fast-parser`` is in mypy since mid-May. It looks like nobody is complaining. Maybe it's time to add this to the PEP?