### PR TITLE
PEP 561: Point to mypy implementation and clarify stub package priority.

### DIFF
--- a/pep-0561.rst
+++ b/pep-0561.rst
@@ -195,7 +195,7 @@ checker [pkg_checker]_ which reads the metadata of installed packages and
 reports on their status as either not typed, inline typed, or a stub package.
 
 The mypy type checker has an implementation of PEP 561 searching which can be
-read about in the [mypy docs]_.
+read about in the mypy docs [4]_.
 
 
 Acknowledgements
@@ -260,14 +260,14 @@ References
 .. [3] PEP 426 definitions
    (https://www.python.org/dev/peps/pep-0426/)
 
+.. [4] Example implementation in a type checker
+   (https://mypy.readthedocs.io/en/latest/installed_packages.html)
+
 .. [typed_pkg] Sample typed package
    (https://github.com/ethanhs/sample-typed-package)
 
 .. [pkg_checker] Sample package checker
    (https://github.com/ethanhs/check_typedpkg)
-
-.. [mypy docs] Example implementation in a type checker
-   (https://mypy.readthedocs.io/en/latest/installed_packages.html)
 
 Copyright
 =========

--- a/pep-0561.rst
+++ b/pep-0561.rst
@@ -165,8 +165,8 @@ resolve modules containing type information:
    checkers SHOULD provide this to allow the user complete control of which
    stubs to use, and patch broken stubs/inline types from packages.
 
-3. Stub packages - these packages can supersede the installed packages.
-   They can be found at ``foopkg-stubs`` for package ``foopkg``.
+3. Stub packages - these packages SHOULD supersede any installed inline
+   package. They can be found at ``foopkg-stubs`` for package ``foopkg``.
 
 4. Inline packages - if there is nothing overriding the installed
    package, and it opts into type checking, inline types SHOULD be used.
@@ -189,10 +189,13 @@ Implementation
 ==============
 
 The proposed scheme of indicating support for typing is completely backwards
-compatible, and requires no modification to tooling. A sample package with
-inline types is available [typed_pkg]_, as well as a sample package checker
-[pkg_checker]_ which reads the metadata of installed packages and reports on
-their status as either not typed, inline typed, or a stub package.
+compatible, and requires no modification to package tooling. A sample package
+with inline types is available [typed_pkg]_, as well as a sample package
+checker [pkg_checker]_ which reads the metadata of installed packages and
+reports on their status as either not typed, inline typed, or a stub package.
+
+The mypy type checker has an implementation of PEP 561 searching which can be
+read about in the [mypy docs]_.
 
 
 Acknowledgements
@@ -205,6 +208,11 @@ Smith, and Guido van Rossum.
 
 Version History
 ===============
+
+* 2018-04-09
+
+    * Add reference to mypy implementation
+    * Clarify stub package priority.
 
 * 2018-02-02
 
@@ -257,6 +265,9 @@ References
 
 .. [pkg_checker] Sample package checker
    (https://github.com/ethanhs/check_typedpkg)
+
+.. [mypy docs] Example implementation in a type checker
+   (https://mypy.readthedocs.io/en/latest/installed_packages.html)
 
 Copyright
 =========


### PR DESCRIPTION
This update points to a real implementation in a type checker for PEP 561. I also modified the language to clarify that stub packages should take priority over any installed inline packages (so not just those in the same directory).