### PR TITLE
typo fix for pep 544

### DIFF
--- a/pep-0544.txt
+++ b/pep-0544.txt
@@ -439,7 +439,7 @@ the class actually implements the protocol correctly::
 
         # Type checker might warn that 'intensity' is not defined
 
-A class can explicitly inherit from multiple protocols and also form normal
+A class can explicitly inherit from multiple protocols and also from normal
 classes. In this case methods are resolved using normal MRO and a type checker
 verifies that all subtyping are correct. The semantics of ``@abstractmethod``
 is not changed, all of them must be implemented by an explicit subclass


### PR DESCRIPTION
"form" appears to be a typo for "from", but it's possible I'm confused.