### PR TITLE
PEP 7: add curly braces to if block

### DIFF
--- a/pep-0007.txt
+++ b/pep-0007.txt
@@ -127,8 +127,9 @@ Code lay-out
 
       if (type->tp_dictoffset != 0 && base->tp_dictoffset == 0 &&
           type->tp_dictoffset == b_size &&
-          (size_t)t_size == b_size + sizeof(PyObject *))
+          (size_t)t_size == b_size + sizeof(PyObject *)) {
           return 0; /* "Forgive" adding a __dict__ only */
+      }
 
 * Put blank lines around functions, structure definitions, and major
   sections inside functions.


### PR DESCRIPTION
according to PEP 7, "braces are strongly preferred but may be omitted where C permits".
thus, IMHO, the examples in the PEP should have curly braces too.