### PR TITLE
PEP 572: Fix typo ("assing -> assign")

### DIFF
--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -595,7 +595,7 @@ Broadly the same semantics as the current proposal, but spelled differently.
    would create unnecessary confusion or require special-casing
    (e.g. to forbid assignment within the headers of these statements).
 
-   (Note that ``with EXPR as VAR`` does *not* simply assing the value
+   (Note that ``with EXPR as VAR`` does *not* simply assign the value
    of ``EXPR`` to ``VAR`` -- it calls ``EXPR.__enter__()`` and assigns
    the result of *that* to ``VAR``.)
 


### PR DESCRIPTION
Exactly what it says on the tin. :stuck_out_tongue: