### PR TITLE
517: Add user parameter to install_editable hook (Option 1a)

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -214,12 +214,11 @@ Mandatory.
 
 ::
 
-  def install_editable(prefix, config_settings, metadata_directory=None):
+  def install_editable(prefix, user, config_settings, metadata_directory=None):
       ...
 
 Must perform whatever actions are necessary to install the current
-project into the Python installation at ``install_prefix`` in an
-"editable" fashion. This is intentionally underspecified, because it's
+project in an "editable" fashion. This is intentionally underspecified, because it's
 included as a stopgap to avoid regressing compared to the current
 equally underspecified setuptools ``develop`` command; hopefully a
 future PEP will replace this hook with something that works better and
@@ -227,13 +226,13 @@ is better specified. (Unfortunately, cleaning up editable installs to
 actually work well and be well-specified turns out to be a large and
 difficult job, so we prefer not to do a half-way job here.)
 
+If ``user`` is true, the editable install should be done to the user's home
+directory, as with the ``--user`` option to ``setup.py``. Otherwise, it should
+be installed to a Python installation or environment at ``prefix``, following
+the install scheme relevant to the current platform.
+
 For the meaning and requirements of the ``metadata_directory``
 argument, see ``build_wheel`` above.
-
-[XX UNRESOLVED: it isn't entirely clear whether ``prefix`` alone is
-enough to support all needed configurations -- in particular,
-@takluyver has suggested that contra to the distutils docs, ``--user``
-on Windows is not expressible in terms of a regular prefix install.]
 
 Optional. If not defined, then this build backend does not support
 editable builds.


### PR DESCRIPTION
This is one option for fixing the problem I believe exists with `--user` editable installs.