### PR TITLE
PEP 484: Remove statement about unicode, in the python2.7 section.

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -2150,7 +2150,7 @@ Notes:
 
 When checking Python 2.7 code, type checkers should treat the ``int`` and
 ``long`` types as equivalent. For parameters typed as ``Text``, arguments of
-both ``str`` and ``unicode`` should be acceptable.
+type ``str`` as well as ``unicode`` should be acceptable.
 
 Rejected Alternatives
 =====================

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -2149,8 +2149,8 @@ Notes:
         # # type: () -> None # This is OK
 
 When checking Python 2.7 code, type checkers should treat the ``int`` and
-``long`` types as equivalent. For parameters typed as ``unicode`` or
-``Text``, arguments of type ``str`` should be acceptable.
+``long`` types as equivalent. For parameters typed as ``Text``, arguments of
+both ``str`` and ``unicode`` should be acceptable.
 
 Rejected Alternatives
 =====================


### PR DESCRIPTION
See https://github.com/python/typing/issues/418#issuecomment-313753006.
Let's leave it up to type-checkers whether they want `unicode`, in Python 2 code, to mean "only unicode" or "str or unicode".