### PR TITLE
PEP 545: Update contribution agreement according to the PSF recommendations

### DIFF
--- a/pep-0545.txt
+++ b/pep-0545.txt
@@ -497,11 +497,30 @@ the Python github organization (See `Repository For Po Files`_.), and
 grant the language coordinator push rights to this repository.
 
 
-Setup the Documentation Contribution Agreement Bot
---------------------------------------------------
+Setup the Documentation Contribution Agreement
+----------------------------------------------
 
-The newly created repository have to be added in the list of
-repositories The Knight Who Say Ni is watching.
+The README file should clearly show the following Documentation
+Contribution Agreement::
+
+   NOTE REGARDING THE LICENSE FOR TRANSLATIONS: Python's documentation is
+   maintained using a global network of volunteers. By posting this
+   project on Transifex, Github, and other public places, and inviting
+   you to participate, we are proposing an agreement that you will
+   provide your improvements to Python's documentation or the translation
+   of Python's documentation for the PSF's use under the CC0 license
+   (available at
+   `https://creativecommons.org/publicdomain/zero/1.0/legalcode`_). In
+   return, you may publicly claim credit for the portion of the
+   translation you contributed and if your translation is accepted by the
+   PSF, you may (but are not required to) submit a patch including an
+   appropriate annotation in the Misc/ACKS or TRANSLATORS file. Although
+   nothing in this Documentation Contribution Agreement obligates the PSF
+   to incorporate your textual contribution, your participation in the
+   Python community is welcomed and appreciated.
+
+   You signify acceptance of this agreement by submitting your work to
+   the PSF for inclusion in the documentation.
 
 
 Add support for translations in docsbuild-scripts

--- a/pep-0545.txt
+++ b/pep-0545.txt
@@ -82,8 +82,8 @@ the translation language, which can be considered noise but at least
 is inconsistent, issues should be placed outside `bugs.python.org
 <https://bugs.python.org/>`_ (b.p.o).
 
-As all translation must have their own github project (see `Repository
-for Po Files`_), they must use the associated github issue tracker.
+As all translation must have their own GitHub project (see `Repository
+for Po Files`_), they must use the associated GitHub issue tracker.
 
 Considering the noise induced by translation issues redacted in any
 languages which may beyond every warnings land in b.p.o, triage will
@@ -281,13 +281,13 @@ repository.
 
 Considering that each translation will be exposed via git
 repositories, and that Python has migrated to GitHub, translations
-will be hosted on github.
+will be hosted on GitGub.
 
 For consistency and discoverability, all translations should be in the
-same github organization and named according to a common pattern.
+same GitGub organization and named according to a common pattern.
 
 Given that we want translations to be official, and that Python
-already has a github organization, translations should be hosted as
+already has a GitGub organization, translations should be hosted as
 projects of the `Python GitHub organization`_.
 
 For consistency, translation repositories should be called
@@ -304,7 +304,7 @@ of who translated what in the process.
 
 Versions can be hosted on different repositories, different directories
 or different branches.  Storing them on different repositories will
-probably pollute the Python github organization.  As it
+probably pollute the Python GitHub organization.  As it
 is typical and natural to use branches to separate versions, branches
 should be used to do so.
 
@@ -349,7 +349,7 @@ about the subject:
 
 
 It looks like having a "Documentation Contribution Agreement"
-is the most simple thing we can do as we can use multiple ways (github
+is the most simple thing we can do as we can use multiple ways (GitHub
 bots, invitation page, …) in different context to ensure contributors
 are agreeing with it.
 
@@ -410,12 +410,12 @@ so moving them to the Python documentation organization will not be a
 problem.  We'll however be following the `New Translation Procedure`_.
 
 
-Setup a github bot for Documentation Contribution Agreement
+Setup a GitHub bot for Documentation Contribution Agreement
 -----------------------------------------------------------
 
-To help ensuring contributors from github have signed the
+To help ensuring contributors from GitHub have signed the
 Documentation Contribution Agreement, We can setup the "The Knights
-Who Say Ni" github bot customized for this agreement on the migrated
+Who Say Ni" GitHub bot customized for this agreement on the migrated
 repositories [29]_.
 
 
@@ -493,7 +493,7 @@ Create Github Repository
 
 Create a repository named "python-docs-{LANGUAGE_TAG}" (IETF language
 tag, without redundent region subtag, with a dash, and lowercased.) on
-the Python github organization (See `Repository For Po Files`_.), and
+the Python GitHub organization (See `Repository For Po Files`_.), and
 grant the language coordinator push rights to this repository.
 
 
@@ -505,7 +505,7 @@ Contribution Agreement::
 
    NOTE REGARDING THE LICENSE FOR TRANSLATIONS: Python's documentation is
    maintained using a global network of volunteers. By posting this
-   project on Transifex, Github, and other public places, and inviting
+   project on Transifex, GitHub, and other public places, and inviting
    you to participate, we are proposing an agreement that you will
    provide your improvements to Python's documentation or the translation
    of Python's documentation for the PSF's use under the CC0 license
@@ -587,7 +587,7 @@ References
 .. [7] Tags for Identifying Languages: Formatting of Language Tags
    (https://tools.ietf.org/html/rfc5646#section-2.1.1)
 
-.. [8] Docsbuild-scripts github repository
+.. [8] Docsbuild-scripts GitHub repository
    (https://github.com/python/docsbuild-scripts/)
 
 .. [9] i18n: Highlight untranslated paragraphs
@@ -614,7 +614,7 @@ References
 .. [16] French translation
    (https://www.afpy.org/doc/python/)
 
-.. [17] French translation github
+.. [17] French translation on GitHub
    (https://github.com/AFPy/python_doc_fr)
 
 .. [18] French mailing list
@@ -623,7 +623,7 @@ References
 .. [19] Japanese translation
    (http://docs.python.jp/3/)
 
-.. [20] Japanese github
+.. [20] Japanese translation on GitHub
    (https://github.com/python-doc-ja/python-doc-ja)
 
 .. [21] Spanish translation


### PR DESCRIPTION
The bot will not be required as the agreement is just to be displayed,
there's no actual signing part.

It's done like this to enable contributions from many different
sources: we'll just have to clearly display this agreement on every
contribution sources.