### PR TITLE
PEP 572: Explain why 'as TARGET' is inferior

### DIFF
--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -620,6 +620,10 @@ Broadly the same semantics as the current proposal, but spelled differently.
    would create unnecessary confusion or require special-casing
    (e.g. to forbid assignment within the headers of these statements).
 
+   (Note that ``with EXPR as VAR`` does *not* simply assing the value
+   of ``EXPR`` to ``VAR`` -- it calls ``EXPR.__enter__()`` and assigns
+   the result of *that* to ``VAR``.)
+
    Additional reasons to prefer ``:=`` over this spelling include:
 
    - In ``if f(x) as y`` the assignment target doesn't jump out at you

--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -615,12 +615,36 @@ Broadly the same semantics as the current proposal, but spelled differently.
 
        stuff = [[f(x) as y, x/y] for x in range(5)]
 
-   Since ``EXPR as NAME`` already has meaning in ``except`` and ``with``
-   statements (with different semantics), this would create unnecessary
-   confusion or require special-casing (eg to forbid assignment within the
-   headers of these statements).
+   Since ``EXPR as NAME`` already has meaning in ``import``,
+   ``except`` and ``with`` statements (with different semantics), this
+   would create unnecessary confusion or require special-casing
+   (e.g. to forbid assignment within the headers of these statements).
 
-   TODO: Explain more why this is bad, since this keeps coming up (it's also readability)
+   Additional reasons to prefer ``:=`` over this spelling include:
+
+   - In ``if f(x) as y`` the assignment target doesn't jump out at you
+     -- it just reads like ``if f x blah blah`` and it is too similar
+     visually to ``if f(x) and y``.
+
+   - In all other situations where an ``as`` clause is allowed, even
+     readers with intermediary skills are led to anticipate that
+     clause (however optional) by the keyword that starts the line,
+     and the grammar ties that keyword closely to the as clause:
+
+     - ``import foo as bar``
+     - ``except Exc as var``
+     - ``with ctxmgr() as var``
+
+     To the contrary, the assignment expression does not belong to the
+     ``if`` or ``while`` that starts the line, and we intentionally
+     allow assignment expressions in other contexts as well.
+
+   - The parallel cadence between
+
+     - ``NAME = EXPR``
+     - ``if NAME := EXPR``
+
+     reinforces the visual recognition of assignment expressions.
 
 2. ``EXPR -> NAME``::
 
@@ -630,8 +654,10 @@ Broadly the same semantics as the current proposal, but spelled differently.
    programmable calculators. (Note that a left-facing arrow ``y <- f(x)`` is
    not possible in Python, as it would be interpreted as less-than and unary
    minus.) This syntax has a slight advantage over 'as' in that it does not
-   conflict with ``with`` and ``except`` statements, but otherwise is
-   equivalent.
+   conflict with ``with``, ``except`` and ``import``, but otherwise is
+   equivalent.  But it is entirely unrelated to Python's other use of
+   ``->`` (function return type annotations), and compared to ``:=``
+   (which dates back to Algol-58) it has a much weaker tradition.
 
 3. Adorning statement-local names with a leading dot::
 


### PR DESCRIPTION
Also explain what's wrong with `->`.