### PR TITLE
Added libresolv to whitelisted manylinux1 libraries

### DIFF
--- a/pep-0513.txt
+++ b/pep-0513.txt
@@ -141,6 +141,7 @@ included in the following list: ::
     libnsl.so.1
     libutil.so.1
     libpthread.so.0
+    libresolv.so.2
     libX11.so.6
     libXext.so.6
     libXrender.so.1


### PR DESCRIPTION
See bug pypa/auditwheel#80 for details.