### PR TITLE
[WIP] New PEP: dict grouping

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -609,6 +609,26 @@ Grouping is used in many analysis tasks, such as clustering.
 How to Teach This
 =================
 
+I suggest first demonstrating ``sorted`` on a list, then using
+``sorted``'s key-function parameter, because sorting a list keeps the
+same data type for input and output.
+
+::
+
+   >>> actors = ['Graham', 'Eric', 'Terry', 'Terry', 'John', 'Michael']
+   >>> sorted(actors)
+   ['Eric', 'Graham', 'John', 'Michael', 'Terry', 'Terry']
+   >>> sorted(actors, key=len)
+   ['Eric', 'John', 'Terry', 'Terry', 'Graham', 'Michael']
+
+
+After the students are happy with the idea of ``len`` as a sorting key,
+ask them what they think ``dict.grouping`` will do. Give them a moment
+to consider the possibilities before demonstrating the results.
+
+   >>> dict.grouping(actors, key=len)
+   {4: ['Eric', 'John'], 5: ['Terry', 'Terry'], 6: ['Graham'], 7: ['Michael']}
+
 
 
 References

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -65,10 +65,9 @@ Error-prone when using groups:
 
 In many situations, a ``defaultdict`` is useful for building a mapping,
 but a regular dict is better for the returned type. Pytoolz'
-``toolz.itertoolz.frequencies_`` illustrates the issue.
+``toolz.itertoolz.frequencies`` illustrates the issue.
 
-.. _toolz.itertoolz.frequencies:
-   https://github.com/pytoolz/toolz/blob/master/toolz/itertoolz.py#L527
+https://github.com/pytoolz/toolz/blob/master/toolz/itertoolz.py#L527
 
 
 ``itertools.groupby``
@@ -205,7 +204,7 @@ https://docs.rs/itertools/*/itertools/trait.Itertools.html#method.group_by
 Clojure
 ~~~~~~~
 
-Clojure has ``group-by_``, which is nearly identical to this proposal:
+Clojure has ``group-by``, which is nearly identical to this proposal:
 ``(group-by f coll)``. The choice of the name begs a different order for
 the parameters as well, as the phrase "group by key" is quite natural,
 inviting a curry.
@@ -215,7 +214,7 @@ inviting a curry.
    user=> (group-by first ["python" "jython" "cython" "pypy" "cpython"])
    {\p ["python" "pypy"], \j ["jython"], \c ["cython" "cpython"]}
 
-.. _group-by: https://clojuredocs.org/clojure.core/group-by
+https://clojuredocs.org/clojure.core/group-by
 
 
 Community Libraries

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -30,9 +30,9 @@ of lists, especially now that dictionaries maintain insertion order.
 We currently have three reasonable techniques to create groups from a
 sequence or iterable:
 
-- itertools.groupby
-- collections.defaultdict
-- dict.setdefault
+- ``itertools.groupby``
+- ``collections.defaultdict``
+- ``dict.setdefault``
 
 Unfortunately, both ``itertools.groupby`` and
 ``collections.defaultdict`` are error-prone, and ``dict.setdefault`` is
@@ -46,7 +46,7 @@ The ``defaultdict`` is elegant for building a grouping, but many
 otherwise-expert programmers will accidentally insert new groups when
 they intended to raise a ``KeyError``.
 
-Elegant for creating groups:
+Elegant for creating groups::
 
    >>> from collections import defaultdict
    >>> groups = defaultdict(set)
@@ -54,7 +54,7 @@ Elegant for creating groups:
    ...     groups[x % 2].add(x)
    ...
 
-Error-prone when using groups:
+Error-prone when using groups::
 
    >>> groups
    defaultdict(<class 'set'>, {0: {0, 2, 4, 6}, 1: {1, 3, 5}})
@@ -77,15 +77,17 @@ Many users of ``itertools.groupby`` will forget to sort
 the data before grouping, accidentally creating two or more separate
 groups for the same key.
 
+::
+
    >>> from itertools import groupby
    >>> mod_2 = lambda x: x % 2
 
-Mistake:
+Mistake::
 
    >>> {k: set(group) for k, group in groupby(range(7), key=mod_2)}
    {0: {6}, 1: {5}}
 
-Correct:
+Correct::
    
    >>> numbers = sorted(range(7), key=mod_2)
    >>> {k: set(group) for k, group in groupby(numbers, key=mod_2)}
@@ -98,6 +100,8 @@ Correct:
 The ``dict.setdefault`` method is often the best choice for grouping,
 but suffers from a less-beautiful appearance. Secondarily,
 ``setdefault`` cannot easily create a grouping as an expression.
+
+::
 
    >>> groups = {}
    >>> for x in range(7):
@@ -119,7 +123,7 @@ construct a new dictionary based on an iterable and a key-function.
 
 The behavior would be comparable to the following ``dict`` extension:
 
-.. code: python
+::
 
    class Dict(dict):
 
@@ -209,8 +213,6 @@ Clojure has ``group-by``, which is nearly identical to this proposal:
 the parameters as well, as the phrase "group by key" is quite natural,
 inviting a curry.
 
-.. code: clojure
-
    user=> (group-by first ["python" "jython" "cython" "pypy" "cpython"])
    {\p ["python" "pypy"], \j ["jython"], \c ["cython" "cpython"]}
 
@@ -230,7 +232,7 @@ breaks the pattern established by builtins ``sorted``, ``min``, ``max``,
 and standard library ``itertools.groupby``, which all have the sequence
 as the first parameter.
 
-..code: python
+::
 
    >>> names = ['Alice', 'Bob', 'Charlie', 'Dan', 'Edith', 'Frank']
    >>> groupby(len, names)  
@@ -245,20 +247,19 @@ Pandas
 While Pandas may be most famous for its ``DataFrame``, the better
 comparison in this situation would be ``Series.groupby``.
 
+::
 
-.. code: python
+    In [1]: import pandas as pd
 
-   In [1]: import pandas as pd
+    In [2]: def mod(x):
+    ...:     def modulo(n):
+    ...:         return n % x
+    ...:     return modulo
+    ...:
 
