### PR TITLE
Mark several PEPs as final

### DIFF
--- a/pep-0345.txt
+++ b/pep-0345.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Richard Jones <richard@python.org>
 Discussions-To: Distutils SIG
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 28-Apr-2005

--- a/pep-0376.txt
+++ b/pep-0376.txt
@@ -3,7 +3,7 @@ Title: Database of Installed Python Distributions
 Version: $Revision$
 Last-Modified: $Date$
 Author: Tarek Ziadé <tarek@ziade.org>
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 22-Feb-2009

--- a/pep-0425.txt
+++ b/pep-0425.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: 07-Aug-2012
 Author: Daniel Holth <dholth@gmail.com>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 27-Jul-2012

--- a/pep-0427.txt
+++ b/pep-0427.txt
@@ -5,7 +5,7 @@ Last-Modified: $Date$
 Author: Daniel Holth <dholth@gmail.com>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
 Discussions-To: <distutils-sig@python.org>
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 20-Sep-2012

--- a/pep-0506.txt
+++ b/pep-0506.txt
@@ -3,7 +3,7 @@ Title: Adding A Secrets Module To The Standard Library
 Version: $Revision$
 Last-Modified: $Date$
 Author: Steven D'Aprano <steve@pearwood.info>
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 19-Sep-2015

--- a/pep-0539.txt
+++ b/pep-0539.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Erik M. Bray, Masayuki Yamamoto
 BDFL-Delegate: Nick Coghlan
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 20-Dec-2016


### PR DESCRIPTION
- 376, 425, 427: reference implementations now live outside CPython
- 506: implemented and released in Python 3.6
- 539: implemented in Python 3.7