### PR TITLE
Defer PEP 547

### DIFF
--- a/pep-0547.rst
+++ b/pep-0547.rst
@@ -4,12 +4,23 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Marcel Plch <gmarcel.plch@gmail.com>,
         Petr Viktorin <encukou@gmail.com>
-Status: Draft
+Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 25-May-2017
 Python-Version: 3.7
 Post-History: 
+
+
+Deferral Notice
+===============
+
+Cython -- the most important use case for this PEP and the only explicit
+one -- is not ready for multi-phase initialization yet.
+It keeps global state in C-level static variables.
+See discussion at `Cython issue 1923`_.
+
+The PEP is deferred until the situation changes.
 
 
 Abstract
@@ -186,6 +197,7 @@ References
 .. _GitHub: https://github.com/python/cpython/pull/1761
 .. _Cython issue 1715: https://github.com/cython/cython/issues/1715
 .. _Possible Future Extensions section: https://www.python.org/dev/peps/pep-0489/#possible-future-extensions
+.. _Cython issue 1923: https://github.com/cython/cython/pull/1923
 
 
 Copyright


### PR DESCRIPTION
Officially defer PEP 547. It is not ready, yet.

@Traceur759, do you agree?