### PR TITLE
PEP 517: Update hooks in line with discussion

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -200,7 +200,7 @@ If build_directory is None, the backend may do an 'in place' build which
 modifies the source directory. The semantics of this are not specified
 here.
 
-Whateveer the value of build_directory, the backend may also store intermediates
+Whatever the value of build_directory, the backend may also store intermediates
 in other cache locations or temporary directories, which it is responsible for
 managing. The presence or absence of any caches should not make a
 material difference to the final result of the build.

--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -275,7 +275,7 @@ some convenient format for re-use by the actual wheel-building step.
 This must return the basename (not the full path) of the ``.dist-info``
 directory it creates, as a unicode string.
 
-Optional. If a build frontend needs this information and the method is
+If a build frontend needs this information and the method is
 not defined, it should call ``build_wheel`` and look at the resulting
 metadata directly.
 

--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -164,24 +164,101 @@ with tools that do not use this spec.
 
 The build backend object is expected to have attributes which provide
 some or all of the following hooks. The common ``config_settings``
-argument is described after the individual hooks::
+argument is described after the individual hooks.
 
-  def get_build_wheel_requires(config_settings):
+Mandatory hooks
+===============
+
+::
+
+    build_wheel(wheel_directory, config_settings={}, build_directory=None, metadata_directory=None):
+        ...
+
+Must build a .whl file, and place it in the specified ``wheel_directory``.
+
+If the build frontend has previously called ``prepare_wheel_metadata`` and
+depends on the wheel resulting from this call to have metadata
+matching this earlier call, then it should provide the path to the created
+``.dist-info`` directory as the ``metadata_directory`` argument. If this
+argument is provided, then ``build_wheel`` MUST produce a wheel with identical
+metadata. The directory passed in by the build frontend MUST be
+identical to the directory created by ``prepare_wheel_metadata``,
+including any unrecognized files it created.
+
+If build_directory is not None, it is a unicode string containing the
+path to a directory where intermediate build artifacts may be stored.
+This may be empty, or it may contain artifacts from a previous build to
+be used as a cache. The backend is responsible for determining whether
+any cached artifacts are outdated. When a build_directory is provided,
+the backend should not create or modify any files in the source
+directory (the working directory where the hook is called). If the
+backend cannot reliably avoid modifying the directory it builds from, it
+should copy any files it needs to build_directory and perform the build
+there.
+
+If build_directory is None, the backend may do an 'in place' build which
+modifies the source directory. The semantics of this are not specified
+here.
+
+Whateveer the value of build_directory, the backend may also store intermediates
+in other cache locations or temporary directories, which it is responsible for
+managing. The presence or absence of any caches should not make a
+material difference to the final result of the build.
+
+The hook must return the basename (not the full path) of the ``.whl`` file it
+creates, as a unicode string.
+
+::
+
+    def build_sdist(sdist_directory, config_settings={}):
+        ...
+
+Must build a .tar.gz source distribution and place it in the specified
+``sdist_directory``.
+
+A .tar.gz source distribution (sdist) contains a single top-level directory called
+``{name}-{version}`` (e.g. ``foo-1.0``), containing the source files of the
+package. This directory must also contain the
+``pyproject.toml`` from the build directory, and a PKG-INFO file containing
+metadata in the format described in
+`PEP 345 <https://www.python.org/dev/peps/pep-0345/>`_. Although historically
+zip files have also been used as sdists, this hook should produce a gzipped
+tarball. This is already the more common format for sdists, and having a
+consistent format makes for simpler tooling.
+
+The generated tarball should use the modern POSIX.1-2001 pax tar format, which
+specifies UTF-8 based file names. This is not yet the default for the tarfile
+module shipped with Python 3.6, so backends using the tarfile module need to
+explicitly pass ``format=tarfile.PAX_FORMAT``.
+
+The hook must return the basename (not the full path) of the ``.tar.gz`` file it
+creates, as a unicode string.
+
+Frontends performing a local installation may want to produce an sdist as an
+intermediate, but are advised to be prepared to use a fallback if it fails, as
+e.g. some backends may require version control tools to build an sdist.
+
+Optional hooks
+==============
+
+  def get_requires_for_build_wheel(config_settings={}):
       ...
 
 This hook MUST return an additional list of strings containing PEP 508
 dependency specifications, above and beyond those specified in the
