### PR TITLE
Add build_sdist and tweak the existing interface

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -166,14 +166,15 @@ The build backend object is expected to have attributes which provide
 some or all of the following hooks. The common ``config_settings``
 argument is described after the individual hooks::
 
-  def get_build_requires(config_settings):
+  def get_build_requires(source_directory, config_settings):
       ...
 
 This hook MUST return an additional list of strings containing PEP 508
 dependency specifications, above and beyond those specified in the
-``pyproject.toml`` file. Example::
+``pyproject.toml`` file. The ``source_directory`` parameter MUST be a path that
+points to the source tree that is being operated on. Example::
 
-  def get_build_requires(config_settings):
+  def get_build_requires(source_directory, config_settings):
       return ["wheel >= 0.25", "setuptools"]
 
 Optional. If not defined, the default implementation is equivalent to
@@ -181,15 +182,15 @@ Optional. If not defined, the default implementation is equivalent to
 
 ::
 
-  def get_wheel_metadata(metadata_directory, config_settings):
+  def get_wheel_metadata(source_directory, metadata_directory, config_settings):
       ...
 
 Must create a ``.dist-info`` directory containing wheel metadata
 inside the specified ``metadata_directory`` (i.e., creates a directory
-like ``{metadata_directory}/{package}-{version}.dist-info/``. This
-directory MUST be a valid ``.dist-info`` directory as defined in the
-wheel specification, except that it need not contain ``RECORD`` or
-signatures. The hook MAY also create other files inside this
+like ``{metadata_directory}/{package}-{version}.dist-info/`` for the source tree
+indicated by ``source_directory``. This directory MUST be a valid ``.dist-info``
+directory as defined in the wheel specification, except that it need not contain
+``RECORD`` or signatures. The hook MAY also create other files inside this
 directory, and a build frontend MUST ignore such files; the intention
 here is that in cases where the metadata depends on build-time
 decisions, the build backend may need to record these decisions in
@@ -203,11 +204,11 @@ metadata directly.
 
 ::
 
-  def build_wheel(wheel_directory, config_settings, metadata_directory=None):
+  def build_wheel(source_directory, wheel_directory, config_settings, metadata_directory=None):
       ...
 
-Must build a ``.whl`` file, and place it in the specified
-``wheel_directory``.
+Must build a ``.whl`` file from the ``source_directory``, and place it in the
+specified ``wheel_directory``.
 
 If the build frontend has previously called ``get_wheel_metadata`` and
 depends on the wheel resulting from this call to have metadata
@@ -505,14 +506,14 @@ build backend::
     # mypackage_custom_build_backend.py
     import os.path
 
-    def get_build_requires(config_settings, config_directory):
+    def get_build_requires(source_directory, config_settings, config_directory):
         return ["wheel"]
 
-    def build_wheel(wheel_directory, config_settings, config_directory=None):
+    def build_wheel(source_directory, wheel_directory, config_settings, config_directory=None):
         from wheel.archive import archive_wheelfile
         path = os.path.join(wheel_directory,
                             "mypackage-0.1-py2.py3-none-any")
-        archive_wheelfile(path, "src/")
+        archive_wheelfile(path, os.path.join(source_directory, "src/"))
 
 Of course, this is a *terrible* build backend: it requires the user to
 have manually set up the wheel metadata in
@@ -608,19 +609,19 @@ make the ``get_wheel_metadata`` command optional. In our design, this
 can easily be worked around by a tool like ``pip``, which can put code
 in its subprocess runner like::
 
-    def get_wheel_metadata(output_dir, config_settings):
+    def get_wheel_metadata(source_dir, output_dir, config_settings):
          if hasattr(backend, "get_wheel_metadata"):
-             backend.get_wheel_metadata(output_dir, config_settings)
+             backend.get_wheel_metadata(source_dir, output_dir, config_settings)
          else:
-             backend.build_wheel(output_dir, config_settings)
+             backend.build_wheel(source_dir, output_dir, config_settings)
              touch(output_dir / "PIP_ALREADY_BUILT_WHEELS")
              unzip_metadata(output_dir/*.whl)
 
-    def build_wheel(output_dir, config_settings, metadata_dir):
+    def build_wheel(source_dir, output_dir, config_settings, metadata_dir):
          if os.path.exists(metadata_dir / "PIP_ALREADY_BUILT_WHEELS"):
              copy(metadata_dir / *.whl, output_dir)
          else:
-             backend.build_wheel(output_dir, config_settings, metadata_dir)
+             backend.build_wheel(source_dir, output_dir, config_settings, metadata_dir)
 
 and thus expose a totally uniform interface to the rest of ``pip``,
 with no extra subprocess calls, no duplicated builds, etc. But

--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -535,19 +535,15 @@ build backend::
 
     # mypackage_custom_build_backend.py
     import os.path
+    import shutil
 
     def build_sdist(source_directory, sdist_directory, config_settings):
-        import shutil
         shutil.copytree(source_directory, sdist_directory)
 
-    def get_build_requires(source_directory, config_settings, config_directory):
-        return ["wheel"]
-
     def build_wheel(source_directory, wheel_directory, config_settings, config_directory=None):
-        from wheel.archive import archive_wheelfile
         path = os.path.join(wheel_directory,
                             "mypackage-0.1-py2.py3-none-any")
-        archive_wheelfile(path, os.path.join(source_directory, "src/"))
+        shutil.copytree(source_directory, wheel_directory)
 
 Of course, this is a *terrible* build backend: it requires the user to
 have manually set up the wheel metadata in

--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -196,7 +196,11 @@ here is that in cases where the metadata depends on build-time
 decisions, the build backend may need to record these decisions in
 some convenient format for re-use by the actual wheel-building step.
 
-Return value is ignored.
+The return value MUST be a list that contains the name of the ``.dist-info``
+that was placed into ``metadata_directory`` (e.g. if the backend wrote a
+directory at ``{metadata_directory}/spam-1.0.dist-info`` then the return value
+should be ``["spam-1.0.dist-info"]``). This list MUST contain one, and only one
+entry.
 
 Optional. If a build frontend needs this information and the method is
 not defined, it should call ``build_wheel`` and look at the resulting

--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -166,6 +166,24 @@ The build backend object is expected to have attributes which provide
 some or all of the following hooks. The common ``config_settings``
 argument is described after the individual hooks::
 
+  def build_sdist(source_directory, sdist_directory, config_settings):
+      ...
+
+MUST build an unpacked sdist from the ``source_directory`` and place it into the
+specified ``sdist_directory``. If the ``source_directory`` is already an
+unpacked sdist (as opposed to a VCS source tree) then it SHOULD simply copy the
+entire tree into ``sdist_directory``.
+
+This method only places the *contents* of the sdist file, without actually
+creating the final artifact. This is to allow flexibility in how the result is
+going to be used. A front end like pip, which is only going to immediately
+build a wheel from this directory can speed up the installation process by
+skipping a round trip through tar+gz. However a command like a hypothetical
+``twine sdist`` could call this method and then ultimately tar+gz up this
+directory to produce the sdist artifact.
+
+Mandatory.
+
   def get_build_requires(source_directory, config_settings):
       ...
 
@@ -517,6 +535,10 @@ build backend::
 
     # mypackage_custom_build_backend.py
     import os.path
+
+    def build_sdist(source_directory, sdist_directory, config_settings):
+        import shutil
+        shutil.copytree(source_directory, sdist_directory)
 
     def get_build_requires(source_directory, config_settings, config_directory):
         return ["wheel"]

--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -211,8 +211,8 @@ metadata directly.
   def build_wheel(source_directory, wheel_directory, config_settings, metadata_directory=None):
       ...
 
-Must build a ``.whl`` file from the ``source_directory``, and place it in the
-specified ``wheel_directory``.
+Must build the contents of a ``.whl`` file from the ``source_directory`` and
+place it in the specified ``wheel_directory``.
 
 If the build frontend has previously called ``get_wheel_metadata`` and
 depends on the wheel resulting from this call to have metadata
@@ -222,6 +222,14 @@ provided, then ``build_wheel`` MUST produce a wheel with identical
 metadata. The directory passed in by the build frontend MUST be
 identical to the directory created by ``get_wheel_metadata``,
 including any unrecognized files it created.
+
+This method only places the *contents* of the wheel file, without actually
+creating the final artifact. This is to allow flexibility in how the result is
+going to be used. A front end like pip, which is only going to immediately
+install this wheel can speed up the installation process by skipping a round
+trip through zip. However a command like a hypothetical ``twine wheel`` could
+call this method and then ultimately zip up this directory to produce the
+wheel artifact.
 
 Mandatory.
 


### PR DESCRIPTION
* Add the ``source_directory`` parameter to the build backend methods. This provides an explicit way to pass the source tree that is currently being operated on into each method.
* Return the name of the metadata directory from ``get_wheel_metadata`` as a single item list, allowing future expansion to multiple wheels if needed.
  * Note: This could/should arguably be a single string and if we end up supporting multiple wheels, allow a list return value as well, or create a new method that returns a list.
* For performance reasons, create an unpacked wheel instead of an already zipped ``.whl`` file.
* Add a mandatory ``build_sdist`` method which will build an unpacked sdist, similarly to how ``build_wheel`` creates an unpacked wheel file.