### PR TITLE
fixed pythocat link

### DIFF
--- a/pep-0512.txt
+++ b/pep-0512.txt
@@ -960,7 +960,7 @@ References
 .. [#devguide-merge-across-branches] Devguide instructions on how to merge across branches
    (https://docs.python.org/devguide/committing.html#merging-between-different-branches-within-the-same-major-version)
 
-.. [#pythocat] Pythocat (https://octodex.github.com/pythocat/)
+.. [#pythocat] Pythocat (https://octodex.github.com/pythocat)
 
 .. [#tracker-plans] Wiki page for bugs.python.org feature development
    (https://wiki.python.org/moin/TrackerDevelopmentPlanning)


### PR DESCRIPTION
Removed trailing slash from pythocat link, since it wouldn't resolve with it. (Also testing how easy it is to make a pull request prior to forking a repo.)

I can confirm it was quite easy to contribute! Nice job on the migration to Github. :)