### PR TITLE
Correct bad naming in TypeScript example

### DIFF
--- a/pep-0544.txt
+++ b/pep-0544.txt
@@ -205,7 +205,7 @@ approaches related to structural subtyping in Python and other languages:
         size?: int;
     }
 
-    function printLabel(obj: LabeledValue) {
+    function printLabel(obj: LabeledItem) {
         console.log(obj.label);
     }
 


### PR DESCRIPTION
The interface should be named `LabeledItem` and not `LabeledValue`.