### PR TITLE
pep-567: Tweak C API

### DIFF
--- a/pep-0567.rst
+++ b/pep-0567.rst
@@ -556,9 +556,13 @@ C API
 
 5. ``PyContext * PyContext_New()``: create a new empty context.
 
-6. ``PyContext * PyContext_Copy()``: get a copy of the current context.
+6. ``PyContext * PyContext_Copy(PyContext *)``: return a shallow
+   copy of the passed context object.
 
-7. ``int PyContext_Enter(PyContext *)`` and
+7. ``PyContext * PyContext_CopyCurrent()``: get a copy of the current
+   context.
+
+8. ``int PyContext_Enter(PyContext *)`` and
    ``int PyContext_Exit(PyContext *)`` allow to set and restore
    the context for the current OS thread.  It is required to always
    restore the previous context::


### PR DESCRIPTION
Changes:

* Rename `PyContext * PyContext_Copy()` to `PyContext * PyContext_CopyCurrent()`;

* Add a new `PyContext * PyContext_Copy(PyContext *)` function.

This brings parity between C & Python APIs. 

@gvanrossum: this is the last change I can currently think of.