### PR TITLE
PEP 394: Allow the `python` command to not be installed, and other minor edits

### DIFF
--- a/pep-0394.txt
+++ b/pep-0394.txt
@@ -276,7 +276,8 @@ References
 .. [6] PEP 394 - Clarification of what "python" command should invoke
    (https://mail.python.org/pipermail/python-dev/2014-September/136374.html)
 
-.. [7] PEP 394: Allow changing the `python` command in some cases
+.. [7] PEP 394: Allow the `python` command to not be installed, and other
+   minor edits
    (https://github.com/python/peps/pull/630)
 
 Copyright

--- a/pep-0394.txt
+++ b/pep-0394.txt
@@ -22,8 +22,9 @@ Python interpreter (i.e. the version invoked by the ``python`` command).
 
 * ``python2`` will refer to some version of Python 2.x.
 * ``python3`` will refer to some version of Python 3.x.
-* for the time being, all distributions *should* ensure that ``python``
-  refers to the same target as ``python2``.
+* for the time being, all distributions *should* ensure that ``python``,
+  if installed, refers to the same target as ``python2``, unless the system
+  administrator or user deliberately override this.
 * however, end users should be aware that ``python`` refers to ``python3``
   on at least Arch Linux (that change is what prompted the creation of this
   PEP), so ``python`` should be used in the shebang line only for scripts
@@ -43,11 +44,14 @@ Recommendation
 * When  invoked, ``python2`` should run some version of the Python 2
   interpreter, and ``python3`` should run some version of the Python 3
   interpreter.
-* The more general ``python`` command should be installed whenever
-  any version of Python 2 is installed and should invoke the same version of
+* If the ``python`` command is installed, it should invoke the same version of
   Python as the ``python2`` command (however, note that some distributions
   have already chosen to have ``python`` implement the ``python3``
-  command; see the `Rationale`_ and `Migration Notes`_ below).
+  command, and system administrators may be allowed to change the default;
+  see further recommendations and the `Rationale`_ and `Migration Notes`_
+  below).
+* The ``python`` command should be available whenever ``python2`` is available,
+  except in controlled environments as discussed below.
 * The Python 2.x ``idle``, ``pydoc``, and ``python-config`` commands should
   likewise be available as ``idle2``, ``pydoc2``, and ``python2-config``,
   with the original commands invoking these versions by default, but possibly
@@ -62,14 +66,35 @@ Recommendation
   context.
 * One exception to this is scripts that are deliberately written to be source
   compatible with both Python 2.x and 3.x. Such scripts may continue to use
-  ``python`` on their shebang line without affecting their portability.
+  ``python`` on their shebang line.
+* When packaging software that is source compatible with both versions,
+  distributions may change such ``python`` shebangs to ``python3`` (or
+  ``python2``). This ensures software is used with the latest version of
+  Python available, and it can remove a dependency on Python 2.
 * When reinvoking the interpreter from a Python script, querying
   ``sys.executable`` to avoid hardcoded assumptions regarding the
   interpreter location remains the preferred approach.
+* In controlled environments aimed at expert users, where being explicit
+  is valued over user experience (for example, in test environments and
+  package build systems), distributions may choose to not provide the
+  ``python`` command even if ``python2`` is available.
+  (All software in such a controlled environment must use ``python3`` or
+  ``python2`` rather than ``python``, which means scripts that deliberately
+  use ``python`` need to be modified for such environments.)
+* System administrators and users may be empowered to change the meaning of
+  the ``python`` command to ``python3``. This should be a deliberate action
+  by the administrator. Related documentation should include a discussion
+  of the effects -- for example, a link to the "Migration Notes" section of
+  this PEP.
+* When a virtual environment (created by the PEP 405 ``venv`` package or a
+  similar tool) is active, the ``python`` command should refer to the
+  virtual environment's interpreter. In other words, activating a virtual
+  environment counts as deliberate user action to change the default
+  ``python`` interpreter.
 
 These recommendations are the outcome of the relevant python-dev discussions
-in March and July 2011 ([1]_, [2]_), February 2012 ([4]_) and
-September 2014 ([6]_).
+in March and July 2011 ([1]_, [2]_), February 2012 ([4]_),
+September 2014 ([6]_), and April 2018 (XXX).
 
 
 Rationale
@@ -92,9 +117,9 @@ Future Changes to this Recommendation
 =====================================
 
 It is anticipated that there will eventually come a time where the third
-party ecosystem surrounding Python 3 is sufficiently mature for this
-recommendation to be updated to suggest that the ``python`` symlink
-refer to ``python3`` rather than ``python2``.
+party ecosystem surrounding Python 2 becomes irrelevant in most use cases,
+at which point this recommendation should be updated to suggest that the
+``python`` symlink refer to ``python3`` rather than ``python2``.
 
 This recommendation will be periodically reviewed over the next few years,
 and updated when the core development team judges it appropriate. As a
@@ -150,15 +175,15 @@ making such a change.
 * When the ``pythonX.X`` binaries are provided by a distribution, the
   ``python2`` and ``python3`` commands should refer to one of those files
   rather than being provided as a separate binary file.
-* It is suggested that even distribution-specific packages follow the
-  ``python2``/``python3`` convention, even in code that is not intended to
+* It is suggested that distribution-specific packages use ``python2`` or
+  ``python3`` rather than ``python``, even in code that is not intended to
   operate on other distributions. This will reduce problems if the
   distribution later decides to change the version of the Python interpreter
   that the ``python`` command invokes, or if a sysadmin installs a custom
   ``python`` command with a different major version than the distribution
   default. Distributions can test whether they are fully following this
-  convention by changing the ``python`` interpreter on a test box and checking
-  to see if anything breaks.
+  convention by changing or removing the ``python`` command on a test box
+  and checking to see if anything breaks.
 * If the above point is adhered to and sysadmins are permitted to change the
   ``python`` command, then the ``python`` command should always be implemented
   as a link to the interpreter binary (or a link to a link) and not vice
@@ -185,6 +210,16 @@ create these symbolic links and avoid further problems. It is a significantly
 more obvious breakage than the sometimes cryptic errors that can arise when
 attempting to execute a script containing Python 2 specific syntax with a
 Python 3 interpreter.
+
+
+Forward Compatibility
+=====================
+
+A problem can arise if a script compatible with both Python 2 and 3, which
+has ``python`` in its shebang line, is invoked on a system that does not have
+Python 2 (and thus, the ``python`` command) installed.
+This is mostly a non-issue -- as with any other case of a required interpreter
+not being installed, the sysadmin can install the ``python`` command.
 
 
 Application to the CPython Reference Interpreter

--- a/pep-0394.txt
+++ b/pep-0394.txt
@@ -23,8 +23,8 @@ Python interpreter (i.e. the version invoked by the ``python`` command).
 * ``python2`` will refer to some version of Python 2.x.
 * ``python3`` will refer to some version of Python 3.x.
 * for the time being, all distributions *should* ensure that ``python``,
-  if installed, refers to the same target as ``python2``, unless the system
-  administrator or user deliberately override this.
+  if installed, refers to the same target as ``python2``, unless the user
+  deliberately overrides this or a virtual environment is active.
 * however, end users should be aware that ``python`` refers to ``python3``
   on at least Arch Linux (that change is what prompted the creation of this
   PEP), so ``python`` should be used in the shebang line only for scripts
@@ -47,11 +47,7 @@ Recommendation
 * If the ``python`` command is installed, it should invoke the same version of
   Python as the ``python2`` command (however, note that some distributions
   have already chosen to have ``python`` implement the ``python3``
-  command, and system administrators may be allowed to change the default;
-  see further recommendations and the `Rationale`_ and `Migration Notes`_
-  below).
-* The ``python`` command should be available whenever ``python2`` is available,
-  except in controlled environments as discussed below.
+  command; see the `Rationale`_ and `Migration Notes`_ below).
 * The Python 2.x ``idle``, ``pydoc``, and ``python-config`` commands should
   likewise be available as ``idle2``, ``pydoc2``, and ``python2-config``,
   with the original commands invoking these versions by default, but possibly
