### PR TITLE
Remove trailing spaces.

### DIFF
--- a/pep-0005.txt
+++ b/pep-0005.txt
@@ -77,7 +77,7 @@ Steps For Introducing Backwards-Incompatible Features
    deprecated construct to the alternative one.
 
 ..
-   Local Variables: 
-   mode: indented-text 
-   indent-tabs-mode: nil 
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
    End:

--- a/pep-0012.txt
+++ b/pep-0012.txt
@@ -267,7 +267,7 @@ per indent level.
 Literal Blocks
 --------------
 
-..  
+..
     In the text below, double backquotes are used to denote inline
     literals.  "``::``" is written so that the colons will appear in a
     monospaced font; the backquotes (``) are markup, not part of the

--- a/pep-0100.txt
+++ b/pep-0100.txt
@@ -195,7 +195,7 @@ Unicode Ordinals
                   objects)
         --> Unicode ordinal number (32-bit)
 
-      unichr(i) 
+      unichr(i)
           --> Unicode object for character i (provided it is 32-bit);
               ValueError otherwise
 
@@ -277,7 +277,7 @@ Codecs (Coder/Decoders) Lookup
     following arguments:
 
       encoder and decoder:
-      
+
         These must be functions or methods which have the same
         interface as the .encode/.decode methods of Codec instances
         (see Codec Interface). The functions/methods are expected to
@@ -413,7 +413,7 @@ Codecs Interface Definition
                Use StreamCodec for codecs which have to keep state in
                order to make encoding/decoding efficient.
 
-            """ 
+            """
 
     StreamWriter and StreamReader define the interface for stateful
     encoders/decoders which work on streams.  These allow processing
@@ -626,7 +626,7 @@ Case Conversion
     Case conversion is rather complicated with Unicode data, since
     there are many different conditions to respect.  See
 
-      http://www.unicode.org/unicode/reports/tr13/ 
+      http://www.unicode.org/unicode/reports/tr13/
 
     for some guidelines on implementing case conversion.
 
@@ -725,11 +725,11 @@ Internal Format
     additional constants for convenience and reference (codecs.BOM
     will either be BOM_BE or BOM_LE depending on the platform):
 
-      BOM_BE: '\376\377' 
+      BOM_BE: '\376\377'
         (corresponds to Unicode U+0000FEFF in UTF-16 on big endian
          platforms == ZERO WIDTH NO-BREAK SPACE)
 
-      BOM_LE: '\377\376' 
+      BOM_LE: '\377\376'
         (corresponds to Unicode U+0000FFFE in UTF-16 on little endian
          platforms == defined as being an illegal Unicode character)
 
@@ -841,7 +841,7 @@ Internal Argument Parsing
 
       "t#": Same as "s#".
 
-      "es": 
+      "es":
             Takes two parameters: encoding (const char *) and buffer
             (char **).
 
@@ -902,7 +902,7 @@ Internal Argument Parsing
             return str;
         }
 
-    Using "es" with auto-allocation returning a NULL-terminated string:    
+    Using "es" with auto-allocation returning a NULL-terminated string:
 
         static PyObject *
         test_parser(PyObject *self,
@@ -978,7 +978,7 @@ Unicode Methods & Attributes
 
     All Python string methods, plus:
 
-      .encode([encoding=<default encoding>][,errors="strict"]) 
+      .encode([encoding=<default encoding>][,errors="strict"])
          --> see Unicode Output
 
       .splitlines([include_breaks=0])

--- a/pep-0101.txt
+++ b/pep-0101.txt
@@ -180,7 +180,7 @@ How to Make A Release
 
   ___ Commit your changes to pydoc_topics.py
       (and any fixes you made in the docs).
- 
+
   ___ Consider running autoconf using the currently accepted standard version
       in case ``configure`` or other autoconf-generated files were last
       committed with a newer or older version and may contain spurious or
@@ -464,7 +464,7 @@ How to Make A Release
 
           You should always purge the cache of the directory listing as people
           use that to browse the release files:
-          
+
           $ curl -X PURGE https://www.python.org/ftp/python/2.7.5/
 
   ___ For the extra paranoid, do a completely clean test of the release.
@@ -561,17 +561,17 @@ How to Make A Release
       are removed, too.)
 
   ___ If this is a final release...
-  
+
       ___ Add the new version to `https://www.python.org/doc/versions/` and
           remove the current version from any 'in development' section.
 
       ___ For X.Y.Z, edit all the previous X.Y releases' page(s) to
           point to the new release.  This includes the content field of the
           `Downloads -> Releases` entry for the release::
-          
+
             Note: Python x.y.m has been superseded by
             `Python x.y.n </downloads/release/python-xyn/>`_.
-          
+
           And, for those releases having separate release page entries
           (phasing these out?), update those pages as well,
           e.g. `download/releases/x.y.z::

--- a/pep-0102.txt
+++ b/pep-0102.txt
@@ -2,8 +2,8 @@ PEP: 102
 Title: Doing Python Micro Releases
 Version: $Revision$
 Last-Modified: $Date$
-Author: anthony@interlink.com.au (Anthony Baxter), 
-    barry@python.org (Barry Warsaw), 
+Author: anthony@interlink.com.au (Anthony Baxter),
+    barry@python.org (Barry Warsaw),
     guido@python.org (Guido van Rossum)
 Status: Superseded
 Type: Informational
@@ -34,7 +34,7 @@ Abstract
     is just PEP 101, trimmed down to only include the bits that are
     relevant for micro releases, a.k.a. patch, or bug fix releases.
 
-    It is organized as a recipe and you can actually print this out and 
+    It is organized as a recipe and you can actually print this out and
     check items off as you complete them.
 
 
@@ -61,11 +61,11 @@ How to Make A Release
     maintenance branch of the major release, e.g. Python 2.1.2 is made
     from the release21-maint branch.
 
-  ___ Send an email to python-dev@python.org indicating the release is 
+  ___ Send an email to python-dev@python.org indicating the release is
       about to start.
 
-  ___ Put a freeze on check ins into the maintenance branch.  At this 
-      point, nobody except the RM should make any commits to the branch 
+  ___ Put a freeze on check ins into the maintenance branch.  At this
+      point, nobody except the RM should make any commits to the branch
       (or his duly assigned agents, i.e. Guido the BDFL, Fred Drake for
       documentation, or Thomas Heller for Windows).  If the RM screwed up
       and some desperate last minute change to the branch is
@@ -189,8 +189,8 @@ How to Make A Release
       merging Windows-specific changes from trunk to branch, and from
       branch to trunk.
 
-  ___ Sean performs his Red Hat magic, generating a set of RPMs.  He 
-      uploads these files to python.org.  He then sends the RM a notice 
+  ___ Sean performs his Red Hat magic, generating a set of RPMs.  He
+      uploads these files to python.org.  He then sends the RM a notice
       which includes the location and MD5 checksum of the RPMs.
 
   ___ It's Build Time!
@@ -231,7 +231,7 @@ How to Make A Release
       % tar -cf - Python-2.1.2 | gzip -9 > Python-2.1.2.tgz
       % tar -cf - Python-2.1.2 | bzip2 -9 > Python-2.1.2.tar.bz2
 
-  ___ Calculate the MD5 checksum of the tgz and tar.bz2 files you 
+  ___ Calculate the MD5 checksum of the tgz and tar.bz2 files you
       just created
       % md5sum Python-2.1.2.tgz
 
@@ -434,17 +434,17 @@ Final Release Notes
         lose patience <wink>.
 
     The python.org site also needs some tweaking when a new bugfix release
-    is issued.  
+    is issued.
 
     ___ The documentation should be installed at doc/<version>/.
 
-    ___ Add a link from doc/<previous-minor-release>/index.ht to the 
+    ___ Add a link from doc/<previous-minor-release>/index.ht to the
         documentation for the new version.
 
-    ___ All older doc/<old-release>/index.ht files should be updated to 
+    ___ All older doc/<old-release>/index.ht files should be updated to
         point to the documentation for the new version.
 
-    ___ /robots.txt should be modified to prevent the old version's 
+    ___ /robots.txt should be modified to prevent the old version's
         documentation from being crawled by search engines.
 
 

--- a/pep-0200.txt
+++ b/pep-0200.txt
@@ -27,7 +27,7 @@ Release Schedule
 [revised 5 Oct 2000]
 
 
-* 26-Sep-2000: 2.0 beta 2 
+* 26-Sep-2000: 2.0 beta 2
 * 9-Oct-2000: 2.0 release candidate 1 (2.0c1)
 * 16-Oct-2000: 2.0 final
 
@@ -366,7 +366,7 @@ Postponed
 
   - http://www.python.org/pipermail/python-dev/2000-April/subject.html
     Subject: "Why do we need Traceback Objects?"
-  
+
   - http://www.python.org/pipermail/python-dev/1999-August/002252.html
 
 * test harness for C code - Trent Mick

--- a/pep-0201.txt
+++ b/pep-0201.txt
@@ -54,7 +54,7 @@ in function::
     >>> a = (1, 2, 3)
     >>> b = (4, 5, 6)
     >>> for i in map(None, a, b): print i
-    ... 
+    ...
     (1, 4)
     (2, 5)
     (3, 6)
@@ -83,7 +83,7 @@ For these reasons, several proposals were floated in the Python 2.0
 beta time frame for syntactic support of lockstep for-loops. Here are
 two suggestions::
 
-  for x in seq1, y in seq2: 
+  for x in seq1, y in seq2:
     # stuff
 
 ::

--- a/pep-0202.txt
+++ b/pep-0202.txt
@@ -24,7 +24,7 @@ The Proposed Solution
 It is proposed to allow conditional construction of list literals using for and
 if clauses.  They would nest in the same way for loops and if statements nest
 now.
-    
+
 
 Rationale
 =========

--- a/pep-0203.txt
+++ b/pep-0203.txt
@@ -26,20 +26,20 @@ Proposed semantics
 
     The proposed patch that adds augmented assignment to Python
     introduces the following new operators:
-    
+
        += -= *= /= %= **= <<= >>= &= ^= |=
-    
+
     They implement the same operator as their normal binary form,
     except that the operation is done `in-place' when the left-hand
     side object supports it, and that the left-hand side is only
     evaluated once.
-    
+
     They truly behave as augmented assignment, in that they perform
     all of the normal load and store operations, in addition to the
     binary operation they are intended to do. So, given the expression:
-    
+
        x += y
-    
+
     The object `x' is loaded, then `y' is added to it, and the
     resulting object is stored back in the original place. The precise
     action performed on the two arguments depends on the type of `x',
@@ -58,11 +58,11 @@ Proposed semantics
     operation. If the class or type does not implement the `in-place'
     hooks, the normal hooks for the particular binary operation are
     used.
-    
+
     So, given an instance object `x', the expression
-    
+
         x += y
-    
+
     tries to call x.__iadd__(y), which is the `in-place' variant of
     __add__. If __iadd__ is not present, x.__add__(y) is attempted,
     and finally y.__radd__(x) if __add__ is missing too.  There is no
