### PR TITLE
PEP-508: Fix imprecisions about `python_version`

### DIFF
--- a/pep-0508.txt
+++ b/pep-0508.txt
@@ -53,7 +53,7 @@ Examples
 
 All features of the language shown with a name based lookup::
 
-    requests [security,tests] >= 2.8.1, == 2.8.* ; python_version < "2.7.10"
+    requests [security,tests] >= 2.8.1, == 2.8.* ; python_version < "2.7"
 
 A minimal URL based lookup::
 

--- a/pep-0508.txt
+++ b/pep-0508.txt
@@ -324,8 +324,8 @@ permitted to be present in PyPI uploaded distributions anyway.
 
 Secondly, PEP-426 markers which have had some reasonable deployment,
 particularly in wheels and pip, will handle version comparisons with
-``python_version`` "2.7.10" differently. Specifically in 426 "2.7.10" is less
-than "2.7.9". This backward incompatibility is deliberate. We are also
+``python_full_version`` "2.7.10" differently. Specifically in 426 "2.7.10" is
+less than "2.7.9". This backward incompatibility is deliberate. We are also
 defining new operators - "~=" and "===", and new variables -
 ``platform_release``, ``platform_system``, ``implementation_name``, and
 ``implementation_version`` which are not present in older marker


### PR DESCRIPTION
This PR has 2 changes. They come from a discussion on pypa/packaging/issues/86.

This first is not a mistake per-say. I changed the example to compare
`python_version < 2.7` instead of `2.7.10`, as it'll avoid some surprise, if comparing while having Python 2.7.13 installed, and then expection this to be False, but then evaluates as True because the user forgot that `python_version` is only the first two number of the python version, which is roughly equivalent to `2.7.0` in PEP-440 version comparison.

The second one is a small mistake. The PEP stated:
> PEP-426 markers [...] will handle version comparisons with ``python_version`` "2.7.10" differently.

which is wrong, because `python_version` will never be "2.7.10", because it's only the first two version numbers, "2.7". This is why I changed for `python_full_version`.