### PR TITLE
Fix footnote/reference links in PEP 496

### DIFF
--- a/pep-0496.txt
+++ b/pep-0496.txt
@@ -26,11 +26,10 @@ required in particular environments, and to indicate supported platforms
 for distributions with additional constraints beyond the availability of a
 Python runtime.
 
-Environment markers were first specified in PEP-0345[1]. PEP-0426[2] (which
-would replace PEP-0345) proposed extensions to the markers. When
-2.7.10 was released, even these extensions became insufficient due to
-their reliance on simple lexical comparisons, and thus this PEP has
-been born.
+Environment markers were first specified in PEP-0345 [#pep345]_. PEP-0426
+[#pep426]_ (which would replace PEP-0345) proposed extensions to the markers.
+When 2.7.10 was released, even these extensions became insufficient due to
+their reliance on simple lexical comparisons, and thus this PEP has been born.
 
 Rationale
 =========
@@ -98,7 +97,7 @@ The pseudo-grammar is ::
 ``SUBEXPR`` is either a Python string (such as ``'win32'``) or one of
 the ``Strings`` marker variables listed below.
 
-``VEREXPR`` is a PEP-0440[3] version identifier, or one of the
+``VEREXPR`` is a PEP-0440 [#pep440]_ version identifier, or one of the
 ``Version number`` marker variables listed below. Comparisons between
 version numbers are done using PEP-0440 semantics.
 
@@ -151,13 +150,13 @@ respectively, in accordance with the following algorithm::
 References
 ==========
 
-.. [1] PEP 345, Metadata for Python Software Packages 1.2, Jones
+.. [#pep345] PEP 345, Metadata for Python Software Packages 1.2, Jones
    (http://www.python.org/dev/peps/pep-0345)
 
-.. [2] PEP 426, Metadata for Python Software Packages 2.0, Coghlan, Holth, Stufft
+.. [#pep426] PEP 426, Metadata for Python Software Packages 2.0, Coghlan, Holth, Stufft
    (http://www.python.org/dev/peps/pep-0426)
 
-.. [3] PEP 440, Version Identification and Dependency Specification, Coghlan, Stufft
+.. [#pep440] PEP 440, Version Identification and Dependency Specification, Coghlan, Stufft
    (https://www.python.org/dev/peps/pep-0440/)
 
 Copyright


### PR DESCRIPTION
The footnote/reference links in PEP 496 weren't actually hyperlinks.  This fixes that.
