### PR TITLE
fix typos in PEP 544

### DIFF
--- a/pep-0544.txt
+++ b/pep-0544.txt
@@ -672,7 +672,7 @@ Protocols are essentially anonymous. To emphasize this point, static type
 checkers might refuse protocol classes inside ``NewType()`` to avoid an
 illusion that a distinct type is provided::
 
-  form typing import NewType , Protocol, Iterator
+  from typing import NewType, Protocol, Iterator
 
   class Id(Protocol):
       code: int
@@ -731,7 +731,7 @@ with PEP 484. Examples::
 
   def process(items: Iterable[int]) -> None:
       if isinstance(items, Iterator):
-          # 'items' have type 'Iterator[int]' here
+          # 'items' has type 'Iterator[int]' here
       elif isinstance(items, Sequence[int]):
           # Error! Can't use 'isinstance()' with subscripted protocols
 
@@ -864,7 +864,8 @@ reasons:
   which won't happen.
 * Protocol classes should generally not have many method implementations,
   as they describe an interface, not an implementation.
-  Most classes have many implementations, making them bad protocol classes.
+  Most classes have many method implementations, making them bad protocol
+  classes.
 * Experience suggests that many classes are not practical as protocols anyway,
   mainly because their interfaces are too large, complex or
   implementation-oriented (for example, they may include de facto


### PR DESCRIPTION
Fixes a few typos in an example and a confusing phrase.