### PR TITLE
Ordered **kwargs starts in 3.6 instead of 3.5.

### DIFF
--- a/pep-0468.txt
+++ b/pep-0468.txt
@@ -168,7 +168,7 @@ that this feature will not be a significant burden.
 Specification
 =============
 
-Starting in version 3.5 Python will preserve the order of keyword
+Starting in version 3.6 Python will preserve the order of keyword
 arguments as passed to a function.  To accomplish this the collected
 kwargs will now be an ordered mapping.  Note that this does not necessarily
 mean OrderedDict.  dict in CPython 3.6 is now ordered, similar to PyPy.


### PR DESCRIPTION
Looks like a typo to me. But not sure.