### PR TITLE
Mention how to calculate the ABI flag for CPython

### DIFF
--- a/pep-0425.txt
+++ b/pep-0425.txt
@@ -109,7 +109,8 @@ ABI Tag
 The ABI tag indicates which Python ABI is required by any included
 extension modules.  For implementation-specific ABIs, the implementation
 is abbreviated in the same way as the Python Tag, e.g. `cp33d` would be
-the CPython 3.3 ABI with debugging.
+the CPython 3.3 ABI with debugging (calculated by concatenating the Python
+tag with `sys.abiflags()`).
 
 The CPython stable ABI is `abi3` as in the shared library suffix.
 


### PR DESCRIPTION
It's not obvious where to find the suffix for the ABI tag if you don't happen to just know.