### PR TITLE
Fixed a (critical) typo

### DIFF
--- a/pep-0485.txt
+++ b/pep-0485.txt
@@ -390,7 +390,7 @@ there was no benefit to the method worth reducing the range of
 functionality or adding the complexity of checking values to determine
 the order of computation.
 
-This leaves the boost "weak" test (2)-- or using the smaller value to
+This leaves the boost "weak" test (2)-- or using the larger value to
 scale the tolerance, or the Boost "strong" (3) test, which uses the
 smaller of the values to scale the tolerance. For small tolerance,
 they yield the same result, but this proposal uses the boost "weak"


### PR DESCRIPTION
I somehow had "smaller" for both the weak and strong cases -- not sure how I let that slip through originally