### PR TITLE
Readme: Change pep-0999.txt to pep-0999.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Generating HTML
 
 Do not commit changes with bad formatting.  To check the formatting of
 a PEP, use the Makefile.  In particular, to generate HTML for PEP 999,
-your source code should be in ``pep-0999.txt`` and the HTML will be
+your source code should be in ``pep-0999.rst`` and the HTML will be
 generated to ``pep-0999.html`` by the command ``make pep-0999.html``.
 The default Make target generates HTML for all PEPs.  If you don't have
 Make, use the ``pep2html.py`` script.


### PR DESCRIPTION
`.rst` file extension is now supported. I think new PEPs should be in `.rst`.