### PR TITLE
pep-567: ContextVar.reset() raises a RuntimeErorr on already used tokens

### DIFF
--- a/pep-0567.rst
+++ b/pep-0567.rst
@@ -174,14 +174,16 @@ not set)::
     # After reset: var.get(None) is None,
     # i.e. 'var' was removed from the current context.
 
-``ContextVar.reset()`` method is idempotent and can be called
-multiple times on the same Token object: second and later calls
-will be no-ops.  The method raises a ``ValueError`` if:
+The ``ContextVar.reset()`` method raises:
 
-* it is called with a token object created by another variable; or
+* a ``ValueError`` if it is called with a token object created
+  by another variable;
 
-* the current ``Context`` object does not match the one where
-  the token object was created.
+* a ``ValueError`` if the current ``Context`` object does not match
+  the one where the token object was created;
+
+* a ``RuntimeError`` if the token object has already been used once
+  to reset the variable.
 
 
 contextvars.Token
@@ -463,6 +465,9 @@ directly::
             return Token(ts.context, self, old_value)
 
         def reset(self, token):
+            if token._used:
+                raise RuntimeError("Token has already been used once")
+
             if token._var is not self:
                 raise ValueError(
                     "Token was created by a different ContextVar")
@@ -471,9 +476,6 @@ directly::
             if token._context is not ts.context:
                 raise ValueError(
                     "Token was created in a different Context")
-
-            if token._used:
-                return
 
             if token._old_value is Token.MISSING:
                 ts.context._data = data.delete(token._var)


### PR DESCRIPTION
cc @gvanrossum 