### PR TITLE
PEP 484: Add NoReturn type

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -1063,6 +1063,54 @@ in turn, to ``collections.abc.Callable``::
       ...
 
 
+The ``NoReturn`` type
+---------------------
+
+``typing`` module provides a special type ``NoReturn`` to annotate functions
+that never return normally. For example, a function that unconditionally
+raises an exception::
+
+  from typing import NoReturn
+
+  def stop() -> NoReturn:
+      raise Exception('no way')
+
+Such return annotation is used in ``typeshed`` stubs for functions
+such as ``sys.exit``. Static type checkers will ensure that functions
+annotated as returning ``NoReturn`` truly never return, either implicitly
+or explicitly::
+
+  import sys
+  from typing import NoReturn
+
+    def f(x: int) -> NoReturn:  # Error, f(0) implicitly returns None
+        if x != 0:
+            sys.exit(1)
+
+The checkers will also recognize that the code after calls to such functions
+is unreachable and will behave accordingly::
+
+  # continue from first example
+  def g(x: int) -> int:
+      if x > 0:
+          return x
+      stop()
+      return 'whatever works'  # No error reported by checkers that
+                               # ignore errors in unreachable blocks
+
+The ``NoReturn`` type is only valid as a return annotation of functions,
+and considered an error if appears in other positions::
+
+  from typing import List, NoReturn
+
+  # All of the following are errors
+  def bad1(x: Noreturn) -> int:
+      ...
+  bad2 = None  # type: NoReturn
+  def bad3() -> List[NoReturn]:
+      ...
+
+
 The type of class objects
 -------------------------
 

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -573,7 +573,7 @@ argument(s) is substituted.  Otherwise, ``Any`` is assumed.  Example::
   x = Node('')  # Inferred type is Node[str]
   y = Node(0)   # Inferred type is Node[int]
   z = Node()    # Inferred type is Node[Any]
-
+noret
 In case the inferred type uses ``[Any]`` but the intended type is more
 specific, you can use a type comment (see below) to force the type of
 the variable, e.g.::
@@ -1073,12 +1073,11 @@ raises an exception::
   from typing import NoReturn
 
   def stop() -> NoReturn:
-      raise Exception('no way')
+      raise RuntimeError('no way')
 
-Such return annotation is used in ``typeshed`` stubs for functions
-such as ``sys.exit``. Static type checkers will ensure that functions
-annotated as returning ``NoReturn`` truly never return, either implicitly
-or explicitly::
+The ``NoReturn`` annotation is used for functions such as ``sys.exit``.
+Static type checkers will ensure that functions annotated as returning
+``NoReturn`` truly never return, either implicitly or explicitly::
 
   import sys
   from typing import NoReturn
@@ -1095,8 +1094,8 @@ is unreachable and will behave accordingly::
       if x > 0:
           return x
       stop()
-      return 'whatever works'  # No error reported by checkers that
-                               # ignore errors in unreachable blocks
+      return 'whatever works'  # Error might be not reported by some checkers
+                               # that ignore errors in unreachable blocks
 
 The ``NoReturn`` type is only valid as a return annotation of functions,
 and considered an error if it appears in other positions::

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -1066,7 +1066,7 @@ in turn, to ``collections.abc.Callable``::
 The ``NoReturn`` type
 ---------------------
 
-``typing`` module provides a special type ``NoReturn`` to annotate functions
+The ``typing`` module provides a special type ``NoReturn`` to annotate functions
 that never return normally. For example, a function that unconditionally
 raises an exception::
 
@@ -1099,12 +1099,12 @@ is unreachable and will behave accordingly::
                                # ignore errors in unreachable blocks
 
 The ``NoReturn`` type is only valid as a return annotation of functions,
-and considered an error if appears in other positions::
+and considered an error if it appears in other positions::
 
   from typing import List, NoReturn
 
   # All of the following are errors
-  def bad1(x: Noreturn) -> int:
+  def bad1(x: NoReturn) -> int:
       ...
   bad2 = None  # type: NoReturn
   def bad3() -> List[NoReturn]:

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -573,7 +573,7 @@ argument(s) is substituted.  Otherwise, ``Any`` is assumed.  Example::
   x = Node('')  # Inferred type is Node[str]
   y = Node(0)   # Inferred type is Node[int]
   z = Node()    # Inferred type is Node[Any]
-noret
+
 In case the inferred type uses ``[Any]`` but the intended type is more
 specific, you can use a type comment (see below) to force the type of
 the variable, e.g.::


### PR DESCRIPTION
As discussed in https://github.com/python/typing/issues/165, it is time to document the ``NoReturn`` type.

@gvanrossum Please take a look when you will have time.