### PR TITLE
V3 revision of PEP 561: Distributing Type Information

### DIFF
--- a/pep-0561.rst
+++ b/pep-0561.rst
@@ -72,10 +72,16 @@ Packaging Type Information
 --------------------------
 In order to make packaging and distributing type information as simple and
 easy as possible, the distribution of type information, and typed Python code
-is done through existing packaging frameworks. This PEP requires packaging
-tools to support a new value in the ``*.distinfo/METADATA`` file. The key
-must have a name of ``Typed`` and have a value of either ``inline`` or 
-``stubs``.
+is done through existing packaging frameworks. This PEP adds a new item to the
+``*.distinfo/METADATA`` file to contain metadata about a package's support for
+typing. The new item is optional, but must have a name of ``Typed`` and have a
+value of either ``inline`` or ``stubs``, if present.
+
+Metadata Examples::
+
+    Typed: inline
+    Typed: stubs
+
 
 Stub Only Packages
 ''''''''''''''''''

--- a/pep-0561.rst
+++ b/pep-0561.rst
@@ -12,7 +12,7 @@ Post-History:
 Abstract
 ========
 
-PEP 484 introduced type hints to Python, with goals of making typing
+PEP 484 introduced type hinting to Python, with goals of making typing
 gradual and easy to adopt. Currently, typing information must be distributed 
 manually. This PEP provides a standardized means to package and distribute
 type information and an ordering for type checkers to resolve modules and 
@@ -59,8 +59,9 @@ This PEP aims to support these scenarios and make them simple to add to
 packaging and deployment.
 
 The two major parts of this specification are the packaging specifications
-and the resolution order for resolving module type information. This spec
-is meant to replace the ``shared/typehints/pythonX.Y/`` spec of PEP 484 [2]_.
+and the resolution order for resolving module type information. The packaging
+spec is based on and extends PEP 345 metadata. The type checking spec is
+meant to replace the ``shared/typehints/pythonX.Y/`` spec of PEP 484 [2]_.
 
 New third party stub libraries are encouraged to distribute stubs via the
 third party packaging proposed in this PEP in place of being added to 
@@ -69,28 +70,12 @@ party stubs in typeshed are encouraged to be split into their own package.
 
 Packaging Type Information
 --------------------------
-
-Packages must opt into supporting typing. This will be done though a distutils
-extension [3]_, providing a ``typed`` keyword argument to the distutils
-``setup()`` command. The argument value will depend on the kind of type
-information the package provides. The new keyword will be added to
-Python 3.7 and will also be accessible in the ``typing_extensions`` package
-though a distutils extension. This enables a package maintainer to write
-
-::
-    
-    setup(
-        ...
-        setup_requires=["typing_extensions"],
-        typed="inline",
-        ...
-    )
-
-Inline Typed Packages
-'''''''''''''''''''''
-
-Packages that have inline type annotations simply have to pass the value
-``"inline"`` to the ``typed`` argument in ``setup()``.
+In order to make packaging and distributing type information as simple and
+easy as possible, the distribution of type information, and typed Python code
+is done through existing packaging frameworks. This PEP requires packaging
+tools to support a new value in the ``*.distinfo/METADATA`` file. The key
+must have a name of ``Typed`` and have a value of either ``inline`` or 
+``stubs``.
 
 Stub Only Packages
 ''''''''''''''''''
@@ -103,10 +88,7 @@ example, the ``flyingcircus`` package would have its stubs in the folder
 ``flyingcircus/flyingcircus/``. This path is chosen so that if stubs are
 not found in ``flyingcircus/`` the type checker may treat the subdirectory as
 a normal package. The normal resolution order of checking ``*.pyi`` before
-``*.py`` will be maintained. The value of the ``typed`` argument to 
-``setup()`` is ``"stubs"`` for this type of distribution. The author of the
-package is suggested to use ``package_data`` to assure the stub files are
-installed alongside the runtime Python code.
+``*.py`` will be maintained.
 
 Third Party Stub Packages
 '''''''''''''''''''''''''
@@ -119,12 +101,14 @@ similar, but slightly different from that of stub only packages. If the stubs
 are for the library ``flyingcircus`` then the package should be named 
 ``flyingcircus-stubs`` and the stub files should be put in a sub-directory
 named ``flyingcircus``. This allows the stubs to be checked as if they were in
-a regular package. These packages should also pass ``"stubs"`` as the value 
-of ``typed`` argument in ``setup()``. These packages are suggested to use
-``package_data`` to package stub files. 
+a regular package. 
 
-In addition, the package should indicate which version(s) of the runtime
-package are supported via the ``install_requires`` argument to ``setup()``.
+In addition, the third party stub package should indicate which version(s)
+of the runtime package are supported by indicating the runtime package's
+version(s) through the normal dependency data. For example, if there was a
+stub package ``flyingcircus-stubs``, it can indicate the versions of the
+runtime ``flyingcircus`` package supported through ``install_requires``
+in distutils based tools, or the equivalent in other packaging tools.
 
 Type Checker Module Resolution Order
 ------------------------------------
@@ -140,8 +124,9 @@ resolve modules containing type information:
 
 3. Third party stub packages - these packages can supersede the installed
    untyped packages. They can be found at ``pkg-stubs`` for package ``pkg``,
-   however it is encouraged to check their metadata to confirm that they opt
-   into type checking via the ``typed`` keyword.
+   however it is encouraged to check the package's metadata using packaging
+   query APIs such as ``pkg_resources`` to assure that the package is meant
+   for type checking, and is compatible with the installed version.
 
 4. Inline packages - finally, if there is nothing overriding the installed
    package, and it opts into type checking.
@@ -149,14 +134,10 @@ resolve modules containing type information:
 5. Typeshed (if used) - Provides the stdlib types and several third party
    libraries
 
-When resolving step (3) type checkers should assure the version of the stubs
-is compatible with the installed runtime package through the method described
-above.
-
 Type checkers that check a different Python version than the version they run
 on must find the type information in the ``site-packages``/``dist-packages``
 of that Python version. This can be queried e.g.
-``pythonX.Y -c 'import sys; print(sys.exec_prefix)'``. It is also recommended
+``pythonX.Y -c 'import site; print(site.getsitepackages())'``. It is also recommended
 that the type checker allow for the user to point to a particular Python
 binary, in case it is not in the path.
 
@@ -173,9 +154,6 @@ References
 
 .. [2] PEP 484, Storing and Distributing Stub Files
    (https://www.python.org/dev/peps/pep-0484/#storing-and-distributing-stub-files)
-
-.. [3] Distutils Extensions, Adding setup() arguments
-   (http://setuptools.readthedocs.io/en/latest/setuptools.html#adding-setup-arguments)
 
 Copyright
 =========


### PR DESCRIPTION
I have made some more edits to my PEP. In summary:

* Move to adding a new metadata specifier so that more tools can participate
* Clarify version matching between third party stubs and runtime packages.
* various other fixes for clarity, readability, and removal of repetition

@ncoghlan I would appreciate a review of this new version if you have time. Thanks!