### PR TITLE
PEP 541: document issue tracker

### DIFF
--- a/pep-0541.txt
+++ b/pep-0541.txt
@@ -109,6 +109,7 @@ following means of contact:
 
 The maintainers stop trying to reach the user after six weeks.
 
+Ownership change requests are to be raised at [9]_
 
 Abandoned projects
 ------------------
@@ -219,17 +220,17 @@ names as unavailable for security reasons.
 Intellectual property policy
 ----------------------------
 
-It is the policy of Python Software Foundation and the Package Index 
-maintainers to be appropriately responsive to claims of intellectual 
+It is the policy of Python Software Foundation and the Package Index
+maintainers to be appropriately responsive to claims of intellectual
 property infringement by third parties. It is not the policy of
 the Python Software Foundation nor the Package Index maintainers
-to pre-screen uploaded packages for any type of intellectual property 
-infringement. 
+to pre-screen uploaded packages for any type of intellectual property
+infringement.
 
 Possibly-infringing packages should be reported to legal@python.org
-and counsel to the Python Software Foundation will determine an 
+and counsel to the Python Software Foundation will determine an
 appropriate response. A package can be removed or transferred to a
-new owner at the sole discretion of the Python Software Foundation to 
+new owner at the sole discretion of the Python Software Foundation to
 address a claim of infringement.
 
 A project published on the Package Index meeting ANY of the following
@@ -244,9 +245,9 @@ or transferral to a new owner:
   the subject of a complaint; or
 * project is subject to an active lawsuit.
 
-In the event of a complaint for intellectual property infringement, 
-a copy of the complaint will be sent to the package owner. In some 
-cases, action may be taken by the Package Index maintainers before 
+In the event of a complaint for intellectual property infringement,
+a copy of the complaint will be sent to the package owner. In some
+cases, action may be taken by the Package Index maintainers before
 the owner responds.
 
 
@@ -335,6 +336,8 @@ References
 .. [8] Python Packaging Working Group
    (https://wiki.python.org/psf/PackagingWG/)
 
+.. [9] Python Packaging Issue Tracker
+   (https://github.com/pypa/warehouse/issues)
 
 Copyright
 =========


### PR DESCRIPTION
Adds information about the location of the issue tracker used for processing ownership change requests.