### PR TITLE
PEP 572: Add another UAEAP bullet point

### DIFF
--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -201,6 +201,19 @@ in order to avoid ambiguities or user confusion:
   ungrouped assortment of symbols and operators composed of ``:`` and
   ``=`` is hard to read correctly.
 
+- Unparenthesized assignment expressions are prohibited in lambda functions.
+  Example::
+
+    (lambda: x := 1) # INVALID
+    lambda: (x := 1) # Valid, but unlikely to be useful
+    (x := lambda: 1) # Valid
+
+  This allows ``lambda`` to always bind less tightly than ``:=``; creating
+  a name binding inside the lambda function is unlikely to be of value, as
+  there is no way to make use of it. In cases where the name will be used
+  more than once, the expression is likely to need parenthesizing anyway,
+  so this prohibition will rarely affect code.
+
 Scope of the target
 -------------------
 

--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -207,11 +207,12 @@ in order to avoid ambiguities or user confusion:
     (lambda: x := 1) # INVALID
     lambda: (x := 1) # Valid, but unlikely to be useful
     (x := lambda: 1) # Valid
+    lambda line: (m := re.match(pattern, line)) and m.group(1) # Valid
 
-  This allows ``lambda`` to always bind less tightly than ``:=``; creating
-  a name binding inside the lambda function is unlikely to be of value, as
-  there is no way to make use of it. In cases where the name will be used
-  more than once, the expression is likely to need parenthesizing anyway,
+  This allows ``lambda`` to always bind less tightly than ``:=``; having a
+  name binding at the top level inside a lambda function is unlikely to be of
+  value, as there is no way to make use of it. In cases where the name will be
+  used more than once, the expression is likely to need parenthesizing anyway,
   so this prohibition will rarely affect code.
 
 Scope of the target


### PR DESCRIPTION
(This section would gzip very efficiently. "Unparenthesized assignment
expressions are prohibited...")