### PR TITLE
use correct path separator

### DIFF
--- a/pep-0376.txt
+++ b/pep-0376.txt
@@ -43,8 +43,8 @@ Right now, when a distribution is installed in Python, every element can
 be installed in a different directory.
 
 For instance, `Distutils` installs the pure Python code in the `purelib`
-directory, which is ``lib\python2.6\site-packages`` for unix-like systems and
-Mac OS X, or `Lib/site-packages` under Python's installation directory for
+directory, which is ``lib/python2.6/site-packages`` for unix-like systems and
+Mac OS X, or `Lib\site-packages` under Python's installation directory for
 Windows.
 
 Additionally, the `install_egg_info` subcommand of the Distutils `install`


### PR DESCRIPTION
use `/` for unix-like path separator and `\` for Windows path separator