### PR TITLE
Fixes to PEP 263 and PEP 272

### DIFF
--- a/pep-0263.txt
+++ b/pep-0263.txt
@@ -67,10 +67,10 @@ or (using formats recognized by popular editors)::
 or::
 
     #!/usr/bin/python
-    # vim: set fileencoding=<encoding name> ::
+    # vim: set fileencoding=<encoding name> :
 
 More precisely, the first or second line must match the regular
-expression "``^[ \t\v]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)```".
+expression "^[ \t\v]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)".
 The first group of this
 expression is then interpreted as encoding name. If the encoding
 is unknown to Python, an error is raised during compilation. There
@@ -80,7 +80,7 @@ is ignored.
 
 To aid with platforms such as Windows, which add Unicode BOM marks
 to the beginning of Unicode files, the UTF-8 signature
-'``\xef\xbb\xbf``' will be interpreted as 'utf-8' encoding as well
+'\xef\xbb\xbf' will be interpreted as 'utf-8' encoding as well
 (even if no magic encoding comment is given).
 
 If a source file uses both the UTF-8 BOM mark signature and a

--- a/pep-0272.txt
+++ b/pep-0272.txt
@@ -191,8 +191,8 @@ Here's an example, using a module named 'DES'::
     >>> len(plaintext)
     34
     >>> obj.encrypt(plaintext)
-    Traceback (innermost last)::
-        File "<stdin>", line 1, in <module>
+    Traceback (innermost last):
+      File "<stdin>", line 1, in ?
     ValueError: Strings for DES must be a multiple of 8 in length
     >>> ciphertext = obj.encrypt(plain+'XXXXXX')   # Add padding
     >>> ciphertext


### PR DESCRIPTION
PEP 263: remove extra colon and unnecessary backticks
PEP 272: remove extra colon and change back traceback code

@berkerpeksag I addressed the comments from the previous PRs.
Thanks.