### PR TITLE
Fix broken url in PEP 3107

### DIFF
--- a/pep-3107.txt
+++ b/pep-3107.txt
@@ -275,7 +275,7 @@ References and Footnotes
    http://mail.python.org/pipermail/python-3000/2006-May/002103.html
 
 .. [#typecheck]
-   http://archive.is/dcuD
+   http://web.archive.org/web/20070730120117/http://oakwinter.com/code/typecheck/
 
 .. [#maxime]
    http://web.archive.org/web/20070603221429/http://maxrepo.info/


### PR DESCRIPTION
Fixes https://github.com/python/peps/issues/168 for real