### PR TITLE
PEP 545: fix transifex url

### DIFF
--- a/pep-0545.txt
+++ b/pep-0545.txt
@@ -609,7 +609,7 @@ References
    (https://github.com/AFPy/python_doc_fr/graphs/contributors?from=2016-01-01&to=2016-12-31&type=c)
 
 .. [15] Python-doc on Transifex
-   (https://www.transifex.com/python-doc/)
+   (https://www.transifex.com/python-doc/public/)
 
 .. [16] French translation
    (https://www.afpy.org/doc/python/)


### PR DESCRIPTION
People get 404 when visiting the old url, if they haven't joined the
translation team.