### PR TITLE
PEP 484: Clarify scoping of type variables

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -472,9 +472,9 @@ However, there are some special cases in the static typechecking context:
     def fun_2(x: T) -> T: ... # and here could be different
 
     fun_1(1)                  # This is OK, T is inferred to be int
-    fun_2('a')                # This is aslo OK, now T is str
+    fun_2('a')                # This is also OK, now T is str
 
-* A type variable used in a method of a generic class that coincisides
+* A type variable used in a method of a generic class that coincides
   with one of the variables that parameterize this class is always bound
   to that variable. Example::
 
@@ -537,8 +537,22 @@ However, there are some special cases in the static typechecking context:
         class MyGeneric(Generic[T]):
             ...
 
-* A generic class nested in another generic class cannot use the same
-  type variables, unless the inner class definition is inside a function.
+* A generic class nested in another generic class cannot use same type
+  variables. Scope of type variables of the outer class doesn't cover the
+  inner one::
+
+    T = TypeVar('T')
+    S = TypeVar('S')
+
+    class Outer(Generic[T]):
+        class Bad(Iterable[T]):      # Error
+            ...
+        class AlsoBad:
+            x = None # type: List[T] # Also an error
+
+        class Inner(Iterable[S]):    # OK
+            ...
+        attr = None # type: Inner[T] # Also OK
 
 
 Instantiating generic classes and type erasure

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -538,8 +538,8 @@ However, there are some special cases in the static typechecking context:
             ...
 
 * A generic class nested in another generic class cannot use same type
-  variables. Scope of type variables of the outer class doesn't cover the
-  inner one::
+  variables. The scope of the type variables of the outer class
+  doesn't cover the inner one::
 
     T = TypeVar('T')
     S = TypeVar('S')


### PR DESCRIPTION
This question appeared recently on mypy's gitter channel. Here I clarify scoping rules for type variables in inner classes and add an example.

It was discussed, that these rules are maybe too restrictive. But this is necessary if we want to keep
```python
class Bad(Iterable[T]):
    ...
```
and
```python
class Bad(Iterable[T], Generic[T]):
    ...
```
equivalent. If people will ask, then we could later relax the rule and allow binding of inner class type variables to outer class type variables (however, I think this is highly unlikely).

@gvanrossum Please take a look.