### PR TITLE
Incredibly minor typo fix in pep-0001

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -68,7 +68,7 @@ PEP Workflow
 Python's BDFL
 -------------
 
-There are several reference in this PEP to the "BDFL". This acronym stands
+There are several references in this PEP to the "BDFL". This acronym stands
 for "Benevolent Dictator for Life" and refers to Guido van Rossum, the
 original creator of, and the final design authority for, the Python
 programming language.


### PR DESCRIPTION
Minor and inconsequential, but just one of those itches that I had to scratch.

Changes "reference" to "references".