-``pyproject.toml`` file, to be installed when building a wheel. Example::
+``pyproject.toml`` file, to be installed when calling the ``build_wheel`` or
+``prepare_metadata_for_build_wheel`` hooks.
 
-  def get_build_wheel_requires(config_settings):
+Example::
+
+  def get_requires_for_build_wheel(config_settings):
       return ["wheel >= 0.25", "setuptools"]
 
-Optional. If not defined, the default implementation is equivalent to
-``return []``.
+If not defined, the default implementation is equivalent to ``return []``.
 
 ::
 
-  def prepare_wheel_metadata(metadata_directory, config_settings):
+  def prepare_metadata_for_build_wheel(metadata_directory, config_settings={}):
       ...
 
 Must create a ``.dist-info`` directory containing wheel metadata
@@ -204,92 +281,16 @@ metadata directly.
 
 ::
 
-  def prepare_wheel_build_files(build_directory, config_settings):
-      ...
-
-Must copy or create any files needed to build a wheel of this package into
-``build_directory``. For instance, ``pyproject.toml`` should
-be copied unmodified into the root of this directory. For tools such
-as `setuptools_scm <https://github.com/pypa/setuptools_scm>`_, this may include
-extracting some information from a version control system.
-The ``build_wheel`` hook will subsequently be run from the ``build_directory``
-populated by this hook. The contents of the resulting wheel should be the same
-whether ``build_wheel`` is invoked in an original source directory, the build
-directory populated by this hook, or an unpacked sdist directory.
-
-Because the wheel will be built from a temporary build directory, ``build_wheel``
-may create intermediate files in the working directory, and does not need to
-take care to clean them up.
-
-The return value will be ignored.
-
-Optional. If this hook is not defined, frontends may call ``build_sdist``
-and unpack the archive to use as a build directory. Backends in which
-building an sdist has additional requirements should define
-``prepare_wheel_build_files``.
-
-::
-
-  def build_wheel(wheel_directory, config_settings, metadata_directory=None):
-      ...
-
-Must build a .whl file, and place it in the specified ``wheel_directory``.
-
-If the build frontend has previously called ``prepare_wheel_metadata`` and
-depends on the wheel resulting from this call to have metadata
-matching this earlier call, then it should provide the path to the created
-``.dist-info`` directory as the ``metadata_directory`` argument. If this
-argument is provided, then ``build_wheel`` MUST produce a wheel with identical
-metadata. The directory passed in by the build frontend MUST be
-identical to the directory created by ``prepare_wheel_metadata``,
-including any unrecognized files it created.
-
-This must return the basename (not the full path) of the ``.whl`` file it
-creates, as a unicode string.
-
-Mandatory.
-
-::
-
-  def get_build_sdist_requires(config_settings):
+  def get_requires_for_build_sdist(config_settings={}):
     ...
 
 This hook MUST return an additional list of strings containing PEP 508
 dependency specifications, above and beyond those specified in the
-``pyproject.toml`` file. These dependencies will be installed for building an
-sdist.
+``pyproject.toml`` file. These dependencies will be installed when calling the
+``build_sdist`` hook.
 
-Optional. If not defined, the default implementation is equivalent to
-``return []``.
+If not defined, the default implementation is equivalent to ``return []``.
 
