### PR TITLE
Use number 9999 in a draft PEP

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -147,7 +147,7 @@ errors may be corrected by the editors).
 The standard PEP workflow is:
 
 * You, the PEP author, fork the `PEP repository`_, and create a file named
-  ``pep-0xxx.rst`` that contains your new PEP.  Use "XXX" as your draft PEP
+  ``pep-9999.rst`` that contains your new PEP.  Use "9999" as your draft PEP
   number.
 * Push this to your GitHub fork and submit a pull request.
 * The PEP editors review your PR for structure, formatting, and other errors.

--- a/pep-0012.txt
+++ b/pep-0012.txt
@@ -58,7 +58,7 @@ directions below.
   will allow PEPs to be rendered on GitHub. ``.txt`` extensions still
   exists for legacy reasons.
 
-- Replace the "PEP: 12" header with "PEP: XXX" since you don't yet
+- Replace the "PEP: 12" header with "PEP: 9999" since you don't yet
   have a PEP number assignment.
 
 - Change the Title header to the title of your PEP.


### PR DESCRIPTION
Update PEP 1 and PEP 12 with instruction to use the number 9999.

Closes https://github.com/python/peps/issues/223