### PR TITLE
Fix typos in PEP 491

### DIFF
--- a/pep-0491.txt
+++ b/pep-0491.txt
@@ -301,7 +301,7 @@ to their location within the archive (so a wheel is still installed
 correctly if unpacked with a standard unzip tool, or perhaps not
 unpacked at all).
 
-If the ``WHEEL`` metadata contains these files:
+If the ``WHEEL`` metadata contains these fields::
 
    Install-Paths-To: wheel/_paths.py
    Install-Paths-To: wheel/_paths.json


### PR DESCRIPTION
Two lines of RFC822-style headers were being formatted as a single-line blockquote instead of a preformatted code block.  In addition, the prose immediately before them called them "files" instead of "fields."  This PR fixes that.
