### PR TITLE
Update PEP 11 for PEP 538 acceptance

### DIFF
--- a/pep-0011.txt
+++ b/pep-0011.txt
@@ -144,6 +144,17 @@ patches will be accepted. Such build files will be removed from the
 source tree 3 years after the extended support for the compiler has
 ended (but continue to remain available in revision control).
 
+Legacy C Locale
+---------------
+
+Starting with CPython 3.7.0, \*nix platforms are expected to provide
+at least one of ``C.UTF-8`` (full locale), ``C.utf8`` (full locale) or
+``UTF-8`` (``LC_CTYPE``-only locale) as an alternative to the legacy ``C``
+locale.
+
+Any Unicode related integration problems that occur only in the legacy ``C``
+locale and cannot be reproduced in an appropriately configured non-ASCII
+locale will be closed as "won't fix".
 
 No-longer-supported platforms
 -----------------------------

--- a/pep-0011.txt
+++ b/pep-0011.txt
@@ -152,7 +152,7 @@ at least one of ``C.UTF-8`` (full locale), ``C.utf8`` (full locale) or
 ``UTF-8`` (``LC_CTYPE``-only locale) as an alternative to the legacy ``C``
 locale.
 
-Any Unicode related integration problems that occur only in the legacy ``C``
+Any Unicode-related integration problems that occur only in the legacy ``C``
 locale and cannot be reproduced in an appropriately configured non-ASCII
 locale will be closed as "won't fix".
 


### PR DESCRIPTION
Part of the PEP 538 implementation is to add a new
"Legacy C Locale" section to PEP 11 that explicitly
limits our support for running Python 3.7+ in the
ASCII based legacy C locale.

(Note: if PEP 540 is also accepted, this section will
be amended accordingly)