### PR TITLE
Tiny bit more clarity about the format specifiers in PEP 498

### DIFF
--- a/pep-0498.txt
+++ b/pep-0498.txt
@@ -212,6 +212,7 @@ conversions are applied before the call to ``format()``. The only
 reason to use ``'!s'`` is if you want to specify a format specifier
 that applies to ``str``, not to the type of the expression.
 
+F-strings use the same format specifier mini-language as ``str.format``.
 Similar to ``str.format()``, optional format specifiers maybe be
 included inside the f-string, separated from the expression (or the
 type conversion, if specified) by a colon. If a format specifier is


### PR DESCRIPTION
See this thread on python-dev:

https://mail.python.org/pipermail/python-dev/2017-December/151282.html

NOTE: PEPs aren't really supposed to be documentation for end users, so maybe there's not point in this little clarification. And some clarification has been added to the main Python docs.

But why not? People do come here to learn about new features.