### PR TITLE
Fix typos in PEP 524 and PEP 529

### DIFF
--- a/pep-0524.txt
+++ b/pep-0524.txt
@@ -41,7 +41,7 @@ short Python script used to compute a MD5 hash, systemd-cron, script
 called very early in the init process. The system initialization blocks
 on this script which blocks on ``getrandom(0)`` to initialize Python.
 
-The Python initilization requires random bytes to implement a
+The Python initialization requires random bytes to implement a
 counter-measure against the hash denial-of-service (hash DoS), see:
 
 * `Issue #13703: Hash collision security issue
@@ -101,7 +101,7 @@ Python cannot produce itself secure entropy, it can only wait until
 system urandom is initialized. But in this use case, the whole system
 initialization is blocked by this script, so the system fails to boot.
 
-The real answer is that the system iniitalization must not be blocked by
+The real answer is that the system initialization must not be blocked by
 such script. It is ok to start the script very early at system
 initialization, but the script may blocked a few seconds until it is
 able to generate the secret.

--- a/pep-0529.txt
+++ b/pep-0529.txt
@@ -119,7 +119,7 @@ utf-16-le and returned as text (in whatever the minimal representation is). When
 Python code requests paths as ``bytes``, the paths will be transcoded from
 utf-16-le into utf-8 using surrogatepass (Windows does not validate surrogate
 pairs, so it is possible to have invalid surrogates in filenames). Equally, when
-paths are provided as ``bytes``, they are trasncoded from utf-8 into utf-16-le
+paths are provided as ``bytes``, they are transcoded from utf-8 into utf-16-le
 and passed to the \*W APIs.
 
 The use of utf-8 will not be configurable, except for the provision of a


### PR DESCRIPTION
Reported at https://github.com/python/pythondotorg/issues/1038