### PR TITLE
Fix IPython spelling in pep 485

### DIFF
--- a/pep-0485.txt
+++ b/pep-0485.txt
@@ -463,7 +463,7 @@ Expected Uses
 The primary expected use case is various forms of testing -- "are the
 results computed near what I expect as a result?" This sort of test
 may or may not be part of a formal unit testing suite. Such testing
-could be used one-off at the command line, in an iPython notebook,
+could be used one-off at the command line, in an IPython notebook,
 part of doctests, or simple asserts in an ``if __name__ == "__main__"``
 block.
 


### PR DESCRIPTION
It's upper case I. 