### PR TITLE
[WIP] PEP 484: Describe a way of annotating decorated declarations

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -280,15 +280,16 @@ Decorators
 ----------
 
 Decorators can modify the types of the functions or classes they
-decorate. To annotate a decorated declaration with the eventual
-decorated type, put a type comment on the line with the decorator::
+decorate. Use the `decorated_type` decorator to declare the type of
+the resulting item after all other decorators have been applied.::
 
-  from typing import ContextManager, Generator
+  from typing import ContextManager, Generator, decorated_type
   from contextlib import contextmanager
 
   class DatabaseSession: ...
 
-  @contextmanager  # type: Callable[[str], ContextManager[DatabaseSession]]
+  @decorated_type(Callable[[str], ContextManager[DatabaseSession]])
+  @contextmanager
   def session(url: str) -> Generator[DatabaseSession, None, None]:
       s = DatabaseSession(url)
       try:
@@ -296,12 +297,12 @@ decorated type, put a type comment on the line with the decorator::
       finally:
           s.close()
 
-If both the decorator and the function being decorated have type
-annotations, a type checker should make sure the inferred type for the
-decorated function is compatible with the declared type. Otherwise,
-the checker can assume the declared type of the topmost decorator
-is accurate for the decorated function's call sites.
-
+The argument of `decorated_type` is a type annotation on the name
+being declared (`session`, in the example above). If you have multiple
+decorators, `decorated_type` must be topmost.  The `decorated_type`
+decorator is invalid on a function declaration that is also decorated
+with `overload`, but you can annotate the implementation of the
+overload series with `decorated_type`.
 
 Generics
 --------

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -276,6 +276,33 @@ implemented by deferring to ``isinstance(x, collections.abc.Callable)``.
 However, ``isinstance(x, typing.Callable[...])`` is not supported.
 
 
+Decorators
+----------
+
+Decorators can modify the types of the functions or classes they
+decorate. To annotate a decorated declaration with the eventual
+decorated type, put a type comment on the line with the decorator::
+
+  from typing import ContextManager, Generator
+  from contextlib import contextmanager
+
+  class DatabaseSession: ...
+
+  @contextmanager  # type: Callable[[str], ContextManager[DatabaseSession]]
+  def session(url: str) -> Generator[DatabaseSession, None, None]:
+      s = DatabaseSession(url)
+      try:
+          yield s
+      finally:
+          s.close()
+
+If both the decorator and the function being decorated have type
+annotations, a type checker should make sure the inferred type for the
+decorated function is compatible with the declared type. Otherwise,
+the checker can assume the declared type of the topmost decorator
+is accurate for the decorated function's call sites.
+
+
 Generics
 --------
 

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -283,7 +283,7 @@ Decorators can modify the types of the functions or classes they
 decorate. Use the `decorated_type` decorator to declare the type of
 the resulting item after all other decorators have been applied.::
 
-  from typing import ContextManager, Generator, decorated_type
+  from typing import ContextManager, Iterator, decorated_type
   from contextlib import contextmanager
 
   class DatabaseSession: ...

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -280,8 +280,8 @@ Decorators
 ----------
 
 Decorators can modify the types of the functions or classes they
-decorate. Use the `decorated_type` decorator to declare the type of
-the resulting item after all other decorators have been applied.::
+decorate. Use the ``decorated_type`` decorator to declare the type of
+the resulting item after all other decorators have been applied::
 
   from typing import ContextManager, Iterator, decorated_type
   from contextlib import contextmanager
@@ -297,12 +297,12 @@ the resulting item after all other decorators have been applied.::
       finally:
           s.close()
 
-The argument of `decorated_type` is a type annotation on the name
-being declared (`session`, in the example above). If you have multiple
-decorators, `decorated_type` must be topmost.  The `decorated_type`
-decorator is invalid on a function declaration that is also decorated
-with `overload`, but you can annotate the implementation of the
-overload series with `decorated_type`.
+The argument of ``decorated_type`` is a type annotation on the name
+being declared (``session``, in the example above). If you have
+multiple decorators, ``decorated_type`` must be topmost.  The
+``decorated_type`` decorator is invalid on a function declaration that
+is also decorated with ``overload``, but you can annotate the
+implementation of the overload series with ``decorated_type``.
 
 Generics
 --------

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -290,7 +290,7 @@ the resulting item after all other decorators have been applied.::
 
   @decorated_type(Callable[[str], ContextManager[DatabaseSession]])
   @contextmanager
-  def session(url: str) -> Generator[DatabaseSession, None, None]:
+  def session(url: str) -> Iterator[DatabaseSession]:
       s = DatabaseSession(url)
       try:
           yield s


### PR DESCRIPTION
We want to be able to declare the fully-decorated type of a decorated declaration:
* Your decorator might not have type annotations, but you'd still like to check call sites of your decorated function
* When you're trying to figure out how to use a function, it's nice to have its signature right there to look at -- if all you have is the undecorated signature, it might be misleading.

In relation to https://github.com/python/typing/issues/412