### PR TITLE
Withdraw PEP 103

### DIFF
--- a/pep-0103.txt
+++ b/pep-0103.txt
@@ -3,11 +3,22 @@ Title: Collecting information about git
 Version: $Revision$
 Last-Modified: $Date$
 Author: Oleg Broytman <phd@phdru.name>
-Status: Draft
+Status: Withdrawn
 Type: Informational
 Content-Type: text/x-rst
 Created: 01-Jun-2015
 Post-History: 12-Sep-2015
+
+Withdrawal
+==========
+
+This PEP was withdrawn as it's too generic and doesn't really deals
+with Python development. It is no longer updated.
+
+The content was moved to `Python Wiki`_. Make further updates in the
+wiki.
+
+.. _`Python Wiki`: https://wiki.python.org/moin/Git
 
 Abstract
 ========


### PR DESCRIPTION
Withdraw PEP 103 as it's too generic and doesn't really deals with Python development.