### PR TITLE
Fix on PEP0487 "Subclass registration" example.

### DIFF
--- a/pep-0487.txt
+++ b/pep-0487.txt
@@ -199,7 +199,7 @@ subclasses of a plugin baseclass. This can be done as follows::
 
        def __init_subclass__(cls, **kwargs):
            super().__init_subclass__(**kwargs)
-           cls.subclasses.append(cls)
+           PluginBase.subclasses.append(cls)
 
 In this example, ``PluginBase.subclasses`` will contain a plain list of all
 subclasses in the entire inheritance tree.  One should note that this also


### PR DESCRIPTION
`cls.subclasses.append(cls)` would add a class attribute named `subclasses` to the class being created, no to the `PluginBase` base class, and append itself to that attribute.