### PR TITLE
PEP 518: Add subsections to Specification section

### DIFF
--- a/pep-0518.txt
+++ b/pep-0518.txt
@@ -129,17 +129,27 @@ of requirements for the build system to simply begin execution.
 Specification
 =============
 
+File Format
+-----------
+
 The build system dependencies will be stored in a file named
-``pyproject.toml`` that is written in the TOML format [#toml]_. This
-format was chosen as it is human-usable (unlike JSON [#json]_), it is
-flexible enough (unlike configparser [#configparser]_), stems from a
-standard (also unlike configparser [#configparser]_), and it is not
-overly complex (unlike YAML [#yaml]_). The TOML format is already in
-use by the Rust community as part of their
+``pyproject.toml`` that is written in the TOML format [#toml]_.
+
+This format was chosen as it is human-usable (unlike JSON [#json]_),
+it is flexible enough (unlike configparser [#configparser]_), stems
+from a standard (also unlike configparser [#configparser]_), and it
+is not overly complex (unlike YAML [#yaml]_). The TOML format is
+already in use by the Rust community as part of their
 Cargo package manager [#cargo]_ and in private email stated they have
 been quite happy with their choice of TOML. A more thorough
 discussion as to why various alternatives were not chosen can be read
 in the `Other file formats`_ section.
+
+Tables not specified in this PEP are reserved for future use by other
+PEPs.
+
+build-system table
+------------------
 
 There will be a ``[build-system]`` table in the
 configuration file to store build-related data. Initially only one key
@@ -147,6 +157,35 @@ of the table will be valid and mandatory: ``requires``. That key will
 have a value of a list of strings representing the PEP 508
 dependencies required to execute the build system (currently that
 means what dependencies are required to execute a ``setup.py`` file).
+
+For the vast majority of Python projects that rely upon setuptools,
+the ``pyproject.toml`` file will be::
+
+  [build-system]
+  # Minimum requirements for the build system to execute.
+  requires = ["setuptools", "wheel"]  # PEP 508 specifications.
+
+Because the use of setuptools and wheel are so expansive in the
+community at the moment, build tools are expected to use the example
+configuration file above as their default semantics when a
+``pyproject.toml`` file is not present.
+
+tool table
+----------
+
+Tools can have users specify configuration data as long as they use
+a sub-table within ``[tool]``, e.g. the
+`flit <https://pypi.python.org/pypi/flit>`_ tool would store its
+configuration in ``[tool.flit]``.
+
+We need some mechanism to allocate names within the ``tool.*``
+namespace, to make sure that different projects don't attempt to use
+the same sub-table and collide. Our rule is that a project can use
+the subtable ``tool.$NAME`` if, and only if, they own the entry for
+``$NAME`` in the Cheeseshop/PyPI.
+
+JSON Schema
+-----------
 
 To provide a type-specific representation of the resulting data from
 the TOML file for illustrative purposes only, the following JSON
@@ -179,31 +218,6 @@ Schema [#jsonschema]_ would match the data format::
           }
       }
   }
-
-For the vast majority of Python projects that rely upon setuptools,
-the ``pyproject.toml`` file will be::
-
-  [build-system]
-  # Minimum requirements for the build system to execute.
-  requires = ["setuptools", "wheel"]  # PEP 508 specifications.
-
-Because the use of setuptools and wheel are so expansive in the
-community at the moment, build tools are expected to use the example
-configuration file above as their default semantics when a
-``pyproject.toml`` file is not present.
-
-All other top-level keys and tables are reserved for future use by
-other PEPs except for the ``[tool]`` table. Within that table, tools
-can have users specify configuration data as long as they use a
-sub-table within ``[tool]``, e.g. the
-`flit <https://pypi.python.org/pypi/flit>`_ tool would store its
-configuration in ``[tool.flit]``.
-
-We need some mechanism to allocate names within the ``tool.*``
-namespace, to make sure that different projects don't attempt to use
-the same sub-table and collide. Our rule is that a project can use
-the subtable ``tool.$NAME`` if, and only if, they own the entry for
-``$NAME`` in the Cheeseshop/PyPI.
 
 
 Rejected Ideas


### PR DESCRIPTION
It is common to reference to different parts of the specification when
discussing the changes brought about by this PEP. This change makes it
easier to do so by introducing subsections to the main specification.

/cc @ncoghlan @dstufft @njs @brettcannon