### PR TITLE
PEP 517: Clear up ambiguity about metadata_directory

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -696,8 +696,8 @@ in its subprocess runner like::
              unzip_metadata(output_dir/*.whl)
 
     def build_wheel(output_dir, config_settings, metadata_dir):
-         if os.path.exists(metadata_dir / "PIP_ALREADY_BUILT_WHEELS"):
-             copy(metadata_dir / *.whl, output_dir)
+         if os.path.exists(metadata_dir.parent / "PIP_ALREADY_BUILT_WHEELS"):
+             copy(metadata_dir.parent / *.whl, output_dir)
          else:
              backend.build_wheel(output_dir, config_settings, metadata_dir)
 

--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -211,9 +211,9 @@ Must build a .whl file, and place it in the specified ``wheel_directory``.
 
 If the build frontend has previously called ``prepare_wheel_metadata`` and
 depends on the wheel resulting from this call to have metadata
-matching this earlier call, then it should provide the path to the
-previous ``metadata_directory`` as an argument. If this argument is
-provided, then ``build_wheel`` MUST produce a wheel with identical
+matching this earlier call, then it should provide the path to the created
+``.dist-info`` directory as the ``metadata_directory`` argument. If this
+argument is provided, then ``build_wheel`` MUST produce a wheel with identical
 metadata. The directory passed in by the build frontend MUST be
 identical to the directory created by ``prepare_wheel_metadata``,
 including any unrecognized files it created.


### PR DESCRIPTION
An ambiguity in the wording made it look like `metadata_directory` for `build_wheel` would be the same directory as was passed in to the `prepare_wheel_metadata` hook. It makes more sense, I think, for it to be the `.dist-info` directory returned from `prepare_wheel_metadata`.