### PR TITLE
Note ASCII-only requirement for public APIs

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -850,6 +850,14 @@ names.
 In some fonts, these characters are indistinguishable from the
 numerals one and zero.  When tempted to use 'l', use 'L' instead.
 
+While support for Unicode identifiers has been added to allow all
+Python developers to use variable names in their native languages,
+the 7-bit ASCII text encoding remains the lowest common denominator
+for text entry when developing Python programs. Accordingly, all
+public standard library APIs use ASCII-only identifiers, and the
+reference implementation's use of non-ASCII identifiers is limited
+to appropriately testing that functionality.
+
 Package and Module Names
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1040,27 +1048,27 @@ Any backwards compatibility guarantees apply only to public interfaces.
 Accordingly, it is important that users be able to clearly distinguish
 between public and internal interfaces.
 
-Documented interfaces are considered public, unless the documentation
-explicitly declares them to be provisional or internal interfaces exempt
-from the usual backwards compatibility guarantees. All undocumented
-interfaces should be assumed to be internal.
+* Documented interfaces are considered public, unless the documentation
+  explicitly declares them to be provisional or internal interfaces exempt
+  from the usual backwards compatibility guarantees. All undocumented
+  interfaces should be assumed to be internal.
 
-To better support introspection, modules should explicitly declare the
-names in their public API using the ``__all__`` attribute. Setting
-``__all__`` to an empty list indicates that the module has no public API.
+* To better support introspection, modules should explicitly declare the
+  names in their public API using the ``__all__`` attribute. Setting
+  ``__all__`` to an empty list indicates that the module has no public API.
 
-Even with ``__all__`` set appropriately, internal interfaces (packages,
-modules, classes, functions, attributes or other names) should still be
-prefixed with a single leading underscore.
+* Even with ``__all__`` set appropriately, internal interfaces (packages,
+  modules, classes, functions, attributes or other names) should still be
+  prefixed with a single leading underscore.
 
-An interface is also considered internal if any containing namespace
-(package, module or class) is considered internal.
+* An interface is also considered internal if any containing namespace
+  (package, module or class) is considered internal.
 
-Imported names should always be considered an implementation detail.
-Other modules must not rely on indirect access to such imported names
-unless they are an explicitly documented part of the containing module's
-API, such as ``os.path`` or a package's ``__init__`` module that exposes
-functionality from submodules.
+* Imported names should always be considered an implementation detail.
+  Other modules must not rely on indirect access to such imported names
+  unless they are an explicitly documented part of the containing module's
+  API, such as ``os.path`` or a package's ``__init__`` module that exposes
+  functionality from submodules.
 
 
 Programming Recommendations

--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -850,13 +850,29 @@ names.
 In some fonts, these characters are indistinguishable from the
 numerals one and zero.  When tempted to use 'l', use 'L' instead.
 
+ASCII Compatibility
+~~~~~~~~~~~~~~~~~~~
+
 While support for Unicode identifiers has been added to allow all
 Python developers to use variable names in their native languages,
 the 7-bit ASCII text encoding remains the lowest common denominator
-for text entry when developing Python programs. Accordingly, all
-public standard library APIs use ASCII-only identifiers, and the
-reference implementation's use of non-ASCII identifiers is limited
-to appropriately testing that functionality.
+for text entry when developing Python programs.
+
+Accordingly, all identifiers in the Python standard library must be
+ASCII-only identifiers.
+
+In addition, string literals and comments should also be ASCII
+compatible. The only exceptions are (a) test cases testing the
+non-ASCII features, and (b) names of authors. Authors whose
+names are not based on the Latin alphabet MUST provide a Latin
+transliteration of their names. 
+
+Readability as English pseudo-code
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Standard library Identifiers should be English words wherever
+feasible. However, abbreviations and technical terms which aren't
+English may also be used when appropriate.
 
 Package and Module Names
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -861,11 +861,11 @@ for text entry when developing Python programs.
 Accordingly, all identifiers in the Python standard library must be
 ASCII-only identifiers.
 
-In addition, string literals and comments should also be ASCII
-compatible. The only exceptions are (a) test cases testing the
-non-ASCII features, and (b) names of authors. Authors whose
-names are not based on the Latin alphabet MUST provide a Latin
-transliteration of their names. 
+In addition, string literals and comments used in the reference
+implementation should also be ASCII compatible. The only exceptions
+are (a) test cases testing the non-ASCII features, and (b) names of
+authors. Authors whose names are not based on the Latin alphabet
+MUST provide a Latin transliteration of their names. 
 
 Readability as English pseudo-code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Due to ASCII continuing to be the lowest common denominator
for text entry, we explicitly restrict public standard library APIs
to using ASCII identifiers.

This also reformats the section defining public APIs as a set
of bullet-points, rather than a series of paragraphs.