### PR TITLE
Add links to PEP 563.

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -2247,7 +2247,7 @@ allowed use of annotations in Python 3.8.  This should give authors of
 packages that use annotations plenty of time to devise another
 approach, even if type hints become an overnight success.
 
-(*UPDATE:* As of fall 2017, the timeline for the end if provisional
+(*UPDATE:* As of fall 2017, the timeline for the end of provisional
 status for this PEP and for the ``typing.py`` module has changed, and
 so has the deprecation schedule for other uses of annotations.  For
 the updated schedule see PEP 563.)

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -2247,6 +2247,11 @@ allowed use of annotations in Python 3.8.  This should give authors of
 packages that use annotations plenty of time to devise another
 approach, even if type hints become an overnight success.
 
+(*UPDATE:* As of fall 2017, the timeline for the end if provisional
+status for this PEP and for the ``typing.py`` module has changed, and
+so has the deprecation schedule for other uses of annotations.  For
+the updated schedule see PEP 563.)
+
 Another possible outcome would be that type hints will eventually
 become the default meaning for annotations, but that there will always
 remain an option to disable them.  For this purpose the current
@@ -2326,6 +2331,9 @@ follows::
 
 Such a ``__future__`` import statement may be proposed in a separate
 PEP.
+
+(*UPDATE:* That ``__future__`` import statement and its consequences
+are discussed in PEP 563.)
 
 
 The double colon


### PR DESCRIPTION
Promise an updated schedule for non-provisional status and the end of
non-typing annotations in PEP 563, and link there for the `__future__`
statement as well.

**NOTE:** This requires an update to PEP 563 as well, since it currently refers to the end of PEP 484's provisional status. I want to [keep it provisional](https://github.com/python/typing/issues/495#issuecomment-342644111) for at least one more release cycle, at least for some restricted value of provisional: the basic spelling of types won't change incompatibly, and the typing.py module won't be withdrawn, but we need to be able to add new features to typing.py in bugfix releases, and we need the freedom to change *undocumented* parts of the implementation as well. The goal is that by the time 3.8 comes around we can import typing.py much faster than currently (ideally 10x).

@ambv Do you want me to propose an update to PEP 563 or do you want to try your hand at it?