-::
-
-  def build_sdist(sdist_directory, config_settings):
-      ...
-
-Must build a .tar.gz source distribution and place it in the specified
-``sdist_directory``.
-
-A .tar.gz source distribution (sdist) contains a single top-level directory called
-``{name}-{version}`` (e.g. ``foo-1.0``), containing the source files of the
-package. This directory must also contain the
-``pyproject.toml`` from the build directory, and a PKG-INFO file containing
-metadata in the format described in
-`PEP 345 <https://www.python.org/dev/peps/pep-0345/>`_. Although historically
-zip files have also been used as sdists, this hook should produce a gzipped
-tarball. This is already the more common format for sdists, and having a
-consistent format makes for simpler tooling.
-
-The generated tarball should use the modern POSIX.1-2001 pax tar format, which
-specifies UTF-8 based file names. This is not yet the default for the tarfile
-module shipped with Python 3.6, so backends using the tarfile module need to
-explicitly pass ``format=tarfile.PAX_FORMAT``.
-
-This must return the basename (not the full path) of the ``.tar.gz`` file it
-creates, as a unicode string.
-
-Mandatory, but it may not succeed in all situations: for instance, some tools
-can only build an sdist from a VCS checkout.
 
 .. note:: Editable installs
 
@@ -372,18 +373,18 @@ following criteria:
 - All requirements specified by the project's build-requirements must
   be available for import from Python. In particular:
 
-  - The ``get_build_wheel_requires`` and ``get_build_sdist_requires`` hooks are
+  - The ``get_requires_for_build_wheel`` and ``get_requires_for_build_sdist`` hooks are
     executed in an environment which contains the bootstrap requirements
     specified in the ``pyproject.toml`` file.
 
-  - The ``prepare_wheel_metadata``, ``prepare_wheel_build_files`` and
-    ``build_wheel`` hooks are executed in an environment which contains the
+  - The ``prepare_metadata_for_build_wheel`` and ``build_wheel`` hooks are
+    executed in an environment which contains the
     bootstrap requirements from ``pyproject.toml`` and those specified by the
-    ``get_build_wheel_requires`` hook.
+    ``get_requires_for_build_wheel`` hook.
 
   - The ``build_sdist`` hook is executed in an environment which contains the
     bootstrap requirements from ``pyproject.toml`` and those specified by the
-    ``get_build_sdist_requires`` hook.
+    ``get_requires_for_build_sdist`` hook.
 
 - This must remain true even for new Python subprocesses spawned by
   the build environment, e.g. code like::
@@ -469,7 +470,8 @@ hood and apply duct tape when necessary.
  Source distributions
 ======================
 
-For now, we continue with the legacy sdist format which is mostly
+We continue with the legacy sdist format, adding some new restrictions.
+This format is mostly
 undefined, but basically comes down to: a file named
 ``{NAME}-{VERSION}.{EXT}``, which unpacks into a buildable source tree
 called ``{NAME}-{VERSION}/``. Traditionally these have always
@@ -480,6 +482,13 @@ Integration frontends require that an sdist named
 ``{NAME}-{VERSION}.{EXT}`` will generate a wheel named
 ``{NAME}-{VERSION}-{COMPAT-INFO}.whl``.
 
+The new restrictions for sdists built by PEP 517 backends are:
+
+- They will be gzipped tar archives, with the ``.tar.gz`` extension. Zip
+  archives, or other compression formats for tarballs, are not allowed at
+  present.
+- Tar archives must be created in the modern POSIX.1-2001 pax tar format, which
+  uses UTF-8 for file names.
 
 ===================================
  Comparison to competing proposals
@@ -808,6 +817,10 @@ automatically upgrade packages to the new format:
   format is already standardised). Close control of archive creation is
   important for reproducible builds. And it's not clear that tasks requiring an
   unpacked distribution will be more common than those requiring an archive.
+* We considered an extra hook to copy files to a build directory before invoking
+  ``build_wheel``. Looking at existing build systems, we found that passing
+  a build directory into ``build_wheel`` makes more sense for many tools than
+  pre-emptively copying files into a build directory.
 
 ===========
  Copyright

--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -169,12 +169,17 @@ argument is described after the individual hooks.
 Mandatory hooks
 ===============
 
+build_wheel
+-----------
+
 ::
 
-    build_wheel(wheel_directory, config_settings={}, build_directory=None, metadata_directory=None):
+    build_wheel(wheel_directory, config_settings=None, build_directory=None, metadata_directory=None):
         ...
 
-Must build a .whl file, and place it in the specified ``wheel_directory``.
+Must build a .whl file, and place it in the specified ``wheel_directory``. It
+must return the basename (not the full path) of the ``.whl`` file it creates,
+as a unicode string.
 
 If the build frontend has previously called ``prepare_wheel_metadata`` and
 depends on the wheel resulting from this call to have metadata
