### PR TITLE
PEP 541: Make the Packaging WG the approval authority

### DIFF
--- a/pep-0541.txt
+++ b/pep-0541.txt
@@ -3,7 +3,7 @@ Title: Package Index Name Retention
 Version: $Revision$
 Last-Modified: $Date$
 Author: Łukasz Langa <lukasz@python.org>
-BDFL-Delegate: Donald Stufft <donald@stufft.io>
+BDFL-Delegate: Mark Mangoba <mmangoba@python.org>
 Discussions-To: distutils-sig <distutils-sig@python.org>
 Status: Draft
 Type: Process

--- a/pep-0541.txt
+++ b/pep-0541.txt
@@ -48,10 +48,6 @@ recommend its acceptance to the PSF's Packaging Working Group. After
 consultation with the PSF's General Counsel, adoption of the policy will then
 be subject to a formal vote within the working group.
 
-The aim of this approach is to help make it clear that any concerns with the
-outcome of the policy should be taken up with the PSF directly, rather than
-with the community volunteers that take on the responsibility of applying it.
-
 This formal approval process will be used for both initial adoption of the
 policy, and for adoption of any future amendments.
 

--- a/pep-0541.txt
+++ b/pep-0541.txt
@@ -36,6 +36,26 @@ This document aims to provide general guidelines for solving the
 most typical cases of such conflicts.
 
 
+Approval Process
+================
+
+As the application of this policy has potential legal ramifications for the
+Python Software Foundation, the approval process used is more formal than that
+used for most PEPs.
+
+Rather than accepting the PEP directly, the assigned BDFL-Delegate will instead
+recommend its acceptance to the PSF's Packaging Working Group. After
+consultation with the PSF's General Counsel, adoption of the policy will then
+be subject to a formal vote within the working group.
+
+The aim of this approach is to help make it clear that any concerns with the
+outcome of the policy should be taken up with the PSF directly, rather than
+with the community volunteers that take on the responsibility of applying it.
+
+This formal approval process will be used for both initial adoption of the
+policy, and for adoption of any future amendments.
+
+
 Specification
 =============
 


### PR DESCRIPTION
It isn't appropriate for the PSF to ask a single community
volunteer to accept full responsibility for the PSF's
policy on PyPI name management.

Delegating the task to the Packaging Working Group is more
appropriate, since we're already responsible for handling
the PSF's budget in this area, and there's a lot of overlap
between budget management and risk management.