### PR TITLE
PEP 484: Do not require type checkers to treat a None default specially

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -984,16 +984,17 @@ for example, the above is equivalent to::
 
   def handle_employee(e: Optional[Employee]) -> None: ...
 
-Type checkers may also automatically assume an optional type when the
-default value is ``None``, for example::
+A past version of this PEP allowed type checkers to assume an optional
+type when the default value is ``None``, as in this code::
 
   def handle_employee(e: Employee = None): ...
 
-This may be treated as equivalent to::
+This would have been treated as equivalent to::
 
   def handle_employee(e: Optional[Employee] = None) -> None: ...
 
-Type checkers may also require the optional type to be made explicit.
+This is no longer the recommended behavior. Type checkers should move
+towards requiring the optional type to be made explicit.
 
 Support for singleton types in unions
 -------------------------------------

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -984,15 +984,16 @@ for example, the above is equivalent to::
 
   def handle_employee(e: Optional[Employee]) -> None: ...
 
-An optional type is also automatically assumed when the default value is
-``None``, for example::
+Type checkers may also automatically assume an optional type when the
+default value is ``None``, for example::
 
   def handle_employee(e: Employee = None): ...
 
-This is equivalent to::
+This may be treated as equivalent to::
 
   def handle_employee(e: Optional[Employee] = None) -> None: ...
 
+Type checkers may also require the optional type to be made explicit.
 
 Support for singleton types in unions
 -------------------------------------


### PR DESCRIPTION
Following discussion in python/typing#275, there is a consensus that it is better to require optional types to be made explicit. This PR changes the wording of PEP 484 to allow, but not require, type checkers to treat a None default as implicitly making an argument Optional.