### PR TITLE
PEP 574: rename BYTEARRAY to BYTEARRAY8

### DIFF
--- a/pep-0574.rst
+++ b/pep-0574.rst
@@ -274,7 +274,7 @@ Protocol changes
 
 Three new opcodes are introduced:
 
-* ``BYTEARRAY`` creates a bytearray from the data following it in the pickle
+* ``BYTEARRAY8`` creates a bytearray from the data following it in the pickle
   stream and pushes it on the stack (just like ``BINBYTES8`` does for bytes
   objects);
 * ``NEXT_BUFFER`` fetches a buffer from the ``buffers`` iterable and pushes


### PR DESCRIPTION
Because the `BYTEARRAY` opcode needs to include the 64-bit length of the data (like `BINBYTES8` does already), I would find it more consistent to name that opcode `BYTEARRAY8` directly.

This is actually what @pitrou ended implementing in his draft branch for pickle protocol 5.