### PR TITLE
PEP 572: Annotations are supported, via separate declarations

### DIFF
--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -354,9 +354,9 @@ found in assignment statements:
     px, py, pz = position
     name, phone, email, *other_info = contact
 
-- Type annotations are not supported::
+- Inline type annotations are not supported::
 
-    # No equivalent
+    # Closest equivalent is "p: Optional[int]" as a separate declaration
     p: Optional[int] = None
 
 - Augmented assignment is not supported::


### PR DESCRIPTION
The current PEP wording suggests assignment expressions can't be
annotated at all, which isn't quite true: as with any other name binding
operation, they can still be annotated via a separate local declaration.