### PR TITLE
Fix spelling: smorgasboard -> smorgasbord.

### DIFF
--- a/pep-3103.txt
+++ b/pep-3103.txt
@@ -23,7 +23,7 @@ Abstract
 
 Python-dev has recently seen a flurry of discussion on adding a switch
 statement.  In this PEP I'm trying to extract my own preferences from
-the smorgasboard of proposals, discussing alternatives and explaining
+the smorgasbord of proposals, discussing alternatives and explaining
 my choices where I can.  I'll also indicate how strongly I feel about
 alternatives I discuss.
 


### PR DESCRIPTION
Fix spelling: smorgasboard -> smorgasbord.

Clarification: the word "smorgasboard" does not exist.  Merriam-Webster lists "smorgasbord", as does the Oxford English Dictionary.  Google Ngram shows the spelling "smorgasbord" is used about 200× more than the spelling "smorgasboard".