### PR TITLE
PEP 484: Add implicit promotions for Python 2.7

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -2126,6 +2126,9 @@ Notes:
         '''Docstring'''
         # # type: () -> None # This is OK
 
+When checking Python 2.7 code, type checkers should treat the ``int`` and
+``long`` types as equivalent. For parameters typed as ``unicode`` or
+``Text``, arguments of type ``str`` should be acceptable.
 
 Rejected Alternatives
 =====================


### PR DESCRIPTION
This was discussed in https://github.com/python/typeshed/issues/270#issuecomment-296411726. Both mypy and pytype behave as described already. We should document this behavior in the PEP to make sure people are aware of it and promote uniformity.

Mypy also implicitly promotes bytearray to bytes in both Python 2 and 3. Not sure if that's worth codifying in the PEP too.

@vlasovskikh Is this also OK for PyCharm?