### PR TITLE
Clarify the prohibition on locals() and globals().

### DIFF
--- a/pep-0498.txt
+++ b/pep-0498.txt
@@ -164,7 +164,10 @@ globals() has access to far more information than needed to do the
 string interpolation.
 
 Guido stated [#]_ that any solution to better string interpolation
-would not use locals() or globals().
+would not use locals() or globals() in its implementation.  (This does
+not forbid users from passing locals() or globals() in, it just
+doesn't require it, nor does it allow using these functions under the
+hood.)
 
 Specification
 =============


### PR DESCRIPTION
It applies to the implementation, not to end users passing these in to
f-string -- the latter is fine (e.g. print(f"Locals are {locals()}")).

CC: @mariatta