@@ -68,8 +64,8 @@ Recommendation
   compatible with both Python 2.x and 3.x. Such scripts may continue to use
   ``python`` on their shebang line.
 * When packaging software that is source compatible with both versions,
-  distributions may change such ``python`` shebangs to ``python3`` (or
-  ``python2``). This ensures software is used with the latest version of
+  distributions may change such ``python`` shebangs to ``python3``.
+  This ensures software is used with the latest version of
   Python available, and it can remove a dependency on Python 2.
 * When reinvoking the interpreter from a Python script, querying
   ``sys.executable`` to avoid hardcoded assumptions regarding the
@@ -81,11 +77,6 @@ Recommendation
   (All software in such a controlled environment must use ``python3`` or
   ``python2`` rather than ``python``, which means scripts that deliberately
   use ``python`` need to be modified for such environments.)
-* System administrators and users may be empowered to change the meaning of
-  the ``python`` command to ``python3``. This should be a deliberate action
-  by the administrator. Related documentation should include a discussion
-  of the effects -- for example, a link to the "Migration Notes" section of
-  this PEP.
 * When a virtual environment (created by the PEP 405 ``venv`` package or a
   similar tool) is active, the ``python`` command should refer to the
   virtual environment's interpreter. In other words, activating a virtual
@@ -94,7 +85,7 @@ Recommendation
 
 These recommendations are the outcome of the relevant python-dev discussions
 in March and July 2011 ([1]_, [2]_), February 2012 ([4]_),
