### PR TITLE
[WIP] PEP 582: (First draft) Using namespace on projects packages

### DIFF
--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -1,0 +1,123 @@
+PEP: 582
+Title: Manage packages on repositories with namespaces
+Version: $Revision$
+Last-Modified: $Date$
+Author: Hervé Beraud <herveberaud.pro@gmail.com>
+Status: Draft
+Type: Standards Track
+Content-Type: text/x-rst
+Created: 25-Jun-2018
+Python-Version: 3.8
+
+
+Abstract
+========
+
+This PEP outlines some functionalities to introduce on python packages
+management and best practices to allow a more flexible approach to work 
+on forked project and to reduce security risks with packages repositories and
+dependencies requirements.
+
+This PEP will be introducing namespace on projects naming for allow user to
+work on forks and testing package deployment and installation.
+
+Also namespace reduce the risk that users deal with a 
+miscellaneous package come from a typo squatting.
+
+
+Motivation
+==========
+
+Currently When a project is already register on pypi it's not possible 
+to users to test a fork of any projects with the same name when 
+it's already exist, on pypi.org and on test.pypi.org the problem is the same. 
+
+Manage projects by namespace increase possiblities for the python community.
+
+With this feature we can introduce trusted packages by allow install/search 
+without namespace and add namespaces on untrusted packages like the 
+docker behavior (`docker pull nginx` or `docker pull 4383/nginx`).
+
+Also, project namespace and trusted packages help us to reduce some 
+security risks, like typo squatting (example_, `pypa github discussion`_).
+
+.. _example: http://www.nbu.gov.sk/skcsirt-sa-20170909-pypi/index.html
+.. _pypa_github_discussion: https://github.com/pypa/pypi-legacy/issues/644
+
+
+Rationale
+=========
+
+With this feature we can introduce trusted packages by allow install/search 
+without namespace and add namespaces on untrusted packages like the 
+docker command behavior (`docker pull nginx` or `docker pull 4383/nginx`).
+
+
+How to work docker command?
+---------------------------
+
+On docker a trusted package is package maintained by the docker team himeself.
+Namespace does not exist when the package is maintained by the docker team.
+When a package is maintain by a third user namespace appear into the name.
+
+
+How to work inside the python community?
+----------------------------------------
+
+The goal of this PEP is not to delegate the trusted projects maintainance 
+to the pypa team or to a specific python contributor team. Projects rest
+owned and maintained by their original teams.
+
+This PEP propose to create a specific repository on github to manage/elect
+trusted projects. The repository need to be hosted under the 
+pypa organisation and can be named `pypa/trusted`.
+
+
+How to define the namespace?
+----------------------------
+
+By default the used namespace is the username of the pypa account.
+
+
+What's the impact on the python ecosystem?
+------------------------------------------
+
+- Warehouse need to be updated to deal with namespaces and need to store this
+information and need to allow to change this information by call API for allow
+the voting system defined by PEP-582 to update this information when a package
+is move to trusted.
+- pip need to be updated to deal with namespaces
+- generated packages need to contains package namespace informations when we
+use `pip show <package_name>` to allow upgrade of old packages
+- pip and others packages managers need to manage site-packages with namespaces
+to allow projects with same name to coexist together.
+- PEP-583 and the trusted packages mechanism avoid the fact that third 
+party projects need to update their dependencies once dependencies have been
+declared trusted.
+
+
+Benefits
+========
+
+- Improve project trust
+- Improve package trusting and reduce the risk that users deal with 
+  a miscellaneous package
+- Allow users to provide forked version of an official project
+- Allow users to test that packaging work fine on pypi
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/pep-0583.rst
+++ b/pep-0583.rst
@@ -1,0 +1,155 @@
+PEP: 583
+Title: Vote for trusted packages
+Version: $Revision$
+Last-Modified: $Date$
+Author: Hervé Beraud <herveberaud.pro@gmail.com>
+Status: Draft
+Type: Standards Track
+Content-Type: text/x-rst
+Created: 25-Jun-2018
+Python-Version: 3.8
+
+
+Abstract
+========
+
+This PEP outlines the voting mechanism to define trusted packages.
+It's the continuity of the PEP-582 and it's the methodoly part of the set
+of the functionality defined for the new behavior of the package management.
+
+
+Motivation
+==========
+
+Packages namespaces introduced by the PEP-582 need to define a voting
+system to remove namespaces on mainstream packages or on none forked
+packages.
+
+With this feature we can introduce trusted packages by allow install/search 
+without namespace and add namespaces on untrusted packages like the 
+docker behavior (`docker pull nginx` or `docker pull 4383/nginx`).
+
+Also, project namespace and trusted packages help us to reduce some 
+security risks, like typo squatting (example_, `pypa github discussion`_).
+
+.. _example: http://www.nbu.gov.sk/skcsirt-sa-20170909-pypi/index.html
+.. _pypa_github_discussion: https://github.com/pypa/pypi-legacy/issues/644
+
+
+Rationale
+=========
+
+With this mechanism we can introduce trusted packages by allowing 
+install/search without namespace and add namespaces on untrusted packages like
+the docker command behavior (`docker pull nginx` or `docker pull 4383/nginx`).
+
+
+How to work docker command?
+---------------------------
+
+On docker a trusted package is package maintained by the docker team himeself.
+Namespace does not exist when the package is maintained by the docker team.
+When a package is maintain by a third user namespace appear into the name.
+
+
+How to work inside the python community?
+----------------------------------------
+
+The goal of this PEP is not to delegate the trusted projects maintainance 
+to the pypa team or to a specific python contributor team. Projects rest
+owned and maintained by their original teams.
+
+This PEP propose to create a specific repository on github to manage/elect
+trusted projects. The repository need to be hosted under the 
+pypa organisation and can be named `pypa/trusted`.
+
+
+How to define the namespace?
+----------------------------
+
+By default the used namespace is the username of the pypa account.
+
+
+how to define if a project is trusted?
+--------------------------------------
+
+Projects can being trusted by sending a pull request on the `pypa/trusted`
+repository.
+
+A pull request need to be a formalized file where projects teams can define 
+a project owning.
+
+A unique pull request by project need to send and a robot can check if the
+project was already trusted to reduce boring tasks.
+
+A review must be realized on these pull requests and if the pypa team decide to
+accept the project become automaticaly trusted. 
+
+Merge a pull request allow Pypa to remove the namespace automaticaly.
+To define if a project is trusted project the maintainers need to send
+a formalized pull request to the `pypa/trusted` repository.
+
+Reviewer accept or reject the pull request. We can require a minimum number of
+review to ensure that is a really trusted package.
+
+
+How to standardize informations sended with the pull request?
+-------------------------------------------------------------
+
+Like PEPs repository, `pypa/trusted` must contains a file by project who ask
+to become trusted.
+
+Each files must be named with the same name of the project without prefixed
+by the namespace. The mechanisme avoid two person to ask the same name for
+two different projects (forks use case...).
+
+Each files must contains the following information in yaml format (by example):
+- name: the project name
+- namespace: the project namespace
+- author_email: the email of the author to be sure that correspond 
+  to package informations.
+
+
+How reviewers must validate pull requests?
+------------------------------------------
+
+Each reviewer need to verify that informations correspond to the original
+project maintainer (none forked project), that project is not a typo squatting
+(cf. requests/request).
+
+
+What's the impact on the python ecosystem?
+------------------------------------------
+
+- Warehouse need to be updated to deal with namespaces
+- pip need to be updated to deal with namespaces
+
+I don't think that distutils or setuptools are impacted by this.
+
+
+Benefits
+========
+
+- Improve project trust
+- Improve package trusting and reduce the risk that users deal with 
+  a miscellaneous package
+- Allow users to provide forked version of an official project
+- Allow users to test that packaging work fine on pypi
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:
+


