### PR TITLE
PEP 517: Specify UTF-8 for captured output

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -262,6 +262,15 @@ tree, and MAY print arbitrary informational text on stdout and
 stderr. They MUST NOT read from stdin, and the build frontend MAY
 close stdin before invoking the hooks.
 
+The build frontend may capture stdout and/or stderr from the backend. If the
+backend detects that an output stream is not a terminal/console (e.g.
+``not sys.stdout.isatty()``), it SHOULD ensure that any output it writes to that
+stream is UTF-8 encoded. The build frontend MUST NOT fail if captured output is
+not valid UTF-8, but it MAY not preserve all the information in that case (e.g.
+it may decode using the *replace* error handler in Python). If the output stream
+is a terminal, the build backend is responsible for presenting its output
+accurately, as for any program running in a terminal.
+
 If a hook raises an exception, or causes the process to terminate,
 then this indicates an error.
 


### PR DESCRIPTION
From a discussion on the mailing list.

This is not yet completely agreed upon, but it's my best take on the solution.