### PR TITLE
PEP 572: add stdlib example using yield statement

### DIFF
--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -530,6 +530,28 @@ it harder to understand.
         elif m := undef_rx.match(line):
             vars[m.group(1)] = 0
 
+codecs.py
+^^^^^^^^^
+
+Similar to the first example, shows the usage with a ``yield`` statement.
+
+- Current::
+
+    for input in iterator:
+        output = encoder.encode(input)
+        if output:
+            yield output
+    output = encoder.encode("", True)
+    if output:
+        yield output
+
+- Improved::
+
+    for input in iterator:
+        if output := encoder.encode(input):
+            yield output
+    if output := encoder.encode("", True):
+        yield output
 
 Simplifying list comprehensions
 -------------------------------


### PR DESCRIPTION
Note: `site.py` example a few lines earlier illustrates the same concept, so in a way this is a repetition. It merely wants to make it clear that `:=` can also be used with `yield` statements.