### PR TITLE
Change irregardless to regardless

### DIFF
--- a/pep-0540.txt
+++ b/pep-0540.txt
@@ -18,7 +18,7 @@ Abstract
 Add a new "UTF-8 Mode" to enhance Python's use of UTF-8.  When UTF-8 Mode
 is active, Python will:
 
-* use the ``utf-8`` encoding, irregardless of the locale currently set by
+* use the ``utf-8`` encoding, regardless of the locale currently set by
   the current platform, and
 * change the ``stdin`` and ``stdout`` error handlers to
   ``surrogateescape``.


### PR DESCRIPTION
Most dictionaries list it as nonstandard or incorrect usage, and recommend that "regardless" be used instead