### PR TITLE
Fix PEP summary/email line indent in pep-0000.html

### DIFF
--- a/pep2html.py
+++ b/pep2html.py
@@ -296,7 +296,7 @@ def fixfile(inpath, input_lines, outfile):
                     print(re.sub(
                         parts[1],
                         '<a href="%s">%s</a>' % (url, parts[1]),
-                        line, 1), end=' ', file=outfile)
+                        line, 1), end='', file=outfile)
                     continue
                 elif parts and '@' in parts[-1]:
                     # This is a pep email address line, so filter it.
@@ -305,7 +305,7 @@ def fixfile(inpath, input_lines, outfile):
                         print('<pre>', file=outfile)
                         need_pre = 0
                     print(re.sub(
-                        parts[-1], url, line, 1), end=' ', file=outfile)
+                        parts[-1], url, line, 1), end='', file=outfile)
                     continue
             line = fixpat.sub(lambda x, c=inpath: fixanchor(c, x), line)
             if need_pre:


### PR DESCRIPTION
The PEP summary/email lines that aren't the first line in their group
have an extra leading space because the previous line is printed with a
trailing space. The special lines read from pep-0000.txt should be
printed with no extra ending to be consistent with what the python2
version did with a print statement that ends with a comma.