### PR TITLE
Pep 508 parser fixes

### DIFF
--- a/pep-0508.txt
+++ b/pep-0508.txt
@@ -479,6 +479,7 @@ A test program - if the grammar is in a string ``grammar``::
         "name<=1"
         "name>=3",
         "name>=3,<2",
+        "name@http://foo.com",
         "name [fred,bar] @ http://foo.com ; python_version=='2.7'",
         "name[quux, strange];python_version<'2.7' and platform_version=='2'",
         "name; os_name=='a' or os_name=='b'",

--- a/pep-0508.txt
+++ b/pep-0508.txt
@@ -426,7 +426,7 @@ The complete parsley grammar::
                       | ( ( h16 ':'){0,6} h16 )? '::' )
     h16           = hexdig{1,4}
     ls32          = ( h16 ':' h16) | IPv4address
-    IPv4address   = dec_octet '.' dec_octet '.' dec_octet '.' Dec_octet
+    IPv4address   = dec_octet '.' dec_octet '.' dec_octet '.' dec_octet
     nz            = ~'0' digit
     dec_octet     = (
                       digit # 0-9

--- a/pep-0508.txt
+++ b/pep-0508.txt
@@ -476,6 +476,7 @@ A test program - if the grammar is in a string ``grammar``::
         "A.B-C_D",
         "aa",
         "name",
+        "name<=1"
         "name>=3",
         "name>=3,<2",
         "name [fred,bar] @ http://foo.com ; python_version=='2.7'",

--- a/pep-0508.txt
+++ b/pep-0508.txt
@@ -356,7 +356,7 @@ Complete Grammar
 The complete parsley grammar::
 
     wsp           = ' ' | '\t'
-    version_cmp   = wsp* <'<' | '<=' | '!=' | '==' | '>=' | '>' | '~=' | '==='>
+    version_cmp   = wsp* <'<=' | '<' | '!=' | '==' | '>=' | '>' | '~=' | '==='>
     version       = wsp* <( letterOrDigit | '-' | '_' | '.' | '*' | '+' | '!' )+>
     version_one   = version_cmp:op version:v wsp* -> (op, v)
     version_many  = version_one:v1 (wsp* ',' version_one)*:v2 -> [v1] + v2

--- a/pep-0508.txt
+++ b/pep-0508.txt
@@ -394,7 +394,7 @@ The complete parsley grammar::
     extras        = '[' wsp* extras_list?:e wsp* ']' -> e
     name_req      = (name:n wsp* extras?:e wsp* versionspec?:v wsp* quoted_marker?:m
                      -> (n, e or [], v or [], m))
-    url_req       = (name:n wsp* extras?:e wsp* urlspec:v wsp+ quoted_marker?:m
+    url_req       = (name:n wsp* extras?:e wsp* urlspec:v (wsp+ | end) quoted_marker?:m
                      -> (n, e or [], v, m))
     specification = wsp* ( url_req | name_req ):s wsp* -> s
     # The result is a tuple - name, list-of-extras,


### PR DESCRIPTION
Fix 1 bug. Enhance handling of trailing whitespace for URLs. Correct spelling.

Add tests.