### PR TITLE
PEP 526: Variable __annotations__ should be ordered

### DIFF
--- a/pep-0526.txt
+++ b/pep-0526.txt
@@ -385,7 +385,7 @@ evaluated::
 In addition, at the module or class level, if the item being annotated is a
 *simple name*, then it and the annotation will be stored in the
 ``__annotations__`` attribute of that module or class (mangled if private)
-as a dictionary mapping from names to evaluated annotations.
+as an ordered mapping from names to evaluated annotations.
 Here is an example::
 
   from typing import Dict
@@ -402,8 +402,8 @@ Here is an example::
 
   __annotations__['s'] = str
 
-But attempting to update ``__annotations__`` to something other than a dict
-may result in a TypeError::
+But attempting to update ``__annotations__`` to something other than an
+ordered mapping may result in a TypeError::
 
   class C:
       __annotations__ = 42
@@ -593,7 +593,7 @@ Rejected/Postponed Proposals
   This was proposed to prohibit setting ``__annotations__`` to something
   non-dictionary or non-None. Guido has rejected this idea as unnecessary;
   instead a TypeError will be raised if an attempt is made to update
-  ``__annotations__`` when it is anything other than a dict.
+  ``__annotations__`` when it is anything other than a mapping.
 
 - **Treating bare annotations the same as global or nonlocal:**
   The rejected proposal would prefer that the presence of an


### PR DESCRIPTION
Fixes https://github.com/python/typing/issues/339

Following the discussion on python/typing issue (and taking into account that ``dict`` in 3.6 is ordered beeing an implementation detail) it is proposed to make ``__annotations__`` ordered.

@gvanrossum Please, take a look.