### PR TITLE
PEP 263: Fix escaping of "\"s in regex and strings

### DIFF
--- a/pep-0263.txt
+++ b/pep-0263.txt
@@ -69,8 +69,11 @@ or::
     #!/usr/bin/python
     # vim: set fileencoding=<encoding name> :
 
-More precisely, the first or second line must match the regular
-expression "^[ \t\v]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)".
+More precisely, the first or second line must match the following
+regular expression::
+
+    ^[ \t\v]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)
+
 The first group of this
 expression is then interpreted as encoding name. If the encoding
 is unknown to Python, an error is raised during compilation. There
@@ -80,7 +83,7 @@ is ignored.
 
 To aid with platforms such as Windows, which add Unicode BOM marks
 to the beginning of Unicode files, the UTF-8 signature
-'\xef\xbb\xbf' will be interpreted as 'utf-8' encoding as well
+``\xef\xbb\xbf`` will be interpreted as 'utf-8' encoding as well
 (even if no magic encoding comment is given).
 
 If a source file uses both the UTF-8 BOM mark signature and a


### PR DESCRIPTION
Observed to be missing the backslashes on
https://www.python.org/dev/peps/pep-0263/#defining-the-encoding