-September 2014 ([6]_), and April 2018 (XXX).
+September 2014 ([6]_), and discussion on GitHub in April 2018 ([7]_).
 
 
 Rationale
@@ -115,11 +106,6 @@ on the part of distribution maintainers.
 
 Future Changes to this Recommendation
 =====================================
-
-It is anticipated that there will eventually come a time where the third
-party ecosystem surrounding Python 2 becomes irrelevant in most use cases,
-at which point this recommendation should be updated to suggest that the
-``python`` symlink refer to ``python3`` rather than ``python2``.
 
 This recommendation will be periodically reviewed over the next few years,
 and updated when the core development team judges it appropriate. As a
@@ -175,15 +161,13 @@ making such a change.
 * When the ``pythonX.X`` binaries are provided by a distribution, the
   ``python2`` and ``python3`` commands should refer to one of those files
   rather than being provided as a separate binary file.
-* It is suggested that distribution-specific packages use ``python2`` or
-  ``python3`` rather than ``python``, even in code that is not intended to
+* It is strongly encouraged that distribution-specific packages use ``python2``
+  or ``python3`` rather than ``python``, even in code that is not intended to
   operate on other distributions. This will reduce problems if the
   distribution later decides to change the version of the Python interpreter
   that the ``python`` command invokes, or if a sysadmin installs a custom
   ``python`` command with a different major version than the distribution
-  default. Distributions can test whether they are fully following this
-  convention by changing or removing the ``python`` command on a test box
-  and checking to see if anything breaks.
+  default.
 * If the above point is adhered to and sysadmins are permitted to change the
   ``python`` command, then the ``python`` command should always be implemented
   as a link to the interpreter binary (or a link to a link) and not vice
@@ -210,16 +194,6 @@ create these symbolic links and avoid further problems. It is a significantly
 more obvious breakage than the sometimes cryptic errors that can arise when
 attempting to execute a script containing Python 2 specific syntax with a
 Python 3 interpreter.
-
-
-Forward Compatibility
-=====================
-
-A problem can arise if a script compatible with both Python 2 and 3, which
-has ``python`` in its shebang line, is invoked on a system that does not have
-Python 2 (and thus, the ``python`` command) installed.
-This is mostly a non-issue -- as with any other case of a required interpreter
-not being installed, the sysadmin can install the ``python`` command.
 
 
 Application to the CPython Reference Interpreter
@@ -301,6 +275,9 @@ References
 
 .. [6] PEP 394 - Clarification of what "python" command should invoke
    (https://mail.python.org/pipermail/python-dev/2014-September/136374.html)
+
+.. [7] PEP 394: Allow changing the `python` command in some cases
+   (https://github.com/python/peps/pull/630)
 
 Copyright
 ===========

--- a/pep-0394.txt
+++ b/pep-0394.txt
@@ -4,7 +4,8 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Kerrick Staley <mail@kerrickstaley.com>,
         Nick Coghlan <ncoghlan@gmail.com>,
-        Barry Warsaw <barry@python.org>
+        Barry Warsaw <barry@python.org>,
+        Petr Viktorin <encukou@gmail.com>
 Status: Active
 Type: Informational
 Content-Type: text/x-rst


### PR DESCRIPTION
Please do not merge yet. I'll send this for discussion on python-dev, but I think a concrete pull request makes the review easier.

---

In Fedora, I found that PEP 394's strict recommendation that `python` points to `python2` is holding us back. I would like to officially relax this in several cases.

The problems are:
- For developers that are not following the language's development, the fact that `python` invokes `python2` sends a strong signal that 2 is somehow the preferred version, and it's OK to start new projects in it.
- Users <s>and sysadmins</s> that *do* want to “live in the future” are switching the symlink to `python3` themselves. We would like to give them a supported, documented way to do so -- and make surer they're aware of the caveats.
- The `python2` command is still not available out-of-the box on macOS, so it didn't completely live up to the expectation of being the cross-platform way to launch python2 scripts.
- `python` in the shebang line can mean *either* that a script is carefully written to be 2/3 compatible, *or* that the author/maintainer is lazy or unaware of the recommendations. While Fedora guidelines have long banned the unversioned command, we feel that the only way to *enforce* that guidelines is to provide environments where the `python` command does not work (unless explicitly installed).

To help solve these, I would like to relax recommendations on the Unix ``python -> python2`` symlink in these cases:

- Users <s>and administrators</s> can, by a deliberate action, change ``python`` to invoke Python 3. (Activating a venv counts as such an action, but so would e.g. using alternates, installing a non-default overriding package, or replacing /usr/bin/python.)
- In controlled environments where being explicit is valued more than user experience (test environments, build systems, etc.), distributions can omit the ``python`` command even when ``python2`` is installed.

This PR also spells out several other things, which I felt were hidden between the lines -- but correct me if you disagree with my reading.
