### PR TITLE
Replace tabs with spaces and fix identation errors.

### DIFF
--- a/pep-0010.txt
+++ b/pep-0010.txt
@@ -61,10 +61,10 @@ References
 ==========
 
 .. [1] Python Developer's Guide,
-	(http://www.python.org/dev/)
+   (http://www.python.org/dev/)
 
 .. [2] Apache Project Guidelines and Voting Rules
-	(http://httpd.apache.org/dev/guidelines.html)
+   (http://httpd.apache.org/dev/guidelines.html)
 
 
 Copyright

--- a/pep-0213.txt
+++ b/pep-0213.txt
@@ -202,17 +202,17 @@ Caveats
    arguably not worth the extra implementation effort. This snippet
    demonstrates the current behavior::
 
-	   >>> def prn(*args):print args
-	   >>> class a:
+       >>> def prn(*args):print args
+       >>> class a:
 
-	   ...    __setattr__=prn
+       ...    __setattr__=prn
        >>> a().foo=5
-	   (<__main__.a instance at 882890>, 'foo', 5)
+       (<__main__.a instance at 882890>, 'foo', 5)
 
-	   >>> class b: pass
-	   >>> bi=b()
-	   >>> bi.__setattr__=prn
-	   >>> b.foo=5
+       >>> class b: pass
+       >>> bi=b()
+       >>> bi.__setattr__=prn
+       >>> b.foo=5
 
 
 2. Assignment to __dict__["XXX"] can overwrite the attribute

--- a/pep-0214.txt
+++ b/pep-0214.txt
@@ -40,7 +40,7 @@ Proposal
     must yield an object with a write() method (i.e. a file-like
     object).  Thus these two statements are equivalent:
 
-	print 'hello world'
+        print 'hello world'
         print >> sys.stdout, 'hello world'
 
     As are these two statements:
@@ -110,24 +110,24 @@ Alternative Approaches
     would act much like extended print, with a few additional
     features.
 
-	def writeln(*args, **kws):
-	    import sys
-	    file = sys.stdout
-	    sep = ' '
-	    end = '\n'
-	    if kws.has_key('file'):
-		file = kws['file']
-		del kws['file']
-	    if kws.has_key('nl'):
-		if not kws['nl']:
-		    end = ' '
-		del kws['nl']
-	    if kws.has_key('sep'):
-		sep = kws['sep']
-		del kws['sep']
-	    if kws:
-		raise TypeError('unexpected keywords')
-	    file.write(sep.join(map(str, args)) + end)
+        def writeln(*args, **kws):
+            import sys
+            file = sys.stdout
+            sep = ' '
+            end = '\n'
+            if kws.has_key('file'):
+                file = kws['file']
+                del kws['file']
+            if kws.has_key('nl'):
+                if not kws['nl']:
+                    end = ' '
+                del kws['nl']
+            if kws.has_key('sep'):
+                sep = kws['sep']
+                del kws['sep']
+            if kws:
+                raise TypeError('unexpected keywords')
+            file.write(sep.join(map(str, args)) + end)
 
     writeln() takes a three optional keyword arguments.  In the
     context of this proposal, the relevant argument is `file' which

--- a/pep-0224.txt
+++ b/pep-0224.txt
@@ -154,7 +154,7 @@ accidentally concatenated to the attribute's value::
 
    class C:
        x = "text" \
-	   "x's docstring"
+           "x's docstring"
 
 The trailing slash would cause the Python compiler to concatenate
 the attribute value and the docstring.

--- a/pep-0308.txt
+++ b/pep-0308.txt
@@ -112,7 +112,7 @@ Proposal
 
     The proposed syntax is as follows:
 
-	(if <condition>: <expression1> else: <expression2>) 
+        (if <condition>: <expression1> else: <expression2>)
 
     Note that the enclosing parentheses are not optional.
     

--- a/pep-0310.txt
+++ b/pep-0310.txt
@@ -60,21 +60,21 @@ Basic Syntax and Semantics
 
 The syntax of a 'with' statement is as follows::
 
-	'with' [ var '=' ] expr ':'
+    'with' [ var '=' ] expr ':'
         suite
 
 This statement is defined as being equivalent to the following
 sequence of statements::
 
-	var = expr
+    var = expr
 
-	if hasattr(var, "__enter__"):
+    if hasattr(var, "__enter__"):
         var.__enter__()
 
-	try:
+    try:
         suite
 
-	finally:
+    finally:
         var.__exit__()
 
 (The presence of an ``__exit__`` method is *not* checked like that of

--- a/pep-0321.txt
+++ b/pep-0321.txt
@@ -49,23 +49,23 @@ Options:
 
 1) Add functions to the ``datetime`` module::
 
-	import datetime
-	d = datetime.parse_iso8601("2003-09-15T10:34:54")
-	
+        import datetime
+        d = datetime.parse_iso8601("2003-09-15T10:34:54")
+
 2) Add class methods to the various types.  There are already various 
    class methods such as ``.now()``, so this would be pretty natural.::
 
-	import datetime
-	d = datetime.date.parse_iso8601("2003-09-15T10:34:54")
-	
+        import datetime
+        d = datetime.date.parse_iso8601("2003-09-15T10:34:54")
+
 3) Add a separate module (possible names: date, date_parse, parse_date)
    or subpackage (possible names: datetime.parser) containing parsing 
    functions::
    
-   	import datetime
-   	d = datetime.parser.parse_iso8601("2003-09-15T10:34:54")
-   	
-   	
+        import datetime
+        d = datetime.parser.parse_iso8601("2003-09-15T10:34:54")
+
+
 Unresolved questions:
 
 * Naming convention to use.
@@ -77,7 +77,7 @@ Unresolved questions:
   none is expected, or if no time is provided?
 * Anything special required for I18N?  For time zones?
 
-	
+
 Generic Input Parsing
 =======================
 
@@ -99,20 +99,20 @@ Options:
 
 1) Provide predefined format strings, so you could write this::
 
-	import datetime
-	d = datetime.datetime(...)
-	print d.strftime(d.RFC2822_FORMAT) # or datetime.RFC2822_FORMAT?
-	
+        import datetime
+        d = datetime.datetime(...)
+        print d.strftime(d.RFC2822_FORMAT) # or datetime.RFC2822_FORMAT?
+
 2) Provide new methods on all the objects::
-	
-	d = datetime.datetime(...)
-	print d.rfc822_time()
+
+        d = datetime.datetime(...)
+        print d.rfc822_time()
 
 
 Relevant functionality in other languages includes the `PHP date`_
 function (Python implementation by Simon Willison at
 http://simon.incutio.com/archive/2003/10/07/dateInPython)
-	
+
 
 References
 ==========

--- a/pep-0339.txt
+++ b/pep-0339.txt
@@ -435,12 +435,12 @@ Important Files
       "An implementation of the Zephyr Abstract Syntax Definition
       Language."  Uses SPARK_ to parse the ASDL files.
 
-    - asdl_c.py
-        "Generate C code from an ASDL description."  Generates
-        Python/Python-ast.c and Include/Python-ast.h .
+  - asdl_c.py
+      "Generate C code from an ASDL description."  Generates
+      Python/Python-ast.c and Include/Python-ast.h .
 
-    - spark.py
-        SPARK_ parser generator
+  - spark.py
+      SPARK_ parser generator
 
 + Python/
 
@@ -467,7 +467,7 @@ Important Files
       Emits bytecode based on the AST.
 
   - symtable.c
-        Generates a symbol table from AST.
+      Generates a symbol table from AST.
 
   - pyarena.c
       Implementation of the arena memory manager.
@@ -490,12 +490,12 @@ Important Files
       Declares PyAST_FromNode() external (from Python/ast.c).
 
   - code.h
-        Header file for Objects/codeobject.c; contains definition of
-        PyCodeObject.
+      Header file for Objects/codeobject.c; contains definition of
+      PyCodeObject.
 
   - symtable.h
-        Header for Python/symtable.c .  struct symtable and
-        PySTEntryObject are defined here.
+      Header for Python/symtable.c .  struct symtable and
+      PySTEntryObject are defined here.
 
   - pyarena.h
       Header file for the corresponding Python/pyarena.c .

--- a/pep-0339.txt
+++ b/pep-0339.txt
@@ -59,22 +59,22 @@ Querying data from the node structs can be done with the following
 macros (which are all defined in Include/token.h):
 
 - ``CHILD(node *, int)``
-	Returns the nth child of the node using zero-offset indexing
+        Returns the nth child of the node using zero-offset indexing
 - ``RCHILD(node *, int)``
-	Returns the nth child of the node from the right side; use
-	negative numbers!
+        Returns the nth child of the node from the right side; use
+        negative numbers!
 - ``NCH(node *)``
-	Number of children the node has
+        Number of children the node has
 - ``STR(node *)``
-	String representation of the node; e.g., will return ``:`` for a
-	COLON token
+        String representation of the node; e.g., will return ``:`` for a
+        COLON token
 - ``TYPE(node *)``
-	The type of node as specified in ``Include/graminit.h``
+        The type of node as specified in ``Include/graminit.h``
 - ``REQ(node *, TYPE)``
-	Assert that the node is the type that is expected
+        Assert that the node is the type that is expected
 - ``LINENO(node *)``
-	retrieve the line number of the source code that led to the
-	creation of the parse rule; defined in Python/ast.c
+        retrieve the line number of the source code that led to the
+        creation of the parse rule; defined in Python/ast.c
 
 To tie all of this example, consider the rule for 'while'::
 
@@ -110,10 +110,10 @@ approach and syntax::
 
   module Python
   {
-	stmt = FunctionDef(identifier name, arguments args, stmt* body,
-			    expr* decorators)
-	      | Return(expr? value) | Yield(expr value)
-	      attributes (int lineno)
+        stmt = FunctionDef(identifier name, arguments args, stmt* body,
+                            expr* decorators)
+              | Return(expr? value) | Yield(expr value)
+              attributes (int lineno)
   }
 
 The preceding example describes three different kinds of statements;
@@ -232,13 +232,13 @@ Function and macros for creating and using ``asdl_seq *`` types as found
 in Python/asdl.c and Include/asdl.h:
 
 - ``asdl_seq_new()``
-	Allocate memory for an asdl_seq for the specified length
+        Allocate memory for an asdl_seq for the specified length
 - ``asdl_seq_GET()``
-	Get item held at a specific position in an asdl_seq
+        Get item held at a specific position in an asdl_seq
 - ``asdl_seq_SET()``
-	Set a specific index in an asdl_seq to the specified value
+        Set a specific index in an asdl_seq to the specified value
 - ``asdl_seq_LEN(asdl_seq *)``
-	Return the length of an asdl_seq
+        Return the length of an asdl_seq
 
 If you are working with statements, you must also worry about keeping
 track of what line number generated the statement.  Currently the line
@@ -437,7 +437,7 @@ Important Files
 
     - asdl_c.py
         "Generate C code from an ASDL description."  Generates
-	Python/Python-ast.c and Include/Python-ast.h .
+        Python/Python-ast.c and Include/Python-ast.h .
 
     - spark.py
         SPARK_ parser generator
@@ -467,14 +467,14 @@ Important Files
       Emits bytecode based on the AST.
 
   - symtable.c
-	Generates a symbol table from AST.
+        Generates a symbol table from AST.
 
   - pyarena.c
       Implementation of the arena memory manager.
 
   - import.c
       Home of the magic number (named ``MAGIC``) for bytecode versioning
-	
+
 
 + Include/
 
@@ -490,12 +490,12 @@ Important Files
       Declares PyAST_FromNode() external (from Python/ast.c).
 
   - code.h
-	Header file for Objects/codeobject.c; contains definition of
-	PyCodeObject.
+        Header file for Objects/codeobject.c; contains definition of
+        PyCodeObject.
 
   - symtable.h
-	Header for Python/symtable.c .  struct symtable and
-	PySTEntryObject are defined here.
+        Header for Python/symtable.c .  struct symtable and
+        PySTEntryObject are defined here.
 
   - pyarena.h
       Header file for the corresponding Python/pyarena.c .

--- a/pep-0348.txt
+++ b/pep-0348.txt
@@ -118,47 +118,47 @@ New Hierarchy
 
    +-- BaseException (new; broader inheritance for subclasses)
        +-- Exception
-	   +-- GeneratorExit (defined in PEP 342 [#PEP342]_)
-	   +-- StandardError
-	       +-- ArithmeticError
-		   +-- DivideByZeroError
-		   +-- FloatingPointError
-		   +-- OverflowError
-	       +-- AssertionError
-	       +-- AttributeError
-	       +-- EnvironmentError
-		   +-- IOError
-		   +-- EOFError
-		   +-- OSError
-	       +-- ImportError
-	       +-- LookupError
-		   +-- IndexError
-		   +-- KeyError
-	       +-- MemoryError
-	       +-- NameError
-		   +-- UnboundLocalError
-	       +-- NotImplementedError (stricter inheritance)
-	       +-- SyntaxError
-		   +-- IndentationError
-		       +-- TabError
-	       +-- TypeError
-	       +-- RuntimeError
-	       +-- UnicodeError
-		   +-- UnicodeDecodeError
-		   +-- UnicodeEncodeError
-		   +-- UnicodeTranslateError
-	       +-- ValueError
-	       +-- ReferenceError
-	   +-- StopIteration
-	   +-- SystemError
-	   +-- Warning
-	       +-- DeprecationWarning
-	       +-- FutureWarning
-	       +-- PendingDeprecationWarning
-	       +-- RuntimeWarning
-	       +-- SyntaxWarning
-	       +-- UserWarning
-	   + -- WindowsError
+           +-- GeneratorExit (defined in PEP 342 [#PEP342]_)
+           +-- StandardError
+               +-- ArithmeticError
+                   +-- DivideByZeroError
+                   +-- FloatingPointError
+                   +-- OverflowError
+               +-- AssertionError
+               +-- AttributeError
+               +-- EnvironmentError
+                   +-- IOError
+                   +-- EOFError
+                   +-- OSError
+               +-- ImportError
+               +-- LookupError
+                   +-- IndexError
+                   +-- KeyError
+               +-- MemoryError
+               +-- NameError
+                   +-- UnboundLocalError
+               +-- NotImplementedError (stricter inheritance)
+               +-- SyntaxError
+                   +-- IndentationError
+                       +-- TabError
+               +-- TypeError
+               +-- RuntimeError
+               +-- UnicodeError
+                   +-- UnicodeDecodeError
+                   +-- UnicodeEncodeError
+                   +-- UnicodeTranslateError
+               +-- ValueError
+               +-- ReferenceError
+           +-- StopIteration
+           +-- SystemError
+           +-- Warning
+               +-- DeprecationWarning
+               +-- FutureWarning
+               +-- PendingDeprecationWarning
+               +-- RuntimeWarning
+               +-- SyntaxWarning
+               +-- UserWarning
+           + -- WindowsError
        +-- KeyboardInterrupt (stricter inheritance)
        +-- SystemExit (stricter inheritance)
 

--- a/pep-0358.txt
+++ b/pep-0358.txt
@@ -105,9 +105,9 @@ returns a bytes object (similar to binascii.unhexlify).  For
 example::
 
     >>> bytes.fromhex('5c5350ff')
-	b'\\SP\xff'
+    b'\\SP\xff'
     >>> bytes.fromhex('5c 53 50 ff')
-	b'\\SP\xff'
+    b'\\SP\xff'
 
 The object has a ``.hex()`` method that does the reverse conversion
 (similar to binascii.hexlify)::

--- a/pep-0379.txt
+++ b/pep-0379.txt
@@ -72,8 +72,7 @@ name::
 
     f() -> name[0]      # where 'name' exists previously.
 
-	f() -> name.attr    # again 'name' exists prior to this
-	expression.:
+    f() -> name.attr    # again 'name' exists prior to this expression.
 
     f() -> name
 

--- a/pep-0447.txt
+++ b/pep-0447.txt
@@ -46,9 +46,9 @@ dictionary::
    class type:
       def __getdescriptor__(cls, name):
           try:
-	      return cls.__dict__[name]
-	  except KeyError:
-	      raise AttributeError(name) from None
+              return cls.__dict__[name]
+          except KeyError:
+              raise AttributeError(name) from None
 
 Rationale
 =========
@@ -120,84 +120,84 @@ keeping and speed tricks)::
 
     def _PyType_Lookup(tp, name):
         mro = tp.mro()
-	assert isinstance(mro, tuple)
+        assert isinstance(mro, tuple)
 
-	for base in mro:
-	   assert isinstance(base, type)
+        for base in mro:
+           assert isinstance(base, type)
 
-	   # PEP 447 will change these lines:
-	   try:
-	       return base.__dict__[name]
-	   except KeyError:
-	       pass
+           # PEP 447 will change these lines:
+           try:
+               return base.__dict__[name]
+           except KeyError:
+               pass
 
-	return None
+        return None
 
 
     class object:
         def __getattribute__(self, name):
-	    assert isinstance(name, str)
+            assert isinstance(name, str)
 
-	    tp = type(self)
-	    descr = _PyType_Lookup(tp, name)
+            tp = type(self)
+            descr = _PyType_Lookup(tp, name)
 
-	    f = None
-	    if descr is not None:
-	        f = descr.__get__
-		if f is not None and descr.__set__ is not None:
-		    # Data descriptor
-		    return f(descr, self, type(self))
+            f = None
+            if descr is not None:
+                f = descr.__get__
+                if f is not None and descr.__set__ is not None:
+                    # Data descriptor
+                    return f(descr, self, type(self))
 
             dict = self.__dict__
-	    if dict is not None:
-	        try:
-		    return self.__dict__[name]
+            if dict is not None:
+                try:
+                    return self.__dict__[name]
                 except KeyError:
-	            pass
+                    pass
 
             if f is not None:
-	        # Non-data descriptor
-	        return f(descr, self, type(self))
+                # Non-data descriptor
+                return f(descr, self, type(self))
 
             if descr is not None:
-	        # Regular class attribute
-	        return descr
+                # Regular class attribute
+                return descr
 
             raise AttributeError(name)
 
 
     class super:
         def __getattribute__(self, name):
-	   assert isinstance(name, unicode)
+           assert isinstance(name, unicode)
 
-	   if name != '__class__':
-	       starttype = self.__self_type__
-	       mro = startype.mro()
+           if name != '__class__':
+               starttype = self.__self_type__
+               mro = startype.mro()
 
-	       try:
-	           idx = mro.index(self.__thisclass__)
+               try:
+                   idx = mro.index(self.__thisclass__)
 
-	       except ValueError:
-	           pass
+               except ValueError:
+                   pass
 
-	       else:
-	           for base in mro[idx+1:]:
-		       # PEP 447 will change these lines:
-		       try:
-		           descr = base.__dict__[name]
+               else:
+                   for base in mro[idx+1:]:
+                       # PEP 447 will change these lines:
+                       try:
+                           descr = base.__dict__[name]
                        except KeyError:
-		           continue
+                           continue
 
-		       f = descr.__get__
-		       if f is not None:
-		           return f(descr,
-			       None if (self.__self__ is self.__self_type__) else self.__self__,
-			       starttype)
+                       f = descr.__get__
+                       if f is not None:
+                           return f(descr,
+                               None if (self.__self__ is self.__self_type__) else self.__self__,
+                               starttype)
 
-		       else:
-		           return descr
+                       else:
+                           return descr
 
-	   return object.__getattribute__(self, name)
+           return object.__getattribute__(self, name)
 
 
 This PEP should change the dict lookup at the lines starting at "# PEP 447" with
@@ -239,10 +239,10 @@ uppercase versions of names::
 
     class UpperCaseAccess (type):
         def __getdescriptor__(cls, name):
-	    try:
+            try:
                 return cls.__dict__[name.upper()]
-	    except KeyError:
-	        raise AttributeError(name) from None
+            except KeyError:
+                raise AttributeError(name) from None
 
     class SillyObject (metaclass=UpperCaseAccess):
         def m(self):

--- a/pep-0495.txt
+++ b/pep-0495.txt
@@ -451,7 +451,7 @@ The DST Transitions
 -------------------
 
 On a missing time introduced at the start of DST, the values returned
-by ``utcoffset()`` and ``dst()`` methods should	be as follows
+by ``utcoffset()`` and ``dst()`` methods should be as follows
 
 +-----------------+----------------+------------------+
 |                 |   fold=0       |    fold=1        |
@@ -845,10 +845,10 @@ implemented in user code:
           return u
       if (u < v) == dt.fold:
           if raise_on_fold:
-       	      raise AmbiguousTimeError
+              raise AmbiguousTimeError
       else:
-	  if raise_on_gap:
-	      raise MissingTimeError
+          if raise_on_gap:
+              raise MissingTimeError
       return u
 
 Moreover, raising an error in the problem cases is only one of many

--- a/pep-0497.txt
+++ b/pep-0497.txt
@@ -2,8 +2,8 @@ PEP: 497
 Title: A standard mechanism for backward compatibility
 Version: $Revision$
 Last-Modified: $Date$
-Author:	Ed Schofield <ed at pythoncharmers.com>
-Status:	Draft
+Author: Ed Schofield <ed at pythoncharmers.com>
+Status: Draft
 Type: Process
 Content-Type: text/x-rst
 Created: 04-Aug-2015

--- a/pep-0500.txt
+++ b/pep-0500.txt
@@ -131,8 +131,8 @@ Subtraction
                    if self_diff is not other_diff and self_diff.__func__ is not other_diff.__func__:
                        raise ValueError("Cannot find difference of two datetimes with "
                                         "different tzinfo.__datetime_diff__ implementations.")
-		   return self_diff(self, other)
-	   elif isinstance(other, timedelta):
+                   return self_diff(self, other)
+           elif isinstance(other, timedelta):
                try:
                    sub = self.tzinfo.__datetime_sub__
                except AttributeError:
@@ -166,15 +166,15 @@ The PDDM methods implemented by ``tzstrict`` will be equivalent to the following
       def __datetime_diff__(self, dt1, dt2):
           utc_dt1 = dt1.astimezone(timezone.utc)
           utc_dt2 = dt2.astimezone(timezone.utc)
-	  return utc_dt2 - utc_dt1 
+          return utc_dt2 - utc_dt1
 
       def __datetime_add__(self, dt, delta):
           utc_dt = dt.astimezone(timezone.utc)
-	  return (utc_dt + delta).astimezone(self)
+          return (utc_dt + delta).astimezone(self)
 
       def __datetime_sub__(self, dt, delta):
           utc_dt = dt.astimezone(timezone.utc)
-	  return (utc_dt - delta).astimezone(self)
+          return (utc_dt - delta).astimezone(self)
 
 
 Parsing and formatting

--- a/pep-0518.txt
+++ b/pep-0518.txt
@@ -6,7 +6,7 @@ Author: Brett Cannon <brett@python.org>,
         Nathaniel Smith <njs@pobox.com>,
         Donald Stufft <donald@stufft.io>
 BDFL-Delegate: Nick Coghlan
-Discussions-To:	distutils-sig <distutils-sig at python.org>
+Discussions-To: distutils-sig <distutils-sig at python.org>
 Status: Accepted
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-3108.txt
+++ b/pep-3108.txt
@@ -946,8 +946,8 @@ In Python 2.6
    or the following if it is an extension module::
    
      if (PyErr_WarnPy3k("the XXX module has been removed in "
- 	                   "Python 3.0", 2) < 0)
- 	    return;
+                        "Python 3.0", 2) < 0)
+         return;
 
    (the Python-Dev TextMate bundle, available from ``Misc/TextMate``,
    contains a command that will generate all of this for you).

--- a/pep-3136.txt
+++ b/pep-3136.txt
@@ -187,7 +187,7 @@ than a label::
                 break 2;
             }
             ....
-	}
+        }
         ...
     }
 

--- a/pep-3140.txt
+++ b/pep-3140.txt
@@ -202,7 +202,7 @@ calling ``repr`` explicitly.
 References
 ==========
 
-.. [1] Guido van Rossum, PEP: str(container) should call str(item),	not
+.. [1] Guido van Rossum, PEP: str(container) should call str(item), not
        repr(item)
        http://mail.python.org/pipermail/python-3000/2008-May/013876.html
 

--- a/pep-3141.txt
+++ b/pep-3141.txt
@@ -412,7 +412,7 @@ different extensions of the real numbers. For example, a complex type
 could reasonably implement hash() as follows::
 
         def __hash__(self):
-	    return hash(complex(self))
+            return hash(complex(self))
 
 but should be careful of any values that fall outside of the built in
 complex's range or precision.


### PR DESCRIPTION
In some files mixed tabs and spaces were used in Python code.
Some files looked correctly only with 4-space tabs.