@@ -205,16 +210,17 @@ in other cache locations or temporary directories, which it is responsible for
 managing. The presence or absence of any caches should not make a
 material difference to the final result of the build.
 
-The hook must return the basename (not the full path) of the ``.whl`` file it
-creates, as a unicode string.
+build_sdist
+-----------
 
 ::
 
-    def build_sdist(sdist_directory, config_settings={}):
+    def build_sdist(sdist_directory, config_settings=None):
         ...
 
 Must build a .tar.gz source distribution and place it in the specified
-``sdist_directory``.
+``sdist_directory``. It must return the basename (not the full path) of the
+``.tar.gz`` file it creates, as a unicode string.
 
 A .tar.gz source distribution (sdist) contains a single top-level directory called
 ``{name}-{version}`` (e.g. ``foo-1.0``), containing the source files of the
@@ -231,9 +237,6 @@ specifies UTF-8 based file names. This is not yet the default for the tarfile
 module shipped with Python 3.6, so backends using the tarfile module need to
 explicitly pass ``format=tarfile.PAX_FORMAT``.
 
-The hook must return the basename (not the full path) of the ``.tar.gz`` file it
-creates, as a unicode string.
-
 Frontends performing a local installation may want to produce an sdist as an
 intermediate, but are advised to be prepared to use a fallback if it fails, as
 e.g. some backends may require version control tools to build an sdist.
@@ -241,7 +244,12 @@ e.g. some backends may require version control tools to build an sdist.
 Optional hooks
 ==============
 
-  def get_requires_for_build_wheel(config_settings={}):
+get_requires_for_build_wheel
+----------------------------
+
+::
+
+  def get_requires_for_build_wheel(config_settings=None):
       ...
 
 This hook MUST return an additional list of strings containing PEP 508
@@ -256,18 +264,22 @@ Example::
 
 If not defined, the default implementation is equivalent to ``return []``.
 
+prepare_metadata_for_build_wheel
+--------------------------------
+
 ::
 
-  def prepare_metadata_for_build_wheel(metadata_directory, config_settings={}):
+  def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
       ...
 
 Must create a ``.dist-info`` directory containing wheel metadata
 inside the specified ``metadata_directory`` (i.e., creates a directory
-like ``{metadata_directory}/{package}-{version}.dist-info/``. This
+like ``{metadata_directory}/{package}-{version}.dist-info/``). This
 directory MUST be a valid ``.dist-info`` directory as defined in the
 wheel specification, except that it need not contain ``RECORD`` or
 signatures. The hook MAY also create other files inside this
-directory, and a build frontend MUST ignore such files; the intention
+directory, and a build frontend MUST preserve, but otherwise ignore, such files;
+the intention
 here is that in cases where the metadata depends on build-time
 decisions, the build backend may need to record these decisions in
 some convenient format for re-use by the actual wheel-building step.
@@ -279,9 +291,12 @@ If a build frontend needs this information and the method is
 not defined, it should call ``build_wheel`` and look at the resulting
 metadata directly.
 
+get_requires_for_build_sdist
+----------------------------
+
 ::
 
-  def get_requires_for_build_sdist(config_settings={}):
+  def get_requires_for_build_sdist(config_settings=None):
     ...
 
 This hook MUST return an additional list of strings containing PEP 508
@@ -489,6 +504,8 @@ The new restrictions for sdists built by PEP 517 backends are:
   present.
 - Tar archives must be created in the modern POSIX.1-2001 pax tar format, which
   uses UTF-8 for file names.
+- The source tree contained in an sdist is expected to include the
+  ``pyproject.toml`` file.
 
 ===================================
  Comparison to competing proposals


### PR DESCRIPTION
This brings the hooks in line with discussion on the mailing list:

- Remove the hook to copy input files to a build directory before building a wheel.
- Add the `build_directory=None` parameter to the `build_wheel` hook.
- Rename the optional hooks to make it clearer what they do.