### PR TITLE
"func_annotations" -> " __annotations__"

### DIFF
--- a/pep-3107.txt
+++ b/pep-3107.txt
@@ -159,11 +159,11 @@ Accessing Function Annotations
 ==============================
 
 Once compiled, a function's annotations are available via the
-function's ``func_annotations`` attribute.  This attribute is
+function's ``__annotations__`` attribute.  This attribute is
 a mutable dictionary, mapping parameter names to an object
 representing the evaluated annotation expression
 
-There is a special key in the ``func_annotations`` mapping,
+There is a special key in the ``__annotations__`` mapping,
 ``"return"``.  This key is present only if an annotation was supplied
 for the function's return value.
 
@@ -172,7 +172,7 @@ For example, the following annotation::
     def foo(a: 'x', b: 5 + 6, c: list) -> max(2, 9):
         ...
 
-would result in a ``func_annotation`` mapping of ::
+would result in an ``__annotations__`` mapping of ::
 
     {'a': 'x',
      'b': 11,
@@ -183,7 +183,7 @@ The ``return`` key was chosen because it cannot conflict with the name
 of a parameter; any attempt to use ``return`` as a parameter name
 would result in a ``SyntaxError``.
 
-``func_annotations`` is an empty, mutable dictionary if there are no
+``__annotations__`` is an empty, mutable dictionary if there are no
 annotations on the function or if the functions was created from
 a ``lambda`` expression.
 

--- a/pep-3107.txt
+++ b/pep-3107.txt
@@ -151,7 +151,7 @@ parentheses around the parameter list.  However it was decided
 [#lambda]_ not to make this change because:
 
 1. It would be an incompatible change.
-2. Lambda's are neutered anyway.
+2. Lambdas are neutered anyway.
 3. The lambda can always be changed to a function.
 
 


### PR DESCRIPTION
Since we ended up with `__annotations__`, it would be much less confusing if this used it instead of referring to a property that does not exist.