### PR TITLE
PEP 544: Specify self-types in protocols

### DIFF
--- a/pep-0544.txt
+++ b/pep-0544.txt
@@ -590,8 +590,8 @@ Continuing the previous example::
 Self-types in protocols
 -----------------------
 
-The self-types in protocols follow the [specification]_ of PEP 484.
-For example::
+The self-types in protocols follow the corresponding specification
+[self-types]_ of PEP 484. For example::
 
   C = TypeVar('C', bound='Copyable')
   class Copyable(Protocol):
@@ -1396,7 +1396,7 @@ References
 .. [elsewhere]
    https://github.com/python/peps/pull/224
 
-.. [specification]
+.. [self-types]
    https://www.python.org/dev/peps/pep-0484/#annotating-instance-and-class-methods
 
 

--- a/pep-0544.txt
+++ b/pep-0544.txt
@@ -587,6 +587,30 @@ Continuing the previous example::
   walk(tree)  # OK, 'Tree[float]' is a subtype of 'Traversable'
 
 
+Self-types in protocols
+-----------------------
+
+The self-types in protocols follow the [specification]_ of PEP 484.
+For example::
+
+  C = TypeVar('C', bound='Copyable')
+  class Copyable(Protocol):
+      def copy(self: C) -> C:
+
+  class One:
+      def copy(self) -> 'One':
+          ...
+
+  T = TypeVar('T', bound='Other')
+  class Other:
+      def copy(self: T) -> T:
+          ...
+
+  c: Copyable
+  c = One()  # OK
+  c = Other()  # Also OK
+
+
 Using Protocols
 ===============
 
@@ -1371,6 +1395,9 @@ References
 
 .. [elsewhere]
    https://github.com/python/peps/pull/224
+
+.. [specification]
+   https://www.python.org/dev/peps/pep-0484/#annotating-instance-and-class-methods
 
 
 Copyright


### PR DESCRIPTION
This is already implemented in mypy in exactly the same way it works for nominal classes (and thus shares most bugs of self-types in nominal classes). The question is: if self-types in protocols just follow the specification of PEP 484 do we need this additional subsection? (Or is it still helpful just as an example?)

Attn: @gvanrossum @JukkaL @ambv 