### PR TITLE
PEP 554: Fix the examples.

### DIFF
--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -220,7 +220,10 @@ Synchronize using a channel
            print("during")
            reader.close()
            """),
-           reader=r))
+           shared=dict(
+               reader=r,
+               ),
+           )
    t = threading.Thread(target=run)
    print('before')
    t.start()
@@ -244,7 +247,11 @@ Sharing a file descriptor
                print(line)
            writer.send(b'')
            """),
-           reader=r1, writer=s2)
+           shared=dict(
+               reader=r,
+               writer=s2,
+               ),
+           )
    t = threading.Thread(target=run)
    t.start()
    with open('spamspamspam') as infile:
@@ -262,7 +269,10 @@ Passing objects via marshal
    interp.run(tw.dedent("""
        import marshal
        """),
-       reader=r)
+       shared=dict(
+           reader=r,
+           ),
+       )
    def run():
        interp.run(tw.dedent("""
            data = reader.recv()
@@ -271,14 +281,13 @@ Passing objects via marshal
                do_something(obj)
                data = reader.recv()
            reader.close()
-           """),
-           reader=r)
+           """))
    t = threading.Thread(target=run)
    t.start()
    for obj in input:
        data = marshal.dumps(obj)
        s.send(data)
-   s.send(b'')
+   s.send(None)
 
 Passing objects via pickle
 --------------------------
@@ -290,7 +299,10 @@ Passing objects via pickle
    interp.run(tw.dedent("""
        import pickle
        """),
-       reader=r)
+       shared=dict(
+           reader=r,
+           ),
+       )
    def run():
        interp.run(tw.dedent("""
            data = reader.recv()
@@ -299,14 +311,13 @@ Passing objects via pickle
                do_something(obj)
                data = reader.recv()
            reader.close()
-           """),
-           reader=r)
+           """))
    t = threading.Thread(target=run)
    t.start()
    for obj in input:
        data = pickle.dumps(obj)
        s.send(data)
-   s.send(b'')
+   s.send(None)
 
 Running a module
 ----------------


### PR DESCRIPTION
After updating the signature of Interpreter.run(), I forgot to update the examples accordingly.  This change fixes that.