### PR DESCRIPTION
Hi!

### Overview
This is a feature proposal. Now when a project is already register on pypi it's not possible to users to test a fork of any projects with the same name when it's already exist, manage projects by namespace increase possiblities for the python community.

With this feature we can introduce trusted packages by allow install/search without namespace and add namespaces on untrusted packages like docker behavior (`docker pull nginx` or `docker pull 4383/nginx`).

On docker when the package is trusted (docker trusted image mean maintained by docker itself), namespace does not exist, and when a package is maintain by a third user namespace appear into the name.

I don't want delegate official projects maintainance to the pypa team but we can introduce a vote system by sending pull requests to a specific pypa repository. If the pull request is accepted the  namespace was automaticaly removed.

### Features
- Allow community to define trusted project and allow download (install, search, etc...) without prefix with user namespace
- Allow users to upload on pypi project with a name who already exist on pypi but prefixed by user namespace.

### Benefits
- Improve project trust
- Improve package trusting and discrease risk that users deal with a miscellaneous package come from a typo squatting [example 1](http://www.nbu.gov.sk/skcsirt-sa-20170909-pypi/index.html), [pypa github discussion](https://github.com/pypa/pypi-legacy/issues/644)
- Allow users to provide forked version of an official project
- Allow users to test that packaging work fine on pypi

### Examples
With pip:
```sh
$ pip install Django # trusted package
$ pip install 4383/Django # untrusted package
```

Url transposition:
- https://pypi.org/project/Django/ 
- https://pypi.org/project/4383/Django/