### PR TITLE
PEP 545: Update licensing after discussion with Van. L from the PSF

### DIFF
--- a/pep-0545.txt
+++ b/pep-0545.txt
@@ -181,7 +181,7 @@ by changing the end of the path.
 So we should use the following pattern:
 "docs.python.org/LANGUAGE_TAG/VERSION/".
 
-The current documentation is not moved to "/en/", insted
+The current documentation is not moved to "/en/", instead
 "docs.python.org/en/" will redirect to "docs.python.org".
 
 
@@ -293,7 +293,7 @@ projects of the `Python GitHub organization`_.
 
 For consistency, translation repositories should be called
 ``python-docs-LANGUAGE_TAG`` [22]_, using the language tag used in
-paths: without region subtag if redundent, and lowercased.
+paths: without region subtag if redundant, and lowercased.
 
 The docsbuild-scripts may enforce this rule by refusing to fetch
 outside of the Python organization or a wrongly named repository.
@@ -491,7 +491,7 @@ Previous Discussions
 .. _[Python-ideas] Cross link documentation translations (January, 2016):
    https://mail.python.org/pipermail/python-ideas/2016-January/038010.html
 
-.. _[Python-Dev] Translated Python documentation (Febrary 2016):
+.. _[Python-Dev] Translated Python documentation (February 2016):
    https://mail.python.org/pipermail/python-dev/2017-February/147416.html
 
 .. _[Python-ideas] https://docs.python.org/fr/ ? (March 2016):
@@ -532,7 +532,7 @@ References
 .. [10] Wikipedia: Simple English
    (https://simple.wikipedia.org/wiki/Main_Page)
 
-.. [11] Python-dev discussion about simplified english
+.. [11] Python-dev discussion about simplified English
    (https://mail.python.org/pipermail/python-dev/2017-February/147446.html)
 
 .. [12] Passing options to sphinx from Doc/Makefile

--- a/pep-0545.txt
+++ b/pep-0545.txt
@@ -28,8 +28,7 @@ http://docs.python.org/en/ will redirect to http://docs.python.org/.
 
 Sources of translated documentation will be hosted in the Python
 organization on GitHub: https://github.com/python/.  Contributors will
-have to sign the Python Contributor Agreement (CLA) and the license
-will be the PSF License.
+have to accept a Documentation Contribution Agreement (to be written).
 
 
 Motivation
@@ -341,9 +340,8 @@ Each language team should have one coordinator responsible for:
 - Redirect issues posted on b.p.o to the correct GitHub issue tracker
   for the language.
 
-The license will be the `PSF License
-<https://docs.python.org/3/license.html>`_, and copyright should be
-transferable to PSF later.
+The license will be a Documentation Contribution Agreement (to be
+written).
 
 
 Alternatives

--- a/pep-0545.txt
+++ b/pep-0545.txt
@@ -207,13 +207,12 @@ states that tags are not case sensitive.  As the RFC allows lower case,
 and it enhances readability, we should use lowercased tags like
 ``pt-br``.
 
-It's redundant to display both language and country code if they're
-the same, for example: "de-DE" or "fr-FR".  Although it might make
-sense, respectively meaning "German as spoken in Germany" and "French
-as spoken in France", it's not useful information for the reader.  So
-we may drop these redundancies and only keep the country code for
-cases where it makes sense, for example, "pt-BR" for "Portuguese as
-spoken in Brazil".
+We may drop the region subtag when it does does not add
+distinguishing information, for example: "de-DE" or "fr-FR".
+(Although it might make sense, respectively meaning "German as
+spoken in Germany" and "French as spoken in France"). But when
+the region subtag actually adds information, for example "pt-BR"
+for "Portuguese as spoken in Brazil", it should be kept.
 
 So we should use IETF language tags, lowercased, like ``/fr/``,
 ``/pt-br/``, ``/de/`` and so on.

--- a/pep-0545.txt
+++ b/pep-0545.txt
@@ -42,7 +42,7 @@ to all users in any language: this is also why Python 3 supports
 any non-ASCII identifiers:
 https://www.python.org/dev/peps/pep-3131/#rationale
 
-There are a least 3 groups of people who are translating the Python
+There are at least 3 groups of people who are translating the Python
 documentation to their native language (French [16]_ [17]_ [18]_,
 Japanese [19]_ [20]_, Spanish [21]_) even though their translations
 are not visible on d.p.o.  Other, less visible and less organized

--- a/pep-0545.txt
+++ b/pep-0545.txt
@@ -299,7 +299,7 @@ outside of the Python organization or a wrongly named repository.
 
 The CLA bot may be used on the translation repositories, but with a
 limited effect as local coordinators may synchronize themselves with
-translations from an external tool, like transifex, and loose track
+translations from an external tool, like transifex, and lose track
 of who translated what in the process.
 
 Versions can be hosted on different repositories, different directories
@@ -316,8 +316,8 @@ Translation tools
 
 Most of the translation work is actually done on Transifex [15]_.
 
-Other tools may be used later https://pontoon.mozilla.org/
-and http://zanata.org/
+Other tools may be used later like https://pontoon.mozilla.org/
+and http://zanata.org/.
 
 
 Contributor Agreement

--- a/pep-0545.txt
+++ b/pep-0545.txt
@@ -42,15 +42,16 @@ to all users in any language: this is also why Python 3 supports
 any non-ASCII identifiers:
 https://www.python.org/dev/peps/pep-3131/#rationale
 
-There are at least 3 groups of people who are translating the Python
+There are at least 4 groups of people who are translating the Python
 documentation to their native language (French [16]_ [17]_ [18]_,
-Japanese [19]_ [20]_, Spanish [21]_) even though their translations
-are not visible on d.p.o.  Other, less visible and less organized
-groups, are also translating the documentation, we've heard of Russian
-[26]_, Chinese and Korean. Others we haven't found yet might also
-exist.  This PEP defines rules describing how to move translations on
-docs.python.org so they can easily be found by developers, newcomers
-and potential translators.
+Japanese [19]_ [20]_, Spanish [21]_, Hungarian [27]_ [28]_) even
+though their translations are not visible on d.p.o.  Other, less
+visible and less organized groups, are also translating the
+documentation, we've heard of Russian [26]_, Chinese and
+Korean. Others we haven't found yet might also exist.  This PEP
+defines rules describing how to move translations on docs.python.org
+so they can easily be found by developers, newcomers and potential
+translators.
 
 The Japanese team has (as of March 2017) translated ~80% of the
 documentation, the French team ~20%.  French translation went from 6%
@@ -578,6 +579,12 @@ References
 
 .. [26] Документация Python 2.7!
    (http://python-lab.ru/documentation/index.html)
+
+.. [27] Python-oktató
+   (http://harp.pythonanywhere.com/python_doc/tutorial/index.html)
+
+.. [28] The Python-hu Archives
+   (https://mail.python.org/pipermail/python-hu/)
 
 Copyright
 =========


### PR DESCRIPTION
I discussed about the translation licensing issue with Van L and he directed me toward a nice solution which is: The PSF should write a "Documentation Contribution Agreement" and we'll have to ensure by one way or another that each contributors, from each contribution source whatever they are, agree with it.

This PR also contain previously unmerged feedback I got on python-dev (typos and so on).