### PR TITLE
PEP 545: Add rationale about the License Agreement, and be precise ab…

### DIFF
--- a/pep-0545.txt
+++ b/pep-0545.txt
@@ -28,7 +28,7 @@ http://docs.python.org/en/ will redirect to http://docs.python.org/.
 
 Sources of translated documentation will be hosted in the Python
 organization on GitHub: https://github.com/python/.  Contributors will
-have to accept a Documentation Contribution Agreement (to be written).
+have to accept a Documentation Contribution Agreement.
 
 
 Motivation
@@ -319,13 +319,38 @@ Other tools may be used later like https://pontoon.mozilla.org/
 and http://zanata.org/.
 
 
-Contributor Agreement
-'''''''''''''''''''''
+Documentation Contribution Agreement
+''''''''''''''''''''''''''''''''''''
 
-Contributions to translated documentation will be requested to sign
-the Python Contributor Agreement (CLA):
+Documentation does require a license from the translator, as it
+involves creativity in the expression of the ideas.
 
-https://www.python.org/psf/contrib/contrib-form/
+There's multiple solutions, quoting Van Lindberg from the PSF asked
+about the subject:
+
+  1. Docs should either have the copyright​ assigned or be under CCO. A
+     permissive software license (like Apache or MIT) would also get the
+     job done, although it is not quite fit for task.
+
+  2. The translators should either sign an agreement or submit a
+     declaration of the license with the translation.
+
+  3. We should have in the project page an invitation for people to
+     contribute under a defined license, with acceptance defined by their
+     act of contribution. Such as:
+
+  "By posting this project on Transifex and inviting you to
+  participate, we are proposing an agreement that you will provide
+  your translation for the PSF's use under the CC0 license. In return,
+  you may noted that you were the translator for the portion you
+  translate. You signify acceptance of this agreement by submitting
+  your work to the PSF for inclusion in the documentation."
+
+
+It looks like having a "Documentation Contribution Agreement"
+is the most simple thing we can do as we can use multiple ways (github
+bots, invitation page, …) in different context to ensure contributors
+are agreeing with it.
 
 
 Language Team
@@ -335,13 +360,11 @@ Each language team should have one coordinator responsible for:
 
 - Managing the team.
 - Choosing and managing the tools the team will use (chat, mailing list, …).
-- Ensure contributors understand and agree with the CLA.
+- Ensure contributors understand and agree with the documentation
+  contribution agreement.
 - Ensure quality (grammar, vocabulary, consistency, filtering spam, ads, …).
 - Redirect issues posted on b.p.o to the correct GitHub issue tracker
   for the language.
-
-The license will be a Documentation Contribution Agreement (to be
-written).
 
 
 Alternatives
@@ -370,12 +393,29 @@ Esperanto!
 Changes
 =======
 
+Get a Documentation Contribution Agreement
+------------------------------------------
+
+The Documentation Contribution Agreement have to be written by the
+PSF, then listed at https://www.python.org/psf/contrib/ and have its
+own page like https://www.python.org/psf/contrib/doc-contrib-form/.
+
+
 Migrate GitHub Repositories
 ---------------------------
 
 We (authors of this PEP) already own French and Japanese Git repositories,
 so moving them to the Python documentation organization will not be a
 problem.  We'll however be following the `New Translation Procedure`_.
+
+
+Setup a github bot for Documentation Contribution Agreement
+-----------------------------------------------------------
+
+To help ensuring contributors from github have signed the
+Documentation Contribution Agreement, We can setup the "The Knights
+Who Say Ni" github bot customized for this agreement on the migrated
+repositories [29]_.
 
 
 Patch docsbuild-scripts to Compile Translations
@@ -454,6 +494,13 @@ Create a repository named "python-docs-{LANGUAGE_TAG}" (IETF language
 tag, without redundent region subtag, with a dash, and lowercased.) on
 the Python github organization (See `Repository For Po Files`_.), and
 grant the language coordinator push rights to this repository.
+
+
+Setup the Documentation Contribution Agreement Bot
+--------------------------------------------------
+
+The newly created repository have to be added in the list of
+repositories The Knight Who Say Ni is watching.
 
 
 Add support for translations in docsbuild-scripts
@@ -582,6 +629,10 @@ References
 
 .. [28] The Python-hu Archives
    (https://mail.python.org/pipermail/python-hu/)
+
+.. [29] [Python-Dev] PEP 545: Python Documentation Translations
+   (https://mail.python.org/pipermail/python-dev/2017-April/147752.html)
+
 
 Copyright
 =========


### PR DESCRIPTION
…out its implementation.

There stil was unereplaced mentions of the "CLA", the replacement (from CLA to Documentation Contribution Agreement) deserved a more precise explanation in the Rational chapter. Also mentionning Brett's response about using The Knight Who Say Ni (https://mail.python.org/pipermail/python-dev/2017-April/147752.html). 