### PR TITLE
Fix broken links in PEP 426

### DIFF
--- a/pep-0426.txt
+++ b/pep-0426.txt
@@ -512,7 +512,7 @@ All comparisons of distribution names MUST be case insensitive, and MUST
 consider hyphens and underscores to be equivalent.
 
 Index servers MAY consider "confusable" characters (as defined by the
-Unicode Consortium in `TR39: Unicode Security Mechanisms <TR39>`_) to be
+Unicode Consortium in `TR39: Unicode Security Mechanisms <TR39_>`_) to be
 equivalent.
 
 Index servers that permit arbitrary distribution name registrations from
@@ -723,7 +723,7 @@ declare:
   dependencies, without needing to be listed three times
 
 These optional categories are known as
-`Extras <Extras (optional dependencies)>`_. In addition to the four
+`Extras <Extras (optional dependencies)_>`_. In addition to the four
 standard categories, projects may also declare their own custom categories
 in the `Extras`_ field.
 

--- a/pep-0426.txt
+++ b/pep-0426.txt
@@ -1487,9 +1487,6 @@ justifications for needing such a standard can be found in PEP 386.
 
 .. _Python Package Index: http://pypi.python.org/pypi/
 
-.. [2] PEP 301:
-   http://www.python.org/dev/peps/pep-0301/
-
 .. _thematically appropriate: https://www.youtube.com/watch?v=CSe38dzJYkY
 
 .. _TR39: http://www.unicode.org/reports/tr39/tr39-1.html#Confusable_Detection


### PR DESCRIPTION
A couple of links in PEP 426 were broken due to malformed markup.  Also, the PEP 301 reference at the bottom of the file was unused.

The "thematically appropriate" YouTube link is still dead, but I don't know what to do about that one.