### PR TITLE
PEP 373: Add 2.7.15 release dates

### DIFF
--- a/pep-0373.txt
+++ b/pep-0373.txt
@@ -55,9 +55,6 @@ January 1, 2020. All 2.7 development work will cease in 2020.
 
 Planned future release dates:
 
-- 2.7.15rc1 2018-04-14
-- 2.7.15 2018-04-28
-
 - 2.7.16 late 2018 - early 2019
 
 Dates of previous maintenance releases:
@@ -86,6 +83,8 @@ Dates of previous maintenance releases:
 - 2.7.13 2016-12-17
 - 2.7.14rc1 2017-08-26
 - 2.7.14 2017-09-16
+- 2.7.15rc1 2018-04-14
+- 2.7.15 2018-05-01
 
 2.7.0 Release Schedule
 ======================


### PR DESCRIPTION
2.7.15 releases are now past:

https://mail.python.org/pipermail/python-announce-list/2018-May/011914.html
https://mail.python.org/pipermail/python-dev/2018-April/152706.html