### PR TITLE
PEP 1: Update some out of date details

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -441,8 +441,8 @@ Standards Track PEPs will typically have a Python-Version header which
 indicates the version of Python that the feature will be released with.
 Standards Track PEPs without a Python-Version header indicate
 interoperability standards that will initially be supported through
-external libraries and tools, and then supplemented by a later PEP to
-add support to the standard library. Informational and Process PEPs do
+external libraries and tools, and then potentially supplemented by a later PEP
+to add support to the standard library. Informational and Process PEPs do
 not need a Python-Version header.
 
 PEPs may have a Requires header, indicating the PEP numbers that this
@@ -458,10 +458,14 @@ obsolete.
 Auxiliary Files
 ===============
 
-PEPs may include auxiliary files such as diagrams.  Such files must be
+PEPs may include auxiliary files such as diagrams.  Such files should be
 named ``pep-XXXX-Y.ext``, where "XXXX" is the PEP number, "Y" is a
 serial number (starting at 1), and "ext" is replaced by the actual
 file extension (e.g. "png").
+
+Alternatively, all support files may be placed in a subdirectory called
+``pep-XXXX``, where "XXXX" is the PEP number. When using a subdirectory, there
+are no constraints on the names used in files.
 
 
 Reporting PEP Bugs, or Submitting PEP Updates
@@ -472,15 +476,15 @@ factors, such as the maturity of the PEP, the preferences of the PEP
 author, and the nature of your comments.  For the early draft stages
 of the PEP, it's probably best to send your comments and changes
 directly to the PEP author.  For more mature, or finished PEPs you may
-want to submit corrections to the Python `issue tracker`_ so that your
-changes don't get lost.  If the PEP author is a Python developer, assign the
-bug/patch to them, otherwise assign it to a PEP editor.
+want to submit corrections as a `GitHub issue`_ or `GitHub pull request`_ so that
+your changes don't get lost.
 
 When in doubt about where to send your changes, please check first
 with the PEP author and/or a PEP editor.
 
 PEP authors with git push privileges for the PEP repository can update the
-PEPs themselves by using "git push" to submit their changes.
+PEPs themselves by using "git push" or the GitHub PR interface to submit their
+changes.
 
 
 Transferring PEP Ownership
@@ -618,6 +622,8 @@ References and Footnotes
 .. _PEP repository: https://github.com/python/peps
 
 .. _`GitHub pull request`: https://github.com/python/peps/pulls
+
+.. _`GitHub issue`: https://github.com/python/peps/issues
 
 
 Copyright


### PR DESCRIPTION
- some interoperability specifications (e.g. the package index
  download API) will never have a standard library implementation
- auxiliary files can go in a subdirectory
- PEP issues should be reported against the GitHub repo rather than
  bugs.python.org