### PR TITLE
PEP 572: disallow ungrouped assign-expr in annotations

### DIFF
--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -182,6 +182,18 @@ in order to avoid ambiguities or user confusion:
   style recommendation against mutable default values), and also to
   echo the similar prohibition in calls (the previous bullet).
 
+- Unparenthesized assignment expressions are prohibited as annotations
+  for arguments, return values and assignments.  Example::
+
+    def foo(answer: p := 42 = 5):  # INVALID
+        ...
+    def foo(answer: (p := 42) = 5):  # Valid, but probably never useful
+        ...
+
+  The reasoning here is similar to the two previous cases; this
+  ungrouped assortment of symbols and operators composed of ``:`` and
+  ``=`` is hard to read correctly.
+
 Scope of the target
 -------------------
 


### PR DESCRIPTION
A case equally confusing to default values, I think.