### PR TITLE
Fix the 'venv' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,5 +38,6 @@ update:
 	git pull https://github.com/python/peps.git
 
 venv:
-	$(PYTHON) -m venv venv
+	$(PYTHON) -m pip install virtualenv
+	$(PYTHON) -m virtualenv venv
 	./venv/bin/python -m pip install -U docutils


### PR DESCRIPTION
Install virtualenv if needed (assuming pip exists), and use virtualenv, not venv.