### PR TITLE
Remove "XXX Mention docstrings of 2.2 properties."

### DIFF
--- a/pep-0257.txt
+++ b/pep-0257.txt
@@ -72,8 +72,6 @@ extracted by software tools:
 Please see PEP 258, "Docutils Design Specification" [2]_, for a
 detailed description of attribute and additional docstrings.
 
-XXX Mention docstrings of 2.2 properties.
-
 For consistency, always use ``"""triple double quotes"""`` around
 docstrings.  Use ``r"""raw triple double quotes"""`` if you use any
 backslashes in your docstrings.  For Unicode docstrings, use


### PR DESCRIPTION
See https://github.com/python/peps/issues/484 for details.

Closes https://github.com/python/peps/issues/484