### PR TITLE
Document `__foo` syntax for positional-only args

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -1268,6 +1268,21 @@ In such cases the default value may be specified as a literal
 ellipsis, i.e. the above example is literally what you would write.
 
 
+Positional-only arguments
+-------------------------
+
+Some functions are designed to take their arguments only positionally,
+and expect their callers never to use the argument's name to provide
+that argument by keyword. All arguments with names beginning with
+``__`` are assumed to be positional-only::
+
+  def quux(__x: int) -> None: ...
+
+  quux(3)  # This call is fine.
+
+  quux(__x=3)  # This call is an error.
+
+
 Annotating generator functions and coroutines
 ---------------------------------------------
 


### PR DESCRIPTION
This resolves https://github.com/python/typing/issues/336