### PR TITLE
PEP 539: Fix Python-Version header

### DIFF
--- a/pep-0539.txt
+++ b/pep-0539.txt
@@ -4,11 +4,11 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Erik M. Bray, Masayuki Yamamoto
 BDFL-Delegate: Nick Coghlan
-Python-Version: 3.7
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 20-Dec-2016
+Python-Version: 3.7
 Post-History: 16-Dec-2016, 31-Aug-2017, 08-Sep-2017
 Resolution: https://mail.python.org/pipermail/python-dev/2017-September/149358.html
 


### PR DESCRIPTION
Follow-up to https://github.com/python/peps/pull/648

The genpepindex script requires the headers to be in a particular order.
In `pep-0539.txt` the order was different, breaking the build for everyone.
