### PR TITLE
PEP 487: fixed typo

### DIFF
--- a/pep-0487.txt
+++ b/pep-0487.txt
@@ -316,7 +316,7 @@ Backward compatibility issues
 
 The exact calling sequence in ``type.__new__`` is slightly changed, raising
 fears of backwards compatibility. It should be assured by tests that common use
-cases behave as desirerd.
+cases behave as desired.
 
 The following class definitions (except the one defining the metaclass)
 continue to fail with a ``TypeError`` as superfluous class arguments are passed::


### PR DESCRIPTION
Found a typo in PEP 487. Not sure if this is the proper way to go about reporting/fixing it, but here it is regardless.