### PR TITLE
Update PEP 562 following suggestions on python-dev

### DIFF
--- a/pep-0562.rst
+++ b/pep-0562.rst
@@ -114,7 +114,9 @@ an ``AttributeError``::
   def __getattr__(name: str) -> Any: ...
 
 This function will be called only if ``name`` is not found in the module
-through the normal attribute lookup.
+through the normal attribute lookup. Looking up a name as a module global
+will bypass module ``__getattr__``. This is intentional, otherwise calling
+``__getattr__`` for builtins will significantly harm performance.
 
 The ``__dir__`` function should accept no arguments, and return
 a list of strings that represents the names accessible on module::
@@ -131,8 +133,15 @@ Backwards compatibility and impact on performance
 =================================================
 
 This PEP may break code that uses module level (global) names ``__getattr__``
-and ``__dir__``. The performance implications of this PEP are minimal,
-since ``__getattr__`` is called only for missing attributes.
+and ``__dir__``.  (But the language reference explicitly reserves *all*
+undocumented dunder names, and allows "breakage without warning"; see [3]_.)
+The performance implications of this PEP are minimal, since ``__getattr__``
+is called only for missing attributes.
+
+Some tools that perform module attributes discovery might not expect
+``__getattr__``. This problem is not new however, since it is already possible
+to replace a module with a module subclass with overridden ``__getattr__`` and
+``__dir__``, but with this PEP such problems can occur more often.
 
 
 Discussion
@@ -155,6 +164,18 @@ should correspond to the name with which it is accessible via
 One should be also careful to avoid recursion as one would do with
 a class level ``__getattr__``.
 
+To use a module global with triggering ``__getattr__`` (for example if one
+wants to use a lazy loaded submodule) one can access it as::
+
+    sys.modules[__name__].some_global
+
+or as::
+
+    from . import some_global
+
+Note that the latter sets the module attribute, thus ``__getattr__`` will be
+called only once.
+
 
 References
 ==========
@@ -164,6 +185,9 @@ References
 
 .. [2] The reference implementation
    (https://github.com/ilevkivskyi/cpython/pull/3/files)
+
+.. [3] Reserved classes of identifiers
+   (https://docs.python.org/3/reference/lexical_analysis.html#reserved-classes-of-identifiers)
 
 
 Copyright


### PR DESCRIPTION
cc: @gvanrossum 

I didn't add any specification for helper functions. Also I think we don't need module ``__set_name__`` (it was brought by Serhiy) since it is still very new and much less known compared to ``__getattr__``.