### PR TITLE
PEP 572: Acceptance

### DIFF
--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -2,7 +2,7 @@ PEP: 572
 Title: Assignment Expressions
 Author: Chris Angelico <rosuav@gmail.com>, Tim Peters <tim.peters@gmail.com>,
     Guido van Rossum <guido@python.org>
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 28-Feb-2018
@@ -16,15 +16,6 @@ Abstract
 
 This is a proposal for creating a way to assign to variables within an
 expression using the notation ``NAME := expr``.
-
-Pending Acceptance
-------------------
-
-This PEP will be accepted, however it needs some editing for clarity
-and exact specification.  A final draft will be posted to python-dev.
-Note that alternate syntax proposals ("EXPR as NAME", "EXPR given
-...") are no longer under consideration.  Hopefully the final draft
-will be posted well before the end of July 2018.
 
 
 Rationale
@@ -1246,7 +1237,7 @@ Then::
 References
 ==========
 
-.. [1] Proof of concept / reference implementation
+.. [1] Proof of concept / reference implementation (incomplete)
    (https://github.com/Rosuav/cpython/tree/assignment-expressions)
 .. [2] Pivotal post regarding inline assignment semantics
    (https://mail.python.org/pipermail/python-ideas/2018-March/049409.html)
@@ -1257,6 +1248,8 @@ Copyright
 
 This document has been placed in the public domain.
 
+
+
 ..
    Local Variables:
    mode: indented-text

--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -9,7 +9,7 @@ Created: 28-Feb-2018
 Python-Version: 3.8
 Post-History: 28-Feb-2018, 02-Mar-2018, 23-Mar-2018, 04-Apr-2018, 17-Apr-2018,
               25-Apr-2018, 09-Jul-2018
-Resolution: https://mail.python.org/pipermail/python-dev/XXX
+Resolution: https://mail.python.org/pipermail/python-dev/2018-July/154601.html
 
 
 Abstract

--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -9,6 +9,7 @@ Created: 28-Feb-2018
 Python-Version: 3.8
 Post-History: 28-Feb-2018, 02-Mar-2018, 23-Mar-2018, 04-Apr-2018, 17-Apr-2018,
               25-Apr-2018, 09-Jul-2018
+Resolution: https://mail.python.org/pipermail/python-dev/XXX
 
 
 Abstract
@@ -1237,7 +1238,7 @@ Then::
 References
 ==========
 
-.. [1] Proof of concept / reference implementation (incomplete)
+.. [1] Proof of concept implementation
    (https://github.com/Rosuav/cpython/tree/assignment-expressions)
 .. [2] Pivotal post regarding inline assignment semantics
    (https://mail.python.org/pipermail/python-ideas/2018-March/049409.html)


### PR DESCRIPTION
- Delete 'Pending Acceptance' section
- Mark reference implementation as incomplete
- Add the ^L back before the Emacs Local Variables section
