### PR TITLE
Remove spurious whitespace

### DIFF
--- a/pep-3150.txt
+++ b/pep-3150.txt
@@ -487,7 +487,7 @@ alternative that still allows the key function to be defined inline::
                         key=operator.attrgetter(v. 'attr1', 'attr2'))
 
 Again, it gets the job done, but even the most generous of readers would
- not consider that to be "executable pseudocode".
+not consider that to be "executable pseudocode".
 
 If they think both of the above options are ugly and confusing, or they need
 logic in their key function that can't be expressed as an expression (such


### PR DESCRIPTION
There was a spurious space at the beginning of the line, that transformed the paragraph into a definition list item.