### PR TITLE
PEP 567: avoid _NO_DEFAULT, use [default] syntax

### DIFF
--- a/pep-0567.rst
+++ b/pep-0567.rst
@@ -124,7 +124,7 @@ contextvars.ContextVar
 ----------------------
 
 The ``ContextVar`` class has the following constructor signature:
-``ContextVar(name, *, default=_NO_DEFAULT)``.  The ``name`` parameter
+``ContextVar(name, *, [default])``.  The ``name`` parameter
 is used for introspection and debug purposes, and is exposed
 as a read-only ``ContextVar.name`` attribute.  The ``default``
 parameter is optional.  Example::
@@ -132,10 +132,7 @@ parameter is optional.  Example::
     # Declare a context variable 'var' with the default value 42.
     var = ContextVar('var', default=42)
 
-(The ``_NO_DEFAULT`` is an internal sentinel object used to
-detect if the default value was provided.)
-
-``ContextVar.get(default=_NO_DEFAULT)`` returns a value for
+``ContextVar.get([default])`` returns a value for
 the context variable for the current ``Context``::
 
     # Get the value of `var`.
@@ -482,6 +479,9 @@ directly::
                                             token._old_value)
 
             token._used = True
+
+(The ``_NO_DEFAULT`` is an internal sentinel object used to
+detect if the default value was provided.)
 
 Note that the in the reference implementation, ``ContextVar.get()``
 has an internal cache for the most recent value, which allows to


### PR DESCRIPTION
Replace ContextVar(name, *, default=_NO_DEFAULT) with ContextVar(name, *, [default]).
