### PR TITLE
PEP 557, fix markup.

### DIFF
--- a/pep-0557.rst
+++ b/pep-0557.rst
@@ -739,7 +739,7 @@ also execute code immmediately after constructing the object) is
 functionally equivalent to being able to pass parameters to a
 ``__post_init__`` function.
 
-With ``InitVar``'s, ``__post_init__`` functions can now take
+With ``InitVar``s, ``__post_init__`` functions can now take
 parameters.  They are passed first to ``__init__`` which passes them
 to ``__post_init__`` where user code can use them as needed.
 

--- a/pep-0557.rst
+++ b/pep-0557.rst
@@ -745,7 +745,7 @@ to ``__post_init__`` where user code can use them as needed.
 
 The only real difference between alternate classmethod constructors
 and ``InitVar`` pseudo-fields is in regards to required non-field
-parameters during object creation.  With ``InitVar``'s, using
+parameters during object creation.  With ``InitVar``\s, using
 ``__init__`` and the module-level ``replace()`` function ``InitVar``'s
 must always be specified.  Consider the case where a ``context``
 object is needed to create an instance, but isn't stored as a field.

--- a/pep-0557.rst
+++ b/pep-0557.rst
@@ -739,13 +739,13 @@ also execute code immmediately after constructing the object) is
 functionally equivalent to being able to pass parameters to a
 ``__post_init__`` function.
 
-With ``InitVar``s, ``__post_init__`` functions can now take
+With ``InitVar``'s, ``__post_init__`` functions can now take
 parameters.  They are passed first to ``__init__`` which passes them
 to ``__post_init__`` where user code can use them as needed.
 
 The only real difference between alternate classmethod constructors
 and ``InitVar`` pseudo-fields is in regards to required non-field
-parameters during object creation.  With ``InitVar``s, using
+parameters during object creation.  With ``InitVar``'s, using
 ``__init__`` and the module-level ``replace()`` function ``InitVar``'s
 must always be specified.  Consider the case where a ``context``
 object is needed to create an instance, but isn't stored as a field.


### PR DESCRIPTION
I noticed the formatting looks strange on the rendered PEP:

<img width="306" alt="screen shot 2017-11-29 at 10 00 49 pm" src="https://user-images.githubusercontent.com/5844587/33416394-1c3e4b86-d551-11e7-9eb9-682528d432fc.png">

I wonder if it was meant as
```
With ``__InitVar__``s ...
```

instead of 
```
With ``__InitVar__``'s
```
