### PR TITLE
517: Change build_backend to build-backend

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -103,15 +103,15 @@ to it as the ``setup.py``\-style.
 Here we define a new style of source tree based around the
 ``pyproject.toml`` file defined in PEP 518, extending the
 ``[build-system]`` table in that file with one additional key,
-``build_backend``. Here's an example of how it would look::
+``build-backend``. Here's an example of how it would look::
 
     [build-system]
     # Defined by PEP 518:
     requires = ["flit"]
     # Defined by this PEP:
-    build_backend = "flit.api:main"
+    build-backend = "flit.api:main"
 
-``build_backend`` is a string naming a Python object that will be
+``build-backend`` is a string naming a Python object that will be
 used to perform the build (see below for details). This is formatted
 following the same ``module:object`` syntax as a ``setuptools`` entry
 point. For instance, if the string is ``"flit.api:main"`` as in the
@@ -123,7 +123,7 @@ equivalent of::
 
 It's also legal to leave out the ``:object`` part, e.g. ::
 
-    build_backend = "flit.api"
+    build-backend = "flit.api"
 
 which acts like::
 
@@ -141,11 +141,11 @@ And we import ``module_path`` and then lookup
 ``module_path.object_path`` (or just ``module_path`` if
 ``object_path`` is missing).
 
-If the ``pyproject.toml`` file is absent, or the ``build_backend``
+If the ``pyproject.toml`` file is absent, or the ``build-backend``
 key is missing, the source tree is not using this specification, and
 tools should fall back to running ``setup.py``.
 
-Where the ``build_backend`` key exists, it takes precedence over
+Where the ``build-backend`` key exists, it takes precedence over
 ``setup.py``, and source trees need not include ``setup.py`` at all.
 Projects may still wish to include a ``setup.py`` for compatibility
 with tools that do not use this spec.


### PR DESCRIPTION
The key is in the build-system table, so making this a dash would improve consistency. On English keyboards, it also avoids needing to press shift. There seemed to be a consensus on distutils-sig in favour of this change.