### PR TITLE
PEP 572:  clarify Appendix C example

### DIFF
--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -1202,7 +1202,7 @@ closures").  Example::
     a = 42
     def f():
         # `a` is local to `f`, but remains unbound
-        # until the caller executes thise genexp:
+        # until the caller executes this genexp:
         yield ((a := i) for i in range(3))
         yield lambda: a + 100
         print("done")

--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -1201,15 +1201,22 @@ closures").  Example::
 
     a = 42
     def f():
-        # `a` is local to `f`
+        # `a` is local to `f`, but remains unbound
+        # until the caller executes thise genexp:
         yield ((a := i) for i in range(3))
         yield lambda: a + 100
         print("done")
+        try:
+            print(f"`a` is bound to {a}")
+            assert False
+        except UnboundLocalError:
+            print("`a` is not yet bound")
 
 Then::
 
     >>> results = list(f()) # [genexp, lambda]
     done
+    `a` is not yet bound
     # The execution frame for f no longer exists in CPython,
     # but f's locals live so long as they can still be referenced.
     >>> list(map(type, results))
@@ -1236,8 +1243,6 @@ Copyright
 
 This document has been placed in the public domain.
 
-
-
 ..
    Local Variables:
    mode: indented-text


### PR DESCRIPTION
PEP 572: Make very clear in the Appendix C example that the function local remains unbound until the caller executes the genexp.
