### PR TITLE
PEP 263: fix typo in coding regex

### DIFF
--- a/pep-0263.txt
+++ b/pep-0263.txt
@@ -72,7 +72,7 @@ or::
 More precisely, the first or second line must match the following
 regular expression::
 
-    ^[ \t\v]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)
+    ^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)
 
 The first group of this
 expression is then interpreted as encoding name. If the encoding


### PR DESCRIPTION
The characters before the # in a coding declaration line can be spaces, tabs, or form feeds; the escape sequence for a form feed is a `\f`, not a `\v` as is shown here.