### PR TITLE
Use correct status for PEP 496

### DIFF
--- a/pep-0496.txt
+++ b/pep-0496.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: James Polley <jp@jamezpolley.com>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
-Status: Superseded
+Status: Rejected
 Type: Informational
 Content-Type: text/x-rst
 Created: 03-Jul-2015
@@ -14,7 +14,8 @@ PEP Status
 
 After this PEP was initially drafted, PEP 508 was developed and submitted to
 fully specify the dependency declaration syntax, including environment markers.
-Accordingly, this PEP has been marked as Superseded.
+As a result, this PEP ended up being rejected in favour of the more comprehensive
+PEP 508.
 
 Abstract
 ========


### PR DESCRIPTION
PEP 496 was never Accepted or Active, so the correct status
is "Rejected in favour of PEP 508" rather than "Superseded
by PEP 508".