### PR TITLE
566: Mention that version specifiers no longer need to be in parentheses

### DIFF
--- a/pep-0566.txt
+++ b/pep-0566.txt
@@ -87,6 +87,12 @@ Version Specifiers
 Version numbering requirements and the semantics for specifying comparisons
 between versions are defined in PEP 440.
 
+Following :pep:`508`, version specifiers no longer need to be surrounded by
+parentheses in the fields Requires-Dist, Provides-Dist, Obsoletes-Dist or
+Requires-External, so e.g. ``requests >= 2.8.1`` is now a valid value.
+The recommended format is without parentheses, but tools parsing metadata should
+also be able to handle version specifiers in parentheses.
+
 Usage of version specifiers is otherwise unchanged from PEP 345.
 
 Environment markers


### PR DESCRIPTION
This is the text that I proposed on distutils-sig.

cc @ncoghlan @di @dholth .