### PR TITLE
PEP 517: Fix metadata preparation example

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -791,21 +791,37 @@ make the ``prepare_metadata_for_build_wheel`` command optional. In our design,
 this can be readily handled by build frontends, which can put code in
 their subprocess runner like::
 
-    def dump_wheel_metadata(backend, output_dir, config_settings):
-        if hasattr(backend, "prepare_metadata_for_build_wheel"):
-            backend.prepare_metadata_for_build_wheel(output_dir, config_settings)
-        else:
-            wheel_fname = backend.build_wheel(output_dir, config_settings)
-            (output_dir / "ALREADY_BUILT_WHEEL").write_text(wheel_fname)
-            unzip_metadata(output_dir / wheel_fname)
+    def dump_wheel_metadata(backend, working_dir):
+        """Dumps wheel metadata to working directory.
 
-    def ensure_wheel_is_built(backend, output_dir, config_settings, metadata_dir):
-        already_built = metadata_dir.parent / "ALREADY_BUILT_WHEEL"
-        if already_built.exists():
-            wheel_fname = already_built.read_text()
-            copy(metadata_dir.parent / wheel_fname, output_dir)
+           Returns absolute path to resulting metadata directory
+        """
+        if hasattr(backend, "prepare_metadata_for_build_wheel"):
+            subdir = backend.prepare_metadata_for_build_wheel(working_dir)
         else:
-            backend.build_wheel(output_dir, config_settings, metadata_dir)
+            wheel_fname = backend.build_wheel(working_dir))
+            already_built = os.path.join(working_dir, "ALREADY_BUILT_WHEEL")
+            with open(already_built, "w") as f:
+                f.write(wheel_fname)
+            subdir = unzip_metadata(os.path.join(working_dir, wheel_fname))
+        return os.path.join(working_dir, subdir)
+
+    def ensure_wheel_is_built(backend, output_dir, working_dir, metadata_dir):
+        """Ensures built wheel is available in output directory
+
+           Returns absolute path to resulting wheel file
+        """
+        already_built = os.path.join(working_dir, "ALREADY_BUILT_WHEEL")
+        if os.path.exists(already_built):
+            with open(already_built, "r") as f:
+                wheel_fname = f.read().strip()
+            working_path = os.path.join(working_dir, wheel_fname)
+            final_path = os.path.join(output_dir, wheel_fname)
+            os.rename(working_path, final_path)
+            os.remove(already_built)
+        else:
+            wheel_fname = backend.build_wheel(output_dir, metadata_dir=metadata_dir)
+        return os.path.join(output_dir, wheel_fname)
 
 and thus expose a totally uniform interface to the rest of the frontend,
 with no extra subprocess calls, no duplicated builds, etc. But

--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -826,12 +826,14 @@ their subprocess runner like::
 and thus expose a totally uniform interface to the rest of the frontend,
 with no extra subprocess calls, no duplicated builds, etc. But
 obviously this is the kind of code that you only want to write as part
-of a private, within-project interface (e.g. the given example assumes that
-all filesystem paths are supplied as ``pathlib.Path`` instances, rather than
-as plain strings).
+of a private, within-project interface (e.g. the given example requires that
+the working directory be shared between the two calls, but not with any
+other wheel builds, and that the return value from the metadata helper function
+will be passed back in to the wheel building one).
 
 (And, of course, making the ``metadata`` command optional is one piece
-of lowering the barrier to entry, as discussed above.)
+of lowering the barrier to entry for developing new backends, as discussed
+above.)
 
 
 Other differences


### PR DESCRIPTION
- use plain strings rather than pathlib.Path
- drop config_settings as irrelevant
- return relevant absolute paths from the example
  helper functions