### PR TITLE
PEP 484: add an example of iterable unpacking with type comments

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -1370,7 +1370,7 @@ complex cases, a comment of the following format may be used::
   x = []  # type: List[Employee]
   x, y, z = [], [], []  # type: List[int], List[int], List[str]
   x, y, z = [], [], []  # type: (List[int], List[int], List[str])
-  a, b, *c = range(5)  # type: float, float, List[float]
+  a, b, *c = range(5)   # type: float, float, List[float]
   x = [
      1,
      2,

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -1367,9 +1367,10 @@ No first-class syntax support for explicitly marking variables as being
 of a specific type is added by this PEP.  To help with type inference in
 complex cases, a comment of the following format may be used::
 
-  x = []   # type: List[Employee]
+  x = []  # type: List[Employee]
   x, y, z = [], [], []  # type: List[int], List[int], List[str]
   x, y, z = [], [], []  # type: (List[int], List[int], List[str])
+  a, b, *c = range(5)  # type: float, float, List[float]
   x = [
      1,
      2,


### PR DESCRIPTION
Fixes https://github.com/python/typing/issues/363

@gvanrossum Please, take a look.