### PR TITLE
PEP 484: Fix the example code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 *~
 *env
 .vscode
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ __pycache__
 *~
 *env
 .vscode
-*.swp

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -585,7 +585,6 @@ argument(s) is substituted.  Otherwise, ``Any`` is assumed.  Example::
   class Node(Generic[T]):
       def __init__(self, label: T = None) -> None:
           ...
-      x = None  # Type: T
 
   x = Node('')  # Inferred type is Node[str]
   y = Node(0)   # Inferred type is Node[int]

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -583,6 +583,7 @@ argument(s) is substituted.  Otherwise, ``Any`` is assumed.  Example::
   T = TypeVar('T')
 
   class Node(Generic[T]):
+      x = None  # type: T  # Instance attribute (see below)
       def __init__(self, label: T = None) -> None:
           ...
 

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -355,6 +355,7 @@ You can include a ``Generic`` base class to define a user-defined class
 as generic.  Example::
 
   from typing import TypeVar, Generic
+  from logging import Logger
 
   T = TypeVar('T')
 
@@ -373,7 +374,7 @@ as generic.  Example::
           return self.value
 
       def log(self, message: str) -> None:
-          self.logger.info('{}: {}'.format(self.name message))
+          self.logger.info('{}: {}'.format(self.name, message))
 
 ``Generic[T]`` as a base class defines that the class ``LoggedVar``
 takes a single type parameter ``T``. This also makes ``T`` valid as

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -1409,7 +1409,7 @@ for example::
   c = None # type: Coroutine[List[str], str, int]
   ...
   x = c.send('hi') # type: List[str]
-  async def bar(): -> None:
+  async def bar() -> None:
       x = await c # type: int
 
 The module also provides generic ABCs ``Awaitable``,

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -1460,14 +1460,11 @@ No first-class syntax support for explicitly marking variables as being
 of a specific type is added by this PEP.  To help with type inference in
 complex cases, a comment of the following format may be used::
 
-  x = []  # type: List[Employee]
+  x = []                # type: List[Employee]
   x, y, z = [], [], []  # type: List[int], List[int], List[str]
   x, y, z = [], [], []  # type: (List[int], List[int], List[str])
   a, b, *c = range(5)   # type: float, float, List[float]
-  x = [
-     1,
-     2,
-  ]  # type: List[int]
+  x = [1, 2]            # type: List[int]
 
 Type comments should be put on the last line of the statement that
 contains the variable definition. They can also be placed on


### PR DESCRIPTION
Fixed a small syntax error and imported the `logging.Logger` - it is needed in the code for indicate the type of variable `def __init__(..., logger: Logger) -> ...`

P.s. Ignore temporary files for the vim editor.
P.p.s. I'm already signed the CLA.