### PR TITLE
pep-567: Merge "Design Considerations" and "Rejected Ideas"

### DIFF
--- a/pep-0567.rst
+++ b/pep-0567.rst
@@ -582,8 +582,8 @@ Replication of threading.local() interface
 Please refer to :pep:`550` where this topic is covered in detail: [2]_.
 
 
-Replace Token with ContextVar.unset()
--------------------------------------
+Replacing Token with ContextVar.unset()
+---------------------------------------
 
 The Token API allows to get around having a ``ContextVar.unset()``
 method, which is incompatible with chained contexts design of
@@ -614,8 +614,8 @@ with::
             cv.set(old)
 
 
-Token.reset() instead of ContextVar.reset()
--------------------------------------------
+Having Token.reset() instead of ContextVar.reset()
+--------------------------------------------------
 
 Nathaniel Smith suggested to implement the ``ContextVar.reset()``
 method directly on the ``Token`` class, so instead of::
@@ -639,8 +639,8 @@ being clearer to the human reader of the code which variable is
 being reset.
 
 
-Make Context objects picklable
-------------------------------
+Making Context objects picklable
+--------------------------------
 
 Proposed by Antoine Pitrou, this could enable transparent
 cross-process use of ``Context`` objects, so the
@@ -663,8 +663,8 @@ Given the time frame of the Python 3.7 release schedule it was decided
 to defer this proposal to Python 3.8.
 
 
-Make Context a MutableMapping
------------------------------
+Making Context a MutableMapping
+-------------------------------
 
 Making the ``Context`` class implement the ``abc.MutableMapping``
 interface would mean that it is possible to set and unset variables
@@ -709,8 +709,8 @@ This proposal was deferred to Python 3.8+ because of the following:
      ctx.run(func)
 
 
-Have initial values for ContextVars
------------------------------------
+Having initial values for ContextVars
+-------------------------------------
 
 Nathaniel Smith proposed to have a required ``initial_value``
 keyword-only argument for the ``ContextVar`` constructor.

--- a/pep-0567.rst
+++ b/pep-0567.rst
@@ -573,25 +573,30 @@ C API
       if (PyContext_Exit(old_ctx)) goto error;
 
 
-Design Considerations
-=====================
+Rejected Ideas
+==============
 
-Why contextvars.Token and not ContextVar.unset()?
--------------------------------------------------
+Replication of threading.local() interface
+------------------------------------------
+
+Please refer to :pep:`550` where this topic is covered in detail: [2]_.
+
+
+Replace Token with ContextVar.unset()
+-------------------------------------
 
 The Token API allows to get around having a ``ContextVar.unset()``
 method, which is incompatible with chained contexts design of
 :pep:`550`.  Future compatibility with :pep:`550` is desired
-(at least for Python 3.7) in case there is demand to support
-context variables in generators and asynchronous generators.
+in case there is demand to support context variables in generators
+and asynchronous generators.
 
 The Token API also offers better usability: the user does not have
 to special-case absence of a value. Compare::
 
-    token = cv.get()
+    token = cv.set(new_value)
     try:
-        cv.set(blah)
-        # code
+        # cv.get() is new_value
     finally:
         cv.reset(token)
 
@@ -607,15 +612,6 @@ with::
             cv.unset()
         else:
             cv.set(old)
-
-
-Rejected Ideas
-==============
-
-Replication of threading.local() interface
-------------------------------------------
-
-Please refer to :pep:`550` where this topic is covered in detail: [2]_.
 
 
 Token.reset() instead of ContextVar.reset()


### PR DESCRIPTION
The "Design Considerations" section had only one subsection which
was a discussion of a rejected idea.  Merging it into "Rejected Ideas"
simplifies the document structure.

Fix a bug in a code snippet in the "ContextVar.unset()" subsection.

cc @gvanrossum 