### PR TITLE
Fix rendering of editor's first initial

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -85,7 +85,7 @@ details.  The current editors are:
 * Georg Brandl
 * Brett Cannon
 * David Goodger
-* R. David Murray
+* \R. David Murray
 * Jesse Noller
 * Berker Peksag
 * Guido van Rossum


### PR DESCRIPTION
If R. David Murray's first initial is not escaped, it is interpreted as
the alphabetic ordinal in an enumerated list and rendered as
"18. David Murray".