### PR TITLE
Fix the unexpected indentations error on pep-0467.txt

### DIFF
--- a/pep-0467.txt
+++ b/pep-0467.txt
@@ -105,7 +105,7 @@ These methods will only accept integers in the range 0 to 255 (inclusive)::
       File "<stdin>", line 1, in <module>
     TypeError: 'float' object cannot be interpreted as an integer
 
-While this does create some duplication, there are valid reasons for it::
+While this does create some duplication, there are valid reasons for it:
 
 * the ``bchr`` builtin is to recreate the ord/chr/unichr trio from Python
   2 under a different naming scheme


### PR DESCRIPTION
There was an **unexpected indentations error** at 111 line on pep-0467.txt, so the travis build was failed.