### PR TITLE
Post-History should include dates of postings to python-ideas

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -379,7 +379,7 @@ optional and are described below.  All other headers are required. ::
   * Requires: <pep numbers>
     Created: <date created on, in dd-mmm-yyyy format>
   * Python-Version: <version number>
-    Post-History: <dates of postings to python-list and python-dev>
+    Post-History: <dates of postings to python-ideas and/or python-dev>
   * Replaces: <pep number>
   * Superseded-By: <pep number>
   * Resolution: <url>
@@ -434,7 +434,7 @@ Content-Type header is present.
 
 The Created header records the date that the PEP was assigned a
 number, while Post-History is used to record the dates of when new
-versions of the PEP are posted to python-list and/or python-dev.  Both
+versions of the PEP are posted to python-ideas and/or python-dev.  Both
 headers should be in dd-mmm-yyyy format, e.g. 14-Aug-2001.
 
 Standards Track PEPs will typically have a Python-Version header which


### PR DESCRIPTION
Refs: https://mail.python.org/pipermail/python-dev/2017-October/149990.html