### PR TITLE
PEP 541: Update external references

### DIFF
--- a/pep-0541.txt
+++ b/pep-0541.txt
@@ -247,22 +247,18 @@ a copy of the complaint will be sent to the package owner. In some
 cases, action may be taken by the Package Index maintainers before 
 the owner responds.
 
-If you find a project that you think might be considered invalid, create
-a support request [7]_.  Maintainers of the Package Index will review
-the case.
-
 
 The role of the Python Software Foundation
 ------------------------------------------
 
-The Python Software Foundation [8]_ is the non-profit legal entity that
+The Python Software Foundation [7]_ is the non-profit legal entity that
 provides the Package Index as a community service.
 
 The Package Index maintainers can escalate issues covered by this
 document for resolution by the Packaging Workgroup if the matter is not clear
 enough.  Some decisions *require* additional judgement by the Board,
 especially in cases of Code of Conduct violations or legal claims.
-Recommendations made by the Board are sent to the Packaging Workgroup [9]_ for review.
+Recommendations made by the Board are sent to the Packaging Workgroup [8]_ for review.
 
 The Packaging Workgroup has the final say in any disputes covered by this document and
 can decide to reassign or remove a project from the Package Index after
@@ -317,7 +313,7 @@ References
    (https://pypi.org/policy/terms-of-use/)
 
 .. [2] The Python Package Index
-   (https://pypi.python.org/)
+   (https://pypi.org/)
 
 .. [3] The Comprehensive Perl Archive Network
    (http://www.cpan.org/)
@@ -331,13 +327,10 @@ References
 .. [6] Python Community Code of Conduct
    (https://www.python.org/psf/codeofconduct/)
 
-.. [7] PyPI Support Requests
-   (https://sourceforge.net/p/pypi/support-requests/)
-
-.. [8] Python Software Foundation
+.. [7] Python Software Foundation
    (https://www.python.org/psf/)
 
-.. [9] PSF Board Resolutions
+.. [8] Python Packaging Working Group
    (https://wiki.python.org/psf/PackagingWG/)
 
 


### PR DESCRIPTION
- only mention psf-legal@... for IP concerns
- use post-migration link for PyPI
- drop Source Forge footnote entirely