### PR TITLE
PEP 1: Remove legacy reference to pep2pyramid.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,12 +26,41 @@ package, which is available from `PyPI <http://pypi.python.org>`_.
 If you have pip, ``pip install docutils`` should install it.
 
 
-Generating HTML
-===============
+Generating the PEP Index
+========================
+
+PEP 0 is automatically generated based on the metadata headers in other
+PEPs. The script handling this is ``genpepindex.py``, with supporting
+libraries in the ``pep0`` directory.
+
+
+Checking PEP formatting and rendering
+=====================================
 
 Do not commit changes with bad formatting.  To check the formatting of
 a PEP, use the Makefile.  In particular, to generate HTML for PEP 999,
 your source code should be in ``pep-0999.rst`` and the HTML will be
 generated to ``pep-0999.html`` by the command ``make pep-0999.html``.
-The default Make target generates HTML for all PEPs.  If you don't have
-Make, use the ``pep2html.py`` script.
+The default Make target generates HTML for all PEPs.
+
+If you don't have Make, use the ``pep2html.py`` script directly.
+
+
+Generating HTML for python.org
+==============================
+
+python.org includes its own helper modules to render PEPs as HTML, with
+suitable links back to the source pages in the version control repository.
+
+These can be found at https://github.com/python/pythondotorg/tree/master/peps
+
+When making changes to the PEP management process that may import python.org's
+rendering pipeline:
+
+* Clone the python.org repository from https://github.com/python/pythondotorg/
+* Get set up for local python.org development as per
+  https://pythondotorg.readthedocs.io/install.html#manual-setup
+* Adjust ``PEP_REPO_PATH`` in ``pydotorg/settings/local.py`` to refer to your
+  local clone of the PEP repository
+* Run ``./manage.py generate_pep_pages`` as described in
+  https://pythondotorg.readthedocs.io/pep_generation.html

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -354,10 +354,8 @@ ReStructuredText_ allows for rich markup that is still quite easy to
 read, but also results in good-looking and functional HTML. PEP 12
 contains instructions and a template [4]_ for reStructuredText PEPs.
 
-A Python script automatically converts PEPs to HTML for viewing on
-the web [5]_.  The conversion of reStructuredText PEPs is handled by
-the Docutils_ module; the same script also renders a legacy plain-text
-format of PEP internally, to support pre-reST documents.
+The PEP text files are automatically converted to HTML [5]_ for easier
+`online reading <https://www.python.org/dev/peps/>`__.
 
 
 PEP Header Preamble
@@ -604,11 +602,9 @@ References and Footnotes
 .. [4] PEP 12, Sample reStructuredText PEP Template, Goodger, Warsaw
    (http://www.python.org/dev/peps/pep-0012)
 
-.. [5] The script referred to here is pep2pyramid.py, the successor to
-   pep2html.py, both of which live in the same directory in the hg
-   repo as the PEPs themselves.  Try ``pep2html.py --help`` for
-   details.  The URL for viewing PEPs on the web is
-   http://www.python.org/dev/peps/.
+.. [5] More details on the PEP rendering and publication process can be found
+   in the PEPs repo README at
+   https://github.com/python/peps/blob/master/README.rst
 
 .. _issue tracker:
    http://bugs.python.org/


### PR DESCRIPTION
This removes any reference to the technical details of online PEP
publication from PEP 1, replacing it with a reference to the
README in the PEP repository.

It also updates the README with relevant cross-references to the
pythondotorg project (based on some process pointers provided by
Mariatta Wijaya).

Resolves GH-575.