### PR TITLE
Clarify PEP 384

### DIFF
--- a/pep-0384.txt
+++ b/pep-0384.txt
@@ -211,13 +211,9 @@ of a Unicode string can convert it to wchar_t.
 Functions and function-like Macros
 ----------------------------------
 
-All functions starting with _Py are not available to applications
-(see exceptions below).
-Also, all functions that expect parameter types that are unavailable
-to applications are excluded from the ABI, such as PyAST_FromNode
-(which expects a ``node*``).
-
-All other functions are available, unless excluded below.
+By default, all functions are available, unless they are excluded
+below.
+Whether a function is documented or not does not matter.
 
 Function-like macros (in particular, field access macros) remain
 available to applications, but get replaced by function calls
@@ -232,11 +228,16 @@ redirect calls to the new function when the applications is
 recompiled.
 
 If continued provision of the old function is not possible, it may get
-deprecated, then removed, in accordance with PEP 7, causing
+deprecated, then removed, causing
 applications that use that function to break.
 
 Excluded Functions
 ------------------
+
+All functions starting with _Py are not available to applications.
+Also, all functions that expect parameter types that are unavailable
+to applications are excluded from the ABI, such as PyAST_FromNode
+(which expects a ``node*``).
 
 Functions declared in the following header files are not part
 of the ABI:
@@ -266,11 +267,9 @@ In addition, functions expecting ``FILE*`` are not part of
 the ABI, to avoid depending on a specific version of the
 Microsoft C runtime DLL on Windows.
 
-Module and type initalizer functions are not available
-(PyByteArray_Init, PyByteArray_Fini, PyBytes_Fini,
-PyCFunction_Fini, PyDict_Fini, PyFloat_ClearFreeList,
-PyFloat_Fini, PyFrame_Fini, PyList_Fini, PyMethod_Fini,
-PyOS_FiniInterrupts, PySet_Fini, PyTuple_Fini).
+Module and type initializer and finalizer functions are not available
+(PyByteArray_Init, PyOS_FiniInterrupts
+and all functions ending in _Fini or _ClearFreeList).
 
 Several functions dealing with interpreter implementation
 details are not available:


### PR DESCRIPTION
Following the post at https://mail.python.org/pipermail/python-dev/2018-April/152642.html I am adding explicitly that undocumented functions can be considered part of the stable ABI.

Apart from that, some minor reorganization and rewording.