### PR TITLE
PEP 551: Add "discussions-to" header

### DIFF
--- a/pep-0551.rst
+++ b/pep-0551.rst
@@ -3,6 +3,7 @@ Title: Security transparency in the Python runtime
 Version: $Revision$
 Last-Modified: $Date$
 Author: Steve Dower <steve.dower@python.org>
+Discussions-To: <security-sig@python.org>
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst


### PR DESCRIPTION
Discussions to: security-sig@python.org