### PR TITLE
PEP : runtime_assert

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -1,0 +1,100 @@
+PEP: 9999
+Title: Smart runtime assertion 
+Author: Eloi Gaudry <eloi.gaudry@fft.be>
+Status: Draft
+Type: Standards Track
+Python-Version: 2.7
+Content-Type: text/x-rst
+Created: 04-May-2018
+Post-History:
+
+
+Abstract
+========
+
+This PEP aims at offering a runtime assert functionnality, extending
+the compiletime assert already available.
+
+
+
+
+Rationale
+=========
+
+There is no runtime assert relying on python grammar available.
+For diagnostics and/or debugging reasons, it would be valuable to
+add such a feature.
+
+A runtime assert makes sense when extra checks would be needed
+in a production environment (where non-debug builds are used).
+
+By extending the current python grammar, it would be possible to
+limit the overhead induces by those runtime asserts when running
+in a non "assertive" mode (-ed). The idea here is
+to avoid evaluating the expression when runtime assertion is not
+active.
+
+A brief example why avoiding evaluating the expression is needed
+to avoid any overhead in case the runtime assert should be
+ignored.
+
+    ::
+        runtime_assert( 999 in { i:None for i in range( 10000000 ) } )
+
+Usage
+=====
+
+    ::
+        runtime_assert( expr )
+        
+        #would result in 
+        if expr and runtime_assert_active:
+          print RuntimeAssertionError()
+
+
+Implementation details 
+=====================
+There is already an implementation available, robust enough for production.
+The implementation is mainly grammar based, and thus the parser and the grammar needs to be updated:
+ - Python/graminit.c
+ - Python/ast.c
+ - Python/symtable.c
+ - Python/compile.c
+ - Python/Python-ast.c
+ - Python/sysmodule.c
+ - Modules/parsermodule.c
+ - Include/Python-ast.h
+ - Include/graminit.h
+ - Include/pydebug.h
+ - Grammar/Grammar
+ - Parser/Python.asdl
+ - Lib/lib2to3/Grammar.txt
+ - Lib/compiler/ast.py
+ - Lib/compiler/pycodegen.py
+ - Lib/compiler/transformer.py
+ - Lib/symbol.py
+ - Modules/parsermodule.c
+
+
+References
+==========
+
+.. [1] PEP 306, How to Change Python's Grammar
+   (http://www.python.org/dev/peps/pep-0306)
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:


### PR DESCRIPTION
This PEP aims at illustrating the need for runtime assertion in a python production environment, as opposed to the compile time assertion already available in debug builds.

By extending the python grammar a bit, such an assert would come at zero overhead in case it would not be activated, by avoiding evaluating the expression given as argument to the runtime_assert( expr ).