### PR TITLE
Mark PEP 463 as rejected

### DIFF
--- a/pep-0463.txt
+++ b/pep-0463.txt
@@ -15,6 +15,9 @@ Resolution: https://mail.python.org/pipermail/python-dev/2014-March/133118.html
 Rejection Notice
 ================
 
+From https://mail.python.org/pipermail/python-dev/2014-March/133118.html:
+
+"""
 I want to reject this PEP. I think the proposed syntax is acceptable given
 the desired semantics, although it's still a bit jarring. It's probably no
 worse than the colon used with lambda (which echoes the colon used in a def
@@ -38,7 +41,7 @@ great job moderating the discussion, collecting objections, reviewing
 alternatives, and everything else that is required to turn a heated debate
 into a PEP. Well done Chris (and everyone who helped), and good luck with
 your next PEP!
-
+"""
 
 Abstract
 ========

--- a/pep-0463.txt
+++ b/pep-0463.txt
@@ -9,6 +9,7 @@ Content-Type: text/x-rst
 Created: 15-Feb-2014
 Python-Version: 3.5
 Post-History: 20-Feb-2014, 16-Feb-2014
+Resolution: https://mail.python.org/pipermail/python-dev/2014-March/133118.html
 
 
 Rejection Notice

--- a/pep-0463.txt
+++ b/pep-0463.txt
@@ -3,12 +3,40 @@ Title: Exception-catching expressions
 Version: $Revision$
 Last-Modified: $Date$
 Author: Chris Angelico <rosuav@gmail.com>
-Status: Draft
+Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 15-Feb-2014
 Python-Version: 3.5
 Post-History: 20-Feb-2014, 16-Feb-2014
+
+
+Rejection Notice
+================
+
+I want to reject this PEP. I think the proposed syntax is acceptable given
+the desired semantics, although it's still a bit jarring. It's probably no
+worse than the colon used with lambda (which echoes the colon used in a def
+just like the colon here echoes the one in a try/except) and definitely
+better than the alternatives listed.
+
+But the thing I can't get behind are the motivation and rationale. I don't
+think that e.g. dict.get() would be unnecessary once we have except
+expressions, and I disagree with the position that EAFP is better than
+LBYL, or "generally recommended" by Python. (Where do you get that? From
+the same sources that are so obsessed with DRY they'd rather introduce a
+higher-order-function than repeat one line of code? :-)
+
+This is probably the most you can get out of me as far as a pronouncement.
+Given that the language summit is coming up I'd be happy to dive deeper in
+my reasons for rejecting it there (if there's demand).
+
+I do think that (apart from never explaining those dreadful acronyms :-)
+this was a well-written and well-researched PEP, and I think you've done a
+great job moderating the discussion, collecting objections, reviewing
+alternatives, and everything else that is required to turn a heated debate
+into a PEP. Well done Chris (and everyone who helped), and good luck with
+your next PEP!
 
 
 Abstract


### PR DESCRIPTION
Copied the notice from https://mail.python.org/pipermail/python-dev/2014-March/133118.html

I looked at the PEP recently and noticed that it still claims to be a draft. I had to search in my email archive to confirm that it has in fact been rejected.