@@ -71,7 +71,7 @@ Proposed semantics
     the least. The __iadd__ hook should behave similar to __add__,
     returning the result of the operation (which could be `self')
     which is to be assigned to the variable `x'.
- 
+
     For C extension types, the `hooks' are members of the
     PyNumberMethods and PySequenceMethods structures.  Some special
     semantics apply to make the use of these methods, and the mixing
@@ -86,7 +86,7 @@ Proposed semantics
     cannot be swapped.  However, in-place operations do fall back to
     normal binary operations when in-place modification is not
     supported, resuling in the following rules:
-    
+
     - If the left-hand object (`x') is an instance object, and it
       has a `__coerce__' method, call that function with `y' as the
       argument. If coercion succeeds, and the resulting left-hand
@@ -94,7 +94,7 @@ Proposed semantics
       in-place and call the appropriate function for the normal binary
       operation, with the coerced `x' and `y' as arguments. The result
       of the operation is whatever that function returns.
-      
+
       If coercion does not yield a different object for `x', or `x'
       does not define a `__coerce__' method, and `x' has the
       appropriate `__ihook__' for this operation, call that method
@@ -106,7 +106,7 @@ Proposed semantics
       operation, call that function with `x' and `y' as the arguments,
       and the result of the operation is whatever that function
       returns.
-      
+
       Note that no coercion on either `x' or `y' is done in this case,
       and it's perfectly valid for a C type to receive an instance
       object as the second argument; that is something that cannot
@@ -118,7 +118,7 @@ Proposed semantics
       `__coerce__', `__hook__' and `__rhook__'. Otherwise, both
       objects are C types, and they are coerced and passed to the
       appropriate function.
-   
+
     - If no way to process the operation can be found, raise a
       TypeError with an error message specific to the operation.
 
@@ -143,8 +143,8 @@ Rationale
     simplicity of expression; like most new features, augmented
     assignment doesn't add anything that was previously impossible. It
     merely makes these things easier to do.
-    
-    Adding augmented assignment will make Python's syntax more complex. 
+
+    Adding augmented assignment will make Python's syntax more complex.
     Instead of a single assignment operation, there are now twelve
     assignment operations, eleven of which also perform a binary
     operation. However, these eleven new forms of assignment are easy
@@ -153,22 +153,22 @@ Rationale
     understand. Furthermore, languages that do have augmented
     assignment have shown that they are a popular, much used feature.
     Expressions of the form
-    
+
         <x> = <x> <operator> <y>
-        
+
     are common enough in those languages to make the extra syntax
     worthwhile, and Python does not have significantly fewer of those
     expressions. Quite the opposite, in fact, since in Python you can
     also concatenate lists with a binary operator, something that is
     done quite frequently. Writing the above expression as
-    
-        <x> <operator>= <y> 
-    
+
+        <x> <operator>= <y>
+
     is both more readable and less error prone, because it is
     instantly obvious to the reader that it is <x> that is being
     changed, and not <x> that is being replaced by something almost,
     but not quite, entirely unlike <x>.
-    
+
     The new in-place operations are especially useful to matrix
     calculation and other applications that require large objects. In
     order to efficiently deal with the available program memory, such
@@ -178,10 +178,10 @@ Rationale
     object (which may cause the application to run out of memory), add
     the single item, and then possibly delete the original object,
     depending on reference count.
-    
+
     To work around this problem, the packages currently have to use
     methods or functions to modify an object in-place, which is
-    definitely less readable than an augmented assignment expression. 
+    definitely less readable than an augmented assignment expression.
     Augmented assignment won't solve all the problems for these
     packages, since some operations cannot be expressed in the limited
     set of binary operators to start with, but it is a start. A
@@ -193,7 +193,7 @@ New methods
     The proposed implementation adds the following 11 possible `hooks'
     which Python classes can implement to overload the augmented
     assignment operations:
-    
+
         __iadd__
         __isub__
         __imul__
@@ -205,11 +205,11 @@ New methods
         __iand__
         __ixor__
         __ior__
-    
+
     The `i' in `__iadd__' stands for `in-place'.
 
     For C extension types, the following struct members are added:
-    
+
     To PyNumberMethods:
         binaryfunc nb_inplace_add;
         binaryfunc nb_inplace_subtract;
@@ -234,7 +234,7 @@ New methods
     code that wants to use one of the new struct members must first
     check that they are available with the `PyType_HasFeature()'
     macro:
-    
+
     if (PyType_HasFeature(x->ob_type, Py_TPFLAGS_HAVE_INPLACE_OPS) &&
         x->ob_type->tp_as_number && x->ob_type->tp_as_number->nb_inplace_add) {
             /* ... */
@@ -249,10 +249,10 @@ Implementation
     The current implementation of augmented assignment[1] adds, in
     addition to the methods and slots already covered, 13 new bytecodes
     and 13 new API functions.
-    
+
     The API functions are simply in-place versions of the current
     binary-operation API functions:
-    
+
         PyNumber_InPlaceAdd(PyObject *o1, PyObject *o2);
         PyNumber_InPlaceSubtract(PyObject *o1, PyObject *o2);
         PyNumber_InPlaceMultiply(PyObject *o1, PyObject *o2);
@@ -285,22 +285,22 @@ Implementation
         INPLACE_OR
         ROT_FOUR
         DUP_TOPX
-    
+
     The INPLACE_* bytecodes mirror the BINARY_* bytecodes, except that
     they are implemented as calls to the `InPlace' API functions. The
     other two bytecodes are `utility' bytecodes: ROT_FOUR behaves like
     ROT_THREE except that the four topmost stack items are rotated.
-    
+
     DUP_TOPX is a bytecode that takes a single argument, which should
     be an integer between 1 and 5 (inclusive) which is the number of
     items to duplicate in one block. Given a stack like this (where
     the right side of the list is the `top' of the stack):
 
         [1, 2, 3, 4, 5]
-    
+
     "DUP_TOPX 3" would duplicate the top 3 items, resulting in this
     stack:
-    
+
         [1, 2, 3, 4, 5, 3, 4, 5]
 
     DUP_TOPX with an argument of 1 is the same as DUP_TOP. The limit
@@ -322,7 +322,7 @@ Open Issues
     actually necessary. It should be considered whether this bytecode
     is worth having. There seems to be no other possible use for this
     bytecode at this time.
-    
+
 
 Copyright
 

--- a/pep-0207.txt
+++ b/pep-0207.txt
@@ -271,7 +271,7 @@ Motivation
     element pair. Thus, for example, using the arrays x and y defined
     above:
 
-             less(x,y) 
+             less(x,y)
 
     would be an array containing the numbers (1,0,0,0).
 
@@ -388,7 +388,7 @@ Chained Comparisons
              if temp1:
                return y < z
              else:
-               return temp1     
+               return temp1
 
     Note that this requires testing the truth value of the result of
     comparisons, with potential "shortcutting" of the right-side
@@ -418,7 +418,7 @@ Chained Comparisons
                temp2 = y < z
                return boolean_combine(temp1, temp2)
              else:
-               return temp1     
+               return temp1
 
     where boolean_combine is a new function which does something like
     the following:
@@ -433,7 +433,7 @@ Chained Comparisons
                  else: # standard behavior
                      if a:
                          return b
-                     else: 
+                     else:
                          return 0
 
     where the __boolean_and__ special method is implemented for

--- a/pep-0209.txt
+++ b/pep-0209.txt
@@ -7,7 +7,7 @@ Status: Withdrawn
 Type: Standards Track
 Created: 03-Jan-2001
 Python-Version: 2.2
-Post-History: 
+Post-History:
 
 
 Abstract
@@ -64,16 +64,16 @@ Proposal
     C-extension types.
 
     Some planned features are:
-    
+
     1.  Improved memory usage
-    
+
     This feature is particularly important when handling large arrays
     and can produce significant improvements in performance as well as
     memory usage.  We have identified several areas where memory usage
     can be improved:
-    
+
         a.  Use a local coercion model
-    
+
         Instead of using Python's global coercion model which creates
         temporary arrays, Numeric 2, like Numeric 1, will implement a
         local coercion model as described in PEP 208 which defers the
@@ -86,9 +86,9 @@ Proposal
         processor is under load.  To avoid array coercion altogether,
         C functions having arguments of mixed type are allowed in
         Numeric 2.
-    
+
         b.  Avoid creation of temporary arrays
-    
+
         In complex array expressions (i.e. having more than one
         operation), each operation will create a temporary array which
         will be used and then deleted by the succeeding operation.  A
@@ -98,9 +98,9 @@ Proposal
         created.  This can be done by checking the temporary array's
         reference count.  If it is 1, then it will be deleted once the
         operation is done and is a candidate for reuse.
-    
+
         c.  Optional use of memory-mapped files
-    
+
         Numeric users sometimes need to access data from very large
         files or to handle data that is greater than the available
         memory.  Memory-mapped arrays provide a mechanism to do this
@@ -109,7 +109,7 @@ Proposal
         files by eliminating one of two copy steps during a file
         access.  Numeric should be able to access in-memory and
         memory-mapped arrays transparently.
-    
+
         d.  Record access
 
         In some fields of science, data is stored in files as binary
@@ -128,10 +128,10 @@ Proposal
         approaches to implementing records; as either a derived array
         class or a special array type, depending on your point-of-
         view.  We defer this discussion to the Open Issues section.
-    
-    
+
+
     2.  Additional array types
-    
+
     Numeric 1 has 11 defined types: char, ubyte, sbyte, short, int,
     long, float, double, cfloat, cdouble, and object.  There are no
     ushort, uint, or ulong types, nor are there more complex types
@@ -141,9 +141,9 @@ Proposal
     error-prone process.  To enable the easy addition (and deletion)
     of new array types such as a bit type described below, a re-design
     of Numeric is necessary.
-    
+
         a.  Bit type
-    
+
         The result of a rich comparison between arrays is an array of
         boolean values.  The result can be stored in an array of type
         char, but this is an unnecessary waste of memory.  A better
@@ -153,22 +153,22 @@ Proposal
         included in Numeric 2.
 
     3.  Enhanced array indexing syntax
-    
+
     The extended slicing syntax was added to Python to provide greater
     flexibility when manipulating Numeric arrays by allowing
     step-sizes greater than 1.  This syntax works well as a shorthand
     for a list of regularly spaced indices.  For those situations
     where a list of irregularly spaced indices are needed, an enhanced
     array indexing syntax would allow 1-D arrays to be arguments.
-    
+
     4.  Rich comparisons
-    
+
     The implementation of PEP 207: Rich Comparisons in Python 2.1
     provides additional flexibility when manipulating arrays.  We
     intend to implement this feature in Numeric 2.
-    
+
     5. Array broadcasting rules
-    
+
     When an operation between a scalar and an array is done, the
     implied behavior is to create a new array having the same shape as
     the array operand containing the scalar value.  This is called
@@ -180,28 +180,28 @@ Proposal
 Design and Implementation
 
     The design of Numeric 2 has four primary classes:
-    
+
     1.  ArrayType:
-    
+
     This is a simple class that describes the fundamental properties
     of an array-type, e.g. its name, its size in bytes, its coercion
     relations with respect to other types, etc., e.g.
-    
+
     > Int32 = ArrayType('Int32', 4, 'doc-string')
-    
+
     Its relation to the other types is defined when the C-extension
     module for that type is imported.  The corresponding Python code
     is:
-    
+
     > Int32.astype[Real64] = Real64
-    
+
     This says that the Real64 array-type has higher priority than the
     Int32 array-type.
-    
+
     The following attributes and methods are proposed for the core
     implementation.  Additional attributes can be added on an
     individual basis, e.g. .bitsize or .bitstrides for the bit type.
-    
+
     Attributes:
         .name:                  e.g. "Int32", "Float64", etc.
         .typecode:              e.g. 'i', 'f', etc.
@@ -214,33 +214,33 @@ Design and Implementation
         __init__():             initialization
         __del__():              destruction
         __repr__():             representation
-    
+
     C-API:
         This still needs to be fleshed-out.
-    
-    
+
+
     2.  UFunc:
-    
+
     This class is the heart of Numeric 2.  Its design is similar to
     that of ArrayType in that the UFunc creates a singleton callable
     object whose attributes are name, total and input number of
     arguments, a document string, and an empty CFunc dictionary; e.g.
-    
+
     > add = UFunc('add', 3, 2, 'doc-string')
-    
+
     When defined the add instance has no C functions associated with
     it and therefore can do no work.  The CFunc dictionary is
     populated or registered later when the C-extension module for an
     array-type is imported.  The arguments of the register method are:
     function name, function descriptor, and the CUFunc object.  The
     corresponding Python code is
-    
+
     > add.register('add', (Int32, Int32, Int32), cfunc-add)
-    
+
     In the initialization function of an array type module, e.g.
     Int32, there are two C API functions: one to initialize the
     coercion rules and the other to register the CFunc objects.
-    
+
     When an operation is applied to some arrays, the __call__ method
     is invoked.  It gets the type of each array (if the output array
     is not given, it is created from the coercion rules) and checks
@@ -250,24 +250,24 @@ Design and Implementation
     of conversion functions.  The __call__ method then invokes a
     compute method written in C to iterate over slices of each array,
     namely:
-    
+
     > _ufunc.compute(slice, data, func, swap, conv)
-    
+
     The 'func' argument is a CFuncObject, while the 'swap' and 'conv'
     arguments are lists of CFuncObjects for those arrays needing pre-
     or post-processing, otherwise None is used.  The data argument is
     a list of buffer objects, and the slice argument gives the number
     of iterations for each dimension along with the buffer offset and
     step size for each array and each dimension.
-    
+
     We have predefined several UFuncs for use by the __call__ method:
     cast, swap, getobj, and setobj.  The cast and swap functions do
     coercion and byte-swapping, respectively and the getobj and setobj
     functions do coercion between Numeric arrays and Python sequences.
-    
+
     The following attributes and methods are proposed for the core
     implementation.
-    
+
     Attributes:
         .name:                  e.g. "add", "subtract", etc.
         .nargs:                 number of total arguments
@@ -286,19 +286,19 @@ Design and Implementation
 
     C-API:
         This still needs to be fleshed-out.
-    
+
     3.  Array:
-    
+
     This class contains information about the array, such as shape,
     type, endian-ness of the data, etc..  Its operators, '+', '-',
     etc. just invoke the corresponding UFunc function, e.g.
-    
+
     > def __add__(self, other):
     >     return ufunc.add(self, other)
 
     The following attributes, methods, and functions are proposed for
     the core implementation.
-    
+
     Attributes:
         .shape:                 shape of the array
         .format:                type of the array
@@ -319,7 +319,7 @@ Design and Implementation
         copy():                 copy of array
         aslist():               create list from array
         asstring():             create string from array
-        
+
     Functions:
         fromlist():             create array from sequence
         fromstring():           create array from string
@@ -339,9 +339,9 @@ Design and Implementation
 
     C-API:
         This still needs to be fleshed-out.
-    
+
     5.  C-extension modules:
-    
+
     Numeric2 will have several C-extension modules.
 
         a.  _ufunc:
@@ -358,9 +358,9 @@ Design and Implementation
 
         The following attributes and methods are proposed for the core
         implementation.
-    
+
         Attributes:
-        
+
         Methods:
             compute():
 
@@ -368,7 +368,7 @@ Design and Implementation
             This still needs to be fleshed-out.
 
         b.  _int32, _real64, etc.:
-    
+
         There will also be C-extension modules for each array type,
         e.g. _int32module.c, _real64module.c, etc.  As mentioned
         previously, when these modules are imported by the UFunc
@@ -411,7 +411,7 @@ Open Issues
     shorthand for c[i,:] which would imply copy behavior assuming
     slicing syntax returns a copy.  Should Numeric 2 behave the same
     way as lists and return a view or should it return a copy.
-    
+
     3.  How is scalar coercion implemented?
 
     Python has fewer numeric types than Numeric which can cause
@@ -427,9 +427,9 @@ Open Issues
     array.  Whereas an operation between a Python float and an Int16
     array would return a Float64 (double) array.  Operations between
     two arrays use normal coercion rules.
-    
+
     4.  How is integer division handled?
-    
+
     In a future version of Python, the behavior of integer division
     will change.  The operands will be converted to floats, so the
     result will be a float.  If we implement the proposed scalar
@@ -488,14 +488,14 @@ Open Issues
         as an array type, then last dimension defaults to 0 and can
         therefore be neglected for arrays comprised of simple types,
         like numeric.
-   
+
     6.  How are masked-arrays implemented?
 
     Masked-arrays in Numeric 1 are implemented as a separate array
     class.  With the ability to add new array types to Numeric 2, it
     is possible that masked-arrays in Numeric 2 could be implemented
     as a new array type instead of an array class.
-    
+
     7.  How are numerical errors handled (IEEE floating-point errors in
         particular)?
 
@@ -533,7 +533,7 @@ Open Issues
 Implementation Steps
 
     1.  Implement basic UFunc capability
-    
+
         a.  Minimal Array class:
 
         Necessary class attributes and methods, e.g. .shape, .data,
@@ -552,15 +552,15 @@ Implementation Steps
         d.  Minimal C-extension module:
 
         _UFunc, which does the innermost array loop in C.
-    
+
         This step implements whatever is needed to do: 'c = add(a, b)'
         where a, b, and c are 1-D arrays.  It teaches us how to add
         new UFuncs, to coerce the arrays, to pass the necessary
         information to a C iterator method and to do the actually
         computation.
-    
+
     2.  Continue enhancing the UFunc iterator and Array class
-    
+
         a.  Implement some access methods for the Array class:
             print, repr, getitem, setitem, etc.
 
@@ -570,9 +570,9 @@ Implementation Steps
             +, -, *, /, etc.
 
         d.  Enable UFuncs to use Python sequences.
-    
+
     3.  Complete the standard UFunc and Array class behavior
-    
+
         a.  Implement getslice and setslice behavior
 
         b.  Work on Array broadcasting rules
@@ -580,7 +580,7 @@ Implementation Steps
         c.  Implement Record type
 
     4.  Add additional functionality
-    
+
         a.  Add more UFuncs
 
         b.  Implement buffer or mmap access

--- a/pep-0214.txt
+++ b/pep-0214.txt
@@ -32,7 +32,7 @@ Proposal
         print >> mylogfile, 'this message goes to my log file'
 
     Formally, the syntax of the extended print statement is
-    
+
         print_stmt: ... | '>>' test [ (',' test)+ [','] ] )
 
     where the ellipsis indicates the original print_stmt syntax
@@ -153,7 +153,7 @@ More Justification by the BDFL
 
     Challenge: Why not one of these?
 
-        print in stderr items,.... 
+        print in stderr items,....
         print + stderr items,.......
         print[stderr] items,.....
         print to stderr items,.....
@@ -291,7 +291,7 @@ More Justification by the BDFL
                 for i in range(1, n+1):
                     print >> file, i, 'x', j, '=', i*j
                 print >> file
-        
+
     With only a print statement and a println() function, the
     programmer first has to learn about println(), transforming the
     original program to using println():

--- a/pep-0225.txt
+++ b/pep-0225.txt
@@ -63,7 +63,7 @@ Background
 
     - function:   mul(a,b)
     - method:     a.mul(b)
-    - casting:    a.E*b 
+    - casting:    a.E*b
 
     In several aspects these are not as adequate as infix operators.
     More details will be shown later, but the key points are
@@ -149,7 +149,7 @@ Prototype Implementation
 
     - It reserves xor as an infix operator with the semantics
       equivalent to:
-      
+
         def __xor__(a, b):
             if not b: return a
             elif not a: return b
@@ -160,7 +160,7 @@ Prototype Implementation
 
    This is done so that bitwise operators could be regarded as
    elementwise logical operators in the future (see below).
-   
+
 
 Alternatives to adding new operators
 
@@ -173,7 +173,7 @@ Alternatives to adding new operators
        Advantage:
        -  No need for new operators.
 
-       Disadvantage: 
+       Disadvantage:
        - Prefix forms are cumbersome for composite formulas.
        - Unfamiliar to the intended users.
        - Too verbose for the intended users.
@@ -306,7 +306,7 @@ Alternative forms of infix operators
 
     Criteria for choosing among the representations include:
 
-        - No syntactical ambiguities with existing operators.  
+        - No syntactical ambiguities with existing operators.
 
         - Higher readability in actual formulas.  This makes the
           bracketed forms unfavorable.  See examples below.
@@ -363,7 +363,7 @@ Semantics of new operators
        - Allow ~ to be a general elementwise meta-character in future
          extensions.
 
-    It is generally agreed upon that 
+    It is generally agreed upon that
 
        - there is no absolute reason to favor one or the other
        - it is easy to cast from one representation to another in a
@@ -504,7 +504,7 @@ Miscellaneous issues:
 
       Therefore, one objectwise multiplication is sufficient.
 
-    - Bitwise operators. 
+    - Bitwise operators.
 
       - The proposed new math operators use the symbol ~ that is
         "bitwise not" operator.  This poses no compatibility problem
@@ -562,7 +562,7 @@ Impact on general elementization
        In order to have named operators for xor ~xor, it is necessary
        to make xor a reserved word.
 
-    2. List arithmetics. 
+    2. List arithmetics.
 
            [1, 2] + [3, 4]        # [1, 2, 3, 4]
            [1, 2] ~+ [3, 4]       # [4, 6]
@@ -603,7 +603,7 @@ Impact on general elementization
     6. Elementwise format operator (with broadcasting)
 
           a = [1,2,3,4,5]
-          print ["%5d "] ~% a 
+          print ["%5d "] ~% a
           a = [[1,2],[3,4]]
           print ["%5d "] ~~% a
 
@@ -619,7 +619,7 @@ Impact on general elementization
     9. Tuple flattening
 
           a = (1,2);  b = (3,4)
-          f(~a, ~b)                # f(1,2,3,4)      
+          f(~a, ~b)                # f(1,2,3,4)
 
     10. Copy operator
 

--- a/pep-0227.txt
+++ b/pep-0227.txt
@@ -131,7 +131,7 @@ Specification
     Function definition: def name ...
     Argument declaration: def f(...name...), lambda ...name...
     Class definition: class name ...
-    Assignment statement: name = ...    
+    Assignment statement: name = ...
     Import statement: import name, import module as name,
         from module import name
     Implicit assignment: names are bound by for statements and except
@@ -152,7 +152,7 @@ Specification
     If exec is used in a function and the function contains a nested
     block with free variables, the compiler will raise a SyntaxError
     unless the exec explicitly specifies the local namespace for the
-    exec.  (In other words, "exec obj" would be illegal, but 
+    exec.  (In other words, "exec obj" would be illegal, but
     "exec obj in ns" would be legal.)
 
     If a name bound in a function scope is also the name of a module
@@ -213,7 +213,7 @@ Discussion
     and a mechanism to change the bindings (set! in Scheme).
 
     XXX Alex Martelli suggests comparison with Java, which does not
-    allow name bindings to hide earlier bindings.  
+    allow name bindings to hide earlier bindings.
 
 Examples
 
@@ -237,7 +237,7 @@ Examples
     ...             return n * fact(n - 1)
     ...     return fact
     >>> fact = make_fact()
-    >>> fact(7)    
+    >>> fact(7)
     5040L
 
     >>> def make_wrapper(obj):
@@ -363,7 +363,7 @@ Compatibility of C API
 
     The implementation causes several Python C API functions to
     change, including PyCode_New().  As a result, C extensions may
-    need to be updated to work correctly with Python 2.1.  
+    need to be updated to work correctly with Python 2.1.
 
 locals() / vars()
 
@@ -391,7 +391,7 @@ Warnings and Errors
     F contains a function G and G uses the builtin len(), then F is a
     function that contains a nested function (G) with a free variable
     (len).  The label "free-in-nested" will be used to describe these
-    functions. 
+    functions.
 
     import * used in function scope
 
@@ -472,7 +472,7 @@ Implementation
     is referenced by containing scopes; as a result, the function
     where it is defined must allocate separate storage for it on each
     invocation.  A free variable is referenced via a function's
-    closure. 
+    closure.
 
     The choice of free closures was made based on three factors.
     First, nested functions are presumed to be used infrequently,
@@ -481,7 +481,7 @@ Implementation
     Third, the use of nested scopes, particularly where a function
     that access an enclosing scope is returned, should not prevent
     unreferenced objects from being reclaimed by the garbage
-    collector. 
+    collector.
 
     XXX Much more to say here
 

--- a/pep-0231.txt
+++ b/pep-0231.txt
@@ -155,7 +155,7 @@ Examples
         print b.foo
         b.foo = 9
         print b.foo
-    
+
 
     A second, more elaborate example is the implementation of both
     implicit and explicit acquisition in pure Python:
@@ -378,7 +378,7 @@ Examples
             pass
         else:
             assert 0, 'AttributeError expected'
-    
+
 
     C++-like access control can also be accomplished, although less
     cleanly because of the difficulty of figuring out what method is

--- a/pep-0237.txt
+++ b/pep-0237.txt
@@ -50,7 +50,7 @@ Implementation
     Initially, two alternative implementations were proposed (one by
     each author):
 
-    1. The PyInt type's slot for a C long will be turned into a 
+    1. The PyInt type's slot for a C long will be turned into a
 
         union {
             long i;

--- a/pep-0242.txt
+++ b/pep-0242.txt
@@ -50,7 +50,7 @@ Supported Kinds of Ints and Floats
     least two kinds of integer corresponding to the existing int and
     long, and must support at least one kind of floating point number,
     equivalent to the present float.
-    
+
     The range and precision of these required kinds are processor
     dependent, as at present, except for the "long integer" kind,
     which can hold an arbitrary integer.
@@ -133,7 +133,7 @@ Attributes of Module kinds
     float_kinds is a list of the available floating point kinds, sorted
                 from lowest to highest kind.
 
-    default_int_kind is the kind object corresponding to the Python 
+    default_int_kind is the kind object corresponding to the Python
                      literal 0
 
     default_long_kind is the kind object corresponding to the Python
@@ -160,13 +160,13 @@ Complex Numbers
         accept one argument that is of any integer, real, or complex
         kind, or two arguments, each integer or real.
 
-    complex_kinds is a list of the available complex kinds, sorted 
+    complex_kinds is a list of the available complex kinds, sorted
                   from lowest to highest kind.
 
     default_complex_kind is the kind object corresponding to the
                          Python literal 0.0j.  The name of this kind
                          is doublecomplex, and its typecode is 'D'.
-                              
+
     Complex kind objects have these addition attributes:
 
     floatkind is the kind object of the corresponding float type.
@@ -181,10 +181,10 @@ Examples
         single = kinds.float_kind(6, 90)
         double = kinds.float_kind(15, 300)
         csingle = kinds.complex_kind(6, 90)
-     
+
     In the rest of my code:
 
-        from myprecision import tinyint, single, double, csingle  
+        from myprecision import tinyint, single, double, csingle
         n = tinyint(3)
         x = double(1.e20)
         z = 1.2

--- a/pep-0245.txt
+++ b/pep-0245.txt
@@ -150,7 +150,7 @@ Overview of the Interface Syntax
                 "Sets the current fish color to blue"
 
             def getFishColor():
-                "This returns the current fish color" 
+                "This returns the current fish color"
 
     This code, when evaluated, will create two interfaces called
     `CountFishInterface' and `ColorFishInterface'. These interfaces
@@ -198,7 +198,7 @@ Interface Assertion
         class FishMarket implements FishMarketInterface:
             number = 0
             color = None
-            monger_name = 'Crusty Barnacles' 
+            monger_name = 'Crusty Barnacles'
 
             def __init__(self, number, color):
                 self.number = number
@@ -307,11 +307,11 @@ Interface Assertion
         >>> f.getFishMonger()
         Traceback (innermost last):
           File "<stdin>", line 1, in ?
-        Interface.Exceptions.BrokenImplementation: 
+        Interface.Exceptions.BrokenImplementation:
         An object has failed to implement interface FishMarketInterface
 
                 The getFishMonger attribute was not provided.
-        >>> 
+        >>>
 
     This provides for a bit of passive interface enforcement by
     telling you what you forgot to do to implement that interface.
@@ -469,7 +469,7 @@ Open Issues
 Dissenting Opinion
 
     This PEP has not yet been discussed on python-dev.
-        
+
 
 References
 

--- a/pep-0247.txt
+++ b/pep-0247.txt
@@ -34,7 +34,7 @@ Specification
         'string' parameter, if supplied, will be immediately hashed
         into the object's starting state, as if obj.update(string) was
         called.
-        
+
         After creating a hashing object, arbitrary strings can be fed
         into the object using its update() method, and the hash value
         can be obtained at any time by calling the object's digest()
@@ -70,7 +70,7 @@ Specification
         object is created, and this attribute must contain the
         selected size.  Therefore, None is *not* a legal value for this
         attribute.
-                
+
 
     Hashing objects require the following methods:
 
@@ -89,19 +89,19 @@ Specification
     hexdigest()
 
         Return the hash value of this hashing object as a string
-        containing hexadecimal digits.  Lowercase letters should be used 
+        containing hexadecimal digits.  Lowercase letters should be used
         for the digits 'a' through 'f'.  Like the .digest() method, this
         method mustn't alter the object.
-        
+
     update(string)
 
         Hash 'string' into the current state of the hashing object.
         update() can be called any number of times during a hashing
         object's lifetime.
 
-    Hashing modules can define additional module-level functions or 
+    Hashing modules can define additional module-level functions or
     object methods and still be compliant with this specification.
-    
+
     Here's an example, using a module named 'MD5':
 
         >>> from Crypto.Hash import MD5
@@ -110,11 +110,11 @@ Specification
         16
         >>> m.update('abc')
         >>> m.digest()
-        '\x90\x01P\x98<\xd2O\xb0\xd6\x96?}(\xe1\x7fr'    
+        '\x90\x01P\x98<\xd2O\xb0\xd6\x96?}(\xe1\x7fr'
         >>> m.hexdigest()
-        '900150983cd24fb0d6963f7d28e17f72' 
+        '900150983cd24fb0d6963f7d28e17f72'
         >>> MD5.new('abc').digest()
-        '\x90\x01P\x98<\xd2O\xb0\xd6\x96?}(\xe1\x7fr'    
+        '\x90\x01P\x98<\xd2O\xb0\xd6\x96?}(\xe1\x7fr'
 
 
 Rationale
@@ -140,8 +140,8 @@ Rationale
     to place required parameters first, but that also means that the
     'string' parameter moves from the first position to the second.
     It would be possible to get confused and pass a single argument to
-    a keyed hash, thinking that you're passing an initial string to an 
-    unkeyed hash, but it doesn't seem worth making the interface 
+    a keyed hash, thinking that you're passing an initial string to an
+    unkeyed hash, but it doesn't seem worth making the interface
     for keyed hashes more obscure to avoid this potential error.
 
 

--- a/pep-0257.txt
+++ b/pep-0257.txt
@@ -196,7 +196,7 @@ to list each argument on a separate line.  For example::
         real -- the real part (default 0.0)
         imag -- the imaginary part (default 0.0)
         """
-        if imag == 0.0 and real == 0.0: 
+        if imag == 0.0 and real == 0.0:
             return complex_zero
         ...
 

--- a/pep-0258.txt
+++ b/pep-0258.txt
@@ -818,17 +818,17 @@ Example::
    This would break "``from __future__ import``" statements introduced
    in Python 2.1 for multiple module docstrings (main docstring plus
    additional docstring(s)).  The Python Reference Manual specifies:
-   
+
        A future statement must appear near the top of the module.  The
        only lines that can appear before a future statement are:
-   
+
        * the module docstring (if any),
        * comments,
        * blank lines, and
        * other future statements.
-   
+
    Resolution?
-   
+
    1. Should we search for docstrings after a ``__future__``
       statement?  Very ugly.
 

--- a/pep-0262.txt
+++ b/pep-0262.txt
@@ -13,7 +13,7 @@ Introduction
     This PEP describes a format for a database of the Python software
     installed on a system.
 
-    (In this document, the term "distribution" is used to mean a set 
+    (In this document, the term "distribution" is used to mean a set
     of code that's developed and distributed together.  A "distribution"
     is the same as a Red Hat or Debian package, but the term "package"
     already has a meaning in Python terminology, meaning "a directory
@@ -26,8 +26,8 @@ Requirements
     those distributions, are installed on a system.  We want to provide
     features similar to CPAN, APT, or RPM.  Required use cases that
     should be supported are:
- 
-        * Is distribution X on a system?  
+
+        * Is distribution X on a system?
         * What version of distribution X is installed?
         * Where can the new version of distribution X be found?  (This can
           be defined as either "a home page where the user can go and
@@ -86,8 +86,8 @@ Database Contents
         information for a file, as described in PEP 241, "Metadata for
         Python Software Packages".
 
-    FILES section 
-   
+    FILES section
+
         An entry for each file installed by the
         distribution. Generated files such as .pyc and .pyo files are
         on this list as well as the original .py files installed by a
@@ -95,13 +95,13 @@ Database Contents
         though.
 
         Each file's entry is a single tab-delimited line that contains
-        the following fields: 
+        the following fields:
 
-            * The file's full path, as installed on the system.  
+            * The file's full path, as installed on the system.
 
             * The file's size
 
-            * The file's permissions.  On Windows, this field will always be 
+            * The file's permissions.  On Windows, this field will always be
               'unknown'
 
             * The owner and group of the file, separated by a tab.
@@ -117,19 +117,19 @@ Database Contents
     This section is a list of strings giving the services required for
     this module distribution to run properly.  This list includes the
     distribution name ("python-stdlib") and module names ("rfc822",
-    "htmllib", "email", "email.Charset").  It will be specified 
+    "htmllib", "email", "email.Charset").  It will be specified
     by an extra 'requires' argument to the distutils.core.setup()
     function.  For example:
 
-        setup(..., requires=['xml.utils.iso8601', 
+        setup(..., requires=['xml.utils.iso8601',
 
     Eventually there may be automated tools that look through all of
     the code and produce a list of requirements, but it's unlikely
-    that these tools can handle all possible cases; a manual 
+    that these tools can handle all possible cases; a manual
     way to specify requirements will always be necessary.
 
 
-    PROVIDES section 
+    PROVIDES section
 
     This section is a list of strings giving the services provided by
     an installed distribution.  This list includes the distribution name
@@ -146,7 +146,7 @@ Database Contents
     that multiple different XML parsers can be used.  For now this
     ability isn't supported because it raises too many issues: do we
     need a central registry of legal strings, or just let people put
-    whatever they like?  Etc., etc...  
+    whatever they like?  Etc., etc...
 
 
 API Description
@@ -163,14 +163,14 @@ API Description
     distutils.dist.Distribution.  Probably they should be factored out
     into the Distribution class proposed here, but can this be done in a
     backward-compatible way?
-    
+
     InstallationDatabase has the following interface:
 
 class InstallationDatabase:
     def __init__ (self, path=None):
         """InstallationDatabase(path:string)
         Read the installation database rooted at the specified path.
-        If path is None, INSTALLDB is used as the default.    
+        If path is None, INSTALLDB is used as the default.
         """
 
     def get_distribution (self, distribution_name):
@@ -180,13 +180,13 @@ class InstallationDatabase:
 
     def list_distributions (self):
         """list_distributions() : [Distribution]
-        Return a list of all distributions installed on the system, 
+        Return a list of all distributions installed on the system,
         enumerated in no particular order.
         """
 
     def find_distribution (self, path):
         """find_file(path:string) : Distribution
-        Search and return the distribution containing the file 'path'.  
+        Search and return the distribution containing the file 'path'.
         Returns None if the file doesn't belong to any distribution
         that the InstallationDatabase knows about.
         XXX should this work for directories?
@@ -198,7 +198,7 @@ class Distribution:
       Distribution name
     files : {string : (size:int, perms:int, owner:string, group:string,
                        digest:string)}
-       Dictionary mapping the path of a file installed by this distribution 
+       Dictionary mapping the path of a file installed by this distribution
        to information about the file.
 
     The following fields all come from PEP 241.
@@ -209,7 +209,7 @@ class Distribution:
     summary : string
     description : string
     keywords : string
-    home_page : string    
+    home_page : string
     author : string
     author_email : string
     license : string
@@ -233,17 +233,17 @@ class Distribution:
         Checks whether the file's size, checksum, and ownership match,
         returning true if they do.
         """
-        
-     
+
+
 
 Deliverables
 
     A description of the database API, to be added to this PEP.
-  
+
     Patches to the Distutils that 1) implement an InstallationDatabase
     class, 2) Update the database when a new distribution is installed.  3)
     add a simple package management tool, features to be added to this
-    PEP.  (Or should that be a separate PEP?)  See [2] for the current 
+    PEP.  (Or should that be a separate PEP?)  See [2] for the current
     patch.
 
 
@@ -277,7 +277,7 @@ Open Issues
     compatible across Python versions, or is it subject to arbitrary
     change?  Probably we need to guarantee compatibility.
 
-    
+
 Rejected Suggestions
 
     Instead of using one text file per distribution, one large text
@@ -298,17 +298,17 @@ Rejected Suggestions
     permissions, but reading and setting them requires the win32all
     extensions, and they aren't present in the basic Python installer
     for Windows.
-  
+
 
 References
 
     [1] Michael Muller's patch (posted to the Distutils-SIG around 28
         Dec 1999) generates a list of installed files.
 
-    [2] A patch to implement this PEP will be tracked as 
-        patch #562100 on SourceForge.  
+    [2] A patch to implement this PEP will be tracked as
+        patch #562100 on SourceForge.
         http://www.python.org/sf/562100 .
-        Code implementing the installation database is currently in 
+        Code implementing the installation database is currently in
         Python CVS in the nondist/sandbox/pep262 directory.
 
 
@@ -319,7 +319,7 @@ Acknowledgements
     and others.
 
     Many changes and rewrites to this document were suggested by the
-    readers of the Distutils SIG.   
+    readers of the Distutils SIG.
 
 
 Copyright

--- a/pep-0265.txt
+++ b/pep-0265.txt
@@ -214,4 +214,4 @@ This document has been placed in the public domain.
   mode: indented-text
   indent-tabs-mode: nil
   End:
-  
+

--- a/pep-0272.txt
+++ b/pep-0272.txt
@@ -244,4 +244,4 @@ This document has been placed in the public domain.
   mode: indented-text
   indent-tabs-mode: nil
   End:
-  
+

--- a/pep-0275.txt
+++ b/pep-0275.txt
@@ -7,7 +7,7 @@ Status: Rejected
 Type: Standards Track
 Created: 10-Nov-2001
 Python-Version: 2.6
-Post-History: 
+Post-History:
 
 Rejection Notice
 
@@ -22,7 +22,7 @@ Abstract
 
 Problem
 
-    Up to Python 2.5, the typical way of writing multi-value switches 
+    Up to Python 2.5, the typical way of writing multi-value switches
     has been to use long switch constructs of the following type:
 
     if x == 'first state':
@@ -55,7 +55,7 @@ Problem
 
     def handle_data(self, data):
         self.stack.append(data)
- 
+
     A nice example of this is the state machine implemented in
     pickle.py which is used to serialize Python objects. Other
     prominent cases include XML SAX parsers and Internet protocol
@@ -143,23 +143,23 @@ Solution 2: Adding a switch statement to Python
 
          switch EXPR:
              case CONSTANT:
-                 SUITE  
+                 SUITE
              case CONSTANT:
-                 SUITE  
+                 SUITE
              ...
              else:
-                 SUITE  
+                 SUITE
 
          (modulo indentation variations)
 
          The "else" part is optional. If no else part is given and
-         none of the defined cases matches, no action is taken and 
+         none of the defined cases matches, no action is taken and
          the switch statement is ignored. This is in line with the
          current if-behaviour. A user who wants to signal this
          situation using an exception can define an else-branch
          which then implements the intended action.
 
-         Note that the constants need not be all of the same type, but 
+         Note that the constants need not be all of the same type, but
          they should be comparable to the type of the switch variable.
 
      Implementation:
@@ -169,13 +169,13 @@ Solution 2: Adding a switch statement to Python
 
           def whatis(x):
               switch(x):
-                  case 'one': 
+                  case 'one':
                       print '1'
-                  case 'two': 
+                  case 'two':
                       print '2'
-                  case 'three': 
+                  case 'three':
                       print '3'
-                  else: 
+                  else:
                       print "D'oh!"
 
          into (omitting POP_TOP's and SET_LINENO's):
@@ -205,7 +205,7 @@ Solution 2: Adding a switch statement to Python
 
         >>43  LOAD_CONST        0 (None)
           46  RETURN_VALUE
-        
+
         Where the 'SWITCH' opcode would jump to 14, 22, 30 or 38
         depending on 'x'.
 
@@ -233,29 +233,29 @@ Solution 2: Adding a switch statement to Python
 
             case EXPR:
                 of CONSTANT:
-                    SUITE  
+                    SUITE
                 of CONSTANT:
-                    SUITE  
+                    SUITE
                 else:
-                    SUITE  
+                    SUITE
 
             case EXPR:
                 if CONSTANT:
-                     SUITE  
+                     SUITE
                 if CONSTANT:
-                    SUITE  
+                    SUITE
                 else:
-                    SUITE  
+                    SUITE
 
             when EXPR:
                 in CONSTANT_TUPLE:
-                    SUITE  
+                    SUITE
                 in CONSTANT_TUPLE:
-                    SUITE  
+                    SUITE
                 ...
             else:
-                 SUITE  
-        
+                 SUITE
+
         The switch statement could be extended to allow multiple
         values for one section (e.g. case 'a', 'b', 'c': ...). Another
         proposed extension would allow ranges of values (e.g. case

--- a/pep-0277.txt
+++ b/pep-0277.txt
@@ -122,4 +122,4 @@ This document has been placed in the public domain.
   indent-tabs-mode: nil
   fill-column: 70
   End:
-  
+

--- a/pep-0279.txt
+++ b/pep-0279.txt
@@ -223,5 +223,5 @@ This document has been placed in the public domain.
   indent-tabs-mode: nil
   fill-column: 70
   End:
-  
-  
+
+

--- a/pep-0285.txt
+++ b/pep-0285.txt
@@ -199,7 +199,7 @@ Rationale
         1
         >>> cmp(a, a)
         0
-        >>> 
+        >>>
 
     you might be tempted to believe that cmp() also returned a truth
     value, whereas in reality it can return three different values

--- a/pep-0289.txt
+++ b/pep-0289.txt
@@ -134,11 +134,11 @@ semantic and syntactic specification.)
       changes to::
 
          atom: '(' [testlist_gexp] ')'
-    
+
       where testlist_gexp is almost the same as listmaker, but only
       allows a single test after 'for' ... 'in'::
 
-         testlist_gexp: test ( gen_for | (',' test)* [','] )          
+         testlist_gexp: test ( gen_for | (',' test)* [','] )
 
    b)  The rule for arglist needs similar changes.
 
@@ -243,7 +243,7 @@ issues were hard to understand and that users should be strongly
 encouraged to use generator expressions inside functions that consume
 their arguments immediately.  For more complex applications, full
 generator definitions are always superior in terms of being obvious
-about scope, lifetime, and binding [6]_. 
+about scope, lifetime, and binding [6]_.
 
 
 Reduction Functions

--- a/pep-0290.txt
+++ b/pep-0290.txt
@@ -69,7 +69,7 @@ Prior to Python 2.3, comparison operations returned 0 or 1 rather
 than True or False.  Some code may have used this as a shortcut for
 producing zero or one in places where their boolean counterparts are
 not appropriate.  For example::
-    
+
     def identity(m=1):
         """Create and m-by-m identity matrix"""
         return [[i==j for i in range(m)] for j in range(m)]
@@ -147,7 +147,7 @@ Alternative original code with explicit decoration::
 Revised code using a key function::
 
     names.sort(key=str.lower)       # case-insensitive sort
-                
+
 
 Locating: ``grep sort *.py``
 

--- a/pep-0293.txt
+++ b/pep-0293.txt
@@ -199,7 +199,7 @@ Specification
                        s += u"\\U%08x" % ord(c)
                 return (s, exc.end)
             else:
-                raise TypeError("can't handle %s" % exc.__name__) 
+                raise TypeError("can't handle %s" % exc.__name__)
 
        def xmlcharrefreplace(exc):
             if isinstance(exc,
@@ -209,7 +209,7 @@ Specification
                    s += u"&#%d;" % ord(c)
                 return (s, exc.end)
             else:
-                raise TypeError("can't handle %s" % exc.__name__) 
+                raise TypeError("can't handle %s" % exc.__name__)
 
     These five callback handlers will also be accessible to Python as
     codecs.strict_error, codecs.ignore_error, codecs.replace_error,

--- a/pep-0296.txt
+++ b/pep-0296.txt
@@ -44,7 +44,7 @@ Specification
     allocated.  With the alignment restrictions designated in the next
     item, it is trivial for low level extensions to cast the pointer
     to a different type as needed.
-    
+
     Also, since the object is implemented as an array of bytes, it is
     possible to pass the bytes object to the extensive library of
     routines already in the standard library that presently work with
@@ -205,16 +205,16 @@ Specification
        PyObject* PyBytes_FromLength(LONG_LONG len, int readonly);
        PyObject* PyBytes_FromPointer(void* ptr, LONG_LONG len, int readonly
                 void (*dest)(void *ptr, void *user), void* user);
-    
+
     In the PyBytes_FromPointer(...) function, if the dest function pointer is
     passed in as NULL, it will not be called.  This should only be used for
     creating bytes objects from statically allocated space.
-    
+
     The user pointer has been called a closure in other places.  It is a
     pointer that the user can use for whatever purposes.  It will be passed to
     the destructor function on cleanup and can be useful for a number of
     things.  If the user pointer is not needed, NULL should be passed instead.
- 
+
     11. The bytes type will be a new style class as that seems to be where all
     standard Python types are headed.
 

--- a/pep-0301.txt
+++ b/pep-0301.txt
@@ -252,7 +252,7 @@ set available to package authors through the new attribute
 web, and added to the package like so::
 
     setup(
-        name = "roundup", 
+        name = "roundup",
         version = __version__,
         classifiers = [
             'Development Status :: 4 - Beta',
@@ -305,7 +305,7 @@ versions earlier than 2.2.3 or 2.3.
 In the PKG-INFO, the classifiers list items will appear as individual
 ``Classifier:`` entries::
 
-        Name: roundup 
+        Name: roundup
         Version: 0.5.2
         Classifier: Development Status :: 4 - Beta
         Classifier: Environment :: Console (Text Based)

--- a/pep-0305.txt
+++ b/pep-0305.txt
@@ -242,7 +242,7 @@ several functions::
 given name.  ``list_dialects()`` returns a list of all registered
 dialect names.  ``register_dialects()`` associates a string name with
 a dialect class.  ``unregister_dialect()`` deletes a name/dialect
-association. 
+association.
 
 
 Formatting Parameters

--- a/pep-0308.txt
+++ b/pep-0308.txt
@@ -17,7 +17,7 @@ Adding a conditional expression
 
     The motivating use case was the prevalence of error-prone attempts
     to achieve the same effect using "and" and "or". [2]
-    
+
     Previous community efforts to add a conditional expression were
     stymied by a lack of consensus on the best syntax.  That issue was
     resolved by simply deferring to a BDFL best judgment call.
@@ -74,7 +74,7 @@ References
 
     [2] Motivating use case:
         http://mail.python.org/pipermail/python-dev/2005-September/056546.html
-        http://mail.python.org/pipermail/python-dev/2005-September/056510.html        
+        http://mail.python.org/pipermail/python-dev/2005-September/056510.html
 
     [3] Review in the context of real-world code fragments:
         http://mail.python.org/pipermail/python-dev/2005-September/056803.html
@@ -115,7 +115,7 @@ Proposal
         (if <condition>: <expression1> else: <expression2>)
 
     Note that the enclosing parentheses are not optional.
-    
+
     The resulting expression is evaluated like this:
 
     - First, <condition> is evaluated.
@@ -234,7 +234,7 @@ Summary of the Current State of the Discussion
         The leading examples are:
 
             <condition> then <expression1> else <expression2>
-            (if <condition>: <expression1> else: <expression2>) 
+            (if <condition>: <expression1> else: <expression2>)
 
     3.  Do nothing.
 
@@ -274,7 +274,7 @@ Short-Circuit Behavior
     does not provide short-circuit evaluation.
 
     Short-circuit evaluation is desirable on three occasions:
-                                                         
+
     1. When an expression has side-effects
     2. When one or both of the expressions are resource intensive
     3. When the condition serves as a guard for the validity of the
@@ -326,7 +326,7 @@ Detailed Results of Voting
             ACCEPT                  REJECT                  TOTAL
             ---------------------   ---------------------   -----
             Rank1   Rank2   Rank3   Rank1   Rank2   Rank3
-    Letter  
+    Letter
     A       51      33      19      18      20      20      161
     B       45      46      21      9       24      23      168
     C       94      54      29      20      20      18      235

--- a/pep-0318.txt
+++ b/pep-0318.txt
@@ -256,7 +256,7 @@ The rationale for the `order of application`_ (bottom to top) is that it
 matches the usual order for function-application.  In mathematics,
 composition of functions (g o f)(x) translates to g(f(x)).  In Python,
 ``@g @f def foo()`` translates to ``foo=g(f(foo)``.
-                                          
+
 .. _order of application:
     http://mail.python.org/pipermail/python-dev/2004-September/048874.html
 
@@ -284,7 +284,7 @@ the part after the @ sign can be considered to be an expression
 that expression returns is called.  See `declaration arguments`_.
 
 .. _declaration arguments:
-    http://mail.python.org/pipermail/python-dev/2004-September/048874.html               
+    http://mail.python.org/pipermail/python-dev/2004-September/048874.html
 
 
 Syntax Alternatives
@@ -666,7 +666,7 @@ but added:
 Community Consensus
 -------------------
 
-This section documents the rejected J2 syntax, and is included for 
+This section documents the rejected J2 syntax, and is included for
 historical completeness.
 
 The consensus that emerged on comp.lang.python was the proposed J2

--- a/pep-0319.txt
+++ b/pep-0319.txt
@@ -7,13 +7,13 @@ Status: Rejected
 Type: Standards Track
 Created: 24-Feb-2003
 Python-Version: 2.4?
-Post-History: 
+Post-History:
 
 
 Abstract
 
     This PEP proposes adding two new keywords to Python, `synchronize'
-    and 'asynchronize'.  
+    and 'asynchronize'.
 
 Pronouncement
 
@@ -49,7 +49,7 @@ The `synchronize' Keyword
     thread locking issues.
 
 
-The `asynchronize' Keyword  
+The `asynchronize' Keyword
 
     While executing a `synchronize' block of code a programmer may
     want to "drop back" to running asynchronously momentarily to run
@@ -62,7 +62,7 @@ The `asynchronize' Keyword
         ...
 
         acquire_lock()
-        try:    
+        try:
             change_shared_data()
             release_lock()             # become async
             do_blocking_io()
@@ -337,7 +337,7 @@ Formal Syntax
         synchronize_stmt: 'synchronize' [test] ':' suite
         asynchronize_stmt: 'asynchronize' [test] ':' suite
         compound_stmt: ... | synchronized_stmt | asynchronize_stmt
-        
+
     (The '...' indicates other compound statements elided).
 
 
@@ -429,7 +429,7 @@ How Java Does It
     different between the Java keyword and this PEP's 'synchronize')
     which must be qualified on any object.  The syntax is:
 
-        synchronized (Expression) Block 
+        synchronized (Expression) Block
 
     Expression must yield a valid object (null raises an error and
     exceptions during 'Expression' terminate the 'synchronized' block
@@ -469,7 +469,7 @@ Risks
 Dissenting Opinion
 
     This PEP has not been discussed on python-dev.
-        
+
 
 References
 

--- a/pep-0321.txt
+++ b/pep-0321.txt
@@ -8,7 +8,7 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 16-Sep-2003
 Python-Version: 2.4
-Post-History: 
+Post-History:
 
 
 Abstract
@@ -16,9 +16,9 @@ Abstract
 
 Python 2.3 added a number of simple date and time types in the
 ``datetime`` module.  There's no support for parsing strings in various
-formats and returning a corresponding instance of one of the types.  
+formats and returning a corresponding instance of one of the types.
 This PEP proposes adding a family of predefined parsing function for
-several commonly used date and time formats, and a facility for generic 
+several commonly used date and time formats, and a facility for generic
 parsing.
 
 The types provided by the ``datetime`` module all have
@@ -52,16 +52,16 @@ Options:
         import datetime
         d = datetime.parse_iso8601("2003-09-15T10:34:54")
 
-2) Add class methods to the various types.  There are already various 
+2) Add class methods to the various types.  There are already various
    class methods such as ``.now()``, so this would be pretty natural.::
 
         import datetime
         d = datetime.date.parse_iso8601("2003-09-15T10:34:54")
 
 3) Add a separate module (possible names: date, date_parse, parse_date)
-   or subpackage (possible names: datetime.parser) containing parsing 
+   or subpackage (possible names: datetime.parser) containing parsing
    functions::
-   
+
         import datetime
         d = datetime.parser.parse_iso8601("2003-09-15T10:34:54")
 
@@ -72,7 +72,7 @@ Unresolved questions:
 * What exception to raise on errors?  ValueError, or a specialized exception?
 * Should you know what type you're expecting, or should the parsing figure
   it out?  (e.g. ``parse_iso8601("yyyy-mm-dd")`` returns a ``date`` instance,
-  but parsing "yyyy-mm-ddThh:mm:ss" returns a ``datetime``.)  Should 
+  but parsing "yyyy-mm-ddThh:mm:ss" returns a ``datetime``.)  Should
   there be an option to signal an error if a time is provided where
   none is expected, or if no time is provided?
 * Anything special required for I18N?  For time zones?
@@ -90,8 +90,8 @@ implementation be easily retargeted?
 Output Formats
 =======================
 
-Not all input formats need to be supported as output formats, because it's 
-pretty trivial to get the ``strftime()`` argument right for simple things 
+Not all input formats need to be supported as output formats, because it's
+pretty trivial to get the ``strftime()`` argument right for simple things
 such as YYYY/MM/DD.   Only complicated formats need to be supported; RFC2822
 is currently the only one I can think of.
 

--- a/pep-0323.txt
+++ b/pep-0323.txt
@@ -432,7 +432,7 @@ Rationale
                 cop = lit = list(it)
                 break
         for i in lit: print i,
-    
+
     (again, the loop must be broken in two, since iterator 'it'
     gets exhausted by the call list(it)).
 

--- a/pep-0324.txt
+++ b/pep-0324.txt
@@ -170,18 +170,18 @@ Specification
       The program to execute is normally the first item in the args
       sequence or string, but can be explicitly set by using the
       executable argument.
-      
+
       On UNIX, with shell=False (default): In this case, the Popen
       class uses os.execvp() to execute the child program.  args
       should normally be a sequence.  A string will be treated as a
       sequence with the string as the only item (the program to
       execute).
-      
+
       On UNIX, with shell=True: If args is a string, it specifies the
       command string to execute through the shell.  If args is a
       sequence, the first item specifies the command string, and any
       additional items will be treated as additional shell arguments.
-      
+
       On Windows: the Popen class uses CreateProcess() to execute the
       child program, which operates on strings.  If args is a
       sequence, it will be converted to a string using the
@@ -215,7 +215,7 @@ Specification
       will be closed before the child process is executed.
 
     - If shell is true, the specified command will be executed through
-      the shell.  
+      the shell.
 
     - If cwd is not None, the current directory will be changed to cwd
       before the child is executed.

--- a/pep-0326.txt
+++ b/pep-0326.txt
@@ -189,7 +189,7 @@ modified Dijkstra's shortest path algorithm is given below. ::
             self.parent = parent
             self.distance = distance
             self.visited = visited
-    
+
     class MaxNode(SuperNode):
         def __init__(self, node, parent=None, distance=Max,
                      visited=False):
@@ -197,7 +197,7 @@ modified Dijkstra's shortest path algorithm is given below. ::
         def __cmp__(self, other):
             return cmp((self.visited, self.distance),
                        (other.visited, other.distance))
-    
+
     class NoneNode(SuperNode):
         def __init__(self, node, parent=None, distance=None,
                      visited=False):

--- a/pep-0327.txt
+++ b/pep-0327.txt
@@ -563,21 +563,21 @@ API for Py2.4.  Several ideas contributed to the thought process:
 - Interactions between decimal and binary floating point force the user to
   deal with tricky issues of representation and round-off.  Avoidance of those
   issues is a primary reason for having the module in the first place.
-  
+
 - The first release of the module should focus on that which is safe, minimal,
   and essential.
-  
+
 - While theoretically nice, real world use cases for interactions between floats
   and decimals are lacking.  Java included float/decimal conversions to handle
   an obscure case where calculations are best performed in decimal eventhough
   a legacy data structure requires the inputs and outputs to be stored in
   binary floating point.
-  
+
 - If the need arises, users can use string representations as an intermediate
   type.  The advantage of this approach is that it makes explicit the
   assumptions about precision and representation (no wondering what is going
   on under the hood).
-  
+
 - The Java docs for BigDecimal(double val) reflected their experiences with
   the constructor::
 

--- a/pep-0329.txt
+++ b/pep-0329.txt
@@ -119,7 +119,7 @@ Questions and Answers
    This does happen.  For instance, True can be redefined at the module
    level as `True = (1==1)`.  The sample implementation below detects the
    shadowing and leaves the global lookup unchanged.
-   
+
 6. Are you the first person to recognize that most global lookups are for
    values that never change?
 
@@ -187,7 +187,7 @@ Here is a sample implementation for codetweaks.py::
             if opcode in ABORT_CODES:
                 return f    # for simplicity, only optimize common cases
             if opcode == LOAD_GLOBAL:
-                oparg = newcode[i+1] + (newcode[i+2] << 8)            
+                oparg = newcode[i+1] + (newcode[i+2] << 8)
                 name = co.co_names[oparg]
                 if name in env and name not in stoplist:
                     value = env[name]
@@ -234,7 +234,7 @@ Here is a sample implementation for codetweaks.py::
 
     def f(): pass
     try:
-        f.func_code.code                    
+        f.func_code.code
     except AttributeError:                  # detect non-CPython environments
         bind_all = lambda *args, **kwds: 0
     del f
@@ -263,7 +263,7 @@ References
 
 .. [3] Differences between CPython and Jython
        http://www.jython.org/cgi-bin/faqw.py?req=show&file=faq01.003.htp
-    
+
 Copyright
 =========
 

--- a/pep-0334.txt
+++ b/pep-0334.txt
@@ -8,7 +8,7 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 26-Aug-2004
 Python-Version: 3.0
-Post-History: 
+Post-History:
 
 
 Abstract

--- a/pep-0335.txt
+++ b/pep-0335.txt
@@ -372,31 +372,31 @@ Example 1: NumPy Arrays
     #   of booleans.
     #
     #-----------------------------------------------------------------
-    
+
     from numpy import array, ndarray
-    
+
     class BArray(ndarray):
-    
+
         def __str__(self):
             return "barray(%s)" % ndarray.__str__(self)
-    
+
         def __and2__(self, other):
             return (self & other)
-    
+
         def __or2__(self, other):
             return (self & other)
-    
+
         def __not__(self):
             return (self == 0)
-    
+
     def barray(*args, **kwds):
         return array(*args, **kwds).view(type = BArray)
-    
+
     a0 = barray([0, 1, 2, 4])
     a1 = barray([1, 2, 3, 4])
     a2 = barray([5, 6, 3, 4])
     a3 = barray([5, 1, 2, 4])
-    
+
     print "a0:", a0
     print "a1:", a1
     print "a2:", a2
@@ -431,69 +431,69 @@ Example 2: Database Queries
     #   formulate the query.
     #
     #-----------------------------------------------------------------
-    
+
     class SQLNode(object):
-        
+
         def __and2__(self, other):
             return SQLBinop("and", self, other)
-    
+
         def __rand2__(self, other):
             return SQLBinop("and", other, self)
-    
+
         def __eq__(self, other):
             return SQLBinop("=", self, other)
-    
-    
+
+
     class Table(SQLNode):
-    
+
         def __init__(self, name):
             self.__tablename__ = name
-            
+
         def __getattr__(self, name):
             return SQLAttr(self, name)
-        
+
         def __sql__(self):
             return self.__tablename__
-    
-    
+
+
     class SQLBinop(SQLNode):
-    
+
         def __init__(self, op, opnd1, opnd2):
             self.op = op.upper()
             self.opnd1 = opnd1
             self.opnd2 = opnd2
-    
+
         def __sql__(self):
             return "(%s %s %s)" % (sql(self.opnd1), self.op, sql(self.opnd2))
-    
-    
+
+
     class SQLAttr(SQLNode):
-    
+
         def __init__(self, table, name):
             self.table = table
             self.name = name
-        
+
         def __sql__(self):
             return "%s.%s" % (sql(self.table), self.name)
-    
-    
+
+
     class SQLSelect(SQLNode):
-    
+
         def __init__(self, targets):
             self.targets = targets
             self.where_clause = None
-    
+
         def where(self, expr):
             self.where_clause = expr
             return self
-        
+
         def __sql__(self):
             result = "SELECT %s" % ", ".join([sql(target) for target in self.targets])
             if self.where_clause:
                 result = "%s WHERE %s" % (result, sql(self.where_clause))
             return result
-    
-    
+
+
     def sql(expr):
         if isinstance(expr, SQLNode):
             return expr.__sql__()
@@ -501,21 +501,21 @@ Example 2: Database Queries
             return "'%s'" % expr.replace("'", "''")
         else:
             return str(expr)
-    
-    
+
+
     def select(*targets):
         return SQLSelect(targets)
-    
+
     #-----------------------------------------------------------------
-    
+
     dishes = Table("dishes")
     customers = Table("customers")
     orders = Table("orders")
-    
+
     query = select(customers.name, dishes.price, orders.amount).where(
         customers.cust_id == orders.cust_id and orders.dish_id == dishes.dish_id
         and dishes.name == "Spam, Eggs, Sausages and Spam")
-    
+
     print repr(query)
     print sql(query)
 

--- a/pep-0338.txt
+++ b/pep-0338.txt
@@ -162,7 +162,7 @@ The delegation has the form::
 
     ``__file__`` is set to the name provided by the module loader. If
     the loader does not make filename information available, this
-    argument is set to ``None``. 
+    argument is set to ``None``.
 
     ``__builtins__`` is automatically initialised with a reference to
     the top level namespace of the ``__builtin__`` module.

--- a/pep-0339.txt
+++ b/pep-0339.txt
@@ -130,7 +130,7 @@ stmt arguments for 'body', and zero or more expr arguments for
 
 Do notice that something like 'arguments', which is a node type, is
 represented as a single AST node and not as a sequence of nodes as with
-stmt as one might expect.  
+stmt as one might expect.
 
 All three kinds also have an 'attributes' argument; this is shown by the
 fact that 'attributes' lacks a '|' before it.
@@ -147,11 +147,11 @@ The statement definitions above generate the following C structure type::
                         arguments_ty args;
                         asdl_seq *body;
                 } FunctionDef;
-                
+
                 struct {
                         expr_ty value;
                 } Return;
-                
+
                 struct {
                         expr_ty value;
                 } Yield;
@@ -260,7 +260,7 @@ points are instructions that would change the flow of the program (such
 as jumps and 'return' statements).  What this means is that a basic
 block is a chunk of code that starts at the entry point and runs to an
 exit point or the end of the block.
-  
+
 As an example, consider an 'if' statement with an 'else' block.  The
 guard on the 'if' is a basic block which is pointed to by the basic
 block containing the code leading to the 'if' statement.  The 'if'

--- a/pep-0342.txt
+++ b/pep-0342.txt
@@ -429,7 +429,7 @@ Examples
 
 
         # Put them together to make a function that makes thumbnail
-        # pages from a list of images and other parameters.      
+        # pages from a list of images and other parameters.
         #
         def write_thumbnails(pagesize, thumbsize, images, output_dir):
             pipeline = thumbnail_pager(

--- a/pep-0343.txt
+++ b/pep-0343.txt
@@ -322,7 +322,7 @@ Specification: The 'with' Statement
     responsibility of the *caller* of the __exit__() method to do any
     reraising in that case.
 
-    That way, if the caller needs to tell whether the __exit__() 
+    That way, if the caller needs to tell whether the __exit__()
     invocation *failed* (as opposed to successfully cleaning up before
     propagating the original error), it can do so.
 
@@ -333,8 +333,8 @@ Specification: The 'with' Statement
 
     However, if __exit__() propagates an exception to its caller, this
     means that __exit__() *itself* has failed.  Thus, __exit__()
-    methods should avoid raising errors unless they have actually 
-    failed.  (And allowing the original error to proceed isn't a 
+    methods should avoid raising errors unless they have actually
+    failed.  (And allowing the original error to proceed isn't a
     failure.)
 
 Transition Plan
@@ -387,7 +387,7 @@ Generator Decorator
                        # passed to throw(), because __exit__() must not raise
                        # an exception unless __exit__() itself failed.  But
                        # throw() has to raise the exception to signal
-                       # propagation, so this fixes the impedance mismatch 
+                       # propagation, so this fixes the impedance mismatch
                        # between the throw() protocol and the __exit__()
                        # protocol.
                        #
@@ -803,7 +803,7 @@ Examples
                 process(datum)
 
          (Python 2.5's contextlib module contains a version
-          of this context manager) 
+          of this context manager)
 
      11. PEP 319 gives a use case for also having a released()
          context to temporarily release a previously acquired lock;
@@ -876,7 +876,7 @@ Examples
                       # Perform operation
 
          (Python 2.5's contextlib module contains a version
-          of this context manager) 
+          of this context manager)
 
 Reference Implementation
 
@@ -955,7 +955,7 @@ Copyright
     This document has been placed in the public domain.
 
 
-.. 
+..
    Local Variables:
    mode: indented-text
    indent-tabs-mode: nil

--- a/pep-0344.txt
+++ b/pep-0344.txt
@@ -91,7 +91,7 @@ Rationale
     '__context__' because the intended meaning is more specific than
     temporal precedence but less specific than causation: an exception
     occurs in the context of handling another exception.
-    
+
     This PEP suggests names with leading and trailing double-underscores
     for these three attributes because they are set by the Python VM.
     Only in very special cases should they be set by normal assignment.
@@ -177,16 +177,16 @@ Implicit Exception Chaining
                     log(file, exc)
             finally:
                 file.clos()             # oops, misspelled 'close'
-        
+
         def compute():
             1/0
-        
+
         def log(file, exc):
             try:
                 print >>file, exc       # oops, file is not writable
             except:
                 display(exc)
-        
+
         def display(exc):
             print ex                    # oops, misspelled 'exc'
 
@@ -200,7 +200,7 @@ Implicit Exception Chaining
     The proposed semantics are as follows:
 
     1.  Each thread has an exception context initially set to None.
-    
+
     2.  Whenever an exception is raised, if the exception instance does
         not already have a '__context__' attribute, the interpreter sets
         it equal to the thread's exception context.
@@ -225,7 +225,7 @@ Explicit Exception Chaining
         exc = EXCEPTION
         exc.__cause__ = CAUSE
         raise exc
-    
+
     In the following example, a database provides implementations for a
     few different kinds of storage, with file storage as one kind.  The
     database designer wants errors to propagate as DatabaseError objects
@@ -300,7 +300,7 @@ Enhanced Reporting
 
     between tracebacks, depending whether they are linked by __cause__
     or __context__ respectively.  Here is a sketch of the procedure:
-    
+
         def print_chain(exc):
             if exc.__cause__:
                 print_chain(exc.__cause__)
@@ -443,7 +443,7 @@ Open Issue:  Garbage Collection
     instead turn the reference from the stack frame to the 'err' variable
     into a weak reference when the variable goes out of scope [13].
 
-  
+
 Possible Future Compatible Changes
 
     These changes are consistent with the appearance of exceptions as
@@ -517,7 +517,7 @@ References
 
     [9] Tony Olensky, "Omnibus Structured Exception/Error Handling Mechanism"
         http://dev.perl.org/perl6/rfc/88.html
-     
+
    [10] MSDN .NET Framework Library, "Exception.InnerException Property"
         http://msdn.microsoft.com/library/en-us/cpref/html/frlrfsystemexceptionclassinnerexceptiontopic.asp
 

--- a/pep-0352.txt
+++ b/pep-0352.txt
@@ -63,7 +63,7 @@ work in Python 2.x is covered in the `Transition Plan`_ section)::
       Provides an 'args' attribute that contains all arguments passed
       to the constructor.  Suggested practice, though, is that only a
       single string argument be passed to the constructor.
-      
+
       """
 
       def __init__(self, *args):
@@ -231,7 +231,7 @@ desired.
   - deprecate catching string exceptions [done]
 
   - deprecate ``message`` attribute (see `Retracted Ideas`_) [done]
-  
+
 * Python 2.7 [done]
 
   - deprecate raising exceptions that do not inherit from BaseException

--- a/pep-0353.txt
+++ b/pep-0353.txt
@@ -163,7 +163,7 @@ Python versions.
 If the module should be extended to use Py_ssize_t indices, all usages
 of the type int should be reviewed, to see whether it should be
 changed to Py_ssize_t. The compiler will help in finding the spots,
-but a manual review is still necessary. 
+but a manual review is still necessary.
 
 Particular care must be taken for PyArg_ParseTuple calls:
 they need all be checked for s# and t# converters, and
@@ -219,7 +219,7 @@ it does currently. There are two exceptions to this
 statement: if the extension module implements the
 sequence protocol, it must be updated, or the calling
 conventions will be wrong. The other exception is
-the places where Py_ssize_t is output through a 
+the places where Py_ssize_t is output through a
 pointer (rather than a return value); this applies
 most notably to codecs and slice objects.
 
@@ -237,7 +237,7 @@ containers doesn't change, e.g.
 
 * in lists and tuples, a pointer immediately follows
   the ob_size member. This means that the compiler
-  currently inserts a 4 padding bytes; with the 
+  currently inserts a 4 padding bytes; with the
   change, these padding bytes become part of the size.
 * in strings, the ob_shash field follows ob_size.
   This field is of type long, which is a 64-bit

--- a/pep-0359.txt
+++ b/pep-0359.txt
@@ -102,7 +102,7 @@ to access these attributes instead as::
 
     mod.roletypes.thematic
     mod.roletypes.opinion
-    
+
     mod.format.text
     mod.format.html
 
@@ -126,7 +126,7 @@ statement, I could introduce my new namespaces with something like::
     make namespace roletypes:
         thematic = ...
         opinion = ...
-        
+
     make namespace format:
         text = ...
         html = ...
@@ -158,7 +158,7 @@ looks something like::
     hi_there = Tkinter.Button(frame, text="Hello", command=say_hi)
     hi_there.pack(side=Tkinter.LEFT)
     root.mainloop()
-    
+
 could be rewritten to group the Button's function with its
 declaration::
 
@@ -192,16 +192,16 @@ around this somehow.  With the make-statement, you could create a
 where the ``setonce`` descriptor would be defined like::
 
     class setonce(object):
-    
+
         def __init__(self, name, args, kwargs):
             self._name = '_setonce_attr_%s' % name
             self.__doc__ = kwargs.pop('__doc__', None)
-    
+
         def __get__(self, obj, type=None):
             if obj is None:
                 return self
             return getattr(obj, self._name)
-    
+
         def __set__(self, obj, value):
             try:
                 getattr(obj, self._name)
@@ -209,10 +209,10 @@ where the ``setonce`` descriptor would be defined like::
                 setattr(obj, self._name, value)
             else:
                 raise AttributeError("Attribute already set")
-    
+
         def set(self, obj, value):
             setattr(obj, self._name, value)
-    
+
         def __delete__(self, obj):
             delattr(obj, self._name)
 
@@ -280,7 +280,7 @@ objects instead, e.g. Zope's::
 
     class IFoo(Interface):
         """Foo blah blah"""
-  
+
         def fumble(name, count):
             """docstring"""
 
@@ -289,7 +289,7 @@ declared as::
 
     make Interface IFoo:
         """Foo blah blah"""
-  
+
         def fumble(name, count):
             """docstring"""
 
@@ -406,9 +406,9 @@ block by calling the callable's ``__make_dict__`` method, the
 following code would allow the make-statement to be used as above::
 
     class Element(object):
-    
+
         class __make_dict__(dict):
-        
+
             def __init__(self, *args, **kwargs):
                 self._super = super(Element.__make_dict__, self)
                 self._super.__init__(*args, **kwargs)
@@ -416,7 +416,7 @@ following code would allow the make-statement to be used as above::
                 self.text = None
                 self.tail = None
                 self.attrib = {}
-                
+
             def __getitem__(self, name):
                 try:
                     return self._super.__getitem__(name)
@@ -425,20 +425,20 @@ following code would allow the make-statement to be used as above::
                         return getattr(self, 'set_%s' % name)
                     else:
                         return globals()[name]
-                
+
             def __setitem__(self, name, value):
                 self._super.__setitem__(name, value)
                 self.elements.append(value)
-                
+
             def set_attrib(self, **kwargs):
                 self.attrib = kwargs
-                
+
             def set_text(self, text):
                 self.text = text
-                
+
             def set_tail(self, text):
                 self.tail = text
-        
+
         def __new__(cls, name, args, edict):
             get_element = etree.ElementTree.Element
             result = get_element(name, attrib=edict.attrib)
@@ -470,7 +470,7 @@ equivalent nesting with a much more explicit syntax::
             with Element('h1', style='second') as h1:
                 h1.text = 'second h1'
                 h1.tail = 'after second h1'
-    
+
 And if the repetition of the element names here is too much of a DRY
 violoation, it is also possible to eliminate all as-clauses except for
 the first by adding a few methods to Element. [10]_

--- a/pep-0360.txt
+++ b/pep-0360.txt
@@ -67,7 +67,7 @@ ElementTree
     Fredrik Lundh
 
 Fredrik has ceded ElementTree maintenance to the core Python development
-team [#element-tree]_. 
+team [#element-tree]_.
 
 Expat XML parser
 ----------------

--- a/pep-0364.txt
+++ b/pep-0364.txt
@@ -8,7 +8,7 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 01-Mar-2007
 Python-Version: 2.6
-Post-History: 
+Post-History:
 
 
 Abstract
@@ -181,7 +181,7 @@ mappings for an old name, or if a programmatic call is made with an
 old name that is already remapped, the previous mapping is lost.  This
 will not affect any already imported modules.
 
-The following methods are available on the ``sys.stdlib_remapper`` 
+The following methods are available on the ``sys.stdlib_remapper``
 object:
 
 - ``read_mv_file(filename)`` -- Read the given file and register all

--- a/pep-0367.txt
+++ b/pep-0367.txt
@@ -358,7 +358,7 @@ The reference implementation assumes that it is being run on Python 2.5+.
 
         if co_lnotab:
             co_lnotab[0] += preamble_len
-        
+
         co_lnotab = co_lnotab.tostring()
 
         # Our code consists of the preamble and the modified code.
@@ -428,8 +428,8 @@ is simply a local variable compared to when it is used by an inner function.
                  18 LOAD_FAST                1 (super)
                  21 LOAD_ATTR                1 (f)
                  24 CALL_FUNCTION            0
-                 27 BINARY_ADD          
-                 28 RETURN_VALUE        
+                 27 BINARY_ADD
+                 28 RETURN_VALUE
 
 ::
 
@@ -439,7 +439,7 @@ is simply a local variable compared to when it is used by an inner function.
                   3 LOAD_CONST               2 (<class '__main__.C'>)
                   6 LOAD_FAST                0 (self)
                   9 CALL_FUNCTION            2
-                 12 DUP_TOP             
+                 12 DUP_TOP
                  13 STORE_FAST               1 (super)
                  16 STORE_DEREF              0 (super)
 
@@ -453,7 +453,7 @@ is simply a local variable compared to when it is used by an inner function.
 
     224          37 LOAD_FAST                2 (inner)
                  40 CALL_FUNCTION            0
-                 43 RETURN_VALUE        
+                 43 RETURN_VALUE
 
 Note that in the final implementation, the preamble would not be part of the
 bytecode of the method, but would occur immediately following unpacking of

--- a/pep-0369.txt
+++ b/pep-0369.txt
@@ -21,11 +21,11 @@ is no longer valid following the migration to importlib in Python 3.3.
 Abstract
 ========
 
-This PEP proposes enhancements for the import machinery to add 
+This PEP proposes enhancements for the import machinery to add
 post import hooks. It is intended primarily to support the wider
 use of abstract base classes that is expected in Python 3.0.
 
-The PEP originally started as a combined PEP for lazy imports and 
+The PEP originally started as a combined PEP for lazy imports and
 post import hooks. After some discussion on the python-dev mailing
 list the PEP was parted in two separate PEPs. [1]_
 
@@ -37,14 +37,14 @@ Python has no API to hook into the import machinery and execute code
 *after* a module is successfully loaded. The import hooks of PEP 302 are
 about finding modules and loading modules but they were not designed to
 as post import hooks.
-   
+
 
 Use cases
 =========
 
 A use case for a post import hook is mentioned in Nick Coghlan's initial
 posting [2]_. about callbacks on module import. It was found during the
-development of Python 3.0 and its ABCs. We wanted to register classes 
+development of Python 3.0 and its ABCs. We wanted to register classes
 like decimal.Decimal with an ABC but the module should not be imported
 on every interpreter startup. Nick came up with this example::
 
@@ -72,7 +72,7 @@ Post import hook implementation
 ===============================
 
 Post import hooks are called after a module has been loaded. The hooks
-are callable which take one argument, the module instance. They are 
+are callable which take one argument, the module instance. They are
 registered by the dotted name of the module, e.g. 'os' or 'os.path'.
 
 The callable are stored in the dict ``sys.post_import_hooks`` which
@@ -91,7 +91,7 @@ sys.post_import_hooks contains no entry for the module
 A hook is registered and the module is not loaded yet
 '''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-The import hook registry contains an entry 
+The import hook registry contains an entry
 sys.post_import_hooks["name"] = [hook1]
 
 
@@ -121,7 +121,7 @@ may be possible to load the module later.
 A hook is registered but the module is already loaded
 '''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-The hook is fired immediately. 
+The hook is fired immediately.
 
 
 Invariants
@@ -253,7 +253,7 @@ call the ``imp.notify_module_loaded`` function.
 Reference Implementation
 ========================
 
-A reference implementation is already written and is available in the 
+A reference implementation is already written and is available in the
 *py3k-importhook* branch. [4]_ It still requires some cleanups,
 documentation updates and additional unit tests.
 

--- a/pep-0370.txt
+++ b/pep-0370.txt
@@ -25,7 +25,7 @@ Current Python versions don't have a unified way to install packages
 into the home directory of a user (except for Mac Framework
 builds). Users are either forced to ask the system administrator to
 install or update a package for them or to use one of the many
-workarounds like Virtual Python [1]_, Working Env [2]_ or 
+workarounds like Virtual Python [1]_, Working Env [2]_ or
 Virtual Env [3]_.
 
 It's not the goal of the PEP to replace the tools or to implement
@@ -71,7 +71,7 @@ user data directory
 
 user base directory
 
-   It's located inside the user's home directory. The user site and 
+   It's located inside the user's home directory. The user site and
    use config directory are inside the base directory. On some systems
    the directory may be shared with 3rd party apps.
 
@@ -94,7 +94,7 @@ user script directory
 Windows Notes
 -------------
 
-On Windows the *Application Data* directory (aka ``APPDATA``) was chosen 
+On Windows the *Application Data* directory (aka ``APPDATA``) was chosen
 because it is the most designated place for application data. Microsoft
 recommends that software doesn't write to ``USERPROFILE`` [5]_ and
 ``My Documents`` is not suited for application data, either. [8]_ The code
@@ -122,7 +122,7 @@ Mac OS X Notes
 
 On Mac OS X Python uses ~/.local directory as well. [12]_ Framework builds
 of Python include ``~/Library/Python/2.6/site-packages`` as an additional
-search path. 
+search path.
 
 
 Implementation
@@ -130,8 +130,8 @@ Implementation
 
 The site module gets a new method ``adduserpackage()`` which adds the
 appropriate directory to the search path. The directory is not added if
-it doesn't exist when Python is started. However the location of the 
-user site directory and user base directory is stored in an internal 
+it doesn't exist when Python is started. However the location of the
+user site directory and user base directory is stored in an internal
 variable for distutils.
 
 The user site directory is added before the system site directories
@@ -168,7 +168,7 @@ adds the lib/ directory to rpath.
 
 The ``site`` module gets two arguments ``--user-base`` and ``--user-site``
 to print the path to the user base or user site directory to the standard
-output. The feature is intended for scripting, e.g. 
+output. The feature is intended for scripting, e.g.
 ``./configure --prefix $(python2.5 -m site --user-base)``
 
 ``distutils.sysconfig`` will get methods to access the private variables

--- a/pep-0371.txt
+++ b/pep-0371.txt
@@ -18,8 +18,8 @@ Abstract
     into the Python standard library, renamed to "multiprocessing".
 
     The processing package mimics the standard library threading
-    module functionality to provide a process-based approach to 
-    threaded programming allowing end-users to dispatch multiple 
+    module functionality to provide a process-based approach to
+    threaded programming allowing end-users to dispatch multiple
     tasks that effectively side-step the global interpreter lock.
 
     The package also provides server and client functionality
@@ -54,7 +54,7 @@ Rationale
     for another "concurrent" approach - Twisted, Actors, etc).
 
     The Processing package offers CPython a "known API" which mirrors
-    albeit in a PEP 8 compliant manner, that of the threading API, 
+    albeit in a PEP 8 compliant manner, that of the threading API,
     with known semantics and easy scalability.
 
     In the future, the package might not be as relevant should the
@@ -287,12 +287,12 @@ Performance Comparison
     One item of note however, is that there is an implicit overhead
     within the pyprocessing package's Queue implementation due to the
     object serialization.
-    
+
     Alec Thomas provided a short example based on the
     run_benchmarks.py script to demonstrate this overhead versus the
     default Queue implementation:
 
-        cmd: run_bench_queue.py 
+        cmd: run_bench_queue.py
         non_threaded (1 iters)  0.010546 seconds
         threaded (1 threads)    0.015164 seconds
         processes (1 procs)     0.066167 seconds
@@ -380,8 +380,8 @@ Closed Issues
     * DONE: Rename top-level package from "pyprocessing" to
       "multiprocessing".
 
-    * DONE: Also note that the default behavior of process spawning 
-      does not make it compatible with use within IDLE as-is, this 
+    * DONE: Also note that the default behavior of process spawning
+      does not make it compatible with use within IDLE as-is, this
       will be examined as a bug-fix or "setExecutable" enhancement.
 
     * DONE: Add in "multiprocessing.setExecutable()" method to override the

--- a/pep-0372.txt
+++ b/pep-0372.txt
@@ -81,7 +81,7 @@ situations:
   allows an application to set the type of dictionary used internally.
   The motivation for this addition was expressly to allow users to
   provide an ordered dictionary. [1]_
-  
+
 - Code ported from other programming languages such as PHP often
   depends on an ordered dict.  Having an implementation of an
   ordering-preserving dictionary in the standard library could ease
@@ -168,7 +168,7 @@ Does ``OrderedDict.popitem()`` return a particular key/value pair?
     equivalent to ``k=list(od)[-1]; v=od[k]; del od[k]; return (k,v)``.
     The actual implementation is more efficient and pops directly
     from a sorted list of keys.
-    
+
 Does OrderedDict support indexing, slicing, and whatnot?
 
     As a matter of fact, ``OrderedDict`` does not implement the ``Sequence``
@@ -197,7 +197,7 @@ How well does OrderedDict work with the json module, PyYAML, and ConfigParser?
    In Py2.6, the object_hook for json decoders passes-in an already built
    dictionary so order is lost before the object hook sees it.  This
    problem is being fixed for Python 2.7/3.1 by adding a new hook that
-   preserves order (see http://bugs.python.org/issue5381 ).  
+   preserves order (see http://bugs.python.org/issue5381 ).
    With the new hook, order can be preserved::
 
         >>> jtext = '{"one": 1, "two": 2, "three": 3, "four": 4, "five": 5}'

--- a/pep-0378.txt
+++ b/pep-0378.txt
@@ -99,7 +99,7 @@ Research into what Other Languages Do
 =====================================
 
 Scanning the web, I've found that thousands separators are
-usually one of COMMA, DOT, SPACE, APOSTROPHE or UNDERSCORE.  
+usually one of COMMA, DOT, SPACE, APOSTROPHE or UNDERSCORE.
 
 `C-Sharp`_ provides both styles (picture formatting and type specifiers).
 The type specifier approach is locale aware.  The picture formatting only
@@ -216,7 +216,7 @@ Commentary
   individual format strings makes it hard to change that convention
   later.  No workable alternative was suggested but the general idea
   is to set the convention once and have it apply everywhere (others
-  commented that locale already provides a way to do this).                                                              
+  commented that locale already provides a way to do this).
 
 * There are some precedents for grouping digits in the fractional
   part of a floating point number, but this PEP does not venture into

--- a/pep-0382.txt
+++ b/pep-0382.txt
@@ -98,7 +98,7 @@ Specification
 =============
 
 Rather than using an imperative mechanism for importing packages, a
-declarative approach is proposed here: A directory whose name ends 
+declarative approach is proposed here: A directory whose name ends
 with ``.pyp`` (for Python package) contains a portion of a package.
 
 The import statement is extended so that computes the package's

--- a/pep-0383.txt
+++ b/pep-0383.txt
@@ -85,7 +85,7 @@ Unicode strings which then get encoded again (also see the discussion
 below).
 
 Byte-oriented interfaces that already exist in Python 3.0 are not
-affected by this specification. They are neither enhanced nor 
+affected by this specification. They are neither enhanced nor
 deprecated.
 
 External libraries that operate on file names (such as GUI file

--- a/pep-0384.txt
+++ b/pep-0384.txt
@@ -30,7 +30,7 @@ of in-memory structures. For example, the way in which string interning
 works, or the data type used to represent the size of an object, have
 changed during the life of Python 2.x. As a consequence, extension
 modules making direct access to fields of strings, lists, or tuples,
-would break if their code is loaded into a newer version of the 
+would break if their code is loaded into a newer version of the
 interpreter without recompilation: offsets of other fields may have
 changed, making the extension modules access the wrong data.
 
@@ -64,14 +64,14 @@ Specification
 The ABI specification falls into two parts: an API specification,
 specifying what function (groups) are available for use with the
 ABI, and a linkage specification specifying what libraries to link
-with. The actual ABI (layout of structures in memory, function 
-calling conventions) is not specified, but implied by the 
+with. The actual ABI (layout of structures in memory, function
+calling conventions) is not specified, but implied by the
 compiler. As a recommendation, a specific ABI is recommended for
 selected platforms.
 
 During evolution of Python, new ABI functions will be added.
 Applications using them will then have a requirement on a minimum
-version of Python; this PEP provides no mechanism for such 
+version of Python; this PEP provides no mechanism for such
 applications to fall back when the Python library is too old.
 
 Terminology

--- a/pep-0389.txt
+++ b/pep-0389.txt
@@ -121,11 +121,11 @@ possible. Some of the problems included:
   method of custom actions will always be passed a ``values`` object
   which provides an ``ensure_value`` method [12]_, while the argparse
   module allows attributes to be assigned to any object, e.g.::
-  
+
     foo_object = ...
     parser.parse_args(namespace=foo_object)
     foo_object.some_attribute_parsed_from_command_line
-  
+
   Modifying optparse to allow any object to be passed in would be
   difficult because simply passing the ``foo_object`` around instead
   of a ``Values`` instance will break existing custom actions that
@@ -148,7 +148,7 @@ default:
 
 * Python 2.7+ and 3.2+ -- The following note will be added to the
   optparse documentation:
-  
+
     The optparse module is deprecated and will not be developed
     further; development will continue with the argparse module.
 
@@ -179,7 +179,7 @@ be added:
 
   Note that an equivalent command line interface could be produced
   with less code by using the argparse module::
-  
+
     import argparse
 
     if __name__ == '__main__':

--- a/pep-0391.txt
+++ b/pep-0391.txt
@@ -139,7 +139,7 @@ So, for example, consider the following YAML snippet::
        formatter: brief
       h2: #This is another id
        # configuration of handler with id 'h2' goes here
-       formatter: precise       
+       formatter: precise
     loggers:
       foo.bar.baz:
         # other configuration for logger 'foo.bar.baz'
@@ -157,7 +157,7 @@ dictionary and used to determine connections between objects, and are
 not persisted anywhere when the configuration call is complete.
 
 Handler ids are treated specially, see the section on
-`Handler Ids`_, below. 
+`Handler Ids`_, below.
 
 The above snippet indicates that logger named ``foo.bar.baz`` should
 have two handlers attached to it, which are described by the handler
@@ -305,7 +305,7 @@ specify::
     handlers:
       file:
         # configuration of file handler goes here
-        
+
       custom:
         (): my.package.MyHandler
         alternate: cfg://handlers.file
@@ -487,7 +487,7 @@ determine how to instantiate.
   disabled. This setting mirrors the parameter of the same name in
   ``fileConfig()``. If absent, this parameter defaults to ``True``.
   This value is ignored if `incremental` is ``True``.
-  
+
 A Working Example
 -----------------
 

--- a/pep-0395.txt
+++ b/pep-0395.txt
@@ -110,7 +110,7 @@ However, it's hard to blame Django for this, when the same part of Python
 responsible for setting ``__name__ = "__main__"`` in the main module commits
 the exact same error when determining the value for ``sys.path[0]``.
 
-The impact of this can be seen relatively frequently if you follow the 
+The impact of this can be seen relatively frequently if you follow the
 "python" and "import" tags on Stack Overflow. When I had the time to follow
 it myself, I regularly encountered people struggling to understand the
 behaviour of straightforward package layouts like the following (I actually
@@ -349,7 +349,7 @@ dealing with them.
 
 A rough draft of some of the concepts presented here was first posted on the
 python-ideas list ([1]_), but they have evolved considerably since first being
-discussed in that thread. Further discussion has subsequently taken place on 
+discussed in that thread. Further discussion has subsequently taken place on
 the import-sig mailing list ([2]_. [3]_).
 
 

--- a/pep-0397.txt
+++ b/pep-0397.txt
@@ -13,8 +13,8 @@ Resolution: http://mail.python.org/pipermail/python-dev/2012-June/120505.html
 
 Abstract
 
-    This PEP describes a Python launcher for the Windows platform.  A 
-    Python launcher is a single executable which uses a number of 
+    This PEP describes a Python launcher for the Windows platform.  A
+    Python launcher is a single executable which uses a number of
     heuristics to locate a Python executable and launch it with a
     specified command line.
 
@@ -53,10 +53,10 @@ Rationale
     command on Unix-Like Systems' [2] describes additional conventions
     for more fine-grained specification of a particular Python version.
 
-    These 2 facilities combined allow for a portable and somewhat 
+    These 2 facilities combined allow for a portable and somewhat
     predictable way of both starting Python interactively and for allowing
-    Python scripts to execute.  This PEP describes an implementation of a 
-    launcher which can offer the same benefits for Python on the Windows 
+    Python scripts to execute.  This PEP describes an implementation of a
+    launcher which can offer the same benefits for Python on the Windows
     platform and therefore allows the launcher to be the executable
     associated with '.py' files to support multiple Python versions
     concurrently.
@@ -90,7 +90,7 @@ Installation
     The launcher is installed into the Windows directory (see
     discussion below) if installed by a privileged user. The
     stand-alone installer asks for an alternative location of the
-    installer, and adds that location to the user's PATH. 
+    installer, and adds that location to the user's PATH.
 
     The installation in the Windows directory is a 32-bit executable
     (see discussion); the standalone installer may also offer to install
@@ -127,10 +127,10 @@ Python Script Launching
 
     The launcher supports shebang lines referring to Python
     executables with any of the (regex) prefixes "/usr/bin/", "/usr/local/bin"
-    and "/usr/bin/env *", as well as binaries specified without 
+    and "/usr/bin/env *", as well as binaries specified without
 
-    For example, a shebang line of '#! /usr/bin/python' should work even 
-    though there is unlikely to be an executable in the relative Windows 
+    For example, a shebang line of '#! /usr/bin/python' should work even
+    though there is unlikely to be an executable in the relative Windows
     directory "\usr\bin".  This means that many scripts can use a single
     shebang line and be likely to work on both Unix and Windows without
     modification.
@@ -225,12 +225,12 @@ Configuration file
     precedence over the one next to the executable, so a user, who may not
     have write access to the .ini file next to the launcher, can override
     commands in that global .ini file)
- 
+
 Virtual commands in shebang lines
 
     Virtual Commands are shebang lines which start with strings which would
     be expected to work on Unix platforms - examples include
-    '/usr/bin/python', '/usr/bin/env python' and 'python'.  Optionally, the 
+    '/usr/bin/python', '/usr/bin/env python' and 'python'.  Optionally, the
     virtual command may be suffixed with a version qualifier (see below),
     such as '/usr/bin/python2' or '/usr/bin/python3.2'.  The command executed
     is based on the rules described in Python Version Qualifiers
@@ -240,7 +240,7 @@ Customized Commands
 
     The launcher will support the ability to define "Customized Commands" in a
     Windows .ini file (ie, a file which can be parsed by the Windows function
-    GetPrivateProfileString).  A section called '[commands]' can be created 
+    GetPrivateProfileString).  A section called '[commands]' can be created
     with key names defining the virtual command and the value specifying the
     actual command-line to be used for this virtual command.
 
@@ -249,8 +249,8 @@ Customized Commands
     [commands]
     vpython=c:\bin\vpython.exe -foo
 
-    Then a shebang line of '#! vpython' in a script named 'doit.py' will 
-    result in the launcher using the command-line 'c:\bin\vpython.exe -foo 
+    Then a shebang line of '#! vpython' in a script named 'doit.py' will
+    result in the launcher using the command-line 'c:\bin\vpython.exe -foo
     doit.py'
 
     The precise details about the names, locations and search order of the
@@ -258,7 +258,7 @@ Customized Commands
 
 Python Version Qualifiers
 
-    Some of the features described allow an optional Python version qualifier 
+    Some of the features described allow an optional Python version qualifier
     to be used.
 
     A version qualifier starts with a major version number and can optionally
@@ -324,7 +324,7 @@ Command-line handling
     obviously be launched manually without use of this launcher.)  Note that
     this feature can not be used with shebang processing as the file scanned
     for a shebang line and this argument must both be the first argument and
-    therefore are mutually exclusive. 
+    therefore are mutually exclusive.
 
     All other arguments will be passed untouched to the child Python process.
 
@@ -390,7 +390,7 @@ Discussion
     the Win32 Job API will be used to arrange so that the child process is
     automatically killed when the parent is terminated (although children of
     that child process will continue as is the case now.)  As this Windows API
-    is available in Windows XP and later, this launcher will not work on 
+    is available in Windows XP and later, this launcher will not work on
     Windows 2000 or earlier.
 
 References

--- a/pep-0413.txt
+++ b/pep-0413.txt
@@ -68,7 +68,7 @@ To quote the PEP 407 abstract:
     more fluid release of features, by introducing the notion of long-term
     support versions.
 
-I agree with the PEP 407 authors that the current release cycle of the 
+I agree with the PEP 407 authors that the current release cycle of the
 *standard library* is too slow to effectively cope with the pace of change
 in some key programming areas (specifically, web protocols and related
 technologies, including databases, templating and serialisation formats).
@@ -221,7 +221,7 @@ version. Using the initial Python 3.3 release as an example::
 
 This information would also be included in the ``sys.version`` string::
 
-    Python 3.3.0 (33.0, default, Feb 17 2012, 23:03:41) 
+    Python 3.3.0 (33.0, default, Feb 17 2012, 23:03:41)
     [GCC 4.6.1]
 
 
@@ -544,7 +544,7 @@ going to ship standard library updates for the next language release in
 definition update, even those changes that are backwards compatible with the
 previously released version of Python.
 
-The community benefits listed in PEP 407 are equally applicable to this PEP, 
+The community benefits listed in PEP 407 are equally applicable to this PEP,
 at least as far as the standard library is concerned:
 
     People who value reactivity and access to new features (without taking the
@@ -662,7 +662,7 @@ new features (most notably standard library updates) into user's hands more
 quickly.
 
 With the standard library release cycle decoupled (to some degree) from that
-of the core language definition, it provides an opportunity to actually 
+of the core language definition, it provides an opportunity to actually
 *slow down* the rate of change in the language definition. The language
 moratorium for Python 3.2 effectively slowed that cycle down to *more than 3
 years* (3.1: June 2009, 3.3: August 2012) without causing any major

--- a/pep-0417.txt
+++ b/pep-0417.txt
@@ -65,7 +65,7 @@ mock 0.8 introduced a new feature, "auto-speccing", obsoletes
 an older mock feature called "mocksignature". The
 "mocksignature" functionality can be removed from mock
 altogether prior to inclusion.
-    
+
 
 References
 ==========

--- a/pep-0423.txt
+++ b/pep-0423.txt
@@ -8,7 +8,7 @@ Status: Deferred
 Type: Informational
 Content-Type: text/x-rst
 Created: 24-May-2012
-Post-History: 
+Post-History:
 
 
 Abstract
@@ -99,7 +99,7 @@ names:
   name`_" rule, and thus make names consistent.
 
 * make it easy to discover and remember your project:
- 
+
   * `use as much memorable names as possible
     <#pick-memorable-names>`_,
   * `use as much meaningful names as possible
@@ -108,7 +108,7 @@ names:
 
 * `avoid deep nesting`_. Flat things are easier to use and remember
   than nested ones:
- 
+
   * one or two namespace levels are recommended, because they are
     almost always enough.
   * even if not recommended, three levels are, de facto, a common
@@ -146,7 +146,7 @@ Ownership could be:
 
 * an organization.
   Examples:
-  
+
   * `zest.releaser`_ is owned and maintained by Zest Software.
   * `Django`_ is owned and maintained by the Django Software
     Fundation.
@@ -801,7 +801,7 @@ References and footnotes:
 .. _`pypi`: http://pypi.python.org
 .. _`collective.recaptcha`:
    http://pypi.python.org/pypi/collective.recaptcha/
-.. _`pipeline`: http://pypi.python.org/pypi/pipeline/ 
+.. _`pipeline`: http://pypi.python.org/pypi/pipeline/
 .. _`python-pipeline`: http://pypi.python.org/pypi/python-pipeline/
 .. _`django-pipeline`: http://pypi.python.org/pypi/django-pipeline/
 .. _`setup script reference`:

--- a/pep-0431.txt
+++ b/pep-0431.txt
@@ -22,7 +22,7 @@ with ambiguous time specifications during DST changes.
 Withdrawal
 ==========
 
-After lengthy discussion it has turned out that the things I thought was 
+After lengthy discussion it has turned out that the things I thought was
 problem in datetime's implementation are intentional. Those include
 completely ignoring DST transitions when making date time arithmetic.
 That makes the is_dst flags part of this PEP pointless, as they would

--- a/pep-0434.txt
+++ b/pep-0434.txt
@@ -178,9 +178,9 @@ References
 .. [3] Getting Started with Python
    (http://www.python.org/about/gettingstarted/)
 
-.. [4] Batteries Included 
+.. [4] Batteries Included
    (http://docs.python.org/2/tutorial/stdlib.html#batteries-included)
-   
+
 .. [5] IDLE breakpoint facility undocumented, Deily, Ned
    (http://bugs.python.org/issue10405)
 

--- a/pep-0448.txt
+++ b/pep-0448.txt
@@ -191,7 +191,7 @@ over iterables of containers::
 
 This was met with a mix of strong concerns about readability and mild
 support. In order not to disadvantage the less controversial aspects
-of the PEP, this was not accepted with the rest of the proposal. 
+of the PEP, this was not accepted with the rest of the proposal.
 
 Unbracketed comprehensions in function calls, such as ``f(x for x in it)``,
 are already valid.  These could be extended to::

--- a/pep-0450.txt
+++ b/pep-0450.txt
@@ -367,7 +367,7 @@ What Should Be The Name Of The Module?
 Discussion And Resolved Issues
 
     This proposal has been previously discussed here[21].
- 
+
     A number of design issues were resolved during the discussion on
     Python-Ideas and the initial code review.  There was a lot of concern
     about the addition of yet another ``sum`` function to the standard

--- a/pep-0456.txt
+++ b/pep-0456.txt
@@ -54,8 +54,8 @@ This PEP proposes three major changes to the hash code for strings and bytes:
 * The existing FNV code is kept for platforms without a 64-bit data type. The
   algorithm is optimized to process larger chunks per cycle.
 
-* Calculation of the hash of strings and bytes is moved into a single API 
-  function instead of multiple specialized implementations in 
+* Calculation of the hash of strings and bytes is moved into a single API
+  function instead of multiple specialized implementations in
   ``Objects/object.c`` and ``Objects/unicodeobject.c``. The function takes a
   void pointer plus length and returns the hash for it.
 

--- a/pep-0457.txt
+++ b/pep-0457.txt
@@ -295,10 +295,10 @@ Nick Coghlan. (Conversation in person at PyCon US 2013.)
 
 .. [#DICT]
     http://docs.python.org/3/library/stdtypes.html#dict
-    
+
 .. [#RANGE]
     http://docs.python.org/3/library/functions.html#func-range
-    
+
 .. [#BORDER]
     http://docs.python.org/3/library/curses.html#curses.window.border
 

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -153,12 +153,12 @@ Terms used in this PEP are defined as follows:
 
 * Simple index: The HTML page that contains internal links to the
   distributions of a project [17]_.
-  
-* Roles: There is one *root* role in PyPI.  There are multiple roles whose      
-  responsibilities are delegated to them directly or indirectly by the *root*   
-  role. The term top-level role refers to the *root* role and any role          
-  delegated by the *root* role. Each role has a single metadata file that it is 
-  trusted to provide.          
+
+* Roles: There is one *root* role in PyPI.  There are multiple roles whose
+  responsibilities are delegated to them directly or indirectly by the *root*
+  role. The term top-level role refers to the *root* role and any role
+  delegated by the *root* role. Each role has a single metadata file that it is
+  trusted to provide.
 
 * Metadata: Metadata are signed files that describe roles, other metadata, and
   target files.
@@ -173,7 +173,7 @@ Terms used in this PEP are defined as follows:
 * The *snapshot* (*release*) role: In order to prevent confusion due to the
   different meanings of the term "release" used in PEP 426 [17]_ and the TUF
   specification [16]_, the *release* role is renamed as the *snapshot* role.
-  
+
 * Developer: Either the owner or maintainer of a project who is allowed to
   update the TUF metadata as well as distribution metadata and files for the
   project.
@@ -386,7 +386,7 @@ This level of security prevents projects from being accidentally or
 deliberately tampered with by a mirror or a CDN because the mirror or CDN will
 not have any of the keys required to sign for projects.  However, it does not
 protect projects from attackers who have compromised PyPI, since attackers can
-manipulate TUF metadata using the keys stored online.   
+manipulate TUF metadata using the keys stored online.
 
 This PEP proposes that the *bins* role (and its delegated roles) sign for all
 PyPI projects with an online key.  The *targets* role, which only signs with an
@@ -576,7 +576,7 @@ produce consistent snapshots. There are two important reasons for why this PEP
 proposes the simple solution.  First, the solution does not mandate that PyPI
 use any particular file system or tool.  Second, the generic file-system based
 approach allows mirrors to use extant file transfer tools such as rsync to
-efficiently transfer consistent snapshots from PyPI. 
+efficiently transfer consistent snapshots from PyPI.
 
 
 Producing Consistent Snapshots
@@ -1021,7 +1021,7 @@ projects hosted externally:
     the maximum security model) about the distributions that they host
     externally, and a developer public key.  Package managers verify
     distributions by consulting the signed metadata uploaded to PyPI.
-    
+
 Only one of the options listed above should be implemented on PyPI.  Option
 (4) or (5) is RECOMMENDED because external distributions are signed by
 developers. External distributions that are forged (due to a compromised

--- a/pep-0472.txt
+++ b/pep-0472.txt
@@ -2,7 +2,7 @@ PEP: 472
 Title: Support for indexing with keyword arguments
 Version: $Revision$
 Last-Modified: $Date$
-Author: Stefano Borini, Joseph Martinot-Lagarde 
+Author: Stefano Borini, Joseph Martinot-Lagarde
 Discussions-To: python-ideas@python.org
 Status: Draft
 Type: Standards Track
@@ -16,7 +16,7 @@ Abstract
 
 This PEP proposes an extension of the indexing operation to support keyword
 arguments. Notations in the form ``a[K=3,R=2]`` would become legal syntax.
-For future-proofing considerations, ``a[1:2, K=3, R=4]`` are considered and 
+For future-proofing considerations, ``a[1:2, K=3, R=4]`` are considered and
 may be allowed as well, depending on the choice for implementation. In addition
 to a change in the parser, the index protocol (``__getitem__``, ``__setitem__``
 and ``__delitem__``) will also potentially require adaptation.
@@ -53,7 +53,7 @@ keyword arguments in the indexing operation, e.g.
 
     >>> a[K=3, R=2]
 
-which would allow to refer to axes by conventional names. 
+which would allow to refer to axes by conventional names.
 
 One must additionally consider the extended form that allows both positional
 and keyword specification
@@ -79,7 +79,7 @@ keyworded specification: Indexing and contextual option. For indexing:
      >>> rain[time=0:12, location=location]
 
 2. In some domain, such as computational physics and chemistry, the use of a
-   notation such as ``Basis[Z=5]`` is a Domain Specific Language notation to represent 
+   notation such as ``Basis[Z=5]`` is a Domain Specific Language notation to represent
    a level of accuracy
 
    ::
@@ -89,11 +89,11 @@ keyworded specification: Indexing and contextual option. For indexing:
    In this case, the index operation would return a basis set at the chosen level
    of accuracy (represented by the parameter Z). The reason behind an indexing is that
    the BasisSet object could be internally represented as a numeric table, where
-   rows (the "coefficient" axis, hidden to the user in this example) are associated 
+   rows (the "coefficient" axis, hidden to the user in this example) are associated
    to individual elements (e.g. row 0:5 contains coefficients for element 1,
    row 5:8 coefficients for element 2) and each column is associated to a given
    degree of accuracy ("accuracy" or "Z" axis) so that first column is low
-   accuracy, second column is medium accuracy and so on. With that indexing, 
+   accuracy, second column is medium accuracy and so on. With that indexing,
    the user would obtain another object representing the contents of the column
    of the internal table for accuracy level 3.
 
@@ -108,7 +108,7 @@ the indexing. Specifically:
      >>> lst = [1, 2, 3]
      >>> value = lst[5, default=0]  # value is 0
 
-2. For a sparse dataset, to specify an interpolation strategy 
+2. For a sparse dataset, to specify an interpolation strategy
    to infer a missing point from e.g. its surrounding data.
 
    ::
@@ -121,7 +121,7 @@ the indexing. Specifically:
 
      >>> value = array[1, 3, unit="degrees"]
 
-How the notation is interpreted is up to the implementing class. 
+How the notation is interpreted is up to the implementing class.
 
 Current implementation
 ======================
@@ -136,9 +136,9 @@ When an indexing operation is performed, ``__getitem__(self, idx)`` is called.
 Traditionally, the full content between square brackets is turned into a single
 object passed to argument ``idx``:
 
-- When a single element is passed, e.g. ``a[2]``, ``idx`` will be ``2``. 
+- When a single element is passed, e.g. ``a[2]``, ``idx`` will be ``2``.
 - When multiple elements are passed, they must be separated by commas: ``a[2, 3]``.
-  In this case, ``idx`` will be a tuple ``(2, 3)``. With ``a[2, 3, "hello", {}]`` 
+  In this case, ``idx`` will be a tuple ``(2, 3)``. With ``a[2, 3, "hello", {}]``
   ``idx`` will be ``(2, 3, "hello", {})``.
 - A slicing notation e.g. ``a[2:10]`` will produce a slice object, or a tuple
   containing slice objects if multiple values were passed.
@@ -163,7 +163,7 @@ to be addressed
 ::
 
     C0. a[1]; a[1,2]         # Traditional indexing
-    C1. a[Z=3] 
+    C1. a[Z=3]
     C2. a[Z=3, R=4]
     C3. a[1, Z=3]
     C4. a[1, Z=3, R=4]
@@ -199,8 +199,8 @@ Pros
   a plain set of values separated by commas. In the second, we are specifying a
   dictionary, so we are specifying a homogeneous set of key/value pairs, as
   in ``dict(Z=3, R=4)``;
-- Simple and easy to parse on the ``__getitem__`` side: if it gets a tuple, 
-  determine the axes using positioning. If it gets a dictionary, use 
+- Simple and easy to parse on the ``__getitem__`` side: if it gets a tuple,
+  determine the axes using positioning. If it gets a dictionary, use
   the keywords.
 - C interface does not need changes.
 
@@ -216,7 +216,7 @@ Cons
 - Very strict.
 - Destroys ordering of the passed arguments. Preserving the
   order would be possible with an OrderedDict as drafted by PEP-468 [#PEP-468]_.
-- Does not allow use cases with mixed positional/keyword arguments such as 
+- Does not allow use cases with mixed positional/keyword arguments such as
   ``a[1, 2, default=5]``.
 
 Strategy "mixed dictionary"
@@ -259,11 +259,11 @@ underscore followed by their order:
     C0. a[1]; a[1,2]      -> idx = 1; idx = (_0=1, _1=2)
     C1. a[Z=3]            -> idx = (Z=3)
     C2. a[Z=3, R=2]       -> idx = (Z=3, R=2)
-    C3. a[1, Z=3]         -> idx = (_0=1, Z=3) 
+    C3. a[1, Z=3]         -> idx = (_0=1, Z=3)
     C4. a[1, Z=3, R=2]    -> idx = (_0=1, Z=3, R=2)
     C5. a[1, 2, Z=3]      -> idx = (_0=1, _2=2, Z=3)
     C6. a[1, 2, Z=3, R=4] -> (_0=1, _1=2, Z=3, R=4)
-    C7. a[1, Z=3, 2, R=4] -> (_0=1, Z=3, _1=2, R=4) 
+    C7. a[1, Z=3, 2, R=4] -> (_0=1, Z=3, _1=2, R=4)
                           or (_0=1, Z=3, _2=2, R=4)
                           or raise SyntaxError
 
@@ -271,15 +271,15 @@ The required typename of the namedtuple could be ``Index`` or the name of the
 argument in the function definition, it keeps the ordering and is easy to
 analyse by using the ``_fields`` attribute. It is backward compatible, provided
 that C0 with more than one entry now passes a namedtuple instead of a plain
-tuple. 
+tuple.
 
-Pros 
+Pros
 ''''
 - Looks nice. namedtuple transparently replaces tuple and gracefully
   degrades to the old behavior.
 - Does not require a change in the C interface
 
-Cons 
+Cons
 ''''
 - According to some sources [#namedtuple]_ namedtuple is not well developed.
   To include it as such important object would probably require rework
@@ -294,7 +294,7 @@ Cons
   in the "collections" module in the standard library.
 - Differently from a function, the two notations ``gridValues[x=3, y=5, z=8]``
   and ``gridValues[3,5,8]`` would not gracefully match if the order is modified
-  at call time (e.g. we ask for ``gridValues[y=5, z=8, x=3])``. In a function, 
+  at call time (e.g. we ask for ``gridValues[y=5, z=8, x=3])``. In a function,
   we can pre-define argument names so that keyword arguments are properly
   matched. Not so in ``__getitem__``, leaving the task for interpreting and
   matching to ``__getitem__`` itself.
@@ -304,19 +304,19 @@ Strategy "New argument contents"
 --------------------------------
 
 In the current implementation, when many arguments are passed to ``__getitem__``,
-they are grouped in a tuple and this tuple is passed to ``__getitem__`` as the 
+they are grouped in a tuple and this tuple is passed to ``__getitem__`` as the
 single argument ``idx``. This strategy keeps the current signature, but expands the
-range of variability in type and contents of ``idx`` to more complex representations. 
+range of variability in type and contents of ``idx`` to more complex representations.
 
 We identify four possible ways to implement this strategy:
 
-- **P1**: uses a single dictionary for the keyword arguments. 
+- **P1**: uses a single dictionary for the keyword arguments.
 - **P2**: uses individual single-item dictionaries.
 - **P3**: similar to **P2**, but replaces single-item dictionaries with a ``(key, value)`` tuple.
 - **P4**: similar to **P2**, but uses a special and additional new object: ``keyword()``
 
-Some of these possibilities lead to degenerate notations, i.e. indistinguishable 
-from an already possible representation. Once again, the proposed notation 
+Some of these possibilities lead to degenerate notations, i.e. indistinguishable
+from an already possible representation. Once again, the proposed notation
 becomes syntactic sugar for these representations.
 
 Under this strategy, the old behavior for C0 is unchanged.
@@ -326,15 +326,15 @@ Under this strategy, the old behavior for C0 is unchanged.
     C0: a[1]        -> idx = 1                    # integer
         a[1,2]      -> idx = (1,2)                # tuple
 
-In C1, we can use either a dictionary or a tuple to represent key and value pair 
-for the specific indexing entry. We need to have a tuple with a tuple in C1 
-because otherwise we cannot differentiate ``a["Z", 3]`` from ``a[Z=3]``. 
+In C1, we can use either a dictionary or a tuple to represent key and value pair
+for the specific indexing entry. We need to have a tuple with a tuple in C1
+because otherwise we cannot differentiate ``a["Z", 3]`` from ``a[Z=3]``.
 
 ::
 
     C1: a[Z=3]      -> idx = {"Z": 3}             # P1/P2 dictionary with single key
-                    or idx = (("Z", 3),)          # P3 tuple of tuples 
-                    or idx = keyword("Z", 3)      # P4 keyword object 
+                    or idx = (("Z", 3),)          # P3 tuple of tuples
+                    or idx = keyword("Z", 3)      # P4 keyword object
 
 As you can see, notation P1/P2 implies that ``a[Z=3]`` and ``a[{"Z": 3}]`` will
 call ``__getitem__`` passing the exact same value, and is therefore syntactic
@@ -345,10 +345,10 @@ For the C2 case:
 
 ::
 
-    C2. a[Z=3, R=4] -> idx = {"Z": 3, "R": 4}     # P1 dictionary/ordereddict 
-                    or idx = ({"Z": 3}, {"R": 4}) # P2 tuple of two single-key dict 
-                    or idx = (("Z", 3), ("R", 4)) # P3 tuple of tuples 
-                    or idx = (keyword("Z", 3), 
+    C2. a[Z=3, R=4] -> idx = {"Z": 3, "R": 4}     # P1 dictionary/ordereddict
+                    or idx = ({"Z": 3}, {"R": 4}) # P2 tuple of two single-key dict
+                    or idx = (("Z", 3), ("R", 4)) # P3 tuple of tuples
+                    or idx = (keyword("Z", 3),
                               keyword("R", 4) )   # P4 keyword objects
 
 
@@ -364,43 +364,43 @@ The remaining cases are here shown:
     C3. a[1, Z=3]   -> idx = (1, {"Z": 3})                     # P1/P2
                     or idx = (1, ("Z", 3))                     # P3
                     or idx = (1, keyword("Z", 3))              # P4
-                    
+
     C4. a[1, Z=3, R=4] -> idx = (1, {"Z": 3, "R": 4})          # P1
                        or idx = (1, {"Z": 3}, {"R": 4})        # P2
                        or idx = (1, ("Z", 3), ("R", 4))        # P3
-                       or idx = (1, keyword("Z", 3),         
+                       or idx = (1, keyword("Z", 3),
                                     keyword("R", 4))           # P4
-                           
-    C5. a[1, 2, Z=3]   -> idx = (1, 2, {"Z": 3})               # P1/P2 
+
+    C5. a[1, 2, Z=3]   -> idx = (1, 2, {"Z": 3})               # P1/P2
                        or idx = (1, 2, ("Z", 3))               # P3
                        or idx = (1, 2, keyword("Z", 3))        # P4
-                           
+
     C6. a[1, 2, Z=3, R=4] -> idx = (1, 2, {"Z":3, "R": 4})     # P1
                           or idx = (1, 2, {"Z": 3}, {"R": 4})  # P2
                           or idx = (1, 2, ("Z", 3), ("R", 4))  # P3
-                          or idx = (1, 2, keyword("Z", 3), 
+                          or idx = (1, 2, keyword("Z", 3),
                                           keyword("R", 4))     # P4
-                              
+
     C7. a[1, Z=3, 2, R=4] -> idx = (1, 2, {"Z": 3, "R": 4})    # P1. Pack the keyword arguments. Ugly.
                           or raise SyntaxError                 # P1. Same behavior as in function calls.
                           or idx = (1, {"Z": 3}, 2, {"R": 4})  # P2
                           or idx =  (1, ("Z", 3), 2, ("R", 4)) # P3
-                          or idx =  (1, keyword("Z", 3), 
+                          or idx =  (1, keyword("Z", 3),
                                      2, keyword("R", 4))       # P4
 
 Pros
-'''' 
-- Signature is unchanged; 
-- P2/P3 can preserve ordering of keyword arguments as specified at indexing, 
-- P1 needs an OrderedDict, but would destroy interposed ordering if allowed: 
+''''
+- Signature is unchanged;
+- P2/P3 can preserve ordering of keyword arguments as specified at indexing,
+- P1 needs an OrderedDict, but would destroy interposed ordering if allowed:
   all keyword indexes would be dumped into the dictionary;
 - Stays within traditional types: tuples and dicts. Evt. OrderedDict;
 - Some proposed strategies are similar in behavior to a traditional function call;
 - The C interface for ``PyObject_GetItem`` and family would remain unchanged.
 
 Cons
-'''' 
-- Apparenty complex and wasteful; 
+''''
+- Apparenty complex and wasteful;
 - Degeneracy in notation (e.g. ``a[Z=3]`` and ``a[{"Z":3}]`` are equivalent and
   indistinguishable notations at the ``__[get|set|del]item__`` level).
   This behavior may or may not be acceptable.
@@ -409,22 +409,22 @@ Cons
 - ``idx`` type and layout seems to change depending on the whims of the caller;
 - May be complex to parse what is passed, especially in the case of tuple of tuples;
 - P2 Creates a lot of single keys dictionary as members of a tuple. Looks ugly.
-  P3 would be lighter and easier to use than the tuple of dicts, and still 
-  preserves order (unlike the regular dict), but would result in clumsy 
+  P3 would be lighter and easier to use than the tuple of dicts, and still
+  preserves order (unlike the regular dict), but would result in clumsy
   extraction of keywords.
 
 Strategy "kwargs argument"
 ---------------------------
 
-``__getitem__`` accepts an optional ``**kwargs`` argument which should be keyword only. 
+``__getitem__`` accepts an optional ``**kwargs`` argument which should be keyword only.
 ``idx`` also becomes optional to support a case where no non-keyword arguments are allowed.
-The signature would then be either 
+The signature would then be either
 
 ::
 
-    __getitem__(self, idx) 
+    __getitem__(self, idx)
     __getitem__(self, idx, **kwargs)
-    __getitem__(self, **kwargs) 
+    __getitem__(self, **kwargs)
 
 Applied to our cases would produce:
 
@@ -434,7 +434,7 @@ Applied to our cases would produce:
     C1. a[Z=3]            -> idx=None ;  kwargs={"Z":3}
     C2. a[Z=3, R=4]       -> idx=None ;  kwargs={"Z":3, "R":4}
     C3. a[1, Z=3]         -> idx=1    ;  kwargs={"Z":3}
-    C4. a[1, Z=3, R=4]    -> idx=1    ;  kwargs={"Z":3, "R":4} 
+    C4. a[1, Z=3, R=4]    -> idx=1    ;  kwargs={"Z":3, "R":4}
     C5. a[1, 2, Z=3]      -> idx=(1,2);  kwargs={"Z":3}
     C6. a[1, 2, Z=3, R=4] -> idx=(1,2);  kwargs={"Z":3, "R":4}
     C7. a[1, Z=3, 2, R=4] -> raise SyntaxError # in agreement to function behavior
@@ -442,14 +442,14 @@ Applied to our cases would produce:
 Empty indexing ``a[]`` of course remains invalid syntax.
 
 Pros
-'''' 
+''''
 - Similar to function call, evolves naturally from it;
 - Use of keyword indexing with an object whose ``__getitem__``
   doesn't have a kwargs will fail in an obvious way.
   That's not the case for the other strategies.
 
 Cons
-'''' 
+''''
 - It doesn't preserve order, unless an OrderedDict is used;
 - Forbids C7, but is it really needed?
 - Requires a change in the C interface to pass an additional
@@ -459,12 +459,12 @@ Cons
 C interface
 ===========
 
-As briefly introduced in the previous analysis, the C interface would 
+As briefly introduced in the previous analysis, the C interface would
 potentially have to change to allow the new feature. Specifically,
-``PyObject_GetItem`` and related routines would have to accept an additional 
+``PyObject_GetItem`` and related routines would have to accept an additional
 ``PyObject *kw`` argument for Strategy "kwargs argument". The remaining
 strategies would not require a change in the C function signatures, but the
-different nature of the passed object would potentially require adaptation. 
+different nature of the passed object would potentially require adaptation.
 
 Strategy "named tuple" would behave correctly without any change: the class
 returned by the factory method in collections returns a subclass of tuple,
@@ -482,7 +482,7 @@ Use a method
 One could keep the indexing as is, and use a traditional ``get()`` method for those
 cases where basic indexing is not enough. This is a good point, but as already
 reported in the introduction, methods have a different semantic weight from
-indexing, and you can't use slices directly in methods. Compare e.g. 
+indexing, and you can't use slices directly in methods. Compare e.g.
 ``a[1:3, Z=2]`` with ``a.get(slice(1,3), Z=2)``.
 
 The authors however recognize this argument as compelling, and the advantage
@@ -502,17 +502,17 @@ objects for the keys), and accept to use ":" instead of "=".
     slice('K', 3, None)
     >>> a["K":3, "R":4]
     (slice('K', 3, None), slice('R', 4, None))
-    >>> 
+    >>>
 
 While clearly smart, this approach does not allow easy inquire of the key/value
 pair, it's too clever and esotheric, and does not allow to pass a slice as in
 ``a[K=1:10:2]``.
 
-However, Tim Delaney comments 
+However, Tim Delaney comments
 
-    "I really do think that ``a[b=c, d=e]`` should just be syntax sugar for 
-    ``a['b':c, 'd':e]``. It's simple to explain, and gives the greatest backwards 
-    compatibility. In particular, libraries that already abused slices in this 
+    "I really do think that ``a[b=c, d=e]`` should just be syntax sugar for
+    ``a['b':c, 'd':e]``. It's simple to explain, and gives the greatest backwards
+    compatibility. In particular, libraries that already abused slices in this
     way will just continue to work with the new syntax."
 
 We think this behavior would produce inconvenient results. The library Pandas uses
@@ -543,7 +543,7 @@ this notation, although less elegant, can already be used and achieves similar
 results. It's evident that the proposed Strategy "New argument contents" can be
 interpreted as syntactic sugar for this notation.
 
-Additional Comments 
+Additional Comments
 ===================
 
 Commenters also expressed the following relevant points:
@@ -563,7 +563,7 @@ Need for homogeneity of behavior
 --------------------------------
 
 Relative to Strategy "New argument contents", a comment from Ian Cordasco
-points out that 
+points out that
 
     "it would be unreasonable for just one method to behave totally
     differently from the standard behaviour in Python.  It would be confusing for
@@ -573,7 +573,7 @@ points out that
     be pointed out that ``__getitem__`` is already special in some regards when it
     comes to passed arguments.
 
-Chris Angelico also states: 
+Chris Angelico also states:
 
     "it seems very odd to start out by saying "here, let's give indexing the
     option to carry keyword args, just like with function calls", and then come
@@ -587,25 +587,25 @@ strategy is worth of implementation. It is non-ambiguous, simple, does not
 force complex parsing, and addresses the problem of referring to axes either
 by position or by name. The "options" use case is probably best handled with
 a different approach, and may be irrelevant for this PEP. The alternative
-"named tuple" is another valid choice. 
+"named tuple" is another valid choice.
 
 Having .get() become obsolete for indexing with default fallback
 ----------------------------------------------------------------
 
 Introducing a "default" keyword could make ``dict.get()`` obsolete, which would be
-replaced by ``d["key", default=3]``. Chris Angelico however states: 
+replaced by ``d["key", default=3]``. Chris Angelico however states:
 
     "Currently, you need to write ``__getitem__`` (which raises an exception on
     finding a problem) plus something else, e.g. ``get()``, which returns a default
     instead. By your proposal, both branches would go inside ``__getitem__``, which
-    means they could share code; but there still need to be two branches." 
+    means they could share code; but there still need to be two branches."
 
-Additionally, Chris continues: 
+Additionally, Chris continues:
 
     "There'll be an ad-hoc and fairly arbitrary puddle of names (some will go
     ``default=``, others will say that's way too long and go ``def=``, except that
     that's a keyword so they'll use ``dflt=`` or something...), unless there's a
-    strong force pushing people to one consistent name.". 
+    strong force pushing people to one consistent name.".
 
 This argument is valid but it's equally valid for any function call, and is
 generally fixed by established convention and documentation.
@@ -617,7 +617,7 @@ User Drekin commented: "The case of ``a[Z=3]`` and ``a[{"Z": 3}]`` is similar to
 current ``a[1, 2]`` and ``a[(1, 2)]``.  Even though one may argue that the parentheses
 are actually not part of tuple notation but are just needed because of syntax,
 it may look as degeneracy of notation when compared to function call: ``f(1, 2)``
-is not the same thing as ``f((1, 2))``.". 
+is not the same thing as ``f((1, 2))``.".
 
 References
 ==========
@@ -634,9 +634,9 @@ References
 .. [#namedtuple] "namedtuple is not as good as it should be"
        (https://mail.python.org/pipermail/python-ideas/2013-June/021257.html)
 
-.. [#PEP-468] "Preserving the order of \*\*kwargs in a function." 
+.. [#PEP-468] "Preserving the order of \*\*kwargs in a function."
               http://legacy.python.org/dev/peps/pep-0468/
- 
+
 Copyright
 =========
 

--- a/pep-0480.txt
+++ b/pep-0480.txt
@@ -92,7 +92,7 @@ Attackers are considered successful if they can cause a client to install (or
 leave installed) something other than the most up-to-date version of the
 software the client is updating. When an attacker is preventing the
 installation of updates, the attacker's goal is that clients not realize that
-anything is wrong. 
+anything is wrong.
 
 
 Definitions
@@ -144,10 +144,10 @@ Terms used in this PEP are defined as follows:
 * The *snapshot* (*release*) role: In order to prevent confusion due to the
   different meanings of the term "release" used in PEP 426 [1]_ and the TUF
   specification [3]_, the *release* role is renamed to the *snapshot* role.
-  
+
 * Developer: Either the owner or maintainer of a project who is allowed to
   update TUF metadata, as well as distribution metadata and files for a given
-  project. 
+  project.
 
 * Online key: A private cryptographic key that MUST be stored on the PyPI
   server infrastructure.  This usually allows automated signing with the key.
@@ -288,7 +288,7 @@ performed in Python.
 __ https://github.com/pyca/ed25519
 
 
-Cryptographic Key Files 
+Cryptographic Key Files
 -----------------------
 
 The implementation MAY encrypt key files with AES-256-CTR-Mode and strengthen
@@ -682,8 +682,8 @@ attacks, or metadata inconsistency attacks.
 | *OR*              |                   | project, or unclaimed | project, or unclaimed |
 | unclaimed)        |                   | metadata expiry time  | metadata expiry time  |
 +-------------------+-------------------+-----------------------+-----------------------+
-| (timestamp        |                   | YES                   | YES                   | 
-| *AND*             |                   | limited by earliest   | limited by earliest   |   
+| (timestamp        |                   | YES                   | YES                   |
+| *AND*             |                   | limited by earliest   | limited by earliest   |
 | snapshot)         |                   | root, targets,        | root, targets,        |
 | *AND*             | YES               | claimed,              | claimed,              |
 | (targets *OR*     |                   | recently-claimed,     | recently-claimed,     |
@@ -785,7 +785,7 @@ steps taken when either the *timestamp* or *snapshot* keys are compromised:
 
 1.  Revoke the *claimed* role keys from the targets role and replace them with
     newly issued keys.
-    
+
 2.  All project targets of the claimed roles SHOULD be compared with the last
     known good consistent snapshot where none of the *timestamp*, *snapshot*,
     or *claimed* keys were known to have been compromised.  Added, updated, or

--- a/pep-0487.txt
+++ b/pep-0487.txt
@@ -119,16 +119,16 @@ referenced values::
         # this is the new initializer:
         def __set_name__(self, owner, name):
             self.name = name
-            
+
 Such a ``WeakAttribute`` may, for example, be used in a tree structure
 where one wants to avoid cyclic references via the parent::
 
     class TreeNode:
         parent = WeakAttribute()
-        
+
         def __init__(self, parent):
             self.parent = parent
-            
+
 Note that the ``parent`` attribute is used like a normal attribute,
 yet the tree contains no cyclic references and can thus be easily
 garbage collected when out of use. The ``parent`` attribute magically
@@ -358,17 +358,17 @@ Only defining an ``__init__`` method in a metaclass continues to fail with
 
 Defining both ``__init__`` and ``__new__`` continues to work fine.
 
-About the only thing that stops working is passing the arguments of 
+About the only thing that stops working is passing the arguments of
 ``type.__new__`` as keyword arguments::
 
     class MyMeta(type):
         def __new__(cls, name, bases, namespace):
             return super().__new__(cls, name=name, bases=bases,
                                    dict=namespace)
-                                   
+
     class MyClass(metaclass=MyMeta):
         pass
-       
+
 This will now raise ``TypeError``, but this is weird code, and easy
 to fix even if someone used this feature.
 

--- a/pep-0491.txt
+++ b/pep-0491.txt
@@ -12,7 +12,7 @@ Created: 16 April 2015
 Abstract
 ========
 
-This PEP describes the second version of a built-package format for Python 
+This PEP describes the second version of a built-package format for Python
 called "wheel".  Wheel provides a Python-specific, relocatable package format
 that allows people to install software more quickly and predictably than
 re-building from source each time.
@@ -24,14 +24,14 @@ scheme.  Simple wheels can be unpacked onto ``sys.path`` and used directly
 but wheels are usually installed with a specialized installer.
 
 This version of the wheel specification adds support for installing
-distributions into many different directories, and adds a way to find 
+distributions into many different directories, and adds a way to find
 those files after they have been installed.
 
 Rationale
 =========
 
-Wheel 1.0 is best at installing files into ``site-packages`` and a few 
-other locations specified by distutils, but users would like to install 
+Wheel 1.0 is best at installing files into ``site-packages`` and a few
+other locations specified by distutils, but users would like to install
 files from single distribution into many directories -- perhaps separate
 locations for docs, data, and code.  Unfortunately not everyone agrees
 on where these install locations should be relative to the root directory.
@@ -93,9 +93,9 @@ Rewrite ``#!python``.
     a GUI script instead of a console script.
 
 Generate script wrappers.
-    Python scripts are more commonly represented as a ``module:callable`` 
-    string in package metadata, and are not included verbatim in the wheel 
-    archive's ``scripts`` directory.  This kind of script gives the installer 
+    Python scripts are more commonly represented as a ``module:callable``
+    string in package metadata, and are not included verbatim in the wheel
+    archive's ``scripts`` directory.  This kind of script gives the installer
     an opportunity to generate platform specific wrappers.
 
 Recommended archiver features
@@ -156,7 +156,7 @@ non-alphanumeric characters with an underscore ``_``::
     re.sub("[^\w\d.]+", "_", distribution, re.UNICODE)
 
 The archive filename is Unicode.  The packaging tools may only support
-ASCII package names, but Unicode filenames are supported in this 
+ASCII package names, but Unicode filenames are supported in this
 specification.
 
 The filenames *inside* the archive are encoded as UTF-8.  Although some
@@ -208,7 +208,7 @@ its version, e.g. ``1.0.0``, consist of:
 #. ``Build`` is the build number and is omitted if there is no build number.
 #. ``Install-Paths-To`` is a location *relative to the archive* that will be
    overwritten with the install-time paths of each category in the install
-   scheme.  See the install paths section.  May appear 0 or more times.  
+   scheme.  See the install paths section.  May appear 0 or more times.
 #. A wheel installer should warn if Wheel-Version is greater than the
    version it supports, and must fail if Wheel-Version has a greater
    major version than the version it supports.
@@ -256,8 +256,8 @@ The .data directory contains subdirectories with the scripts, headers,
 documentation and so forth from the distribution.  During installation the
 contents of these subdirectories are moved onto their destination paths.
 
-If a subdirectory is not found in the install scheme, the installer should 
-emit a warning, and it should be installed at ``distribution-1.0.data/...`` 
+If a subdirectory is not found in the install scheme, the installer should
+emit a warning, and it should be installed at ``distribution-1.0.data/...``
 as if the package was unpacked by a standard unzip tool.
 
 Install paths
@@ -268,7 +268,7 @@ categories based on GNU autotools.  This expanded scheme should help installers
 to implement system policy, but installers may root each category at any
 location.
 
-A UNIX install scheme might map the categories to their installation patnhs 
+A UNIX install scheme might map the categories to their installation patnhs
 like this::
 
     {
@@ -305,12 +305,12 @@ If the ``WHEEL`` metadata contains these files:
 
    Install-Paths-To: wheel/_paths.py
    Install-Paths-To: wheel/_paths.json
-   
+
 Then the wheel installer, when it is about to unpack ``wheel/_paths.py`` from
 the archive, replaces it with the actual paths used at install time.  The
-paths may be absolute or relative to the generated file.  
+paths may be absolute or relative to the generated file.
 
-If the filename ends with ``.py`` then a Python script is written.  The 
+If the filename ends with ``.py`` then a Python script is written.  The
 script MUST be executed to get the paths, but it will probably look like
 this::
 
@@ -324,12 +324,12 @@ this::
 If the filename ends with ``.json`` then a JSON document is written::
 
     { "data": "../wheel-0.26.0.dev1.data/data", ... }
-    
+
 Only the categories actually used by a particular wheel must be written to
 this file.
 
 These files are designed to be written to a location that can be found by the
-installed package without introducing any dependency on a packaging library.  
+installed package without introducing any dependency on a packaging library.
 
 
 Signed wheel files

--- a/pep-0497.txt
+++ b/pep-0497.txt
@@ -250,7 +250,7 @@ bandwidth to implement / maintain the additional complexity!
 A2: Python-dev can ask the community of developers to step up and
 maintain backward compatibility in Python for legacy language features
 they care about. When the community stops caring about a particular
-obsolete behaviour, Python-dev can stop caring too. 
+obsolete behaviour, Python-dev can stop caring too.
 
 The ``__past__`` mechanism could possibly be designed to be extensible
 by the community, e.g.  as a standard but "blessed" PyPI package, to

--- a/pep-0500.txt
+++ b/pep-0500.txt
@@ -82,7 +82,7 @@ Subtraction of timedelta
 A ``tzinfo`` subclass supporting the PDDM, may define a method called
 ``__datetime_sub__`` that should take two arguments--a datetime and a
 timedelta instances--and return a datetime instance.
- 
+
 
 Formatting
 ----------

--- a/pep-0506.txt
+++ b/pep-0506.txt
@@ -314,7 +314,7 @@ Frequently Asked Questions
   state of MT [#]_ [#]_ and so predict all past and future values.  There
   are a number of known, practical attacks on systems using MT for
   randomness [#]_.
-  
+
 * Q: Attacks on PHP are one thing, but are there any known attacks on
   Python software?
 

--- a/pep-0512.txt
+++ b/pep-0512.txt
@@ -12,7 +12,7 @@ Post-History: 17-Jan-2016, 19-Jan-2016, 23-Jan-2016
 
 
 .. note::
-   
+
    CPython's development process moved to https://github.com/python/cpython
    on 2017-02-10.
 

--- a/pep-0514.txt
+++ b/pep-0514.txt
@@ -429,7 +429,7 @@ do not have any default values::
                 # Tools may use alternate approaches to determine architecture when
                 # the registration does not specify it.
                 print('SysArchitecture:', get_value(tag_key, 'SysArchitecture') or '(unknown)')
-            
+
             try:
                 ip_key = winreg.OpenKey(company_key, tag + '\\InstallPath')
             except FileNotFoundError:
@@ -451,7 +451,7 @@ just-for-me install of 64-bit Python 3.6.0. Other keys may also be created::
         (Default) = (value not set)
         DisplayName = "Python Software Foundation"
         SupportUrl = "http://www.python.org/"
-    
+
     HKEY_CURRENT_USER\Software\Python\PythonCore\3.6
         (Default) = (value not set)
         DisplayName = "Python 3.6 (64-bit)"
@@ -459,11 +459,11 @@ just-for-me install of 64-bit Python 3.6.0. Other keys may also be created::
         Version = "3.6.0"
         SysVersion = "3.6"
         SysArchitecture = "64bit"
-    
+
     HKEY_CURRENT_USER\Software\Python\PythonCore\3.6\Help\Main Python Documentation
         (Default) = "C:\Users\Me\AppData\Local\Programs\Python\Python36\Doc\python360.chm"
         DisplayName = "Python 3.6.0 Documentation"
-    
+
     HKEY_CURRENT_USER\Software\Python\PythonCore\3.6\InstallPath
         (Default) = "C:\Users\Me\AppData\Local\Programs\Python\Python36\"
         ExecutablePath = "C:\Users\Me\AppData\Local\Programs\Python\Python36\python.exe"

--- a/pep-0520.txt
+++ b/pep-0520.txt
@@ -135,7 +135,7 @@ Part 2:
   (e.g. ``OrderdDict``)
 * ``cls.__dict__`` does not change, remaining a read-only proxy around
   ``dict``
-  
+
 Note that Python implementations which have an ordered ``dict`` won't
 need to change anything.
 

--- a/pep-0534.txt
+++ b/pep-0534.txt
@@ -10,7 +10,7 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 5-Sep-2016
 Python-Version: 3.7
-Post-History: 
+Post-History:
 
 
 Abstract

--- a/pep-0754.txt
+++ b/pep-0754.txt
@@ -198,7 +198,7 @@ See http://babbage.cs.qc.edu/courses/cs341/IEEE-754references.html for
 reference material on the IEEE 754 floating point standard.
 
 .. [1] Further information on the reference package is available at
-   http://research.warnes.net/projects/rzope/fpconst/ 
+   http://research.warnes.net/projects/rzope/fpconst/
 
 .. [2] http://sourceforge.net/tracker/?func=detail&aid=1151323&group_id=5470&atid=305470
 

--- a/pep-3000.txt
+++ b/pep-3000.txt
@@ -7,7 +7,7 @@ Status: Final
 Type: Process
 Content-Type: text/x-rst
 Created: 05-Apr-2006
-Post-History: 
+Post-History:
 
 
 Abstract

--- a/pep-3099.txt
+++ b/pep-3099.txt
@@ -121,7 +121,7 @@ Core language
    but that doesn't mean they are available for other uses.  Even
    ignoring the backwards compatibility confusion, the character
    itself causes too many problems (in some fonts, on some keyboards,
-   when typesetting a book, etc). 
+   when typesetting a book, etc).
 
    Thread: "new operators via backquoting",
    http://mail.python.org/pipermail/python-ideas/2007-January/000054.html
@@ -176,7 +176,7 @@ Standard types
 
    Thread: "Iterating over a dict",
    http://mail.python.org/pipermail/python-3000/2006-April/000283.html
-   
+
    Thread: have iter(mapping) generate (key, value) pairs
    http://mail.python.org/pipermail/python-3000/2006-June/002368.html
 

--- a/pep-3100.txt
+++ b/pep-3100.txt
@@ -54,7 +54,7 @@ Style changes
 
 * The C style guide will be updated to use 4-space indents, never tabs.
   This style should be used for all new files; existing files can be
-  updated only if there is no hope to ever merge a particular file from 
+  updated only if there is no hope to ever merge a particular file from
   the Python 2 HEAD.  Within a file, the indentation style should be
   consistent.  No other style guide changes are planned ATM.
 
@@ -402,7 +402,7 @@ References
 
 .. [#pep3107] PEP 3107 (Function Annotations)
    http://www.python.org/dev/peps/pep-3107
-   
+
 .. [#pep3110] PEP 3110 (Catching Exceptions in Python 3000)
    http://www.python.org/dev/peps/pep-3110/#semantic-changes
 
@@ -411,10 +411,10 @@ References
 
 .. [#builtins] New name for __builtins__
    http://mail.python.org/pipermail/python-dev/2007-November/075388.html
-   
+
 .. [#exitfunc-patch] Patch to remove sys.exitfunc
    http://www.python.org/sf/1680961
-   
+
 .. [#remove-operator-funcs] Remove deprecated functions from operator
    http://www.python.org/sf/1516309
 

--- a/pep-3101.txt
+++ b/pep-3101.txt
@@ -104,12 +104,12 @@ String Methods
     argument 0 and 'b' is argument 1.  Each keyword argument is
     identified by its keyword name, so in the above example, 'c' is
     used to refer to the third argument.
-    
+
     There is also a global built-in function, 'format' which formats
     a single value:
-    
+
        print(format(10.0, "7.3g"))
-       
+
     This function is described in a later section.
 
 
@@ -282,7 +282,7 @@ Standard Format Specifiers
     'width' is a decimal integer defining the minimum field width.  If
     not specified, then the field width will be determined by the
     content.
-    
+
     If the width field is preceded by a zero ('0') character, this enables
     zero-padding.  This is equivalent to an alignment type of '=' and a
     fill character of '0'.
@@ -294,7 +294,7 @@ Standard Format Specifiers
     the field content.  The precision is ignored for integer conversions.
 
     Finally, the 'type' determines how the data should be presented.
-    
+
     The available integer presentation types are:
 
         'b' - Binary. Outputs the number in base 2.
@@ -364,7 +364,7 @@ Explicit Conversion Flag
 
     In the preceding example, the string "Hello" will be printed, with quotes,
     in a field of at least 20 characters width.
-    
+
     A custom Formatter class can define additional conversion flags.
     The built-in formatter will raise a ValueError if an invalid
     conversion flag is specified.
@@ -376,34 +376,34 @@ Controlling Formatting on a Per-Type Basis
     a __format__ method.  The __format__ method is responsible for
     interpreting the format specifier, formatting the value, and
     returning the resulting string.
-    
+
     The new, global built-in function 'format' simply calls this special
     method, similar to how len() and str() simply call their respective
     special methods:
-    
+
         def format(value, format_spec):
             return value.__format__(format_spec)
-            
+
     It is safe to call this function with a value of "None" (because the
     "None" value in Python is an object and can have methods.)
 
     Several built-in types, including 'str', 'int', 'float', and 'object'
     define __format__ methods.  This means that if you derive from any of
     those types, your class will know how to format itself.
-    
+
     The object.__format__ method is the simplest: It simply converts the
     object to a string, and then calls format again:
-    
+
         class object:
             def __format__(self, format_spec):
                 return format(str(self), format_spec)
-                
+
     The __format__ methods for 'int' and 'float' will do numeric formatting
     based on the format specifier.  In some cases, these formatting
     operations may be delegated to other types.  So for example, in the case
     where the 'int' formatter sees a format type of 'f' (meaning 'float')
     it can simply cast the value to a float and call format() again.
-    
+
     Any class can override the __format__ method to provide custom
     formatting for that type:
 
@@ -417,7 +417,7 @@ Controlling Formatting on a Per-Type Basis
     of the specifiers parameter to determine whether to return a string or
     unicode object.  It is the responsibility of the __format__ method
     to return an object of the proper type.
-    
+
     Note that the 'explicit conversion' flag mentioned above is not passed
     to the __format__ method.  Rather, it is expected that the conversion
     specified by the flag will be performed before calling __format__.
@@ -434,7 +434,7 @@ User-Defined Formatting
     format engine can be obtained through the 'Formatter' class that
     lives in the 'string' module.  This class takes additional options
     which are not accessible via the normal str.format method.
-    
+
     An application can subclass the Formatter class to create its own
     customized formatting behavior.
 
@@ -456,14 +456,14 @@ User-Defined Formatting
 Formatter Methods
 
     The Formatter class takes no initialization arguments:
-    
+
         fmt = Formatter()
 
     The public API methods of class Formatter are as follows:
 
         -- format(format_string, *args, **kwargs)
         -- vformat(format_string, args, kwargs)
-        
+
     'format' is the primary API method.  It takes a format template,
     and an arbitrary set of positional and keyword arguments.
     'format' is just a wrapper that calls 'vformat'.
@@ -478,7 +478,7 @@ Formatter Methods
     below.)
 
     Formatter defines the following overridable methods:
-        
+
         -- get_value(key, args, kwargs)
         -- check_unused_args(used_args, args, kwargs)
         -- format_field(value, format_spec)
@@ -487,15 +487,15 @@ Formatter Methods
     will be either an integer or a string.  If it is an integer, it represents
     the index of the positional argument in 'args'; If it is a string, then
     it represents a named argument in 'kwargs'.
-    
+
     The 'args' parameter is set to the list of positional arguments to
     'vformat', and the 'kwargs' parameter is set to the dictionary of
     positional arguments.
-    
+
     For compound field names, these functions are only called for the
     first component of the field name; subsequent components are handled
     through normal attribute and indexing operations.
-    
+
     So for example, the field expression '0.name' would cause 'get_value'
     to be called with a 'key' argument of 0.  The 'name' attribute will be
     looked up after 'get_value' returns by calling the built-in 'getattr'
@@ -503,7 +503,7 @@ Formatter Methods
 
     If the index or keyword refers to an item that does not exist, then an
     IndexError/KeyError should be raised.
-    
+
     'check_unused_args' is used to implement checking for unused arguments
     if desired.  The arguments to this function is the set of all argument
     keys that were actually referred to in the format string (integers for
@@ -511,38 +511,38 @@ Formatter Methods
     to the args and kwargs that was passed to vformat.  The set of unused
     args can be calculated from these parameters.  'check_unused_args'
     is assumed to throw an exception if the check fails.
-    
+
     'format_field' simply calls the global 'format' built-in.  The method
     is provided so that subclasses can override it.
 
     To get a better understanding of how these functions relate to each
     other, here is pseudocode that explains the general operation of
     vformat.
-    
+
         def vformat(format_string, args, kwargs):
-        
+
           # Output buffer and set of used args
           buffer = StringIO.StringIO()
           used_args = set()
-          
+
           # Tokens are either format fields or literal strings
           for token in self.parse(format_string):
             if is_format_field(token):
               # Split the token into field value and format spec
               field_spec, _, format_spec = token.partition(":")
-              
+
               # Check for explicit type conversion
               explicit, _, field_spec  = field_spec.rpartition("!")
-              
+
               # 'first_part' is the part before the first '.' or '['
               # Assume that 'get_first_part' returns either an int or
               # a string, depending on the syntax.
               first_part = get_first_part(field_spec)
               value = self.get_value(first_part, args, kwargs)
-              
+
               # Record the fact that we used this arg
               used_args.add(first_part)
-              
+
               # Handle [subfield] or .subfield. Assume that 'components'
               # returns an iterator of the various subfields, not including
               # the first part.
@@ -558,13 +558,13 @@ Formatter Methods
               # Call the global 'format' function and write out the converted
               # value.
               buffer.write(self.format_field(value, format_spec))
-              
+
             else:
               buffer.write(token)
-              
+
           self.check_unused_args(used_args, args, kwargs)
           return buffer.getvalue()
-          
+
     Note that the actual algorithm of the Formatter class (which will be
     implemented in C) may not be the one presented here.  (It's likely
     that the actual implementation won't be a 'class' at all - rather,
@@ -724,7 +724,7 @@ Alternate Feature Proposals
     leading underscore, for example "{0}._private".  However, this
     is a useful ability to have when debugging, so the feature
     was dropped.
-    
+
     Some developers suggested that the ability to do 'getattr' and
     'getitem' access should be dropped entirely.  However, this
     is in conflict with the needs of another set of developers who
@@ -732,7 +732,7 @@ Alternate Feature Proposals
     single argument (without flattening it into individual keyword
     arguments using the **kwargs syntax) and then have the format
     string refer to dict entries individually.
-    
+
     There has also been suggestions to expand the set of expressions
     that are allowed in a format string.  However, this was seen
     to go against the spirit of TOOWTDI, since the same effect can
@@ -742,12 +742,12 @@ Alternate Feature Proposals
     formatting in a data-rich environment, it's recommended to use
     a template engine specialized for this purpose, such as
     Genshi [5] or Cheetah [6].
-    
+
     Many other features were considered and rejected because they
     could easily be achieved by subclassing Formatter instead of
     building the feature into the base implementation.  This includes
     alternate syntax, comments in format strings, and many others.
-    
+
 
 Security Considerations
 
@@ -759,7 +759,7 @@ Security Considerations
     The best way to use string formatting in a way that does not
     create potential security holes is to never use format strings
     that come from an untrusted source.
-    
+
     Barring that, the next best approach is to ensure that string
     formatting has no side effects.  Because of the open nature of
     Python, it is impossible to guarantee that any non-trivial
@@ -804,7 +804,7 @@ References
 
     [4] Composite Formatting - [.Net Framework Developer's Guide]
         http://msdn.microsoft.com/library/en-us/cpguide/html/cpconcompositeformatting.asp?frame=true
-        
+
     [5] Genshi templating engine.
         http://genshi.edgewall.org/
 

--- a/pep-3103.txt
+++ b/pep-3103.txt
@@ -510,7 +510,7 @@ like this::
 
     def foo(x, y):
         switch x:
-        case y: 
+        case y:
             print 42
 
 To the untrained eye (not familiar with Python) this code would be

--- a/pep-3104.txt
+++ b/pep-3104.txt
@@ -129,7 +129,7 @@ adopted.  At the time, Guido's response was:
 
 After PEP 227, the "outer name rebinding discussion" has reappeared
 on Python-Dev enough times that it has become a familiar event,
-having recurred in its present form since at least 2003 [2]_.  
+having recurred in its present form since at least 2003 [2]_.
 Although none of the language changes proposed in these discussions
 have yet been adopted, Guido has acknowledged that a language change
 is worth considering [12]_.
@@ -153,7 +153,7 @@ Scheme, all variables must be declared (with ``define`` or ``let``,
 or as formal parameters).  In Smalltalk, any block can begin by
 declaring a list of local variable names between vertical bars.
 C and C# require type declarations for all variables.  For all these
-cases, the variable belongs to the scope containing the declaration. 
+cases, the variable belongs to the scope containing the declaration.
 
 Ruby (as of 1.8)
 ----------------

--- a/pep-3107.txt
+++ b/pep-3107.txt
@@ -49,7 +49,7 @@ what annotations are and are not:
 
    By itself, Python does not attach any particular meaning or
    significance to annotations.  Left to its own, Python simply makes
-   these expressions available as described in `Accessing Function 
+   these expressions available as described in `Accessing Function
    Annotations`_ below.
 
    The only way that annotations take on meaning is when they are
@@ -91,7 +91,7 @@ follow the parameter name::
 
     def foo(a: expression, b: expression = 5):
         ...
-        
+
 In pseudo-grammar, parameters now look like ``identifier [:
 expression] [= expression]``.  That is, annotations always precede a
 parameter's default value and both annotations and default values are
@@ -105,12 +105,12 @@ are indicated similarly::
 
     def foo(*args: expression, **kwargs: expression):
         ...
-        
+
 Annotations for nested parameters always follow the name of the
 parameter, not the last parenthesis.  Annotating all parameters of a
 nested parameter is not required::
 
-    def foo((x1, y1: expression), 
+    def foo((x1, y1: expression),
             (x2: expression, y2: expression)=(None, None)):
         ...
 
@@ -135,7 +135,7 @@ The grammar for function definitions [#grammar]_ is now::
     funcdef: [decorators] 'def' NAME parameters ['->' test] ':' suite
     parameters: '(' [typedargslist] ')'
     typedargslist: ((tfpdef ['=' test] ',')*
-                    ('*' [tname] (',' tname ['=' test])* [',' '**' tname] 
+                    ('*' [tname] (',' tname ['=' test])* [',' '**' tname]
                      | '**' tname)
                     | tfpdef ['=' test] (',' tfpdef ['=' test])* [','])
     tname: NAME [':' test]
@@ -159,7 +159,7 @@ Accessing Function Annotations
 ==============================
 
 Once compiled, a function's annotations are available via the
-function's ``func_annotations`` attribute.  This attribute is 
+function's ``func_annotations`` attribute.  This attribute is
 a mutable dictionary, mapping parameter names to an object
 representing the evaluated annotation expression
 
@@ -205,7 +205,7 @@ products and packages that could make use of annotations.
   + Predicate logic functions
   + Database query mapping
   + RPC parameter marshaling ([#rpyc]_)
-  
+
 * Other information
 
   + Documentation for parameters and return values ([#pydoc]_)
@@ -235,7 +235,7 @@ The ``Parameter`` object may change or other changes may be warranted.
 Implementation
 ==============
 
-A reference implementation has been checked into the py3k (formerly 
+A reference implementation has been checked into the py3k (formerly
 "p3yk") branch as revision 53170 [#implementation]_.
 
 
@@ -255,7 +255,7 @@ Rejected Proposals
   parameterisation syntax, it was decided that this should also be
   left to third-party libraries.  ([#threadimmlist]_,
   [#threadmixing]_, [#emphasistpls]_).
-  
+
 + Despite yet more discussion, it was decided not to standardize
   a mechanism for annotation interoperability.  Standardizing
   interoperability conventions at this point would be premature.
@@ -297,7 +297,7 @@ References and Footnotes
 
 .. [#implementation]
    http://svn.python.org/view?rev=53170&view=rev
-   
+
 .. [#grammar]
    http://docs.python.org/reference/compound_stmts.html#function-definitions
 
@@ -306,10 +306,10 @@ References and Footnotes
 
 .. [#pep-362]
    http://www.python.org/dev/peps/pep-0362/
-   
+
 .. [#interop0]
    http://mail.python.org/pipermail/python-3000/2006-August/002895.html
-   
+
 .. [#interop1]
    http://mail.python.org/pipermail/python-ideas/2007-January/000032.html
 
@@ -318,28 +318,28 @@ References and Footnotes
 
 .. [#idle]
    http://www.python.org/idle/doc/idle2.html#Tips
-   
+
 .. [#jython]
    http://www.jython.org/Project/index.html
-   
+
 .. [#ironpython]
    http://www.codeplex.com/Wiki/View.aspx?ProjectName=IronPython
-   
+
 .. [#pyprotocols]
    http://peak.telecommunity.com/PyProtocols.html
-   
+
 .. [#adaptationpost]
    http://www.artima.com/weblogs/viewpost.jsp?thread=155123
-   
+
 .. [#scaling]
    http://www-128.ibm.com/developerworks/library/l-cppeak2/
-   
+
 .. [#rpyc]
    http://rpyc.wikispaces.com/
-   
+
 .. [#pydoc]
    http://docs.python.org/library/pydoc.html
-   
+
 
 Copyright
 =========

--- a/pep-3108.txt
+++ b/pep-3108.txt
@@ -562,7 +562,7 @@ for what the module is meant for.
 * dl [done]
 
   + ctypes provides better support for same functionality.
-  
+
 * fpformat [done]
 
   + All functionality is supported by string interpolation.
@@ -585,7 +585,7 @@ for what the module is meant for.
         - imgfile slated for removal in this PEP.
 
 * linuxaudiodev [done]
- 
+
   + Replaced by ossaudiodev.
 
 * mhlib [done]
@@ -942,9 +942,9 @@ In Python 2.6
      warnpy3k("the XXX module has been removed in Python 3.0",
               stacklevel=2)
      del warnpy3k
-     
+
    or the following if it is an extension module::
-   
+
      if (PyErr_WarnPy3k("the XXX module has been removed in "
                         "Python 3.0", 2) < 0)
          return;
@@ -956,10 +956,10 @@ In Python 2.6
    file, use the ``:deprecated:`` option with the ``module`` directive
    along with the ``deprecated`` directive, stating the deprecation
    is occurring in 2.6, but is for the module's removal in 3.0.::
-   
+
      .. deprecated:: 2.6
         The :mod:`XXX` module has been removed in Python 3.0.
-   
+
    For modules simply listed in a file (e.g., ``undoc.rst``), use the
    ``warning`` directive.
 
@@ -1004,7 +1004,7 @@ Python 3.0
 #. Update all references in the documentation from the old name to
    the new name.
 
-#. Run ``regrtest.py -uall`` to verify the rename worked.   
+#. Run ``regrtest.py -uall`` to verify the rename worked.
 
 #. Add an entry in ``Misc/NEWS``.
 
@@ -1020,7 +1020,7 @@ Python 2.6
      .. note::
         The :mod:`OLDNAME` module has been renamed to :mod:`NEWNAME` in
         Python 3.0.
-        
+
 #. Commit the documentation change.
 
 #. Block the revision in py3k.

--- a/pep-3109.txt
+++ b/pep-3109.txt
@@ -27,48 +27,48 @@ preferably only one -- obvious way to do it" [#zen]_. Python 2.x's
 ``raise`` statement violates this principle, permitting multiple
 ways of expressing the same thought. For example, these statements
 are equivalent: ::
-    
+
     raise E, V
-    
+
     raise E(V)
-    
+
 There is a third form of the ``raise`` statement, allowing arbitrary
 tracebacks to be attached to an exception [#grammar]_: ::
 
     raise E, V, T
-    
+
 where T is a traceback. As specified in PEP 344 [#pep344]_,
 exception objects in Python 3.x will possess a ``__traceback__``
 attribute, admitting this translation of the three-expression
 ``raise`` statement: ::
 
     raise E, V, T
-    
+
 is translated to ::
 
     e = E(V)
     e.__traceback__ = T
     raise e
-    
+
 Using these translations, we can reduce the ``raise`` statement from
 four forms to two:
 
 1. ``raise`` (with no arguments) is used to re-raise the active
    exception in an ``except`` suite.
-   
+
 2. ``raise EXCEPTION`` is used to raise a new exception. This form has
    two sub-variants: ``EXCEPTION`` may be an exception class or an
    instance of an exception class; valid exception classes are
    BaseException and its subclasses [#pep352]_. If ``EXCEPTION``
    is a subclass, it will be called with no arguments to obtain
    an exception instance.
-   
+
    To raise anything else is an error.
 
 There is a further, more tangible benefit to be obtained through this
 consolidation, as noted by A.M. Kuchling [#amk-line-noise]_. ::
 
-    PEP 8 doesn't express any preference between the 
+    PEP 8 doesn't express any preference between the
     two forms of raise statements:
     raise ValueError, 'blah'
     raise ValueError("blah")
@@ -76,59 +76,59 @@ consolidation, as noted by A.M. Kuchling [#amk-line-noise]_. ::
     I like the second form better, because if the exception arguments
     are long or include string formatting, you don't need to use line
     continuation characters because of the containing parens.
-    
+
 The BDFL has concurred [#guido-declaration]_ and endorsed the
 consolidation of the several ``raise`` forms.
-    
+
 
 Grammar Changes
 ===============
-    
+
 In Python 3, the grammar for ``raise`` statements will change
 from [#grammar]_ ::
 
     raise_stmt: 'raise' [test [',' test [',' test]]]
-    
+
 to ::
 
     raise_stmt: 'raise' [test]
-    
-    
+
+
 Changes to Builtin Types
 ========================
-    
+
 Because of its relation to exception raising, the signature for the
 ``throw()`` method on generator objects will change, dropping the
-optional second and third parameters. The signature thus changes 
+optional second and third parameters. The signature thus changes
 from [#throw-sig]_ ::
 
     generator.throw(E, [V, [T]])
-    
+
 to ::
 
     generator.throw(EXCEPTION)
-    
+
 Where ``EXCEPTION`` is either a subclass of ``BaseException`` or an
 instance of a subclass of ``BaseException``.
 
-    
+
 Semantic Changes
 ================
 
 In Python 2, the following ``raise`` statement is legal ::
 
     raise ((E1, (E2, E3)), E4), V
-    
+
 The interpreter will take the tuple's first element as the exception
 type (recursively), making the above fully equivalent to ::
 
     raise E1, V
-    
+
 As of Python 3.0, support for raising tuples like this will be
 dropped. This change will bring ``raise`` statements into line with
 the ``throw()`` method on generator objects, which already disallows
 this.
-    
+
 
 Compatibility Issues
 ====================
@@ -144,93 +144,93 @@ The following translations will be performed:
 
 1. Zero- and one-expression ``raise`` statements will be left
    intact.
-   
+
 2. Two-expression ``raise`` statements will be converted from ::
-        
+
         raise E, V
-        
+
    to ::
-   
+
         raise E(V)
-        
+
    Two-expression ``throw()`` calls will be converted from ::
-        
+
         generator.throw(E, V)
-        
+
    to ::
-   
+
         generator.throw(E(V))
-        
+
    See point #5 for a caveat to this transformation.
-        
+
 3. Three-expression ``raise`` statements will be converted from ::
 
         raise E, V, T
-        
+
    to ::
-   
+
         e = E(V)
         e.__traceback__ = T
         raise e
-        
+
    Three-expression ``throw()`` calls will be converted from ::
-   
+
         generator.throw(E, V, T)
-        
+
    to ::
-   
+
         e = E(V)
         e.__traceback__ = T
         generator.throw(e)
-        
+
    See point #5 for a caveat to this transformation.
-        
+
 4. Two- and three-expression ``raise`` statements where ``E`` is a
    tuple literal can be converted automatically using ``2to3``'s
    ``raise`` fixer. ``raise`` statements where ``E`` is a non-literal
    tuple, e.g., the result of a function call, will need to be
    converted manually.
-   
+
 5. Two- and three-expression ``raise`` statements where ``E`` is an
    exception class and ``V`` is an exception instance will need
    special attention. These cases break down into two camps:
-   
+
    1. ``raise E, V`` as a long-hand version of the zero-argument
       ``raise`` statement. As an example, assuming F is a subclass
       of E ::
-      
+
           try:
               something()
           except F as V:
               raise F(V)
           except E as V:
               handle(V)
-              
+
       This would be better expressed as ::
-      
+
           try:
               something()
           except F:
               raise
           except E as V:
               handle(V)
-              
+
    2. ``raise E, V`` as a way of "casting" an exception to another
       class. Taking an example from
       distutils.compiler.unixcompiler ::
-      
+
            try:
                self.spawn(pp_args)
            except DistutilsExecError as msg:
                raise CompileError(msg)
-               
+
       This would be better expressed as ::
-      
+
            try:
                self.spawn(pp_args)
            except DistutilsExecError as msg:
                raise CompileError from msg
-  
+
       Using the ``raise ... from ...`` syntax introduced in
       PEP 344.
 
@@ -246,31 +246,31 @@ References
 
 .. [#zen]
    http://www.python.org/dev/peps/pep-0020/
-   
+
 .. [#grammar]
    http://docs.python.org/reference/simple_stmts.html#raise
-   
+
 .. [#throw-sig]
    http://www.python.org/dev/peps/pep-0342/
-   
+
 .. [#pep344]
    http://www.python.org/dev/peps/pep-0344/
-   
+
 .. [#pep352]
    http://www.python.org/dev/peps/pep-0352/
-   
+
 .. [#amk-line-noise]
    http://mail.python.org/pipermail/python-dev/2005-August/055187.html
 
 .. [#guido-declaration]
    http://mail.python.org/pipermail/python-dev/2005-August/055190.html
-   
+
 .. [#2to3]
    http://svn.python.org/view/sandbox/trunk/2to3/
-   
+
 .. [#raise-fixer]
    http://svn.python.org/view/sandbox/trunk/2to3/fixes/fix_raise.py
-   
+
 .. [#throw-fixer]
    http://svn.python.org/view/sandbox/trunk/2to3/fixes/fix_throw.py
 

--- a/pep-3110.txt
+++ b/pep-3110.txt
@@ -27,11 +27,11 @@ Rationale
    where the parser cannot differentiate whether ::
 
        except <expression>, <expression>:
-    
+
    should be interpreted as ::
 
        except <type>, <type>:
-    
+
    or ::
 
        except <type>, <name>:
@@ -45,7 +45,7 @@ Rationale
    as tuples will be removed, meaning this code will no longer work ::
 
        except os.error, (errno, errstr):
-    
+
    Because the automatic unpacking will no longer be possible, it is
    desirable to remove the ability to use tuples as ``except`` targets.
 
@@ -53,12 +53,12 @@ Rationale
    will possess a ``__traceback__`` attribute. The Open Issues section
    of that PEP includes a paragraph on garbage collection difficulties
    caused by this attribute, namely a "exception -> traceback ->
-   stack frame -> exception" reference cycle, whereby all locals are 
+   stack frame -> exception" reference cycle, whereby all locals are
    kept in scope until the next GC run. This PEP intends to resolve
    this issue by adding a cleanup semantic to ``except`` clauses in
    Python 3 whereby the target name is deleted at the end of the
    ``except`` suite.
-   
+
 4. In the spirit of "there should be one -- and preferably only one
    -- obvious way to do it" [#zen]_, it is desirable to consolidate
    duplicate functionality. To this end, the ``exc_value``,
@@ -71,12 +71,12 @@ Rationale
 
 Grammar Changes
 ===============
-    
+
 In Python 3, the grammar for ``except`` statements will change
 from [#grammar]_ ::
 
     except_clause: 'except' [test [',' test]]
-    
+
 to ::
 
     except_clause: 'except' [test ['as' NAME]]
@@ -84,7 +84,7 @@ to ::
 The use of ``as`` in place of the comma token means that ::
 
     except (AttributeError, os.error):
-    
+
 can be clearly understood as a tuple of exception classes. This new
 syntax was first proposed by Greg Ewing [#firstproposal]_ and
 endorsed ([#firstproposal]_, [#renaming]_) by the BDFL.
@@ -116,7 +116,7 @@ The source-to-source translation, as suggested by Phillip J. Eby
     except E as N:
         except_body
     ...
-    
+
 gets translated to (in Python 2.5 terms) ::
 
     try:
@@ -129,7 +129,7 @@ gets translated to (in Python 2.5 terms) ::
             del N
     ...
 
-An implementation has already been checked into the py3k (formerly 
+An implementation has already been checked into the py3k (formerly
 "p3yk") branch [#translation-checkin]_.
 
 
@@ -140,24 +140,24 @@ Nearly all ``except`` clauses will need to be changed. ``except``
 clauses with identifier targets will be converted from ::
 
     except E, N:
-    
+
 to ::
-    
+
     except E as N:
 
 ``except`` clauses with non-tuple, non-identifier targets
 (e.g., ``a.b.c[d]``) will need to be converted from ::
 
     except E, T:
-    
+
 to ::
 
     except E as t:
         T = t
-        
+
 Both of these cases can be handled by Guido van Rossum's ``2to3``
 utility [#2to3]_ using the ``except`` fixer [#exceptfixer]_.
-        
+
 ``except`` clauses with tuple targets will need to be converted
 manually, on a case-by-case basis. These changes will usually need
 to be accompanied by changes to the exception classes themselves.
@@ -174,7 +174,7 @@ past the end of the ``except`` suite can be easily translated like so
     except E as N:
         ...
     ...
-    
+
 becomes ::
 
     try:
@@ -183,7 +183,7 @@ becomes ::
         n = N
         ...
     ...
-    
+
 This way, when ``N`` is deleted at the end of the block, ``n`` will
 persist and can be used as normal.
 
@@ -242,16 +242,16 @@ References
 
 .. [#pep352]
    http://www.python.org/dev/peps/pep-0352/
-   
+
 .. [#zen]
    http://www.python.org/dev/peps/pep-0020/
-   
+
 .. [#sys-module]
    http://docs.python.org/library/sys.html
-   
+
 .. [#pep3100]
    http://www.python.org/dev/peps/pep-3100/
-   
+
 .. [#pep344]
    http://www.python.org/dev/peps/pep-0344/
 
@@ -260,34 +260,34 @@ References
 
 .. [#renaming]
    http://mail.python.org/pipermail/python-dev/2006-March/062640.html
-   
+
 .. [#grammar]
    http://docs.python.org/reference/compound_stmts.html#try
-   
+
 .. [#except-translation]
    http://mail.python.org/pipermail/python-3000/2007-January/005395.html
-   
+
 .. [#translation-checkin]
    http://svn.python.org/view?rev=53342&view=rev
-   
+
 .. [#2to3]
    https://hg.python.org/sandbox/guido/file/2.7/Lib/lib2to3/
-   
+
 .. [#exceptfixer]
    https://hg.python.org/sandbox/guido/file/2.7/Lib/lib2to3/fixes/fix_except.py
-   
+
 .. [#drop-excinfo]
    http://mail.python.org/pipermail/python-3000/2007-January/005385.html
-   
+
 .. [#replace-excinfo]
    http://mail.python.org/pipermail/python-3000/2007-January/005604.html
-   
+
 .. [#r53342]
    http://svn.python.org/view?view=revision&revision=53342
-   
+
 .. [#r53349]
    http://svn.python.org/view?view=revision&revision=53349
-   
+
 .. [#r55446]
    http://svn.python.org/view/python/trunk/?view=rev&rev=55446
 

--- a/pep-3111.txt
+++ b/pep-3111.txt
@@ -56,7 +56,7 @@ Rationale
 
 Current built-in functions, like input() and raw_input(), are found to be
 extremely useful in traditional teaching settings. (For more details,
-see [2]_ and the discussion that followed.) 
+see [2]_ and the discussion that followed.)
 While the BDFL has clearly stated [3]_ that input() was not to be kept in
 Python 3000, he has also stated that he was not against revising the
 decision of killing raw_input().
@@ -83,12 +83,12 @@ is clunky and inelegant.
 who are mainly interested in *what* the function does, and not *where*
 in the package structure it is located.  The lack of meaning also makes
 it difficult to remember:
-is it "sys.stdin.readline()", or " stdin.sys.readline()"? 
+is it "sys.stdin.readline()", or " stdin.sys.readline()"?
 To a programming novice, there is not any obvious reason to prefer
 one over the other. In contrast, functions simple and direct names like
 print, input, and raw_input, and open are easier to remember.
 
-3. The use of "." notation is unmotivated and confusing to many beginners. 
+3. The use of "." notation is unmotivated and confusing to many beginners.
 For example, it may lead some beginners to think "."  is a standard
 character that could be used in any identifier.
 
@@ -122,7 +122,7 @@ considered.  The various possibilities mentioned in various forums include::
   get_response()
 
 While it was initially rejected by the BDFL, it has been suggested that the
-most direct solution would be to rename "raw_input" to "input" in Python 3000. 
+most direct solution would be to rename "raw_input" to "input" in Python 3000.
 The main objection is that Python 2.x already has a function named "input",
 and, even though it is not going to be included in Python 3000,
 having a built-in function with the same name but different semantics may

--- a/pep-3112.txt
+++ b/pep-3112.txt
@@ -78,7 +78,7 @@ The new syntax for strings, including the new bytes literal, is::
   escapeseq: "\" NL
     | "\\" | "\'" | '\"'
     | "\a" | "\b" | "\f" | "\n" | "\r" | "\t" | "\v"
-    | "\ooo" | "\xhh" 
+    | "\ooo" | "\xhh"
     | "\uxxxx" | "\Uxxxxxxxx" | "\N{name}"
 
 The following additional restrictions apply only to bytes literals

--- a/pep-3116.txt
+++ b/pep-3116.txt
@@ -302,7 +302,7 @@ allow going to the start or end of a stream without a prior
 ``.tell()``.  An implementation could include stream encoder state in
 the cookie returned from ``.tell()``.
 
-    
+
 ``TextIOBase`` implementations also provide several methods that are
 pass-throughs to the underlaying ``BufferedIOBase`` objects:
 
@@ -465,7 +465,7 @@ The ``open()`` Built-in Function
 The ``open()`` built-in function is specified by the following
 pseudo-code::
 
-    def open(filename, mode="r", buffering=None, *, 
+    def open(filename, mode="r", buffering=None, *,
              encoding=None, errors=None, newline=None):
         assert isinstance(filename, (str, int))
         assert isinstance(mode, str)

--- a/pep-3117.txt
+++ b/pep-3117.txt
@@ -91,7 +91,7 @@ Type                       Declarator
 ``frozenset``              ☃ (SNOWMAN)
 ``datetime``               ⌚ (WATCH)
 ``function``               ƛ (LATIN SMALL LETTER LAMBDA WITH STROKE)
-``generator``              ⚛ (ATOM SYMBOL) 
+``generator``              ⚛ (ATOM SYMBOL)
 ``Exception``              ⌁ (ELECTRIC ARROW)
 =========================  ===================================================
 
@@ -207,7 +207,7 @@ References
 
 .. [ZEN] http://www.python.org/dev/peps/pep-0020/
 
-.. [#] Well, it would, if there was a Perl 6. 
+.. [#] Well, it would, if there was a Perl 6.
 
 .. [#] Since the name ``TypeError`` is already in use, this name has been chosen
    for obvious reasons.

--- a/pep-3118.txt
+++ b/pep-3118.txt
@@ -17,17 +17,17 @@ This PEP proposes re-designing the buffer interface (``PyBufferProcs``
 function pointers) to improve the way Python allows memory sharing in
 Python 3.0
 
-In particular, it is proposed that the character buffer portion 
-of the API be eliminated and the multiple-segment portion be 
+In particular, it is proposed that the character buffer portion
+of the API be eliminated and the multiple-segment portion be
 re-designed in conjunction with allowing for strided memory
-to be shared.   In addition, the new buffer interface will 
+to be shared.   In addition, the new buffer interface will
 allow the sharing of any multi-dimensional nature of the
-memory and what data-format the memory contains. 
+memory and what data-format the memory contains.
 
-This interface will allow any extension module to either 
+This interface will allow any extension module to either
 create objects that share memory or create algorithms that
-use and manipulate raw memory from arbitrary objects that 
-export the interface. 
+use and manipulate raw memory from arbitrary objects that
+export the interface.
 
 
 Rationale
@@ -40,7 +40,7 @@ memory between different high-level objects, but it is too limited and
 has issues:
 
 1. There is the little used "sequence-of-segments" option
-   (bf_getsegcount) that is not well motivated. 
+   (bf_getsegcount) that is not well motivated.
 
 2. There is the apparently redundant character-buffer option
    (bf_getcharbuffer)
@@ -63,36 +63,36 @@ has issues:
    Libraries, ctypes, NumPy, data-base interfaces, etc.)
 
 6. There is no way to share discontiguous memory (except through
-   the sequence of segments notion).  
+   the sequence of segments notion).
 
    There are two widely used libraries that use the concept of
    discontiguous memory: PIL and NumPy.  Their view of discontiguous
    arrays is different, though.  The proposed buffer interface allows
-   sharing of either memory model.  Exporters will typically use only one        
-   approach and consumers may choose to support discontiguous 
-   arrays of each type however they choose. 
+   sharing of either memory model.  Exporters will typically use only one
+   approach and consumers may choose to support discontiguous
+   arrays of each type however they choose.
 
    NumPy uses the notion of constant striding in each dimension as its
    basic concept of an array. With this concept, a simple sub-region
-   of a larger array can be described without copying the data.   
+   of a larger array can be described without copying the data.
    Thus, stride information is the additional information that must be
-   shared. 
+   shared.
 
    The PIL uses a more opaque memory representation. Sometimes an
    image is contained in a contiguous segment of memory, but sometimes
    it is contained in an array of pointers to the contiguous segments
    (usually lines) of the image.  The PIL is where the idea of multiple
-   buffer segments in the original buffer interface came from.   
+   buffer segments in the original buffer interface came from.
 
    NumPy's strided memory model is used more often in computational
    libraries and because it is so simple it makes sense to support
-   memory sharing using this model.  The PIL memory model is sometimes 
+   memory sharing using this model.  The PIL memory model is sometimes
    used in C-code where a 2-d array can then be accessed using double
    pointer indirection:  e.g. ``image[i][j]``.
 
    The buffer interface should allow the object to export either of these
    memory models.  Consumers are free to either require contiguous memory
-   or write code to handle one or both of these memory models. 
+   or write code to handle one or both of these memory models.
 
 Proposal Overview
 =================
@@ -103,7 +103,7 @@ Proposal Overview
 * Unify the read/write versions of getting the buffer.
 
 * Add a new function to the interface that should be called when
-  the consumer object is "done" with the memory area.  
+  the consumer object is "done" with the memory area.
 
 * Add a new variable to allow the interface to describe what is in
   memory (unifying what is currently done now in struct and
@@ -113,8 +113,8 @@ Proposal Overview
 
 * Add a new variable for sharing stride information
 
-* Add a new mechanism for sharing arrays that must 
-  be accessed using pointer indirection. 
+* Add a new mechanism for sharing arrays that must
+  be accessed using pointer indirection.
 
 * Fix all objects in the core and the standard library to conform
   to the new interface
@@ -122,10 +122,10 @@ Proposal Overview
 * Extend the struct module to handle more format specifiers
 
 * Extend the buffer object into a new memory object which places
-  a Python veneer around the buffer interface. 
+  a Python veneer around the buffer interface.
 
 * Add a few functions to make it easy to copy contiguous data
-  in and out of object supporting the buffer interface. 
+  in and out of object supporting the buffer interface.
 
 Specification
 =============
@@ -163,7 +163,7 @@ prepared to deal with and therefore what kind of buffer the exporter
 is allowed to return.  The new buffer interface allows for much more
 complicated memory sharing possibilities.  Some consumers may not be
 able to handle all the complexibity but may want to see if the
-exporter will let them take a simpler view to its memory.  
+exporter will let them take a simpler view to its memory.
 
 In addition, some exporters may not be able to share memory in every
 possible way and may need to raise errors to signal to some consumers
@@ -202,7 +202,7 @@ without that information, then a ``PyErr_BufferError`` should be raised.
    then raise an error.
 
 ``PyBUF_FORMAT``
-        
+
    The returned buffer must have true format information if this flag
    is provided.  This would be used when the consumer is going to be
    checking for what 'kind' of data is actually stored.  An exporter
@@ -216,7 +216,7 @@ without that information, then a ``PyErr_BufferError`` should be raised.
    be assumed C-style contiguous (last dimension varies the fastest).
    The exporter may raise an error if it cannot provide this kind of
    contiguous buffer.  If this is not given then shape will be NULL.
-   
+
 ``PyBUF_STRIDES`` (implies ``PyBUF_ND``)
 
    The returned buffer must provide strides information (i.e. the
@@ -232,9 +232,9 @@ without that information, then a ``PyErr_BufferError`` should be raised.
 
    These flags indicate that the returned buffer must be respectively,
    C-contiguous (last dimension varies the fastest), Fortran
-   contiguous (first dimension varies the fastest) or either one.  
+   contiguous (first dimension varies the fastest) or either one.
    All of these flags imply PyBUF_STRIDES and guarantee that the
-   strides buffer info structure will be filled in correctly. 
+   strides buffer info structure will be filled in correctly.
 
 ``PyBUF_INDIRECT`` (implies ``PyBUF_STRIDES``)
 
@@ -244,7 +244,7 @@ without that information, then a ``PyErr_BufferError`` should be raised.
    suboffsets.
 
 
-Specialized combinations of flags for specific kinds of memory_sharing. 
+Specialized combinations of flags for specific kinds of memory_sharing.
 
   Multi-dimensional (but contiguous)
 
@@ -331,7 +331,7 @@ The members of the bufferinfo structure are:
 ``ndim``
     a variable storing the number of dimensions the memory represents.
     Must be >=0.  A value of 0 means that shape and strides and suboffsets
-    must be ``NULL`` (i.e. the memory represents a scalar). 
+    must be ``NULL`` (i.e. the memory represents a scalar).
 
 ``shape``
     an array of ``Py_ssize_t`` of length ``ndims`` indicating the
@@ -345,8 +345,8 @@ The members of the bufferinfo structure are:
     if ``ndims`` is 0).  indicating the number of bytes to skip to get to
     the next element in each dimension.  If this is not requested by
     the caller (``PyBUF_STRIDES`` is not set), then this should be set
-    to NULL which indicates a C-style contiguous array or a 
-    PyExc_BufferError raised if this is not possible. 
+    to NULL which indicates a C-style contiguous array or a
+    PyExc_BufferError raised if this is not possible.
 
 ``suboffsets``
     address of a ``Py_ssize_t *`` variable that will be filled with a
@@ -355,11 +355,11 @@ The members of the bufferinfo structure are:
     indicated dimension is a pointer and the suboffset value dictates
     how many bytes to add to the pointer after de-referencing.  A
     suboffset value that it negative indicates that no de-referencing
-    should occur (striding in a contiguous memory block).  If all 
+    should occur (striding in a contiguous memory block).  If all
     suboffsets are negative (i.e. no de-referencing is needed, then
     this must be NULL (the default value).  If this is not requested
-    by the caller (PyBUF_INDIRECT is not set), then this should be 
-    set to NULL or an PyExc_BufferError raised if this is not possible. 
+    by the caller (PyBUF_INDIRECT is not set), then this should be
+    set to NULL or an PyExc_BufferError raised if this is not possible.
 
     For clarity, here is a function that returns a pointer to the
     element in an N-D array pointed to by an N-dimesional index when
@@ -382,7 +382,7 @@ The members of the bufferinfo structure are:
     Thus slicing in the ith dimension would add to the suboffsets in
     the (i-1)st dimension.  Slicing in the first dimension would change
     the location of the starting pointer directly (i.e. buf would
-    be modified).  
+    be modified).
 
 ``itemsize``
     This is a storage for the itemsize (in bytes) of each element of the shared
@@ -394,11 +394,11 @@ The members of the bufferinfo structure are:
 
 ``internal``
     This is for use internally by the exporting object.  For example,
-    this might be re-cast as an integer by the exporter and used to 
+    this might be re-cast as an integer by the exporter and used to
     store flags about whether or not the shape, strides, and suboffsets
     arrays must be freed when the buffer is released.   The consumer
-    should never alter this value. 
-    
+    should never alter this value.
+
 
 The exporter is responsible for making sure that any memory pointed to
 by buf, format, shape, strides, and suboffsets is valid until
@@ -428,7 +428,7 @@ called.
 
 If the bf_releasebuffer function is not provided (i.e. it is NULL),
 then it does not ever need to be called.
-    
+
 Exporters will need to define a bf_releasebuffer function if they can
 re-allocate their memory, strides, shape, suboffsets, or format
 variables which they might share through the struct bufferinfo.
@@ -436,7 +436,7 @@ Several mechanisms could be used to keep track of how many getbuffer
 calls have been made and shared.  Either a single variable could be
 used to keep track of how many "views" have been exported, or a
 linked-list of bufferinfo structures filled in could be maintained in
-each object.  
+each object.
 
 All that is specifically required by the exporter, however, is to
 ensure that any memory shared through the bufferinfo structure remains
@@ -455,8 +455,8 @@ Return 1 if the getbuffer function is available otherwise 0.
 
 ::
 
-    int PyObject_GetBuffer(PyObject *obj, Py_buffer *view, 
-                           int flags)  
+    int PyObject_GetBuffer(PyObject *obj, Py_buffer *view,
+                           int flags)
 
 This is a C-API version of the getbuffer function call.  It checks to
 make sure object has the required function pointer and issues the
@@ -504,19 +504,19 @@ attribute of the memoryview object.  The struct module can be used to
 "decode" the bytes in Python if desired.  Or the contents can be
 passed to a NumPy array or other object consuming the buffer protocol.
 
-The Python name will be 
+The Python name will be
 
 ``__builtin__.memoryview``
 
 Methods:
 
 |  ``__getitem__``  (will support multi-dimensional slicing)
-|  ``__setitem__``  (will support multi-dimensional slicing)  
+|  ``__setitem__``  (will support multi-dimensional slicing)
 |  ``tobytes``      (obtain a new bytes-object of a copy of the memory).
 |  ``tolist``       (obtain a "nested" list of the memory.  Everything
                     is interpreted into standard Python objects
                     as the struct module unpack would do -- in fact
-                    it uses struct.unpack to accomplish it). 
+                    it uses struct.unpack to accomplish it).
 
 Attributes (taken from the memory of the base object):
 
@@ -538,13 +538,13 @@ description.
 
 ::
 
-    PyObject * PyMemoryView_GetContiguous(PyObject *obj,  int buffertype, 
+    PyObject * PyMemoryView_GetContiguous(PyObject *obj,  int buffertype,
                                           char fortran)
 
 Return a memoryview object to a contiguous chunk of memory represented
 by obj. If a copy must be made (because the memory pointed to by obj
 is not contiguous), then a new bytes object will be created and become
-the base object for the returned memory view object. 
+the base object for the returned memory view object.
 
 The buffertype argument can be PyBUF_READ, PyBUF_WRITE,
 PyBUF_UPDATEIFCOPY to determine whether the returned buffer should be
@@ -566,7 +566,7 @@ is made, then the memory must be freed by calling ``PyMem_Free``.
 
 You receive a new reference to the memoryview object.
 
-:: 
+::
 
     int PyObject_CopyToObject(PyObject *obj, void *buf, Py_ssize_t len,
                               char fortran)
@@ -589,7 +589,7 @@ way is more efficient.
 These last three C-API calls allow a standard way of getting data in and
 out of Python objects into contiguous memory areas no matter how it is
 actually stored.  These calls use the extended buffer interface to perform
-their work. 
+their work.
 
 ::
 
@@ -611,13 +611,13 @@ shape with the given number of bytes per element.
 
 ::
 
-    int PyBuffer_FillInfo(Py_buffer *view, void *buf, 
+    int PyBuffer_FillInfo(Py_buffer *view, void *buf,
                           Py_ssize_t len, int readonly, int infoflags)
 
 Fills in a buffer-info structure correctly for an exporter that can
 only share a contiguous chunk of memory of "unsigned bytes" of the
 given length.  Returns 0 on success and -1 (with raising an error) on
-error. 
+error.
 
 ::
 
@@ -634,7 +634,7 @@ Additions to the struct string-syntax
 
 The struct string-syntax is missing some characters to fully
 implement data-format descriptions already available elsewhere (in
-ctypes and NumPy for example).  The Python 2.5 specification is 
+ctypes and NumPy for example).  The Python 2.5 specification is
 at http://docs.python.org/library/struct.html.
 
 Here are the proposed additions:
@@ -645,17 +645,17 @@ Character         Description
 ================  ===========
 't'               bit (number before states how many bits)
 '?'               platform _Bool type
-'g'               long double  
-'c'               ucs-1 (latin-1) encoding 
-'u'               ucs-2 
-'w'               ucs-4 
-'O'               pointer to Python Object 
+'g'               long double
+'c'               ucs-1 (latin-1) encoding
+'u'               ucs-2
+'w'               ucs-4
+'O'               pointer to Python Object
 'Z'               complex (whatever the next specifier is)
-'&'               specific pointer (prefix before another character) 
-'T{}'             structure (detailed layout inside {}) 
-'(k1,k2,...,kn)'  multi-dimensional array of whatever follows 
+'&'               specific pointer (prefix before another character)
+'T{}'             structure (detailed layout inside {})
+'(k1,k2,...,kn)'  multi-dimensional array of whatever follows
 ':name:'          optional name of the preceding element
-'X{}'             pointer to a function (optional function 
+'X{}'             pointer to a function (optional function
                     signature inside {} with any return value
                     preceded by -> and placed at the end)
 ================  ===========
@@ -693,7 +693,7 @@ Examples of Data-Format Descriptions
 ====================================
 
 Here are some examples of C-structures and how they would be
-represented using the struct-style syntax. 
+represented using the struct-style syntax.
 
 <named> is the constructor for a named-tuple (not-specified yet).
 
@@ -704,7 +704,7 @@ complex double
 RGB Pixel data
     ``'BBB'`` <--> (int, int, int)
     ``'B:r: B:g: B:b:'`` <--> <named>((int, int, int), ('r','g','b'))
-    
+
 Mixed endian (weird but possible)
     ``'>i:big: <i:little:'`` <--> <named>((int, int), ('big', 'little'))
 
@@ -719,10 +719,10 @@ Nested structure
                  unsigned char cval;
              } sub;
         }
-        """i:ival: 
+        """i:ival:
            T{
-              H:sval: 
-              B:bval: 
+              H:sval:
+              B:bval:
               B:cval:
             }:sub:
         """
@@ -733,7 +733,7 @@ Nested array
              int ival;
              double data[16*4];
         }
-        """i:ival: 
+        """i:ival:
            (16,4)d:data:
         """
 
@@ -745,7 +745,7 @@ multi-dimensional arrays which use the same syntax to access elements,
 data[0][1], but whose memory is not necessarily contiguous.  The
 struct-syntax *always* uses contiguous memory and the
 multi-dimensional character is information about the memory to be
-communicated by the exporter.  
+communicated by the exporter.
 
 In other words, the struct-syntax description does not have to match
 the C-syntax exactly as long as it describes the same memory layout.
@@ -753,7 +753,7 @@ The fact that a C-compiler would think of the memory as a 1-d array of
 doubles is irrelevant to the fact that the exporter wanted to
 communicate to the consumer that this field of the memory should be
 thought of as a 2-d array where a new dimension is considered after
-every 4 elements. 
+every 4 elements.
 
 
 Code to be affected
@@ -771,7 +771,7 @@ buffer interface will be modified.  Here is a partial list.
 * mmap module
 * ctypes module
 
-Anything else using the buffer API.  
+Anything else using the buffer API.
 
 
 Issues and Details
@@ -799,14 +799,14 @@ because strided memory is very common when interfacing with compute
 libraries.
 
 Also, with this approach it should be possible to write generic code
-that works with both kinds of memory without copying. 
+that works with both kinds of memory without copying.
 
 Memory management of the format string, the shape array, the strides
 array, and the suboffsets array in the bufferinfo structure is always
 the responsibility of the exporting object.  The consumer should not
-set these pointers to any other memory or try to free them. 
+set these pointers to any other memory or try to free them.
 
-Several ideas were discussed and rejected: 
+Several ideas were discussed and rejected:
 
     Having a "releaser" object whose release-buffer was called.  This
     was deemed unacceptable because it caused the protocol to be
@@ -818,7 +818,7 @@ Several ideas were discussed and rejected:
     This had the advantage that it allowed one to set NULL to
     variables that were not of interest, but it also made the function
     call more difficult.  The flags variable allows the same
-    ability of consumers to be "simple" in how they call the protocol. 
+    ability of consumers to be "simple" in how they call the protocol.
 
 
 Code
@@ -869,7 +869,7 @@ So what does ImageObject's getbuffer do?  Leaving error checking out::
       self->shape_array[0] = height;
       self->shape_array[1] = width;
       view->shape = &self->shape_array;
-      self->stride_array[0] = sizeof(struct rgba*);  
+      self->stride_array[0] = sizeof(struct rgba*);
       self->stride_array[1] = sizeof(struct rgba);
       view->strides = &self->stride_array;
       view->suboffsets = suboffsets;
@@ -877,7 +877,7 @@ So what does ImageObject's getbuffer do?  Leaving error checking out::
       self->view_count ++;
 
       return 0;
-  } 
+  }
 
 
   int Image_releasebuffer(PyObject *self, Py_buffer *view) {
@@ -900,15 +900,15 @@ alive) would do that.
       void *buf;
       Py_ssize_t len;
       int readonly=0;
-        
+
       buf = /* Point to buffer */
       len = /* Set to size of buffer */
       readonly = /* Set to 1 if readonly */
-  
-      return PyObject_FillBufferInfo(view, buf, len, readonly, flags);    
+
+      return PyObject_FillBufferInfo(view, buf, len, readonly, flags);
   }
 
-  /* No releasebuffer is necessary because the memory will never 
+  /* No releasebuffer is necessary because the memory will never
      be re-allocated
   */
 
@@ -922,7 +922,7 @@ from a Python object, obj would do the following:
 
   Py_buffer view;
   int ret;
-      
+
   if (PyObject_GetBuffer(obj, &view, Py_BUF_SIMPLE) < 0) {
        /* error return */
   }
@@ -931,14 +931,14 @@ from a Python object, obj would do the following:
           view.len is the length
           view.readonly is whether or not the memory is read-only.
    */
-  
+
 
   /* After using the information and you don't need it anymore */
-  
+
   if (PyBuffer_Release(obj, &view) < 0) {
           /* error return */
   }
-  
+
 
 Ex. 4
 -----------
@@ -960,11 +960,11 @@ writing an algorithm that only handle contiguous memory could do the following:
 
     /* process memory pointed to by buffer if format is correct */
 
-    /* Optional: 
-    
+    /* Optional:
+
        if, after processing, we want to copy data from buffer back
-       into the object  
- 
+       into the object
+
        we could do
        */
 
@@ -974,7 +974,7 @@ writing an algorithm that only handle contiguous memory could do the following:
 
     /* Make sure that if a copy was made, the memory is freed */
     if (copy == 1) PyMem_Free(buf);
-   
+
 
 Copyright
 =========

--- a/pep-3120.txt
+++ b/pep-3120.txt
@@ -87,7 +87,7 @@ References
 
 .. [#pep263]
    http://www.python.org/dev/peps/pep-0263/
-   
+
 
 
 Copyright

--- a/pep-3121.txt
+++ b/pep-3121.txt
@@ -78,7 +78,7 @@ of memory used for the module is specified at
 the point of creation of the module.
 
 In addition to the initialization function, a module
-may implement a number of additional callback 
+may implement a number of additional callback
 functions, which are invoked when the module's
 tp_traverse, tp_clear, and tp_free functions are
 invoked, and when the module is reloaded.
@@ -97,7 +97,7 @@ PyModuleDef::
   };
 
 Creation of a module is changed to expect an optional
-PyModuleDef*. The module state will be 
+PyModuleDef*. The module state will be
 null-initialized.
 
 Each module method will be passed the module object
@@ -181,7 +181,7 @@ function, and add the following code instead::
     }
     return res;
   }
-    
+
 
 Discussion
 ==========

--- a/pep-3123.txt
+++ b/pep-3123.txt
@@ -46,7 +46,7 @@ The problem here is that the storage is both accessed as
 if it where struct ``PyObject``, and as struct ``FooObject``.
 
 Historically, compilers did not have any problems with this
-code. However, modern compilers use that clause as an 
+code. However, modern compilers use that clause as an
 optimization opportunity, finding that ``f->ob_refcnt`` and
 ``o->ob_refcnt`` cannot possibly refer to the same memory, and
 that therefore the function should return 0, without having
@@ -140,7 +140,7 @@ To support modules that compile with both Python 2.6 and Python 3.0,
 the ``Py_*`` macros are added to Python 2.6. The macros ``Py_INCREF``
 and ``Py_DECREF`` will be changed to cast their argument to ``PyObject *``,
 so that module authors can also explicitly declare the ``ob_base``
-field in modules designed for Python 2.6. 
+field in modules designed for Python 2.6.
 
 Copyright
 =========

--- a/pep-3124.txt
+++ b/pep-3124.txt
@@ -122,7 +122,7 @@ decorator.  Thus, the following code::
 
     from overloading import overload
     from collections import Iterable
-    
+
     def flatten(ob):
         """Flatten an object to its component iterables"""
         yield ob
@@ -225,7 +225,7 @@ registered using the `Extension API`_, and will then be usable with
 ``@when`` and other decorators created by this module (like
 ``@before``, ``@after``, and ``@around``).
 
- 
+
 Method Combination and Overriding
 ---------------------------------
 
@@ -354,7 +354,7 @@ the main function body, and are *never considered ambiguous*.  That
 is, it will not cause any errors to have multiple "before" or "after"
 methods with identical or overlapping signatures.  Ambiguities are
 resolved using the order in which the methods were added to the
-target function.  
+target function.
 
 "Before" methods are invoked most-specific method first, with
 ambiguous methods being executed in the order they were added.  All
@@ -435,7 +435,7 @@ you might write something like this::
 
     class Discount(MethodList):
         """Apply return values as discounts"""
-    
+
         def __call__(self, *args, **kw):
             retval = self.tail(*args, **kw)
             for sig, body in self.sorted():
@@ -453,7 +453,7 @@ you might write something like this::
     # but not over "around" methods
     always_overrides(Around, Discount)
 
-    # Make a decorator called "discount" that works just like the 
+    # Make a decorator called "discount" that works just like the
     # standard decorators...
     discount = Discount.make_decorator('discount')
 
@@ -484,7 +484,7 @@ one would then be able to use those predicates for discounts as well,
 e.g.::
 
     from somewhere import Pred  # some predicate implementation
-    
+
     @discount(
         price,
         Pred("isinstance(product,Shoe) and"
@@ -522,12 +522,12 @@ private method)::
 
     @when(get_conjuncts)
     def get_conjuncts_of_and(ob: And):
-        return ob.conjuncts    
+        return ob.conjuncts
 
 This behavior is both a convenience enhancement when defining lots of
 methods, and a requirement for safely distinguishing multi-argument
 overloads in subclasses.  Consider, for example, the following code::
-        
+
     class A(object):
         def foo(self, ob):
             print "got an object"
@@ -786,9 +786,9 @@ and ``fdel`` attributes::
         def length(self):
             """Read-only length attribute"""
 
-    # ILength(aList).length == list.__len__(aList) 
+    # ILength(aList).length == list.__len__(aList)
     when(ILength.length.fget, (list,))(list.__len__)
-    
+
 
 Alternatively, methods such as ``_get_foo()`` and ``_set_foo()``
 may be defined as part of the interface, and the property defined
@@ -865,8 +865,8 @@ expressive AOP tools.
 XXX spec out full aspect API, including keys, N-to-1 aspects, manual
     attach/detach/delete of aspect instances, and the ``IAspectOwner``
     interface.
-    
-    
+
+
 Extension API
 =============
 

--- a/pep-3129.txt
+++ b/pep-3129.txt
@@ -52,13 +52,13 @@ The following two snippets are semantically identical::
   class A:
     pass
   A = foo(bar(A))
-  
-  
+
+
   @foo
   @bar
   class A:
     pass
-    
+
 For a detailed examination of decorators, please refer to PEP 318.
 
 
@@ -69,16 +69,16 @@ Adapting Python's grammar to support class decorators requires
 modifying two rules and adding a new rule::
 
  funcdef: [decorators] 'def' NAME parameters ['->' test] ':' suite
- 
+
  compound_stmt: if_stmt | while_stmt | for_stmt | try_stmt |
                 with_stmt | funcdef | classdef
-                
+
 need to be changed to ::
- 
+
  decorated: decorators (classdef | funcdef)
 
  funcdef: 'def' NAME parameters ['->' test] ':' suite
- 
+
  compound_stmt: if_stmt | while_stmt | for_stmt | try_stmt |
                 with_stmt | funcdef | classdef | decorated
 
@@ -105,22 +105,22 @@ References
 
 .. [#obscure]
    http://www.python.org/dev/peps/pep-0318/#motivation
-   
+
 .. [#approval]
    http://mail.python.org/pipermail/python-dev/2006-March/062942.html
-   
+
 .. [#motivation]
    http://mail.python.org/pipermail/python-dev/2006-March/062888.html
-   
+
 .. [#semantics]
    http://www.python.org/dev/peps/pep-0318/#current-syntax
 
 .. [#goals]
    http://www.python.org/dev/peps/pep-0318/#design-goals
-   
+
 .. [#implementation]
    http://python.org/sf/1671208
-   
+
 
 
 Copyright

--- a/pep-3131.txt
+++ b/pep-3131.txt
@@ -174,7 +174,7 @@ apply to all modules.
 Discussion
 ==========
 
-Ka-Ping Yee summarizes discussion and further objection 
+Ka-Ping Yee summarizes discussion and further objection
 in [4]_ as such:
 
 A. Should identifiers be allowed to contain any Unicode letter?

--- a/pep-3133.txt
+++ b/pep-3133.txt
@@ -83,13 +83,13 @@ Static Role Assignment
 Let's start out by defining ``Tree`` and ``Dog`` classes ::
 
   class Tree(Vegetable):
-    
+
     def bark(self):
       return self.is_rough()
 
 
   class Dog(Animal):
-    
+
     def bark(self):
       return self.goes_ruff()
 
@@ -99,7 +99,7 @@ what we're expecting. Relying on inheritance and a simple
 ``isinstance()`` test will limit code reuse and/or force any dog-like
 classes to inherit from ``Dog``, whether or not that makes sense.
 Let's see if roles can help. ::
-    
+
   @perform_role(Doglike)
   class Dog(Animal):
     ...
@@ -107,11 +107,11 @@ Let's see if roles can help. ::
   @perform_role(Treelike)
   class Tree(Vegetable):
     ...
-    
+
   @perform_role(SitThere)
   class Rock(Mineral):
     ...
-    
+
 We use class decorators from PEP 3129 to associate a particular role
 or roles with a class.  Client code can now verify that an incoming
 object performs the ``Doglike`` role, allowing it to handle ``Wolf``,
@@ -121,12 +121,12 @@ Roles can be composed via normal inheritance: ::
 
   @perform_role(Guard, MummysLittleDarling)
   class GermanShepherd(Dog):
-    
+
     def guard(self, the_precious):
       while True:
         if intruder_near(the_precious):
           self.growl()
-          
+
     def get_petted(self):
       self.swallow_pride()
 
@@ -159,7 +159,7 @@ their task. ::
 
   >>> performs(our_robot, Guard)
   True
-   
+
 What about that one robot over there? ::
 
   >>> performs(that_robot_over_there, Guard)
@@ -171,7 +171,7 @@ class if its instances fulfill a role: ::
 
   >>> performs(Robot, Guard)
   False
- 
+
 This is because the ``Robot`` class is not interchangeable
 with a ``Robot`` instance.
 
@@ -204,8 +204,8 @@ them.  Here, instances of ``Dog`` will perform both the
 
   class Doglike(FourLegs, Carnivor):
     pass
- 
-  @perform_role(Doglike)  
+
+  @perform_role(Doglike)
   class Dog(Mammal):
     pass
 
@@ -221,7 +221,7 @@ Let's now require that all classes that claim to fulfill the
 
     def bark(self):
       pass
-      
+
 No decorators are required to flag the method as "abstract", and the
 method will never be called, meaning whatever code it contains (if any)
 is irrelevant.  Roles provide *only* abstract methods; concrete
@@ -237,7 +237,7 @@ programmer has misspelled one of the methods required by the role. ::
 
     def run_like_teh_wind(self)
       ...
-      
+
 This will cause the role system to raise an exception, complaining
 that you're missing a ``run_like_the_wind()`` method.  The role
 system carries out these checks as soon as a class is flagged as
@@ -249,7 +249,7 @@ concrete version of ``bark()``, but we've missed the mark a bit. ::
 
   @perform_role(Doglike)
   class Coyote(Mammal):
-    
+
     def bark(self, target=moon):
       pass
 
@@ -272,28 +272,28 @@ mechanism may be implemented without changing the Python interpreter.
      @perform_role(Thieving)
      class Elf(Character):
        ...
-       
+
    ``perform_role()`` accepts multiple arguments, such that this is
    also legal: ::
-   
+
      @perform_role(Thieving, Spying, Archer)
      class Elf(Character):
        ...
-       
+
    The ``Elf`` class now performs both the ``Thieving``, ``Spying``,
-   and ``Archer`` roles.   
+   and ``Archer`` roles.
 
 2. Querying instances ::
 
      if performs(my_elf, Thieving):
        ...
-       
+
    The second argument to ``performs()`` may also be anything with a
    ``__contains__()`` method, meaning the following is legal: ::
-   
+
      if performs(my_elf, set([Thieving, Spying, BoyScout])):
        ...
-       
+
    Like ``isinstance()``, the object needs only to perform a single
    role out of the set in order for the expression to be true.
 
@@ -311,40 +311,40 @@ responsibilities and use-cases has been worked out as follows:
   way of delineating an interface through which a particular set of
   semantics are accessed.  An ``Ordering`` role might require that
   some set of ordering operators  be defined. ::
- 
+
     class Ordering(metaclass=Role):
       def __ge__(self, other):
         pass
-    
+
       def __le__(self, other):
         pass
-        
+
       def __ne__(self, other):
         pass
-      
+
       # ...and so on
-      
+
   In this way, we're able to indicate an object's role or function
   within a larger system without constraining or concerning ourselves
   with a particular implementation.
-      
+
 * Abstract base classes, by contrast, are a way of reusing common,
   discrete units of implementation.  For example, one might define an
   ``OrderingMixin`` that implements several ordering operators in
   terms of other operators. ::
- 
+
     class OrderingMixin:
       def __ge__(self, other):
         return self > other or self == other
-    
+
       def __le__(self, other):
         return self < other or self == other
-    
+
       def __ne__(self, other):
         return not self == other
-      
+
       # ...and so on
-    
+
   Using this abstract base class - more properly, a concrete
   mixin - allows a programmer to define a limited set of operators
   and let the mixin in effect "derive" the others.
@@ -470,7 +470,7 @@ a given role.  It may be desirable to provide an analogue to
   False
   >>> class_performs(Dwarf, Surly)
   True
- 
+
 
 Prettier Dynamic Role Assignment
 --------------------------------
@@ -479,12 +479,12 @@ An early draft of this PEP included a separate mechanism for
 dynamically assigning a role to a class.  This was spelled ::
 
   >>> now_perform(Dwarf, GoldMiner)
- 
+
 This same functionality already exists by unpacking the syntactic
 sugar provided by decorators: ::
 
   >>> perform_role(GoldMiner)(Dwarf)
- 
+
 At issue is whether dynamic role assignment is sufficiently important
 to warrant a dedicated spelling.
 
@@ -500,12 +500,12 @@ translate ::
 
   class MyRole(metaclass=Role):
     ...
-    
+
 into ::
 
   role MyRole:
     ...
-    
+
 Assigning a role could take advantage of the class definition
 arguments proposed in PEP 3115: ::
 
@@ -535,13 +535,13 @@ References
 
 .. [#roles-examples]
    http://www.perlmonks.org/?node_id=384858
-   
+
 .. [#perl6-s12]
    http://dev.perl.org/perl6/doc/design/syn/S12.html
-   
+
 .. [#traits-paper]
    http://www.iam.unibe.ch/~scg/Archive/Papers/Scha03aTraits.pdf
-   
+
 .. [#proposal]
    http://mail.python.org/pipermail/python-3000/2007-April/007026.html
 

--- a/pep-3134.txt
+++ b/pep-3134.txt
@@ -91,7 +91,7 @@ Rationale
     '__context__' because the intended meaning is more specific than
     temporal precedence but less specific than causation: an exception
     occurs in the context of handling another exception.
-    
+
     This PEP suggests names with leading and trailing double-underscores
     for these three attributes because they are set by the Python VM.
     Only in very special cases should they be set by normal assignment.
@@ -177,16 +177,16 @@ Implicit Exception Chaining
                     log(file, exc)
             finally:
                 file.clos()             # oops, misspelled 'close'
-        
+
         def compute():
             1/0
-        
+
         def log(file, exc):
             try:
                 print >>file, exc       # oops, file is not writable
             except:
                 display(exc)
-        
+
         def display(exc):
             print ex                    # oops, misspelled 'exc'
 
@@ -200,7 +200,7 @@ Implicit Exception Chaining
     The proposed semantics are as follows:
 
     1.  Each thread has an exception context initially set to None.
-    
+
     2.  Whenever an exception is raised, if the exception instance does
         not already have a '__context__' attribute, the interpreter sets
         it equal to the thread's exception context.
@@ -225,7 +225,7 @@ Explicit Exception Chaining
         exc = EXCEPTION
         exc.__cause__ = CAUSE
         raise exc
-    
+
     In the following example, a database provides implementations for a
     few different kinds of storage, with file storage as one kind.  The
     database designer wants errors to propagate as DatabaseError objects
@@ -300,7 +300,7 @@ Enhanced Reporting
 
     between tracebacks, depending whether they are linked by __cause__
     or __context__ respectively.  Here is a sketch of the procedure:
-    
+
         def print_chain(exc):
             if exc.__cause__:
                 print_chain(exc.__cause__)
@@ -443,7 +443,7 @@ Open Issue:  Garbage Collection
     instead turn the reference from the stack frame to the 'err' variable
     into a weak reference when the variable goes out of scope [13].
 
-  
+
 Possible Future Compatible Changes
 
     These changes are consistent with the appearance of exceptions as
@@ -523,7 +523,7 @@ References
 
     [9] Tony Olensky, "Omnibus Structured Exception/Error Handling Mechanism"
         http://dev.perl.org/perl6/rfc/88.html
-     
+
    [10] MSDN .NET Framework Library, "Exception.InnerException Property"
         http://msdn.microsoft.com/library/en-us/cpref/html/frlrfsystemexceptionclassinnerexceptiontopic.asp
 

--- a/pep-3136.txt
+++ b/pep-3136.txt
@@ -275,7 +275,7 @@ Or, with ``label`` instead of ``as``::
                 break a_loop
             ...
         ...
-    
+
 
 This has all the benefits outlined above.  It requires modifications
 to the language syntax: the syntax of ``break`` and ``continue``
@@ -438,9 +438,9 @@ Footnotes
    likes: ``as``, ``label``, ``labeled``, ``loop``, ``name``, ``named``,
    ``walrus``, whatever.
 
-.. [#as] The use of ``as`` in a similar context has been proposed here, 
+.. [#as] The use of ``as`` in a similar context has been proposed here,
    http://sourceforge.net/tracker/index.php?func=detail&aid=1714448&group_id=5470&atid=355470
-   but to my knowledge this idea has not been written up as a PEP. 
+   but to my knowledge this idea has not been written up as a PEP.
 
 .. [#breakcontinue] To continue the Nth outer loop, you would write
    break N-1 times and then continue.  Only one ``continue`` would be
@@ -458,7 +458,7 @@ my knowledge.
   ``do...while`` loops
 
   __ http://groups.google.com/group/comp.lang.python/browse_thread/thread/6da848f762c9cf58/979ca3cd42633b52?lnk=gst&q=labeled+break&rnum=3#979ca3cd42633b52
-  
+
 * `break LABEL vs. exceptions + PROPOSAL`__, on python-list, as
   compared to using Exceptions for flow control
 

--- a/pep-3137.txt
+++ b/pep-3137.txt
@@ -266,7 +266,7 @@ always be explicit, using an encoding.  There are two equivalent APIs:
 ``b.decode(<encoding>[, <errors>])``, and
 ``bytes(s, <encoding>[, <errors>])`` is equivalent to
 ``s.encode(<encoding>[, <errors>])``.
-  
+
 There is one exception: we can convert from bytes (or bytearray) to str
 without specifying an encoding by writing ``str(b)``.  This produces
 the same result as ``repr(b)``.  This exception is necessary because

--- a/pep-3139.txt
+++ b/pep-3139.txt
@@ -53,10 +53,10 @@ major groups:
    - ps1 and ps2
    - stdin, stderr, stdout, __stdin__, __stderr__, __stdout__
    - tracebacklimit
-   
+
 
 2. Data and functions that affect the CPython interpreter.
-   
+
    - get/setrecursionlimit
    - get/setcheckinterval
    - _getframe and _current_frame

--- a/pep-3141.txt
+++ b/pep-3141.txt
@@ -259,7 +259,7 @@ totally ordered except for NaNs (which this PEP basically ignores). ::
             raise NotImplementedError
 
         @abstractmethod
-        def __le__(self, other): 
+        def __le__(self, other):
             raise NotImplementedError
 
         # __gt__ and __ge__ are automatically done by reversing the arguments.

--- a/pep-3143.txt
+++ b/pep-3143.txt
@@ -25,7 +25,7 @@ provides a simple interface to the task of becoming a daemon process.
 
 ..  contents::
 ..
-    Table of Contents: 
+    Table of Contents:
     Abstract
     Specification
       Example usage

--- a/pep-3146.txt
+++ b/pep-3146.txt
@@ -202,9 +202,9 @@ which we considered, but found unsatisfactory.
   no plans for 64-bit support; supports x86 only; very difficult to maintain;
   incompatible with SSE2 optimized code due to alignment issues.
 - *PyPy*: PyPy [#pypy]_ has good performance on numerical code, but is slower
-  than Unladen Swallow on some workloads. Migration of large applications from 
-  CPython to PyPy would be prohibitively expensive: PyPy's JIT compiler supports 
-  only 32-bit x86 code generation; important modules, such as MySQLdb and 
+  than Unladen Swallow on some workloads. Migration of large applications from
+  CPython to PyPy would be prohibitively expensive: PyPy's JIT compiler supports
+  only 32-bit x86 code generation; important modules, such as MySQLdb and
   pycrypto, do not build against PyPy; PyPy does not offer an embedding API,
   much less the same API as CPython.
 - *PyV8*: PyV8 [#pyv8]_ is an alpha-stage experimental Python-to-JavaScript
@@ -351,7 +351,7 @@ issue as critical to final merger into the ``py3k`` branch.
 We have obviously not met our initial goal of a 5x performance improvement. A
 `performance retrospective`_ follows, which addresses why we failed to meet our
 initial performance goal. We maintain a list of yet-to-be-implemented
-performance work [#us-perf-punchlist]_. 
+performance work [#us-perf-punchlist]_.
 
 
 Memory Usage
@@ -1114,7 +1114,7 @@ References
 ==========
 
 .. [#us-post-mortem]
-   http://qinsb.blogspot.com/2011/03/unladen-swallow-retrospective.html   
+   http://qinsb.blogspot.com/2011/03/unladen-swallow-retrospective.html
 
 .. [#dead-parrot]
    http://en.wikipedia.org/wiki/Dead_Parrot_sketch
@@ -1495,4 +1495,4 @@ This document has been placed in the public domain.
    End:
 
 
- 
+

--- a/pep-3148.txt
+++ b/pep-3148.txt
@@ -79,7 +79,7 @@ asynchronously.
 
 ``map(func, *iterables, timeout=None)``
 
-    Equivalent to ``map(func, *iterables)`` but func is executed 
+    Equivalent to ``map(func, *iterables)`` but func is executed
     asynchronously and several calls to func may be made concurrently.
     The returned iterator raises a `TimeoutError` if `__next__()` is
     called and the result isn't available after *timeout* seconds from
@@ -94,7 +94,7 @@ asynchronously.
     using when the currently pending futures are done executing.
     Calls to `Executor.submit` and `Executor.map` and made after
     shutdown will raise `RuntimeError`.
- 
+
     If wait is `True` then this method will not return until all the
     pending futures are done executing and the resources associated
     with the executor have been freed. If wait is `False` then this
@@ -161,7 +161,7 @@ And::
         # This will never complete because there is only one worker thread and
         # it is executing this function.
         print(f.result())
-    
+
     executor = ThreadPoolExecutor(max_workers=1)
     executor.submit(wait_on_future)
 
@@ -204,10 +204,10 @@ callable. `Future` instances are returned by `Executor.submit`.
     the call hasn't completed in *timeout* seconds then a
     `TimeoutError` will be raised.  If *timeout* is not specified or
     `None` then there is no limit to the wait time.
-     
+
     If the future is cancelled before completing then `CancelledError`
     will be raised.
-     
+
     If the call raised then this method will raise the same exception.
 
 ``exception(timeout=None)``
@@ -217,10 +217,10 @@ callable. `Future` instances are returned by `Executor.submit`.
     the call hasn't completed in *timeout* seconds then a
     `TimeoutError` will be raised.  If *timeout* is not specified or
     ``None`` then there is no limit to the wait time.
-     
+
     If the future is cancelled before completing then `CancelledError`
     will be raised.
-     
+
     If the call completed without raising then `None` is returned.
 
 ``add_done_callback(fn)``
@@ -228,13 +228,13 @@ callable. `Future` instances are returned by `Executor.submit`.
     Attaches a callable *fn* to the future that will be called when
     the future is cancelled or finishes running.  *fn* will be called
     with the future as its only argument.
-     
+
     Added callables are called in the order that they were added and
     are always called in a thread belonging to the process that added
     them.  If the callable raises an `Exception` then it will be
     logged and ignored.  If the callable raises another
     `BaseException` then behavior is not defined.
-     
+
     If the future has already completed or been cancelled then *fn*
     will be called immediately.
 
@@ -248,16 +248,16 @@ The following `Future` methods are meant for use in unit tests and
 
     Should be called by `Executor` implementations before executing
     the work associated with the `Future`.
-     
+
     If the method returns `False` then the `Future` was cancelled,
     i.e.  `Future.cancel` was called and returned `True`.  Any threads
     waiting on the `Future` completing (i.e. through `as_completed()`
     or `wait()`) will be woken up.
-     
+
     If the method returns `True` then the `Future` was not cancelled
     and has been put in the running state, i.e. calls to
     `Future.running()` will return `True`.
-     
+
     This method can only be called once and cannot be called after
     `Future.set_result()` or `Future.set_exception()` have been
     called.
@@ -270,7 +270,7 @@ The following `Future` methods are meant for use in unit tests and
 
     Sets the result of the work associated with the `Future` to the
     given `Exception`.
-   
+
 Module Functions
 ''''''''''''''''
 
@@ -282,14 +282,14 @@ Module Functions
     futures that completed (finished or were cancelled) before the
     wait completed.  The second set, named "not_done", contains
     uncompleted futures.
-     
+
     *timeout* can be used to control the maximum number of seconds to
     wait before returning.  If timeout is not specified or None then
     there is no limit to the wait time.
-     
+
     *return_when* indicates when the method should return.  It must be
     one of the following constants:
-     
+
     ============================= ==================================================
      Constant                      Description
     ============================= ==================================================
@@ -372,7 +372,7 @@ Web Crawl Example
             future_to_url = dict(
                 (executor.submit(load_url, url, 60), url)
                  for url in URLS)
-    
+
             for future in futures.as_completed(future_to_url):
                 url = future_to_url[future]
                 try:

--- a/pep-3151.txt
+++ b/pep-3151.txt
@@ -196,7 +196,7 @@ Then we can define *useful compatibility* as follows:
   caught after this PEP, but the reverse may be false (because the coalescing
   of ``OSError``, ``IOError`` and others means the ``except`` clause throws
   a slightly broader net)::
-  
+
       try:
           ...
           os.remove(filename)
@@ -477,7 +477,7 @@ Namespace pollution
 Making the exception hierarchy finer-grained makes the root (or builtins)
 namespace larger.  This is to be moderated, however, as:
 
-* only a handful of additional classes are proposed; 
+* only a handful of additional classes are proposed;
 
 * while standard exception types live in the root namespace, they are
   visually distinguished by the fact that they use the CamelCase convention,
@@ -687,7 +687,7 @@ Interpreter core
 Handling of PYTHONSTARTUP raises IOError (but the error gets discarded)::
 
     $ PYTHONSTARTUP=foox ./python
-    Python 3.2a0 (py3k:82920M, Jul 16 2010, 22:53:23) 
+    Python 3.2a0 (py3k:82920M, Jul 16 2010, 22:53:23)
     [GCC 4.4.3] on linux2
     Type "help", "copyright", "credits" or "license" for more information.
     Could not open PYTHONSTARTUP

--- a/pep-3333.txt
+++ b/pep-3333.txt
@@ -191,16 +191,16 @@ WSGI therefore defines two kinds of "string":
   of requests and responses (e.g. POST/PUT input data and HTML page
   outputs).
 
-Do not be confused however: even if Python's ``str`` type is actually 
+Do not be confused however: even if Python's ``str`` type is actually
 Unicode "under the hood", the *content* of native strings must
 still be translatable to bytes via the Latin-1 encoding!  (See
 the section on `Unicode Issues`_ later in  this document for more
 details.)
 
-In short: where you see the word "string" in this document, it refers 
-to a "native" string, i.e., an object of type ``str``, whether it is 
-internally implemented as bytes or unicode.  Where you see references 
-to "bytestring", this should be read as "an object of type ``bytes`` 
+In short: where you see the word "string" in this document, it refers
+to a "native" string, i.e., an object of type ``str``, whether it is
+internally implemented as bytes or unicode.  Where you see references
+to "bytestring", this should be read as "an object of type ``bytes``
 under Python 3, or type ``str`` under Python 2".
 
 And so, even though HTTP is in some sense "really just bytes", there
@@ -231,7 +231,7 @@ support application developers.)
 Here are two example application objects; one is a function, and the
 other is a class::
 
-    HELLO_WORLD = b"Hello world!\n"  
+    HELLO_WORLD = b"Hello world!\n"
 
     def simple_app(environ, start_response):
         """Simplest possible application object"""


### PR DESCRIPTION
Trailing spaces look dirty in some editors. In other editors they are removed automatically, that adds unrelated changes to patches. It is better to remove them all in one commit.

Trailing spaces are removed automatically by the following command:
```sh
egrep -l ' +$' *.txt | xargs sed -i -re 's/ +$//'
```