-   In [2]: def mod(x):
-   ...:     def modulo(n):
-   ...:         return n % x
-   ...:     return modulo
-   ...:
-
-   In [3]: pd.Series(range(10)).groupby(mod(2)).groups
-   Out[3]:
-   {0: Int64Index([0, 2, 4, 6, 8], dtype='int64'),
+    In [3]: pd.Series(range(10)).groupby(mod(2)).groups
+    Out[3]:
+    {0: Int64Index([0, 2, 4, 6, 8], dtype='int64'),
     1: Int64Index([1, 3, 5, 7, 9], dtype='int64')}
 
 http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.groupby.html#pandas.Series.groupby
@@ -267,11 +268,11 @@ As with Clojure, it fits naturally with the phrase, "group by key."
 Using ``Series.groupby`` as an unbound method does not read nearly as
 well.
 
-.. code: python
+::
 
-   In [12]: pd.Series.groupby(numbers, mod(2)).groups
-   Out[12]:
-   {0: Int64Index([0, 2, 4, 6, 8], dtype='int64'),
+    In [12]: pd.Series.groupby(numbers, mod(2)).groups
+    Out[12]:
+    {0: Int64Index([0, 2, 4, 6, 8], dtype='int64'),
     1: Int64Index([1, 3, 5, 7, 9], dtype='int64')}
 
 The ``DataFrame.groupby`` handles an interesting sub-category of usage,
@@ -279,34 +280,34 @@ when each element of the input sequence is itself a sequence with one or
 many key-elements and one or many value-elements. In some cases, the
 key-elements should be dropped from these sequences when grouping.
 
-.. code: python
+::
 
-   >>> sequence = [[1, 11, 12], [1, 13, 14], [2, 21, 22], [2, 23, 24]]
-   >>> dict.grouping(sequence, key=lambda row: row.pop(0))
-   {1: [[11, 12], [13, 14]], 2: [[21, 22], [23, 24]]}
+    >>> sequence = [[1, 11, 12], [1, 13, 14], [2, 21, 22], [2, 23, 24]]
+    >>> dict.grouping(sequence, key=lambda row: row.pop(0))
+    {1: [[11, 12], [13, 14]], 2: [[21, 22], [23, 24]]}
 
 
 
 Examples
 ========
 
-.. code: python
+::
 
-   >>> mod_2 = lambda x: x % 2
-   >>> dict.grouping(range(7), mod_2)
-   {0: [0, 2, 4, 6], 1: [1, 3, 5]}
-
-
-   >>> dict.grouping('ababa')
-   {'a': ['a', 'a', 'a'], 'b': ['b', 'b']}
+    >>> mod_2 = lambda x: x % 2
+    >>> dict.grouping(range(7), mod_2)
+    {0: [0, 2, 4, 6], 1: [1, 3, 5]}
 
 
-   >>> dict.grouping('aBAb', str.casefold)
-   {'a': ['a', 'A'], 'b': ['B', 'b']}
+    >>> dict.grouping('ababa')
+    {'a': ['a', 'a', 'a'], 'b': ['b', 'b']}
 
 
-   >>> dict.grouping('aBAbaB', str.casefold)
-   {'a': ['a', 'A', 'a'], 'b': ['B', 'b', 'B']}
+    >>> dict.grouping('aBAb', str.casefold)
+    {'a': ['a', 'A'], 'b': ['B', 'b']}
+
+
+    >>> dict.grouping('aBAbaB', str.casefold)
+    {'a': ['a', 'A', 'a'], 'b': ['B', 'b', 'B']}
 
 
 Group and Aggregate
@@ -316,49 +317,49 @@ While ``dict.grouping`` creates a dict of lists, preserving the order
 that group members were encountered, it is often useful to create
 "equivalence classes" which are better modeled as a dictionary of sets.
 
-.. code: python
+::
 
-   >>> groups = dict.grouping('aBAbaB', str.casefold)
-   >>> {k: sorted(set(g)) for k, g in groups.items()}
-   {'a': ['A', 'a'], 'b': ['B', 'b']}
+    >>> groups = dict.grouping('aBAbaB', str.casefold)
+    >>> {k: sorted(set(g)) for k, g in groups.items()}
+    {'a': ['A', 'a'], 'b': ['B', 'b']}
 
 
 If each group should be a multiset, where repetitions matter but order
 does not, then a dictionary of Counters is appropriate.
 
-.. code: python
+::
 
-   >>> from collections import Counter
-   >>> groups = dict.grouping('aBAbaB', str.casefold)
-   >>> {k: Counter(g) for k, g in groups.items()}
-   {'a': Counter({'a': 2, 'A': 1}), 'b': Counter({'B': 2, 'b': 1})}
+    >>> from collections import Counter
+    >>> groups = dict.grouping('aBAbaB', str.casefold)
+    >>> {k: Counter(g) for k, g in groups.items()}
+    {'a': Counter({'a': 2, 'A': 1}), 'b': Counter({'B': 2, 'b': 1})}
 
 
 Grouping and performing an aggregation or reduction on the resulting
 groups is a very common task.
 
-.. code: python
+::
 
-   def aggregate(iterable, reducer, key=None):
-       '''
-       Apply a ``reducer`` function to each group in an iterable.
+    def aggregate(iterable, reducer, key=None):
+        '''
+        Apply a ``reducer`` function to each group in an iterable.
 
-           >>> mod_2 = lambda x: x % 2
-           >>> aggregate([1, 2, 3, 4], sum, key=mod_2)
-           {1: 4, 0: 6}
+            >>> mod_2 = lambda x: x % 2
+            >>> aggregate([1, 2, 3, 4], sum, key=mod_2)
+            {1: 4, 0: 6}
 
-       This is convenient for creating dict of sets or a dict of Counters.
+        This is convenient for creating dict of sets or a dict of Counters.
 
-           >>> g = aggregate('AaaBBb', set, key=str.casefold)
-           >>> {k: sorted(v) for k, v in g.items()}
-           {'a': ['A', 'a'], 'b': ['B', 'b']}
+            >>> g = aggregate('AaaBBb', set, key=str.casefold)
+            >>> {k: sorted(v) for k, v in g.items()}
+            {'a': ['A', 'a'], 'b': ['B', 'b']}
 
-           >>> aggregate('AaaBBb', Counter, key=str.casefold)
-           {'a': Counter({'a': 2, 'A': 1}), 'b': Counter({'B': 2, 'b': 1})}
+            >>> aggregate('AaaBBb', Counter, key=str.casefold)
+            {'a': Counter({'a': 2, 'A': 1}), 'b': Counter({'B': 2, 'b': 1})}
 
-       '''
-       g = Dict.grouping(iterable, key)
-       return {k: reducer(v) for k, v in g.items()}
+        '''
+        g = Dict.grouping(iterable, key)
+        return {k: reducer(v) for k, v in g.items()}
 
 
 Group and Transform
@@ -369,30 +370,29 @@ might be to perform a transformation which includes a grouped-
 aggregation, like a z-score, or simply to discard unnecessary
 information.
 
-.. code: python
+::
 
-   def z_score(numbers):
-       '''
-       Subtract mean and divide by standard deviation.
-       '''
-       # https://en.wikipedia.org/wiki/Standard_score
-       mu = statistics.mean(numbers)
-       sigma = statistics.stdev(numbers)
-       return [(x - mu) / sigma for x in numbers]
+    def z_score(numbers):
+        '''
+        Subtract mean and divide by standard deviation.
+        '''
+        # https://en.wikipedia.org/wiki/Standard_score
+        mu = statistics.mean(numbers)
+        sigma = statistics.stdev(numbers)
+        return [(x - mu) / sigma for x in numbers]
 
 
-.. code: python
 
-   def transform(iterable, func, key=None):
-       '''
-       Demultiplex an iterable and transform each element.
+    def transform(iterable, func, key=None):
+        '''
+        Demultiplex an iterable and transform each element.
 
-           >>> transform('abAB', str.swapcase, key=str.casefold)
-           {'a': ['A', 'a'], 'b': ['B', 'b']}
+            >>> transform('abAB', str.swapcase, key=str.casefold)
+            {'a': ['A', 'a'], 'b': ['B', 'b']}
 
-       '''
-       g = Dict.grouping(iterable, key)
-       return {k: [func(x) for x in v] for k, v in g.items()}
+        '''
+        g = Dict.grouping(iterable, key)
+        return {k: [func(x) for x in v] for k, v in g.items()}
 
 
 Markov Chain
@@ -401,59 +401,59 @@ Markov Chain
 A stateful key-function can provide some very succinct code to create
 interesting data structures.
 
-.. code: python
+::
 
-   def markov_chain(iterable):
-       '''
-       Build a Markov chain model of one or many iterables as if they were
-       the output of a Markov process.
+    def markov_chain(iterable):
+        '''
+        Build a Markov chain model of one or many iterables as if they were
+        the output of a Markov process.
 
-           >>> markov_chain([1, 1, 2, 1])
-           {None: [1], 1: [1, 2], 2: [1]}
+            >>> markov_chain([1, 1, 2, 1])
+                    {None: [1], 1: [1, 2], 2: [1]}
 
-       The model is represented as a dict of lists. For each key in the
-       dictionary, the corresponding list holds its possible transitions in
-       proportion to the observed probability from the iterable.
+        The model is represented as a dict of lists. For each key in the
+            dictionary, the corresponding list holds its possible transitions in
+            proportion to the observed probability from the iterable.
 
-       The ``None`` key shows the initial state. Terminating states are
-       those which are present in the dict values, but never in the keys.
-       The model can be trained on multiple observations by merging chains
-       together.
+        The ``None`` key shows the initial state. Terminating states are
+            those which are present in the dict values, but never in the keys.
+            The model can be trained on multiple observations by merging chains
+            together.
 
-           >>> a = [1, 1, 2, 1, 0]
-           >>> b = [2, 1, 0]
-           >>> sequences = [a, b]
-           >>> chains = map(markov_chain, sequences)
-           >>> merge(*chains)
-           {None: [1, 2], 1: [1, 2, 0, 0], 2: [1, 1]}
+            >>> a = [1, 1, 2, 1, 0]
+                    >>> b = [2, 1, 0]
+                    >>> sequences = [a, b]
+                    >>> chains = map(markov_chain, sequences)
+                    >>> merge(*chains)
+                    {None: [1, 2], 1: [1, 2, 0, 0], 2: [1, 1]}
 
-       '''
-       t0 = None
-       def previous(t1):
-           nonlocal t0
-           x, t0 = t0, t1
-           return x
-       return Dict.grouping(iterable, previous)
+        '''
+            t0 = None
+            def previous(t1):
+                nonlocal t0
+                x, t0 = t0, t1
+                return x
+            return Dict.grouping(iterable, previous)
 
 
-   def markov_walk(chain, start=None):
-       '''
-       Markov chain Monte Carlo simulation.
+    def markov_walk(chain, start=None):
+        '''
+        Markov chain Monte Carlo simulation.
 
-           >>> chain = markov_chain([1, 1, 2, 2, 1, 2, 1, 0])
-           >>> chain
-           {None: [1], 1: [1, 2, 2, 0], 2: [2, 1, 1]}
-           >>> random.seed(42)
-           >>> list(markov_walk(chain))
-           [None, 1, 1, 2, 2, 2, 2, 1, 1, 1, 0]
-       '''
-       x = start
-       while True:
-           yield x
-           try:
-               x = random.choice(chain[x])
-           except KeyError:
-               break
+            >>> chain = markov_chain([1, 1, 2, 2, 1, 2, 1, 0])
+                    >>> chain
+                    {None: [1], 1: [1, 2, 2, 0], 2: [2, 1, 1]}
+                    >>> random.seed(42)
+                    >>> list(markov_walk(chain))
+                    [None, 1, 1, 2, 2, 2, 2, 1, 1, 1, 0]
+                '''
+                x = start
+                while True:
+                    yield x
+                    try:
+                        x = random.choice(chain[x])
+                    except KeyError:
+                        break
 
 
 K-Means Clustering
@@ -461,54 +461,54 @@ K-Means Clustering
 
 Grouping is used in many analysis tasks, such as clustering.
 
-.. code: python
+::
 
-   def distance(a, b):
-       '''
-       Euclidean distance between two n-tuples.
+    def distance(a, b):
+        '''
+        Euclidean distance between two n-tuples.
 
-           >>> a = 3, 4
-           >>> b = 0, 0
-           >>> distance(a, b)
-           5.0
+            >>> a = 3, 4
+                    >>> b = 0, 0
+                    >>> distance(a, b)
+                    5.0
 
-       '''
-       return math.sqrt(sum([(x - y) ** 2 for x, y in zip(a, b)]))
-
-
-   def nearest(target, rows):
-       '''
-       Nearest row to the target.
-
-           >>> target = 0, 0
-           >>> rows = [(5, 5), (-4, -4), (1, 1)]
-           >>> nearest(target, rows)
-           (1, 1)
-       '''
-       return min(rows, key=lambda row: distance(target, row))
+        '''
+            return math.sqrt(sum([(x - y) ** 2 for x, y in zip(a, b)]))
 
 
-   def k_means(k, iterable, iterations=5):
-       '''
-       K-Means clustering.
+    def nearest(target, rows):
+        '''
+        Nearest row to the target.
 
-           >>> random.seed(42)
-           >>> rows = [(random.random(), random.random()) for i in range(100)]
-           >>> clusters = k_means(3, rows)
-           >>> for i, (centroid, cluster) in enumerate(clusters.items()):
-           ...     print(f'Cluster {i}: size={len(cluster)}, centroid={centroid}')
-           ...
-           Cluster 0: size=46, centroid=(0.3402505165179919, 0.15547949981178155)
-           Cluster 1: size=30, centroid=(0.9895233506365952, 0.6399997598540929)
-           Cluster 2: size=24, centroid=(0.2498064478821005, 0.9232655992760128)
+            >>> target = 0, 0
+                    >>> rows = [(5, 5), (-4, -4), (1, 1)]
+                    >>> nearest(target, rows)
+                    (1, 1)
+                '''
+                return min(rows, key=lambda row: distance(target, row))
 
-       '''
-       rows = list(iterable)
-       centroids = random.sample(rows, k)
-       for i in range(iterations):
-           clusters = Dict.grouping(rows, key=lambda row: nearest(row, centroids))
-           centroids = {k: [sum(column) for column in zip(*g)] for k, g in clusters.items()}
-       return clusters
+
+    def k_means(k, iterable, iterations=5):
+        '''
+        K-Means clustering.
+
+            >>> random.seed(42)
+                    >>> rows = [(random.random(), random.random()) for i in range(100)]
+                    >>> clusters = k_means(3, rows)
+                    >>> for i, (centroid, cluster) in enumerate(clusters.items()):
+                    ...     print(f'Cluster {i}: size={len(cluster)}, centroid={centroid}')
+                    ...
+                    Cluster 0: size=46, centroid=(0.3402505165179919, 0.15547949981178155)
+                    Cluster 1: size=30, centroid=(0.9895233506365952, 0.6399997598540929)
+                    Cluster 2: size=24, centroid=(0.2498064478821005, 0.9232655992760128)
+
+        '''
+            rows = list(iterable)
+            centroids = random.sample(rows, k)
+            for i in range(iterations):
+                clusters = Dict.grouping(rows, key=lambda row: nearest(row, centroids))
+                centroids = {k: [sum(column) for column in zip(*g)] for k, g in clusters.items()}
+            return clusters
 
 
 

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -374,8 +374,8 @@ A new class in the collections module has some advantages.  In a sense,
 could provide ``map`` and ``aggregate`` methods, which define an
 interface for classes that provide a different internal data structure.
 However, transforming and aggregating the groups can be performed as an
-expressive dictionary comprehension, perhaps with more clarity than
-passing a function to a higher-order method.
+expressive dictionary comprehension, with more flexibility, and perhaps
+more clarity than passing a function to a higher-order method.
 
 ::
 

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -87,7 +87,7 @@ A "naive" solution with the built-in ``dict``.
         if k in d:
             d[k].append(value)
         else:
-            d[k] = value
+            d[k] = [value]
 
 
 ``dict.setdefault``
@@ -111,7 +111,8 @@ It also requires that the keys are comparable.
 ::
 
     from itertools import groupby
-    d = {k: list(values) for k, values in groupby(sorted(names, key=len), key=len)}
+
+    d = {k: list(group) for k, group in groupby(sorted(names, key=len), key=len)}
 
 
 ``collections.defaultdict``
@@ -123,6 +124,7 @@ convert a ``defaultdict`` to a built-in ``dict`` [#]_.
 ::
 
     from collections import defaultdict
+
     d = defaultdict(list)
     for value in names:
         d[len(value)].append(value)
@@ -132,14 +134,35 @@ convert a ``defaultdict`` to a built-in ``dict`` [#]_.
 Examples
 --------
 
-::
+Group words by length::
 
     grouping(words, key=len)
+
+
+Group names by first initial::
+
     grouping(names, key=itemgetter(0))
+
+
+Group people by city::
+
     grouping(contacts, key=itemgetter('city')
+
+
+Group employees by department::
+
     grouping(employees, key=itemgetter('department'))
+
+
+Group files by extension::
+
     grouping(os.listdir('.'), key=lambda filepath: os.path.splitext(filepath)[1])
+
+
+Group transactions by type::
+
     grouping(transactions, key=lambda v: 'debit' if v > 0 else 'credit')
+
 
 Sequences of values that are already paired with their keys can be
 easily transformed after grouping.

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -362,8 +362,8 @@ Rejected Alternatives
 ``key=itemgetter(0)``
 ~~~~~~~~~~~~~~~~~~~~~
 
-The default "identity" key-function is not of much practical use.  In
-``itertools.groupby`` the identity default can be used for finding
+The default equality key-function is not of much practical use.  In
+``itertools.groupby`` the equality default can be used for finding
 "runs" of duplicate values.  In ``grouping``, it is nearly a duplicate
 of ``collections.Counter``, though it might have a use for some unusual
 types of data that compare equal even if some attributes have different
@@ -443,6 +443,18 @@ more clarity than passing a function to a higher-order method.
     {k: func(g) for k, g in groups.items()}                 # aggregate
     {k: [func(v) for v in g] for k, g in groups.items()}    # map
 
+Merging groupings is not a one-liner, but could be included as a recipe
+in the documentation.
+
+::
+
+    def merge(*groupings):
+        'Combine multiple groupings into a single dict of lists'
+        groups = {}
+        for d in groupings:
+            for k, g in d.items():
+                groups.setdefault(k, []).extend(g)
+        return groups
 
 It's hard to estimate the frequency with which programmers use the
 various built-ins.  Grouping is a comparable concept to many tools which

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -10,7 +10,7 @@ Post-History: 28-Jun-2018
 
 
 
-*Last revised 30-Jun-2018*
+*Last revised 01-Jul-2018*
 
 
 
@@ -215,6 +215,17 @@ The map-reduce paradigm is comparable to a group-and-aggregate::
 
     g = grouping(sequence, key=mapper)
     results = {k: reducer(group) for k, group in g.items()}
+
+
+Uniques within each group::
+
+    groups = grouping(sequence, keyfunc)
+    {k: set(g) for k, g in groups.items()}
+
+Counts within each group::
+
+    groups = grouping(sequence, keyfunc)
+    {k: Counter(g) for k, g in groups.items()}
 
 
 
@@ -443,6 +454,15 @@ References
 .. [#] https://clojuredocs.org/clojure.core/group-by
 .. [#] http://toolz.readthedocs.io/en/latest/api.html#toolz.itertoolz.groupby
 .. [#] http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.groupby.html#pandas.Series.groupby
+
+
+
+Acknowledgements
+================
+
+Thanks to David Mertz for suggesting the Grouping class and Chris Barker
+for writing a possible implementation of it.  And of course, thank you
+to all who read this PEP and participated in discussion.
 
 
 

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -125,6 +125,8 @@ The behavior would be comparable to the following ``dict`` extension:
 
 ::
 
+    from itertools import groupby as _groupby
+
     class Dict(dict):
 
         @classmethod
@@ -146,11 +148,9 @@ The behavior would be comparable to the following ``dict`` extension:
             '''
             # https://en.wikipedia.org/wiki/Equivalence_class
             
-            if key is None:
-                return cls({k: list(g) for k, g in groupby(sorted(iterable))})
             groups = cls()
-            for x in iterable:
-                groups.setdefault(key(x), []).append(x)
+            for k, g in _groupby(iterable, key):
+                groups.setdefault(k, []).extend(g)
             return groups
 
 
@@ -414,8 +414,8 @@ that group members were encountered, it is often useful to create
 ::
 
     >>> groups = dict.grouping('aBAbaB', str.casefold)
-    >>> {k: sorted(set(g)) for k, g in groups.items()}
-    {'a': ['A', 'a'], 'b': ['B', 'b']}
+    >>> {k: set(g) for k, g in groups.items()}
+    {'a': {'A', 'a'}, 'b': {'B', 'b'}}
 
 
 If each group should be a multiset, where repetitions matter but order

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -214,6 +214,11 @@ choice for beginners searching for how to create groups of things.
                 >>> g.aggregate(Counter)    # counts
                 {'a': Counter({'A': 2, 'a': 1}), 'b': Counter({'B': 2, 'b': 1})}
 
+            Grouping.aggregate behaves similarly to the "map-reduce"
+            pattern of programming.
+
+                Grouping(sequence, key=mapper).aggregate(reducer)
+
             '''
             return {k: func(g) for k, g in self.items()}
 

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -109,8 +109,9 @@ but suffers from a less-beautiful appearance. Secondarily,
    >>> groups
    {0: {0, 2, 4, 6}, 1: {1, 3, 5}}
 
-
-This appears to be 
+In my experience, many Pythonistas are unaware of ``dict.setdefault``
+even if relatively experienced with Python. It appears to be less well-
+known than ``itertools.groupby`` and ``collections.defaultdict``.
 
 
 

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -65,9 +65,8 @@ Error-prone when using groups::
 
 In many situations, a ``defaultdict`` is useful for building a mapping,
 but a regular dict is better for the returned type. Pytoolz'
-``toolz.itertoolz.frequencies`` illustrates the issue.
+``toolz.itertoolz.frequencies`` [#]_ illustrates the issue.
 
-https://github.com/pytoolz/toolz/blob/master/toolz/itertoolz.py#L527
 
 
 ``itertools.groupby``
@@ -175,48 +174,40 @@ Other Languages
 Java
 ~~~~
 
-Java's ``Collectors.groupingBy`` consumes a stream and creates a
+Java's ``Collectors.groupingBy`` [#]_ consumes a stream and creates a
 ``Map<K, List<T>>`` associating keys with lists of values.
-
-https://docs.oracle.com/javase/8/docs/api/java/util/stream/Collectors.html
 
 
 .NET
 ~~~~
 
-C#'s ``Enumerable.GroupBy`` is similar to Python's ``itertools.groupby``
+C#'s ``Enumerable.GroupBy`` [#]_ is similar to Python's ``itertools.groupby``
 in that it's an iterator yielding groups that implement the
 (``IGrouping<TKey, TElement>``) interface. Despite claiming deferred
 execution, ``Enumerable.GroupBy`` emits complete groups even if the
 input sequence was not sorted by key. Additionally, it allows a
 transform function for the grouped values in addition to a key function.
 
-https://msdn.microsoft.com/en-us/library/bb534304(v=vs.110).aspx
-
 
 Rust
 ~~~~
 
-Rust provides an iterator method ``group_by`` which returns a lazy
+Rust provides an iterator method ``group_by`` [#]_ which returns a lazy
 ``GroupBy`` iterable object which yields iterables for each group. It
 behaves similarly to Python's ``itertools.groupby``, which may repeat
 keys if the input sequence was not ordered by key.
-
-https://docs.rs/itertools/*/itertools/trait.Itertools.html#method.group_by
 
 
 Clojure
 ~~~~~~~
 
-Clojure has ``group-by``, which is nearly identical to this proposal:
+Clojure has ``group-by`` [#]_, which is nearly identical to this proposal:
 ``(group-by f coll)``. The choice of the name begs a different order for
 the parameters as well, as the phrase "group by key" is quite natural,
 inviting a curry.
 
    user=> (group-by first ["python" "jython" "cython" "pypy" "cpython"])
    {\p ["python" "pypy"], \j ["jython"], \c ["cython" "cpython"]}
-
-https://clojuredocs.org/clojure.core/group-by
 
 
 Community Libraries
@@ -225,7 +216,7 @@ Community Libraries
 Toolz
 ~~~~~
 
-Toolz' ``groupby`` requires the key-function as the first positional
+Toolz' ``groupby`` [#]_ requires the key-function as the first positional
 parameter and the sequence to be grouped as the second. This order may
 be more natural if a key-function is always necessary. However, it
 breaks the pattern established by builtins ``sorted``, ``min``, ``max``,
@@ -238,14 +229,12 @@ as the first parameter.
    >>> groupby(len, names)  
    {3: ['Bob', 'Dan'], 5: ['Alice', 'Edith', 'Frank'], 7: ['Charlie']}
 
-http://toolz.readthedocs.io/en/latest/api.html#toolz.itertoolz.groupby
-
 
 Pandas
 ~~~~~~
 
 While Pandas may be most famous for its ``DataFrame``, the better
-comparison in this situation would be ``Series.groupby``.
+comparison in this situation would be ``Series.groupby`` [#]_.
 
 ::
 
@@ -261,8 +250,6 @@ comparison in this situation would be ``Series.groupby``.
     Out[3]:
     {0: Int64Index([0, 2, 4, 6, 8], dtype='int64'),
     1: Int64Index([1, 3, 5, 7, 9], dtype='int64')}
-
-http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.groupby.html#pandas.Series.groupby
 
 As with Clojure, it fits naturally with the phrase, "group by key."
 Using ``Series.groupby`` as an unbound method does not read nearly as
@@ -516,6 +503,17 @@ How to Teach This
 =================
 
 
+
+References
+==========
+
+.. [#] https://github.com/pytoolz/toolz/blob/master/toolz/itertoolz.py#L527
+.. [#] https://docs.oracle.com/javase/8/docs/api/java/util/stream/Collectors.html
+.. [#] https://msdn.microsoft.com/en-us/library/bb534304(v=vs.110).aspx
+.. [#] https://docs.rs/itertools/*/itertools/trait.Itertools.html#method.group_by
+.. [#] https://clojuredocs.org/clojure.core/group-by
+.. [#] http://toolz.readthedocs.io/en/latest/api.html#toolz.itertoolz.groupby
+.. [#] http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.groupby.html#pandas.Series.groupby
 
 
 Copyright

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -163,6 +163,11 @@ Group transactions by type::
     grouping(transactions, key=lambda v: 'debit' if v > 0 else 'credit')
 
 
+Invert a dictionary, ``d``, without discarding repeated values::
+
+    grouping(d, key=lambda k: d[k])
+
+
 Sequences of values that are already paired with their keys can be
 easily transformed after grouping.
 
@@ -354,6 +359,46 @@ Rejected Alternatives
 ---------------------
 
 
+``key=itemgetter(0)``
+~~~~~~~~~~~~~~~~~~~~~
+
+The default "identity" key-function is not of much practical use.  In
+``itertools.groupby`` the identity default can be used for finding
+"runs" of duplicate values.  In ``grouping``, it is nearly a duplicate
+of ``collections.Counter``, though it might have a use for some unusual
+types of data that compare equal even if some attributes have different
+values.
+
+Using a default key-function of ``itemgetter(0)`` would enable a more
+useful default behavior that elegantly handles iterables of ``(key,
+value)`` pairs.
+
+::
+
+    from itertools import groupby as _groupby
+    from operator import itemgetter
+
+    def grouping(iterable, key=itemgetter(0)):
+        '''
+        Group elements of an iterable into a dict of lists.
+
+        The ``key`` is a function computing a key value for each
+        element.  Each key corresponds to a group -- a list of elements
+        in the same order as encountered.
+
+        By default, the key-function gets the 0th index of each element.
+
+            >>> grouping(['apple', 'banana', 'aardvark'])
+            {'a': ['apple', 'aardvark'], 'b': ['banana']}
+
+        '''
+        groups = {}
+        for k, g in _groupby(iterable, key):
+            groups.setdefault(k, []).extend(g)
+        return groups
+
+
+
 ``dict.groupby``
 ~~~~~~~~~~~~~~~~
 
@@ -461,8 +506,9 @@ Acknowledgements
 ================
 
 Thanks to David Mertz for suggesting the Grouping class and Chris Barker
-for writing a possible implementation of it.  And of course, thank you
-to all who read this PEP and participated in discussion.
+for writing a possible implementation of it.  Nicolas Rolin suggested
+itemgetter(0) for the default key-function.  And of course, thank you to
+all who read this PEP and participated in discussion.
 
 
 

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -157,11 +157,11 @@ Alternate: ``collections.Grouping``
 -----------------------------------
 
 Similar to the ``Counter`` class, the ``Grouping`` class would consume a
-sequence and construct a Mapping. This class could house ``aggregate``
-and ``transform`` methods (see *Examples* section). It may feel too
-similar to ``defaultdict``. Since ``Counter`` in a way is already a
-special case of ``defaultdict``, there may be room in the module for
-another.
+sequence and construct a Mapping. In a sense, ``Grouping`` is a special
+case of ``defaultdict``, but a general case of ``Counter``. One benefit
+to a separate class is that it can contain ``aggregate`` and ``map``
+methods for transforming the groups, as well as specialized ``fromkeys``
+and ``update`` methods.
 
 Other possible names are ``Grouper`` or ``GroupBy``. Regardless, with a
 name similar to ``Grouping``, this class will become the "obvious"
@@ -169,28 +169,90 @@ choice for beginners searching for how to create groups of things.
 
 ::
 
+
+    from itertools import groupby as _groupby
+
     class Grouping(dict):
+        '''Dict subclass for grouping elements of a sequence.
+
+        The ``key`` is a function computing a key value for each element.
+        If not specified or is None, key defaults to an identity function
+        and returns the element unchanged.
+
+        Each key value corresponds to a group -- a ``list`` of elements from
+        the input sequence in the same order as encountered.
+
+            >>> Grouping('AbBa', key=str.casefold)
+            Grouping({'a': ['A', 'a'], 'b': ['b', 'B']})
+
         '''
-        Mapping of keys (group labels) to lists (groups).
-        '''
+        # References:
+        #   https://en.wikipedia.org/wiki/Equivalence_class
 
-        def __init__(iterable, key=None):
-            if key is None:
-                key = lambda x: x
-            for x in iterable:
-                self.setdefault(key(x), []).append(x)
+        def __init__(self, iterable=(), key=None):
+            '''Create a new, empty Grouping object.
 
-        def map(func):
             '''
-            Apply a function to each element in every group.
-            '''
-            return {k: map(func, g) for k, g in self.items()}
+            super().__init__()
+            self.update(iterable, key)
 
-        def aggregate(func):
+        def map(self, func):
+            '''Apply a function to each element in every group.
+
             '''
-            Apply a function to each group.
+            return {k: [func(v) for v in g] for k, g in self.items()}
+
+        def aggregate(self, func):
+            '''Apply a function to each group.
+
+                >>> g = Grouping('AaBbAB', key=str.casefold)
+                >>> g.aggregate(''.join)    # concatenate
+                {'a': 'AaA', 'b': 'BbB'}
+                >>> g.aggregate(set)        # uniques
+                {'a': {'A', 'a'}, 'b', {'B', 'b'}}
+                >>> g.aggregate(Counter)    # counts
+                {'a': Counter({'A': 2, 'a': 1}), 'b': Counter({'B': 2, 'b': 1})}
+
             '''
             return {k: func(g) for k, g in self.items()}
+
+        def most_common(self, n=None):
+            '''List the ``n`` largest groups from largest to smallest.  If
+            ``n`` is ``None``, then list all groups.
+
+            '''
+            keyfunc = lambda item: len(item[1])
+            if n is None:
+                return sorted(self.items(), key=keyfunc, reverse=True)
+            return _heapq.nlargest(n, self.items(), key=keyfunc)
+
+        # Override dict methods where necessary
+
+        @classmethod
+        def fromkeys(cls, iterable, v=()):
+            '''
+
+            '''
+            return cls(dict.fromkeys(iterable, list(v)))
+
+        def update(self, iterable=(), key=None):
+            '''Extend groups with elements from an iterable or with
+            key-group items from a dictionary or another Grouping instance.
+
+            The ``key`` function is ignored for dictionaries and Groupings.
+
+                >>> g = Grouping('AbBa', key=str.casefold)
+                >>> g.update(['apple', 'banana'], key=lambda s: s[0])
+                >>> g['a']
+                ['A', 'a', 'apple']
+
+            '''
+            if isinstance(iterable, _collections_abc.Mapping):
+                groups = iterable.items()
+            else:
+                groups = _groupby(iterable, key)
+            for k, g in groups:
+                self.setdefault(k, []).extend(g)
 
 
 

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -212,6 +212,12 @@ Clustering::
     clusters = grouping(rows, key=lambda row: nearest(row, centroids))
 
 
+The map-reduce paradigm is comparable to a group-and-aggregate::
+
+    g = grouping(sequence, key=mapper)
+    results = {k: reducer(group) for k, group in g.items()}
+
+
 
 Rationale
 =========

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -1,0 +1,547 @@
+PEP: 9999
+Title: dict-grouping
+Author: Michael Selik <mike@selik.org>
+Status: Draft
+Type: Standards Track
+Content-Type: text/x-rst
+Created: 28-Jun-2018
+Python-Version: 3.8
+Post-History: 28-Jun-2018
+
+
+
+Abstract
+========
+
+This is a proposal for creating a concise, reliable way to group
+elements of a sequence, resulting in a dictionary of lists.
+
+
+
+Motivation
+==========
+
+One of the most frequent tasks in programming for data analysis is
+grouping data into categories. When creating a new Excel spreadsheet,
+often the user's first task is to create names for the columns or rows.
+The best metaphor for this in Python and the standard library is a dict
+of lists, especially now that dictionaries maintain insertion order.
+
+We currently have three reasonable techniques to create groups from a
+sequence or iterable:
+
+- itertools.groupby
+- collections.defaultdict
+- dict.setdefault
+
+Unfortunately, both ``itertools.groupby`` and
+``collections.defaultdict`` are error-prone, and ``dict.setdefault`` is
+homely (not beautiful).
+
+
+``defaultdict``
+---------------
+
+The ``defaultdict`` is elegant for building a grouping, but many
+otherwise-expert programmers will accidentally insert new groups when
+they intended to raise a ``KeyError``.
+
+Elegant for creating groups:
+
+   >>> from collections import defaultdict
+   >>> groups = defaultdict(set)
+   >>> for x in range(7):
+   ...     groups[x % 2].add(x)
+   ...
+
+Error-prone when using groups:
+
+   >>> groups
+   defaultdict(<class 'set'>, {0: {0, 2, 4, 6}, 1: {1, 3, 5}})
+   >>> len(groups[2])   # accidentally inserts a new group
+   0
+   >>> groups
+   defaultdict(<class 'set'>, {0: {0, 2, 4, 6}, 1: {1, 3, 5}, 2: set()})
+
+In many situations, a ``defaultdict`` is useful for building a mapping,
+but a regular dict is better for the returned type. Pytoolz'
+``toolz.itertoolz.frequencies_`` illustrates the issue.
+
+.. _toolz.itertoolz.frequencies:
+   https://github.com/pytoolz/toolz/blob/master/toolz/itertoolz.py#L527
+
+
+``itertools.groupby``
+---------------------
+
+Many users of ``itertools.groupby`` will forget to sort
+the data before grouping, accidentally creating two or more separate
+groups for the same key.
+
+   >>> from itertools import groupby
+   >>> mod_2 = lambda x: x % 2
+
+Mistake:
+
+   >>> {k: set(group) for k, group in groupby(range(7), key=mod_2)}
+   {0: {6}, 1: {5}}
+
+Correct:
+   
+   >>> numbers = sorted(range(7), key=mod_2)
+   >>> {k: set(group) for k, group in groupby(numbers, key=mod_2)}
+   {0: {0, 2, 4, 6}, 1: {1, 3, 5}}
+
+
+``dict.setdefault``
+-------------------
+
+The ``dict.setdefault`` method is often the best choice for grouping,
+but suffers from a less-beautiful appearance. Secondarily,
+``setdefault`` cannot easily create a grouping as an expression.
+
+   >>> groups = {}
+   >>> for x in range(7):
+   ...     groups.setdefault(x % 2, set()).add(x)
+   ...
+   >>> groups
+   {0: {0, 2, 4, 6}, 1: {1, 3, 5}}
+
+
+This appears to be 
+
+
+
+Specification
+=============
+
+I propose a new ``dict`` classmethod, ``dict.grouping`` which will
+construct a new dictionary based on an iterable and a key-function.
+
+The behavior would be comparable to the following ``dict`` extension:
+
+.. code: python
+
+   class Dict(dict):
+
+       @classmethod
+       def grouping(cls, iterable, key=None):
+           '''
+           Group elements of an iterable into a dict of lists.
+
+           The ``key`` is a function computing a key value for each
+           element. Each key corresponds to a group -- a list of elements
+           in the same order as encountered. By default, the key will be
+           the element itself.
+
+               >>> mod_2 = lambda x: x % 2
+               >>> Dict.grouping(range(7), mod_2)
+               {0: [0, 2, 4, 6], 1: [1, 3, 5]}
+
+               >>> Dict.grouping('AbBa', str.casefold)
+               {'a': ['A', 'a'], 'b': ['b', 'B']}
+           '''
+           # https://en.wikipedia.org/wiki/Equivalence_class
+           
+           if key is None:
+               return cls({k: list(g) for k, g in groupby(sorted(iterable))})
+
+           groups = cls()
+           for x in iterable:
+               groups.setdefault(key(x), []).append(x)
+           return groups
+
+
+
+Rationale
+=========
+
+The concept of a labeled group is common across many programming tasks.
+The ``email.headerregistry.Group`` associates a display name with a list
+of addresses. The ``msilib.RadioButtonGroup`` associates a name with
+members. When the groups are of equal size and ordered, the labeled
+groups can be considered named columns or indexed rows.
+
+This proposal was inspired by similar tools available in other languages
+and in Python community libraries.
+
+
+Other Languages
+---------------
+
+Java
+~~~~
+
+Java's ``Collectors.groupingBy`` consumes a stream and creates a
+``Map<K, List<T>>`` associating keys with lists of values.
+
+https://docs.oracle.com/javase/8/docs/api/java/util/stream/Collectors.html
+
+
+.NET
+~~~~
+
+C#'s ``Enumerable.GroupBy`` is similar to Python's ``itertools.groupby``
+in that it's an iterator yielding groups that implement the
+(``IGrouping<TKey, TElement>``) interface. Despite claiming deferred
+execution, ``Enumerable.GroupBy`` emits complete groups even if the
+input sequence was not sorted by key. Additionally, it allows a
+transform function for the grouped values in addition to a key function.
+
+https://msdn.microsoft.com/en-us/library/bb534304(v=vs.110).aspx
+
+
+Rust
+~~~~
+
+Rust provides an iterator method ``group_by`` which returns a lazy
+``GroupBy`` iterable object which yields iterables for each group. It
+behaves similarly to Python's ``itertools.groupby``, which may repeat
+keys if the input sequence was not ordered by key.
+
+https://docs.rs/itertools/*/itertools/trait.Itertools.html#method.group_by
+
+
+Clojure
+~~~~~~~
+
+Clojure has ``group-by_``, which is nearly identical to this proposal:
+``(group-by f coll)``. The choice of the name begs a different order for
+the parameters as well, as the phrase "group by key" is quite natural,
+inviting a curry.
+
+.. code: clojure
+
+   user=> (group-by first ["python" "jython" "cython" "pypy" "cpython"])
+   {\p ["python" "pypy"], \j ["jython"], \c ["cython" "cpython"]}
+
+.. _group-by: https://clojuredocs.org/clojure.core/group-by
+
+
+Community Libraries
+-------------------
+
+Toolz
+~~~~~
+
+Toolz' ``groupby`` requires the key-function as the first positional
+parameter and the sequence to be grouped as the second. This order may
+be more natural if a key-function is always necessary. However, it
+breaks the pattern established by builtins ``sorted``, ``min``, ``max``,
+and standard library ``itertools.groupby``, which all have the sequence
+as the first parameter.
+
+..code: python
+
+   >>> names = ['Alice', 'Bob', 'Charlie', 'Dan', 'Edith', 'Frank']
+   >>> groupby(len, names)  
+   {3: ['Bob', 'Dan'], 5: ['Alice', 'Edith', 'Frank'], 7: ['Charlie']}
+
+http://toolz.readthedocs.io/en/latest/api.html#toolz.itertoolz.groupby
+
+
+Pandas
+~~~~~~
+
+While Pandas may be most famous for its ``DataFrame``, the better
+comparison in this situation would be ``Series.groupby``.
+
+
+.. code: python
+
+   In [1]: import pandas as pd
+
+   In [2]: def mod(x):
+   ...:     def modulo(n):
+   ...:         return n % x
+   ...:     return modulo
+   ...:
+
+   In [3]: pd.Series(range(10)).groupby(mod(2)).groups
+   Out[3]:
+   {0: Int64Index([0, 2, 4, 6, 8], dtype='int64'),
+    1: Int64Index([1, 3, 5, 7, 9], dtype='int64')}
+
+http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.groupby.html#pandas.Series.groupby
+
+As with Clojure, it fits naturally with the phrase, "group by key."
+Using ``Series.groupby`` as an unbound method does not read nearly as
+well.
+
+.. code: python
+
+   In [12]: pd.Series.groupby(numbers, mod(2)).groups
+   Out[12]:
+   {0: Int64Index([0, 2, 4, 6, 8], dtype='int64'),
+    1: Int64Index([1, 3, 5, 7, 9], dtype='int64')}
+
+The ``DataFrame.groupby`` handles an interesting sub-category of usage,
+when each element of the input sequence is itself a sequence with one or
+many key-elements and one or many value-elements. In some cases, the
+key-elements should be dropped from these sequences when grouping.
+
+.. code: python
+
+   >>> sequence = [[1, 11, 12], [1, 13, 14], [2, 21, 22], [2, 23, 24]]
+   >>> dict.grouping(sequence, key=lambda row: row.pop(0))
+   {1: [[11, 12], [13, 14]], 2: [[21, 22], [23, 24]]}
+
+
+
+Examples
+========
+
+.. code: python
+
+   >>> mod_2 = lambda x: x % 2
+   >>> dict.grouping(range(7), mod_2)
+   {0: [0, 2, 4, 6], 1: [1, 3, 5]}
+
+
+   >>> dict.grouping('ababa')
+   {'a': ['a', 'a', 'a'], 'b': ['b', 'b']}
+
+
+   >>> dict.grouping('aBAb', str.casefold)
+   {'a': ['a', 'A'], 'b': ['B', 'b']}
+
+
+   >>> dict.grouping('aBAbaB', str.casefold)
+   {'a': ['a', 'A', 'a'], 'b': ['B', 'b', 'B']}
+
+
+Group and Aggregate
+-------------------
+
+While ``dict.grouping`` creates a dict of lists, preserving the order
+that group members were encountered, it is often useful to create
+"equivalence classes" which are better modeled as a dictionary of sets.
+
+.. code: python
+
+   >>> groups = dict.grouping('aBAbaB', str.casefold)
+   >>> {k: sorted(set(g)) for k, g in groups.items()}
+   {'a': ['A', 'a'], 'b': ['B', 'b']}
+
+
+If each group should be a multiset, where repetitions matter but order
+does not, then a dictionary of Counters is appropriate.
+
+.. code: python
+
+   >>> from collections import Counter
+   >>> groups = dict.grouping('aBAbaB', str.casefold)
+   >>> {k: Counter(g) for k, g in groups.items()}
+   {'a': Counter({'a': 2, 'A': 1}), 'b': Counter({'B': 2, 'b': 1})}
+
+
+Grouping and performing an aggregation or reduction on the resulting
+groups is a very common task.
+
+.. code: python
+
+   def aggregate(iterable, reducer, key=None):
+       '''
+       Apply a ``reducer`` function to each group in an iterable.
+
+           >>> mod_2 = lambda x: x % 2
+           >>> aggregate([1, 2, 3, 4], sum, key=mod_2)
+           {1: 4, 0: 6}
+
+       This is convenient for creating dict of sets or a dict of Counters.
+
+           >>> g = aggregate('AaaBBb', set, key=str.casefold)
+           >>> {k: sorted(v) for k, v in g.items()}
+           {'a': ['A', 'a'], 'b': ['B', 'b']}
+
+           >>> aggregate('AaaBBb', Counter, key=str.casefold)
+           {'a': Counter({'a': 2, 'A': 1}), 'b': Counter({'B': 2, 'b': 1})}
+
+       '''
+       g = Dict.grouping(iterable, key)
+       return {k: reducer(v) for k, v in g.items()}
+
+
+Group and Transform
+-------------------
+
+Another very common task is grouping and transforming each group. This
+might be to perform a transformation which includes a grouped-
+aggregation, like a z-score, or simply to discard unnecessary
+information.
+
+.. code: python
+
+   def z_score(numbers):
+       '''
+       Subtract mean and divide by standard deviation.
+       '''
+       # https://en.wikipedia.org/wiki/Standard_score
+       mu = statistics.mean(numbers)
+       sigma = statistics.stdev(numbers)
+       return [(x - mu) / sigma for x in numbers]
+
+
+.. code: python
+
+   def transform(iterable, func, key=None):
+       '''
+       Demultiplex an iterable and transform each element.
+
+           >>> transform('abAB', str.swapcase, key=str.casefold)
+           {'a': ['A', 'a'], 'b': ['B', 'b']}
+
+       '''
+       g = Dict.grouping(iterable, key)
+       return {k: [func(x) for x in v] for k, v in g.items()}
+
+
+Markov Chain
+------------
+
+A stateful key-function can provide some very succinct code to create
+interesting data structures.
+
+.. code: python
+
+   def markov_chain(iterable):
+       '''
+       Build a Markov chain model of one or many iterables as if they were
+       the output of a Markov process.
+
+           >>> markov_chain([1, 1, 2, 1])
+           {None: [1], 1: [1, 2], 2: [1]}
+
+       The model is represented as a dict of lists. For each key in the
+       dictionary, the corresponding list holds its possible transitions in
+       proportion to the observed probability from the iterable.
+
+       The ``None`` key shows the initial state. Terminating states are
+       those which are present in the dict values, but never in the keys.
+       The model can be trained on multiple observations by merging chains
+       together.
+
+           >>> a = [1, 1, 2, 1, 0]
+           >>> b = [2, 1, 0]
+           >>> sequences = [a, b]
+           >>> chains = map(markov_chain, sequences)
+           >>> merge(*chains)
+           {None: [1, 2], 1: [1, 2, 0, 0], 2: [1, 1]}
+
+       '''
+       t0 = None
+       def previous(t1):
+           nonlocal t0
+           x, t0 = t0, t1
+           return x
+       return Dict.grouping(iterable, previous)
+
+
+   def markov_walk(chain, start=None):
+       '''
+       Markov chain Monte Carlo simulation.
+
+           >>> chain = markov_chain([1, 1, 2, 2, 1, 2, 1, 0])
+           >>> chain
+           {None: [1], 1: [1, 2, 2, 0], 2: [2, 1, 1]}
+           >>> random.seed(42)
+           >>> list(markov_walk(chain))
+           [None, 1, 1, 2, 2, 2, 2, 1, 1, 1, 0]
+       '''
+       x = start
+       while True:
+           yield x
+           try:
+               x = random.choice(chain[x])
+           except KeyError:
+               break
+
+
+K-Means Clustering
+------------------
+
+Grouping is used in many analysis tasks, such as clustering.
+
+.. code: python
+
+   def distance(a, b):
+       '''
+       Euclidean distance between two n-tuples.
+
+           >>> a = 3, 4
+           >>> b = 0, 0
+           >>> distance(a, b)
+           5.0
+
+       '''
+       return math.sqrt(sum([(x - y) ** 2 for x, y in zip(a, b)]))
+
+
+   def nearest(target, rows):
+       '''
+       Nearest row to the target.
+
+           >>> target = 0, 0
+           >>> rows = [(5, 5), (-4, -4), (1, 1)]
+           >>> nearest(target, rows)
+           (1, 1)
+       '''
+       return min(rows, key=lambda row: distance(target, row))
+
+
+   def k_means(k, iterable, iterations=5):
+       '''
+       K-Means clustering.
+
+           >>> random.seed(42)
+           >>> rows = [(random.random(), random.random()) for i in range(100)]
+           >>> clusters = k_means(3, rows)
+           >>> for i, (centroid, cluster) in enumerate(clusters.items()):
+           ...     print(f'Cluster {i}: size={len(cluster)}, centroid={centroid}')
+           ...
+           Cluster 0: size=46, centroid=(0.3402505165179919, 0.15547949981178155)
+           Cluster 1: size=30, centroid=(0.9895233506365952, 0.6399997598540929)
+           Cluster 2: size=24, centroid=(0.2498064478821005, 0.9232655992760128)
+
+       '''
+       rows = list(iterable)
+       centroids = random.sample(rows, k)
+       for i in range(iterations):
+           clusters = Dict.grouping(rows, key=lambda row: nearest(row, centroids))
+           centroids = {k: [sum(column) for column in zip(*g)] for k, g in clusters.items()}
+       return clusters
+
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+itertools partition recipe
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``partition`` recipe in the itertools module documentation provides
+an example of demultiplexing an iterable into two iterators, based on a
+predicate function applied to each element. Restricting the possible
+values of the predicate to ``{True, False}`` enables this laziness.
+Permitting a more general key-function forces ``dict.grouping`` to
+consume the entire iterable before determining what the keys will be.
+
+.. code: python
+
+   def partition(pred, iterable):
+       'Use a predicate to partition entries into false entries and true entries'
+       # partition(is_odd, range(10)) --> 0 2 4 6 8   and  1 3 5 7 9
+       t1, t2 = tee(iterable)
+       return filterfalse(pred, t1), filter(pred, t2)
+
+
+
+How to Teach This
+=================
+
+
+
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -124,34 +124,73 @@ The behavior would be comparable to the following ``dict`` extension:
 
 ::
 
-   class Dict(dict):
+    class Dict(dict):
 
-       @classmethod
-       def grouping(cls, iterable, key=None):
-           '''
-           Group elements of an iterable into a dict of lists.
+        @classmethod
+        def grouping(cls, iterable, key=None):
+            '''
+            Group elements of an iterable into a dict of lists.
 
-           The ``key`` is a function computing a key value for each
-           element. Each key corresponds to a group -- a list of elements
-           in the same order as encountered. By default, the key will be
-           the element itself.
+            The ``key`` is a function computing a key value for each
+            element. Each key corresponds to a group -- a list of elements
+            in the same order as encountered. By default, the key will be
+            the element itself.
 
-               >>> mod_2 = lambda x: x % 2
-               >>> Dict.grouping(range(7), mod_2)
-               {0: [0, 2, 4, 6], 1: [1, 3, 5]}
+                >>> mod_2 = lambda x: x % 2
+                >>> Dict.grouping(range(7), mod_2)
+                {0: [0, 2, 4, 6], 1: [1, 3, 5]}
 
-               >>> Dict.grouping('AbBa', str.casefold)
-               {'a': ['A', 'a'], 'b': ['b', 'B']}
-           '''
-           # https://en.wikipedia.org/wiki/Equivalence_class
-           
-           if key is None:
-               return cls({k: list(g) for k, g in groupby(sorted(iterable))})
+                >>> Dict.grouping('AbBa', str.casefold)
+                {'a': ['A', 'a'], 'b': ['b', 'B']}
+            '''
+            # https://en.wikipedia.org/wiki/Equivalence_class
+            
+            if key is None:
+                return cls({k: list(g) for k, g in groupby(sorted(iterable))})
+            groups = cls()
+            for x in iterable:
+                groups.setdefault(key(x), []).append(x)
+            return groups
 
-           groups = cls()
-           for x in iterable:
-               groups.setdefault(key(x), []).append(x)
-           return groups
+
+Alternate: ``collections.Grouping``
+-----------------------------------
+
+Similar to the ``Counter`` class, the ``Grouping`` class would consume a
+sequence and construct a Mapping. This class could house ``aggregate``
+and ``transform`` methods (see *Examples* section). It may feel too
+similar to ``defaultdict``. Since ``Counter`` in a way is already a
+special case of ``defaultdict``, there may be room in the module for
+another.
+
+Other possible names are ``Grouper`` or ``GroupBy``. Regardless, with a
+name similar to ``Grouping``, this class will become the "obvious"
+choice for beginners searching for how to create groups of things.
+
+::
+
+    class Grouping(dict):
+        '''
+        Mapping of keys (group labels) to lists (groups).
+        '''
+
+        def __init__(iterable, key=None):
+            if key is None:
+                key = lambda x: x
+            for x in iterable:
+                self.setdefault(key(x), []).append(x)
+
+        def map(func):
+            '''
+            Apply a function to each element in every group.
+            '''
+            return {k: map(func, g) for k, g in self.items()}
+
+        def aggregate(func):
+            '''
+            Apply a function to each group.
+            '''
+            return {k: func(g) for k, g in self.items()}
 
 
 

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -10,6 +10,10 @@ Post-History: 28-Jun-2018
 
 
 
+*Last revised 30-Jun-2018*
+
+
+
 Abstract
 ========
 
@@ -18,261 +22,193 @@ elements of a sequence, resulting in a dictionary of lists.
 
 
 
-Motivation
-==========
-
-One of the most frequent tasks in programming for data analysis is
-grouping data into categories. When creating a new Excel spreadsheet,
-often the user's first task is to create names for the columns or rows.
-The best metaphor for this in Python and the standard library is a dict
-of lists, especially now that dictionaries maintain insertion order.
-
-We currently have three reasonable techniques to create groups from a
-sequence or iterable:
-
-- ``itertools.groupby``
-- ``collections.defaultdict``
-- ``dict.setdefault``
-
-Unfortunately, both ``itertools.groupby`` and
-``collections.defaultdict`` are error-prone, and ``dict.setdefault`` is
-homely (not beautiful).
-
-
-``defaultdict``
----------------
-
-The ``defaultdict`` is elegant for building a grouping, but many
-otherwise-expert programmers will accidentally insert new groups when
-they intended to raise a ``KeyError``.
-
-Elegant for creating groups::
-
-   >>> from collections import defaultdict
-   >>> groups = defaultdict(set)
-   >>> for x in range(7):
-   ...     groups[x % 2].add(x)
-   ...
-
-Error-prone when using groups::
-
-   >>> groups
-   defaultdict(<class 'set'>, {0: {0, 2, 4, 6}, 1: {1, 3, 5}})
-   >>> len(groups[2])   # accidentally inserts a new group
-   0
-   >>> groups
-   defaultdict(<class 'set'>, {0: {0, 2, 4, 6}, 1: {1, 3, 5}, 2: set()})
-
-In many situations, a ``defaultdict`` is useful for building a mapping,
-but a regular dict is better for the returned type. Pytoolz'
-``toolz.itertoolz.frequencies`` [#]_ illustrates the issue.
-
-
-
-``itertools.groupby``
----------------------
-
-Many users of ``itertools.groupby`` will forget to sort
-the data before grouping, accidentally creating two or more separate
-groups for the same key.
-
-::
-
-   >>> from itertools import groupby
-   >>> mod_2 = lambda x: x % 2
-
-Mistake::
-
-   >>> {k: set(group) for k, group in groupby(range(7), key=mod_2)}
-   {0: {6}, 1: {5}}
-
-Correct::
-   
-   >>> numbers = sorted(range(7), key=mod_2)
-   >>> {k: set(group) for k, group in groupby(numbers, key=mod_2)}
-   {0: {0, 2, 4, 6}, 1: {1, 3, 5}}
-
-
-``dict.setdefault``
--------------------
-
-The ``dict.setdefault`` method is often the best choice for grouping,
-but suffers from a less-beautiful appearance. Secondarily,
-``setdefault`` cannot easily create a grouping as an expression.
-
-::
-
-   >>> groups = {}
-   >>> for x in range(7):
-   ...     groups.setdefault(x % 2, set()).add(x)
-   ...
-   >>> groups
-   {0: {0, 2, 4, 6}, 1: {1, 3, 5}}
-
-In my experience, many Pythonistas are unaware of ``dict.setdefault``
-even if relatively experienced with Python. It appears to be less well-
-known than ``itertools.groupby`` and ``collections.defaultdict``.
-
-
-
 Specification
 =============
 
-I propose a new ``dict`` classmethod, ``dict.grouping`` which will
-construct a new dictionary based on an iterable and a key-function.
-
-The behavior would be comparable to the following ``dict`` extension:
+A new built-in function, ``grouping``, will construct a dictionary of
+lists based on an iterable and a key-function.
 
 ::
 
     from itertools import groupby as _groupby
 
-    class Dict(dict):
+    def grouping(iterable, key=None):
+        '''
+        Group elements of an iterable into a dict of lists.
 
-        @classmethod
-        def grouping(cls, iterable, key=None):
-            '''
-            Group elements of an iterable into a dict of lists.
+        The ``key`` is a function computing a key value for each
+        element.  Each key corresponds to a group -- a list of elements
+        in the same order as encountered.  By default, the key will be
+        the element itself.
 
-            The ``key`` is a function computing a key value for each
-            element. Each key corresponds to a group -- a list of elements
-            in the same order as encountered. By default, the key will be
-            the element itself.
-
-                >>> mod_2 = lambda x: x % 2
-                >>> Dict.grouping(range(7), mod_2)
-                {0: [0, 2, 4, 6], 1: [1, 3, 5]}
-
-                >>> Dict.grouping('AbBa', str.casefold)
-                {'a': ['A', 'a'], 'b': ['b', 'B']}
-            '''
-            # https://en.wikipedia.org/wiki/Equivalence_class
-            
-            groups = cls()
-            for k, g in _groupby(iterable, key):
-                groups.setdefault(k, []).extend(g)
-            return groups
-
-
-Alternate: ``collections.Grouping``
------------------------------------
-
-Similar to the ``Counter`` class, the ``Grouping`` class would consume a
-sequence and construct a Mapping. In a sense, ``Grouping`` is a special
-case of ``defaultdict``, but a general case of ``Counter``. One benefit
-to a separate class is that it can contain ``aggregate`` and ``map``
-methods for transforming the groups, as well as specialized ``fromkeys``
-and ``update`` methods.
-
-Other possible names are ``Grouper`` or ``GroupBy``. Regardless, with a
-name similar to ``Grouping``, this class will become the "obvious"
-choice for beginners searching for how to create groups of things.
-
-::
-
-
-    from itertools import groupby as _groupby
-
-    class Grouping(dict):
-        '''Dict subclass for grouping elements of a sequence.
-
-        The ``key`` is a function computing a key value for each element.
-        If not specified or is None, key defaults to an identity function
-        and returns the element unchanged.
-
-        Each key value corresponds to a group -- a ``list`` of elements from
-        the input sequence in the same order as encountered.
-
-            >>> Grouping('AbBa', key=str.casefold)
-            Grouping({'a': ['A', 'a'], 'b': ['b', 'B']})
+            >>> grouping('AbBa', key=str.casefold)
+            {'a': ['A', 'a'], 'b': ['b', 'B']}
 
         '''
-        # References:
-        #   https://en.wikipedia.org/wiki/Equivalence_class
+        groups = {}
+        for k, g in _groupby(iterable, key):
+            groups.setdefault(k, []).extend(g)
+        return groups
 
-        def __init__(self, iterable=(), key=None):
-            '''Create a new, empty Grouping object.
 
-            '''
-            super().__init__()
-            self.update(iterable, key)
 
-        def map(self, func):
-            '''Apply a function to each element in every group.
+Motivation
+==========
 
-            '''
-            return {k: [func(v) for v in g] for k, g in self.items()}
+Grouping, categorizing, classifying, bucketing, or demultiplexing is a
+fundamental concept in programming and analysis.  It deserves a tool in
+Python that is succinct, efficient, and easily accessible.
 
-        def aggregate(self, func):
-            '''Apply a function to each group.
+::
 
-                >>> g = Grouping('AaBbAB', key=str.casefold)
-                >>> g.aggregate(''.join)    # concatenate
-                {'a': 'AaA', 'b': 'BbB'}
-                >>> g.aggregate(set)        # uniques
-                {'a': {'A', 'a'}, 'b', {'B', 'b'}}
-                >>> g.aggregate(Counter)    # counts
-                {'a': Counter({'A': 2, 'a': 1}), 'b': Counter({'B': 2, 'b': 1})}
+    >>> names = ['John', 'Paul', 'George', 'Ringo']
+    >>> grouping(names, key=len)
+    {4: ['John', 'Paul'], 6: ['George'], 5: ['Ringo']}
 
-            Grouping.aggregate behaves similarly to the "map-reduce"
-            pattern of programming.
 
-                Grouping(sequence, key=mapper).aggregate(reducer)
+Comparisons
+-----------
 
-            '''
-            return {k: func(g) for k, g in self.items()}
+::
 
-        def most_common(self, n=None):
-            '''List the ``n`` largest groups from largest to smallest.  If
-            ``n`` is ``None``, then list all groups.
+    d = grouping(names, key=len)
 
-            '''
-            keyfunc = lambda item: len(item[1])
-            if n is None:
-                return sorted(self.items(), key=keyfunc, reverse=True)
-            return _heapq.nlargest(n, self.items(), key=keyfunc)
 
-        # Override dict methods where necessary
+``dict``
+~~~~~~~~
 
-        @classmethod
-        def fromkeys(cls, iterable, v=()):
-            '''
+A "naive" solution with the built-in ``dict``.
 
-            '''
-            return cls(dict.fromkeys(iterable, list(v)))
+::
 
-        def update(self, iterable=(), key=None):
-            '''Extend groups with elements from an iterable or with
-            key-group items from a dictionary or another Grouping instance.
+    d = {}
+    for value in names:
+        k = len(value)
+        if k in d:
+            d[k].append(value)
+        else:
+            d[k] = value
 
-            The ``key`` function is ignored for dictionaries and Groupings.
 
-                >>> g = Grouping('AbBa', key=str.casefold)
-                >>> g.update(['apple', 'banana'], key=lambda s: s[0])
-                >>> g['a']
-                ['A', 'a', 'apple']
+``dict.setdefault``
+~~~~~~~~~~~~~~~~~~~
 
-            '''
-            if isinstance(iterable, _collections_abc.Mapping):
-                groups = iterable.items()
-            else:
-                groups = _groupby(iterable, key)
-            for k, g in groups:
-                self.setdefault(k, []).extend(g)
+A better solution with the ``setdefault`` method.
+
+::
+
+    d = {}
+    for value in names:
+        d.setdefault(len(value), []).append(value)
+
+
+``itertools.groupby``
+~~~~~~~~~~~~~~~~~~~~~
+
+While elegent in its use-case, ``groupby`` here runs in O(n log n) time.
+It also requires that the keys are comparable.
+
+::
+
+    from itertools import groupby
+    d = {k: list(values) for k, values in groupby(sorted(names, key=len), key=len)}
+
+
+``collections.defaultdict``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To avoid accidental inserts later in the code, it can be desirable to
+convert a ``defaultdict`` to a built-in ``dict`` [#]_.
+
+::
+
+    from collections import defaultdict
+    d = defaultdict(list)
+    for value in names:
+        d[len(value)].append(value)
+    d = dict(d)
+
+
+Examples
+--------
+
+::
+
+    grouping(words, key=len)
+    grouping(names, key=itemgetter(0))
+    grouping(contacts, key=itemgetter('city')
+    grouping(employees, key=itemgetter('department'))
+    grouping(os.listdir('.'), key=lambda filepath: os.path.splitext(filepath)[1])
+    grouping(transactions, key=lambda v: 'debit' if v > 0 else 'credit')
+
+Sequences of values that are already paired with their keys can be
+easily transformed after grouping.
+
+::
+
+    >>> foods = [
+    ...     ('fruit', 'apple'),
+    ...     ('vegetable', 'broccoli'),
+    ...     ('fruit', 'clementine'),
+    ...     ('vegetable', 'daikon')
+    ... ]
+    >>> groups = grouping(foods, key=lambda pair: pair[0])
+    >>> {k: [v for _, v in g] for k, g in groups.items()}
+    {'fruit': ['apple', 'clementine'], 'vegetable': ['broccoli', 'daikon']}
+
+
+Stateful key-functions enable sophisticated structures, such as creating
+a transition table (finite state machine) from a sequence of events::
+
+    t0 = None
+    def previous(t1):
+        global t0
+        x, t0 = t0, t1
+        return x
+
+    transitions = grouping(sequence, key=previous)
+
+
+Aggregation
+~~~~~~~~~~~
+
+Group averages::
+
+    from csv import DictReader
+    from statistics import mean
+
+    with open('income.csv') as f:
+        rows = DictReader(f)
+        by_state = grouping(rows, key=itemgetter('state')
+        averages = {state: mean(row['income'] for state, row in by_state.items())}
+
+
+Clustering::
+
+    clusters = grouping(rows, key=lambda row: nearest(row, centroids))
 
 
 
 Rationale
 =========
 
-The concept of a labeled group is common across many programming tasks.
-The ``email.headerregistry.Group`` associates a display name with a list
-of addresses. The ``msilib.RadioButtonGroup`` associates a name with
-members. When the groups are of equal size and ordered, the labeled
-groups can be considered named columns or indexed rows.
+Humans think in taxonomies.  In teaching Python, I've found that many
+students will ask how to construct groups very early in the process of
+learning the language.  If they've used SQL, they're used to the GROUP
+BY clause.  If they've used Excel, they're used to writing row or column
+labels as the first step in building a spreadsheet.
+
+Unfortunately, the three tools currently available for creating groups
+in Python -- ``setdefault``, ``defaultdict``, and ``groupby`` -- invite
+discussions of concepts that a teacher usually prefers to postpone until
+after core skills like sorting and grouping.
 
 This proposal was inspired by similar tools available in other languages
 and in Python community libraries.
+
+The prevalence of similar tools in so many community libraries suggests
+that Python has not yet provided a satisfactory tool and that grouping
+is significant enough to belong in the built-ins.
 
 
 Other Languages
@@ -296,15 +232,6 @@ input sequence was not sorted by key. Additionally, it allows a
 transform function for the grouped values in addition to a key function.
 
 
-Rust
-~~~~
-
-Rust provides an iterator method ``group_by`` [#]_ which returns a lazy
-``GroupBy`` iterable object which yields iterables for each group. It
-behaves similarly to Python's ``itertools.groupby``, which may repeat
-keys if the input sequence was not ordered by key.
-
-
 Clojure
 ~~~~~~~
 
@@ -312,6 +239,8 @@ Clojure has ``group-by`` [#]_, which is nearly identical to this proposal:
 ``(group-by f coll)``. The choice of the name begs a different order for
 the parameters as well, as the phrase "group by key" is quite natural,
 inviting a curry.
+
+::
 
    user=> (group-by first ["python" "jython" "cython" "pypy" "cpython"])
    {\p ["python" "pypy"], \j ["jython"], \c ["cython" "cpython"]}
@@ -377,232 +306,66 @@ key-elements should be dropped from these sequences when grouping.
 ::
 
     >>> sequence = [[1, 11, 12], [1, 13, 14], [2, 21, 22], [2, 23, 24]]
-    >>> dict.grouping(sequence, key=lambda row: row.pop(0))
+    >>> grouping(sequence, key=lambda row: row.pop(0))
     {1: [[11, 12], [13, 14]], 2: [[21, 22], [23, 24]]}
 
 
-
-Examples
-========
-
-::
-
-    >>> mod_2 = lambda x: x % 2
-    >>> dict.grouping(range(7), mod_2)
-    {0: [0, 2, 4, 6], 1: [1, 3, 5]}
+Rejected Alternatives
+---------------------
 
 
-    >>> dict.grouping('ababa')
-    {'a': ['a', 'a', 'a'], 'b': ['b', 'b']}
+``dict.groupby``
+~~~~~~~~~~~~~~~~
+
+The ``grouping`` function returns a ``dict`` and could be considered an
+alternative constructor for the built-in dictionary.  This rationale
+could be extended to say that built-in functions like ``sorted`` are
+``list`` constructors and becomes absurd if taken to the extreme.
+
+However, using the dict namespace could provide valuable clarity if the
+proposed name, "grouping", becomes an issue.  The most common
+alternative name from other languages, "groupby" would too easily
+conflict with ``itertools.groupby`` if made a built-in function.
+
+While "group-by" is a common choice for programming language designers,
+it is more appropriate for languages like SQL in which all operations
+are on iterables (rows in SQL's case).  The phrase "group by" invites
+the key function as the first and preferably only argument.  Python has
+established a pattern for functions taking similar parameters --
+``sorted``, ``min``, ``max``, and ``itertools.groupby`` -- that the
+iterable is the first argument and the key-function is the second.
+
+The ``sorted`` function suggests using the past participle, "grouped."
+The gerund "grouping" is similarly a noun-form of the task, but has the
+advantage of feeling more like a verb or action, which is more pleasant
+for a function name.
 
 
-    >>> dict.grouping('aBAb', str.casefold)
-    {'a': ['a', 'A'], 'b': ['B', 'b']}
+``collections.Grouping``
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-
-    >>> dict.grouping('aBAbaB', str.casefold)
-    {'a': ['a', 'A', 'a'], 'b': ['B', 'b', 'B']}
-
-
-Group and Aggregate
--------------------
-
-While ``dict.grouping`` creates a dict of lists, preserving the order
-that group members were encountered, it is often useful to create
-"equivalence classes" which are better modeled as a dictionary of sets.
-
-::
-
-    >>> groups = dict.grouping('aBAbaB', str.casefold)
-    >>> {k: set(g) for k, g in groups.items()}
-    {'a': {'A', 'a'}, 'b': {'B', 'b'}}
-
-
-If each group should be a multiset, where repetitions matter but order
-does not, then a dictionary of Counters is appropriate.
-
-::
-
-    >>> from collections import Counter
-    >>> groups = dict.grouping('aBAbaB', str.casefold)
-    >>> {k: Counter(g) for k, g in groups.items()}
-    {'a': Counter({'a': 2, 'A': 1}), 'b': Counter({'B': 2, 'b': 1})}
-
-
-Grouping and performing an aggregation or reduction on the resulting
-groups is a very common task.
+A new class in the collections module has some advantages.  In a sense,
+``Grouping`` is a special case of ``defaultdict``, but a general case of
+``Counter``.  Other possible names are ``Grouper`` or ``GroupBy``.  It
+could provide ``map`` and ``aggregate`` methods, which define an
+interface for classes that provide a different internal data structure.
+However, transforming and aggregating the groups can be performed as an
+expressive dictionary comprehension, perhaps with more clarity than
+passing a function to a higher-order method.
 
 ::
 
-    def aggregate(iterable, reducer, key=None):
-        '''
-        Apply a ``reducer`` function to each group in an iterable.
-
-            >>> mod_2 = lambda x: x % 2
-            >>> aggregate([1, 2, 3, 4], sum, key=mod_2)
-            {1: 4, 0: 6}
-
-        This is convenient for creating dict of sets or a dict of Counters.
-
-            >>> g = aggregate('AaaBBb', set, key=str.casefold)
-            >>> {k: sorted(v) for k, v in g.items()}
-            {'a': ['A', 'a'], 'b': ['B', 'b']}
-
-            >>> aggregate('AaaBBb', Counter, key=str.casefold)
-            {'a': Counter({'a': 2, 'A': 1}), 'b': Counter({'B': 2, 'b': 1})}
-
-        '''
-        g = Dict.grouping(iterable, key)
-        return {k: reducer(v) for k, v in g.items()}
+    {k: func(g) for k, g in groups.items()}                 # aggregate
+    {k: [func(v) for v in g] for k, g in groups.items()}    # map
 
 
-Group and Transform
--------------------
+It's hard to estimate the frequency with which programmers use the
+various built-ins.  Grouping is a comparable concept to many tools which
+were deemed important enough to belong in the built-ins, such as
+``filter`` and ``zip``.
 
-Another very common task is grouping and transforming each group. This
-might be to perform a transformation which includes a grouped-
-aggregation, like a z-score, or simply to discard unnecessary
-information.
-
-::
-
-    def z_score(numbers):
-        '''
-        Subtract mean and divide by standard deviation.
-        '''
-        # https://en.wikipedia.org/wiki/Standard_score
-        mu = statistics.mean(numbers)
-        sigma = statistics.stdev(numbers)
-        return [(x - mu) / sigma for x in numbers]
-
-
-
-    def transform(iterable, func, key=None):
-        '''
-        Demultiplex an iterable and transform each element.
-
-            >>> transform('abAB', str.swapcase, key=str.casefold)
-            {'a': ['A', 'a'], 'b': ['B', 'b']}
-
-        '''
-        g = Dict.grouping(iterable, key)
-        return {k: [func(x) for x in v] for k, v in g.items()}
-
-
-Markov Chain
-------------
-
-A stateful key-function can provide some very succinct code to create
-interesting data structures.
-
-::
-
-    def markov_chain(iterable):
-        '''
-        Build a Markov chain model of one or many iterables as if they were
-        the output of a Markov process.
-
-            >>> markov_chain([1, 1, 2, 1])
-                    {None: [1], 1: [1, 2], 2: [1]}
-
-        The model is represented as a dict of lists. For each key in the
-            dictionary, the corresponding list holds its possible transitions in
-            proportion to the observed probability from the iterable.
-
-        The ``None`` key shows the initial state. Terminating states are
-            those which are present in the dict values, but never in the keys.
-            The model can be trained on multiple observations by merging chains
-            together.
-
-            >>> a = [1, 1, 2, 1, 0]
-                    >>> b = [2, 1, 0]
-                    >>> sequences = [a, b]
-                    >>> chains = map(markov_chain, sequences)
-                    >>> merge(*chains)
-                    {None: [1, 2], 1: [1, 2, 0, 0], 2: [1, 1]}
-
-        '''
-            t0 = None
-            def previous(t1):
-                nonlocal t0
-                x, t0 = t0, t1
-                return x
-            return Dict.grouping(iterable, previous)
-
-
-    def markov_walk(chain, start=None):
-        '''
-        Markov chain Monte Carlo simulation.
-
-            >>> chain = markov_chain([1, 1, 2, 2, 1, 2, 1, 0])
-                    >>> chain
-                    {None: [1], 1: [1, 2, 2, 0], 2: [2, 1, 1]}
-                    >>> random.seed(42)
-                    >>> list(markov_walk(chain))
-                    [None, 1, 1, 2, 2, 2, 2, 1, 1, 1, 0]
-                '''
-                x = start
-                while True:
-                    yield x
-                    try:
-                        x = random.choice(chain[x])
-                    except KeyError:
-                        break
-
-
-K-Means Clustering
-------------------
-
-Grouping is used in many analysis tasks, such as clustering.
-
-::
-
-    def distance(a, b):
-        '''
-        Euclidean distance between two n-tuples.
-
-            >>> a = 3, 4
-                    >>> b = 0, 0
-                    >>> distance(a, b)
-                    5.0
-
-        '''
-            return math.sqrt(sum([(x - y) ** 2 for x, y in zip(a, b)]))
-
-
-    def nearest(target, rows):
-        '''
-        Nearest row to the target.
-
-            >>> target = 0, 0
-                    >>> rows = [(5, 5), (-4, -4), (1, 1)]
-                    >>> nearest(target, rows)
-                    (1, 1)
-                '''
-                return min(rows, key=lambda row: distance(target, row))
-
-
-    def k_means(k, iterable, iterations=5):
-        '''
-        K-Means clustering.
-
-            >>> random.seed(42)
-                    >>> rows = [(random.random(), random.random()) for i in range(100)]
-                    >>> clusters = k_means(3, rows)
-                    >>> for i, (centroid, cluster) in enumerate(clusters.items()):
-                    ...     print(f'Cluster {i}: size={len(cluster)}, centroid={centroid}')
-                    ...
-                    Cluster 0: size=46, centroid=(0.3402505165179919, 0.15547949981178155)
-                    Cluster 1: size=30, centroid=(0.9895233506365952, 0.6399997598540929)
-                    Cluster 2: size=24, centroid=(0.2498064478821005, 0.9232655992760128)
-
-        '''
-            rows = list(iterable)
-            centroids = random.sample(rows, k)
-            for i in range(iterations):
-                clusters = Dict.grouping(rows, key=lambda row: nearest(row, centroids))
-                centroids = {k: [sum(column) for column in zip(*g)] for k, g in clusters.items()}
-            return clusters
+While importing is easy, so many Pythonistas build groups inefficiently
+that ``grouping`` should not be tucked away in a module.
 
 
 
@@ -623,24 +386,35 @@ same data type for input and output.
 
 
 After the students are happy with the idea of ``len`` as a sorting key,
-ask them what they think ``dict.grouping`` will do. Give them a moment
-to consider the possibilities before demonstrating the results.
+ask them what they think ``grouping`` will do. Give them a moment to
+consider the possibilities before demonstrating the results.
 
-   >>> dict.grouping(actors, key=len)
+::
+
+   >>> grouping(actors, key=len)
    {4: ['Eric', 'John'], 5: ['Terry', 'Terry'], 6: ['Graham'], 7: ['Michael']}
+
+
+``itertools.groupby``
+---------------------
+
+If you have already introduced the concept of generators and/or
+iterators, it would be helpful to show the differences between
+``grouping`` and ``itertools.groupby``, highlighting that ``groupby``
+may yield the same key twice and that the groups are generators.
 
 
 
 References
 ==========
 
-.. [#] https://github.com/pytoolz/toolz/blob/master/toolz/itertoolz.py#L527
+.. [#] https://github.com/pytoolz/toolz/blob/2bd9139d0d0e17d3426cb467b5f58b1fb6d8a439/toolz/itertoolz.py#L528
 .. [#] https://docs.oracle.com/javase/8/docs/api/java/util/stream/Collectors.html
 .. [#] https://msdn.microsoft.com/en-us/library/bb534304(v=vs.110).aspx
-.. [#] https://docs.rs/itertools/*/itertools/trait.Itertools.html#method.group_by
 .. [#] https://clojuredocs.org/clojure.core/group-by
 .. [#] http://toolz.readthedocs.io/en/latest/api.html#toolz.itertoolz.groupby
 .. [#] http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.groupby.html#pandas.Series.groupby
+
 
 
 Copyright

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -513,30 +513,8 @@ Grouping is used in many analysis tasks, such as clustering.
 
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-itertools partition recipe
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``partition`` recipe in the itertools module documentation provides
-an example of demultiplexing an iterable into two iterators, based on a
-predicate function applied to each element. Restricting the possible
-values of the predicate to ``{True, False}`` enables this laziness.
-Permitting a more general key-function forces ``dict.grouping`` to
-consume the entire iterable before determining what the keys will be.
-
-.. code: python
-
-   def partition(pred, iterable):
-       'Use a predicate to partition entries into false entries and true entries'
-       # partition(is_odd, range(10)) --> 0 2 4 6 8   and  1 3 5 7 9
-       t1, t2 = tee(iterable)
-       return filterfalse(pred, t1), filter(pred, t2)
-
-
-
 How to Teach This
 =================
-
 
 
 

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -199,11 +199,12 @@ Group averages::
 
     from csv import DictReader
     from statistics import mean
+    from operator import itemgetter
 
     with open('income.csv') as f:
         rows = DictReader(f)
-        by_state = grouping(rows, key=itemgetter('state')
-        averages = {state: mean(row['income'] for state, row in by_state.items())}
+        by_state = grouping(rows, key=itemgetter('state'))
+        averages = {state: mean(row['income']) for state, row in by_state.items()}
 
 
 Clustering::

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -84,10 +84,9 @@ A "naive" solution with the built-in ``dict``.
     d = {}
     for value in names:
         k = len(value)
-        if k in d:
-            d[k].append(value)
-        else:
-            d[k] = [value]
+        if k not in d:
+            d[k] = []
+        d[k].append(value)
 
 
 ``dict.setdefault``


### PR DESCRIPTION
The proposal received some positive feedback from folks on python-ideas, so I think it's ready for more formal review and an assigned number to make discussion easier.

I listed `key=itemgetter(0)` in the rejected alternatives, but it's a pretty strong suggestion that I'm considering. I'll need to do more research on how groups are made "in the wild". If (key, value) iterables or similar patterns are highly prevalent input, then this may be better than using an identity key-function default.