### PR TITLE
Arguments that end with `__` are not positional-only

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -1368,11 +1368,12 @@ Positional-only arguments
 Some functions are designed to take their arguments only positionally,
 and expect their callers never to use the argument's name to provide
 that argument by keyword. All arguments with names beginning with
-``__`` are assumed to be positional-only::
+``__`` are assumed to be positional-only, except if their names also
+end with ``__``::
 
-  def quux(__x: int) -> None: ...
+  def quux(__x: int, __y__: int = 0) -> None: ...
 
-  quux(3)  # This call is fine.
+  quux(3, __y__=1)  # This call is fine.
 
   quux(__x=3)  # This call is an error.
 


### PR DESCRIPTION
This came up in python/mypy#5156; we agreed that it was an oversight in the original specification of this feature to not allow this.