### PR TITLE
Linkify the PEP numbers in "Superseded-By" header.

### DIFF
--- a/pep-0101.txt
+++ b/pep-0101.txt
@@ -7,6 +7,7 @@ Status: Active
 Type: Informational
 Content-Type: text/x-rst
 Created: 22-Aug-2001
+Replaces: 102
 Post-History:
 
 

--- a/pep-0101.txt
+++ b/pep-0101.txt
@@ -7,8 +7,8 @@ Status: Active
 Type: Informational
 Content-Type: text/x-rst
 Created: 22-Aug-2001
-Replaces: 102
 Post-History:
+Replaces: 102
 
 
 Abstract

--- a/pep-0292.txt
+++ b/pep-0292.txt
@@ -8,8 +8,8 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 18-Jun-2002
 Python-Version: 2.4
-Replaces: 215
 Post-History: 18-Jun-2002, 23-Mar-2004, 22-Aug-2004
+Replaces: 215
 
 
 Abstract

--- a/pep-0292.txt
+++ b/pep-0292.txt
@@ -8,6 +8,7 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 18-Jun-2002
 Python-Version: 2.4
+Replaces: 215
 Post-History: 18-Jun-2002, 23-Mar-2004, 22-Aug-2004
 
 

--- a/pep-0435.txt
+++ b/pep-0435.txt
@@ -11,6 +11,7 @@ Content-Type: text/x-rst
 Created: 2013-02-23
 Python-Version: 3.4
 Post-History: 2013-02-23, 2013-05-02
+Replaces: 354
 Resolution: https://mail.python.org/pipermail/python-dev/2013-May/126112.html
 
 

--- a/pep-0446.txt
+++ b/pep-0446.txt
@@ -7,6 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 5-August-2013
+Replaces: 433
 Python-Version: 3.4
 
 

--- a/pep-0446.txt
+++ b/pep-0446.txt
@@ -7,8 +7,8 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 5-August-2013
-Replaces: 433
 Python-Version: 3.4
+Replaces: 433
 
 
 Abstract

--- a/pep-3156.txt
+++ b/pep-3156.txt
@@ -10,6 +10,7 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 12-Dec-2012
 Post-History: 21-Dec-2012
+Replaces: 3153
 Resolution: https://mail.python.org/pipermail/python-dev/2013-November/130419.html
 
 Abstract

--- a/pep2html.py
+++ b/pep2html.py
@@ -235,7 +235,7 @@ def fixfile(inpath, input_lines, outfile):
                 else:
                     mailtos.append(part)
             v = COMMASPACE.join(mailtos)
-        elif k.lower() in ('replaces', 'replaced-by', 'requires'):
+        elif k.lower() in ('replaces', 'superseded-by', 'requires'):
             otherpeps = ''
             for otherpep in re.split(',?\s+', v):
                 otherpep = int(otherpep)
@@ -409,7 +409,7 @@ class PEPHeaders(Transform):
                 for node in para:
                     if isinstance(node, nodes.reference):
                         node.replace_self(peps.mask_email(node, pep))
-            elif name in ('replaces', 'replaced-by', 'requires'):
+            elif name in ('replaces', 'superseded-by', 'requires'):
                 newbody = []
                 space = nodes.Text(' ')
                 for refpep in re.split(r',?\s+', body.astext()):

--- a/pep2pyramid.py
+++ b/pep2pyramid.py
@@ -224,7 +224,7 @@ def fixfile(inpath, input_lines, outfile):
                 else:
                     mailtos.append(part)
             v = COMMASPACE.join(mailtos)
-        elif k.lower() in ('replaces', 'replaced-by', 'requires'):
+        elif k.lower() in ('replaces', 'superseded-by', 'requires'):
             otherpeps = ''
             for otherpep in re.split(',?\s+', v):
                 otherpep = int(otherpep)


### PR DESCRIPTION
We're already linking PEP numbers in "Replaces:", and "Requires:".

Adjusted the code so it can link "Superseded-By:".

Add the "Replaces:" header where they're missing.

Closes https://github.com/python/peps/issues/477