### PR TITLE
PEP 517: Remove build_directory parameter

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -174,7 +174,7 @@ build_wheel
 
 ::
 
-    build_wheel(wheel_directory, config_settings=None, build_directory=None, metadata_directory=None):
+    build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
         ...
 
 Must build a .whl file, and place it in the specified ``wheel_directory``. It
@@ -194,33 +194,22 @@ Backends which do not provide the ``prepare_metadata_for_build_wheel`` hook may
 either silently ignore the ``metadata_directory`` parameter to ``build_wheel``,
 or else raise an exception when it is set to anything other than ``None``.
 
-If ``build_directory`` is not None, it is a unicode string containing the
-path to a directory other than the source directory (the working directory where
-the hook is called) where intermediate build artifacts may be stored.
+Wheels built by this hook should, as far as possible, be equivalent to
+first building an sdist and then building a wheel from that sdist.
+Frontends which want to protect against backends violating this expectation
+may call ``build_sdist`` (see below) first, and then call ``build_wheel``
+in the unpacked sdist. But if build_sdist fails with NotImplementedError,
+they will fall back to calling build_wheel in the source directory,
+and rely on the backend to produce an equivalent wheel.
 
-These out-of-tree builds should have the same result as first building an sdist
-and then building a wheel from that sdist. If the backend cannot otherwise
-ensure that unexpected files won't end up in the built wheel archive, it should
-copy any essential input files it needs to ``build_directory`` and perform the
-build there.
+The source directory may be read-only. Backends should therefore be
+prepared to build without creating or modifying any files in the source
+directory, but they may opt not to handle this case, in which case
+failures will be visible to the user. Frontends are not responsible for
+any special handling of read-only source directories.
 
-The provided build directory may be empty, or it may contain artifacts from a
-previous build to be used as a cache. The backend is responsible for determining
-whether any cached artifacts are outdated.
-
-If ``build_directory`` is None, the backend may do an 'in place' build which
-modifies the source directory and may produce different results from those that
-would be obtained by exporting an sdist first. The exact semantics of this will
-depend on the build system in use, and hence are not specified here.
-
-To guard against frontends that are not fully compliant with this specification,
-defensively coded backends may treat
-``os.path.samefile(build_directory, os.getcwd())`` as a request for an in place
-build.
-
-Whatever the value of ``build_directory``, the backend may also store
-intermediate artifacts in other cache locations or temporary directories, which
-it is responsible for managing. The presence or absence of any caches should not
+The backend may store intermediate artifacts in cache locations or
+temporary directories. The presence or absence of any caches should not
 make a material difference to the final result of the build.
 
 build_sdist
@@ -735,26 +724,9 @@ build backend::
         # listed in the project's build system dependencies instead
         return ["wheel"]
 
-    def _prepare_out_of_tree_build(build_directory):
-        """Prepare out-of-tree build by way of unpacking the sdist"""
-        sdist, sdist_filename = _make_sdist(build_directory)
-        os.chdir(build_directory)
-        if os.path.exists(SDIST_NAME):
-            # Prevent caching of stale input files
-            shutil.rmtree(SDIST_NAME)
-        sdist.extractall()
-        os.remove(sdist_filename)
-        os.chdir(SDIST_NAME)
-
-    def build_wheel(wheel_directory, build_directory=None,
+    def build_wheel(wheel_directory,
                     metadata_directory=None, config_settings=None):
         """PEP 517 wheel creation hook"""
-        # First check if the frontend has requested an out-of-tree build
-        out_of_tree_build = (build_directory is not None and
-                             not os.path.samefile(build_directory, os.getcwd())
-        if out_of_tree_build:
-            _prepare_out_of_tree_build(build_directory)
-        # Continue with assembling the wheel archive
         from wheel.archive import archive_wheelfile
         path = os.path.join(wheel_directory, WHEEL_FILENAME)
         archive_wheelfile(path, "src/")


### PR DESCRIPTION
We seem to be reaching the conclusion that this is not needed, and removing it allows the spec to be simpler.