### PR TITLE
PEP 539: Fix wording about Py_tss_NEEDS_INIT

### DIFF
--- a/pep-0539.txt
+++ b/pep-0539.txt
@@ -70,8 +70,7 @@ The specification also adds a few new features:
   where ``NATIVE_TSS_KEY_T`` is a macro whose value depends on the
   underlying native TLS implementation (e.g. ``pthread_key_t``).
 
-* A constant default value for ``Py_tss_t`` variables,
-  ``Py_tss_NEEDS_INIT``.
+* An initializer for ``Py_tss_t`` variables, ``Py_tss_NEEDS_INIT``.
 
 * Three new functions::
 
@@ -157,7 +156,7 @@ Features           - create key                   - create key
                                                     key
                                                   - check key's initialization
                                                     state
-Default Value      (``-1`` as key creation        ``Py_tss_NEEDS_INIT``
+Key Initializer    (``-1`` as key creation        ``Py_tss_NEEDS_INIT``
                    failure)
 Requirement        native threads                 native threads
                    (since CPython 3.7 [9]_)
@@ -287,7 +286,7 @@ part of the C11 threads API [15]_.  However, this is in no way meant to imply
 compatibility with or support for the C11 threads API, or signal any future
 intention of supporting C11--it's just the influence for the naming and design.
 
-The inclusion of the special default value ``Py_tss_NEEDS_INIT`` is required
+The inclusion of the special initializer ``Py_tss_NEEDS_INIT`` is required
 by the fact that not all native TLS implementations define a sentinel value
 for uninitialized TLS keys.  For example, on Windows a TLS key is
 represented by a ``DWORD`` (``unsigned int``) and its value must be treated


### PR DESCRIPTION
Wording-only change, replacing the word "default value" with "initializer" making more sense.

Related PR: https://github.com/python/cpython/pull/4096