### PR TITLE
Fix URL Reconstruction algorithm to support Python 3

### DIFF
--- a/pep-3333.txt
+++ b/pep-3333.txt
@@ -1379,7 +1379,7 @@ URL Reconstruction
 If an application wishes to reconstruct a request's complete URL, it
 may do so using the following algorithm, contributed by Ian Bicking::
 
-    from urllib import quote
+    from urllib.parse import quote
     url = environ['wsgi.url_scheme']+'://'
 
     if environ.get('HTTP_HOST'):


### PR DESCRIPTION
The current algorithm supplied in the URL Reconstruction section utilises urllib.quote, however this was changed in Python 3, so that it is now urllib.parse.quote. As this document was rewritten to support Python 3, the algorithm should also support Python 3.