### PR TITLE
Cross-reference PEP 3131 from PEP 8

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -856,7 +856,7 @@ ASCII Compatibility
 Identifiers used in the standard library must be ASCII compatible
 as described in the
 `policy section <https://www.python.org/dev/peps/pep-3131/#policy-specification>`_
-of PEP 3131
+of PEP 3131.
 
 Package and Module Names
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -850,6 +850,14 @@ names.
 In some fonts, these characters are indistinguishable from the
 numerals one and zero.  When tempted to use 'l', use 'L' instead.
 
+ASCII Compatibility
+~~~~~~~~~~~~~~~~~~~
+
+Identifiers used in the standard library must be ASCII compatible
+as described in the
+`policy section <https://www.python.org/dev/peps/pep-3131/#policy-specification>`_
+of PEP 3131
+
 Package and Module Names
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
PEP 3131 (Unicode identifiers) includes a policy section
covering their use within the standard library.

This adds an explicit cross-reference to that section from
the prescriptive naming conventions section of PEP 8