### PR TITLE
PEP 572: handle comprehension edge cases

### DIFF
--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -210,15 +210,23 @@ The motivation for this special case is twofold.  First, it allows us
 to conveniently capture a "witness" for an ``any()`` expression, or a
 counterexample for ``all()``, for example::
 
-    if any((comment := line).startswith('#') for line in lines):
-        print("First comment:", comment)
+    last_checked = _no_lines = object()
+    if any((last_checked := line).startswith('#') for line in lines):
+        print("First comment:", last_checked)
     else:
-        print("There are no comments")
+        if last_checked is _no_lines:
+            print("There was no input")
+        else:
+            print("There are no comments")
 
-    if all((nonblank := line).strip() == '' for line in lines):
-        print("All lines are blank")
+    last_checked = _no_lines = object()
+    if all((last_checked := line).strip() == '' for line in lines):
+        if last_checked is _no_lines:
+            print("There was no input")
+        else:
+            print("All lines are blank")
     else:
-        print("First non-blank line:", nonblank)
+        print("First non-blank line:", last_checked)
 
 Second, it allows a compact way of updating mutable state from a
 comprehension, for example::
@@ -745,7 +753,7 @@ ruled::
 is a vast improvment over the briefer::
 
     yield (mylast := mylast[1])[0]
-    
+
 The original two statements are doing entirely different conceptual
 things, and slamming them together is conceptually insane.
 
@@ -789,7 +797,7 @@ pattern-matching reading, as::
 
     if result := solution(xs, n):
         # use result
-        
+
 It's also nice to trade away a small amount of horizontal whitespace
 to get another _line_ of surrounding code on screen.  I didn't give
 much weight to this at first, but it was so very frequent it added up,
@@ -820,7 +828,7 @@ is conceptually flat, "the first test that succeeds wins"::
     if reductor := dispatch_table.get(cls):
         rv = reductor(x)
     elif reductor := getattr(x, "__reduce_ex__", None):
-        rv = reductor(4)           
+        rv = reductor(4)
     elif reductor := getattr(x, "__reduce__", None):
         rv = reductor()
     else:
@@ -839,9 +847,9 @@ annoying "artificial" indentation level::
         g = gcd(diff, n)
         if g > 1:
             return g
- 
+
 became::
- 
+
     if (diff := x - x_base) and (g := gcd(diff, n)) > 1:
         return g
 


### PR DESCRIPTION
The stateful comprehension examples mishandled a couple of edge cases:

- they didn't detect the "no input" case (reporting it as "no comments"
  or "no blank lines")
- the chosen target names only made sense when the any() or all()
  operations returned True - this switches them to use a more neutral
  name that doesn't make any assumptions about the overall result