### PR TITLE
PEP 561: Add implementation links and changelog

### DIFF
--- a/pep-0561.rst
+++ b/pep-0561.rst
@@ -107,7 +107,7 @@ similar, but slightly different from that of stub only packages. If the stubs
 are for the library ``flyingcircus`` then the package should be named 
 ``flyingcircus-stubs`` and the stub files should be put in a sub-directory
 named ``flyingcircus``. This allows the stubs to be checked as if they were in
-a regular package. 
+a regular package.
 
 In addition, the third party stub package should indicate which version(s)
 of the runtime package are supported by indicating the runtime package's
@@ -154,12 +154,58 @@ package has not opted into type checking, and the type checker should skip
 that package.
 
 
+Implementation
+==============
+
+A CPython branch with a modified distutils supporting the ``typed`` setup
+keyword lives here: [impl]. In addition, a sample package with inline types is
+available [typed_pkg], as well as a sample package [pkg_checker] which reads the metadata
+of installed packages and reports on their status as either not typed, inline
+typed, or a stub package.
+
+
+Acknowledgements
+================
+
+This PEP would not have been possible without the ideas, feedback, and support
+of Ivan Levkivskyi, Jelle Zijlstra, Nick Coghlan, Daniel F Moisset, and
+Guido van Rossum.
+
+
+Version History
+===============
+
+* 2017-10-26
+    
+    * Added implementation references.
+    * Added acknowledgements and version history.
+
+* 2017-10-06
+
+    * Rewritten to use .distinfo/METADATA over a distutils specific command.
+    * Clarify versioning of third party stub packages.
+
+* 2017-09-11
+
+    * Added information about current solutions and typeshed.
+    * Clarify rationale.
+
+
 References
 ==========
 .. [1] Typeshed (https://github.com/python/typeshed)
 
 .. [2] PEP 484, Storing and Distributing Stub Files
    (https://www.python.org/dev/peps/pep-0484/#storing-and-distributing-stub-files)
+
+.. [impl] CPython sample implementation
+   (https://github.com/ethanhs/cpython/tree/typeddist)
+
+.. [typed_pkg] Sample typed package
+   (https://github.com/ethanhs/sample-typed-package)
+
+.. [pkg_checker] Sample package checker
+   (https://github.com/ethanhs/check_typedpkg)
 
 Copyright
 =========

--- a/pep-0561.rst
+++ b/pep-0561.rst
@@ -158,8 +158,8 @@ Implementation
 ==============
 
 A CPython branch with a modified distutils supporting the ``typed`` setup
-keyword lives here: [impl]. In addition, a sample package with inline types is
-available [typed_pkg], as well as a sample package [pkg_checker] which reads the metadata
+keyword lives here: [impl]_. In addition, a sample package with inline types is
+available [typed_pkg]_, as well as a sample package [pkg_checker]_ which reads the metadata
 of installed packages and reports on their status as either not typed, inline
 typed, or a stub package.
 


### PR DESCRIPTION
Add CPython implementation, sample package to be installed, and package
to check installed packages.