### PR TITLE
PEP 306: Fix dead links for Dev Guide and BPO issue

### DIFF
--- a/pep-0306.txt
+++ b/pep-0306.txt
@@ -93,10 +93,10 @@ References
 ==========
 
 .. [1] CPython Developer's Guide: Changing CPython's Grammar
-       http://cpython-devguide.readthedocs.io/en/latest/grammar.html
+       http://cpython-devguide.readthedocs.io/grammar/
 
 .. [2] SF Bug #676521, parser module validation failure
-       http://www.python.org/sf/676521
+       https://bugs.python.org/issue676521
 
 
 Copyright

--- a/pep-0306.txt
+++ b/pep-0306.txt
@@ -93,7 +93,7 @@ References
 ==========
 
 .. [1] CPython Developer's Guide: Changing CPython's Grammar
-       http://cpython-devguide.readthedocs.io/grammar/
+       https://devguide.python.org/grammar/
 
 .. [2] SF Bug #676521, parser module validation failure
        https://bugs.python.org/issue676521


### PR DESCRIPTION
Two links have been updated:

* The CPython Developer's Guide no longer supports `/en/latest` in the URL. This returns a 404. Updated to a working link.
* http://www.python.org/sf/676521 redirects to https://legacy.python.org/sf/676521. This returns a 403 as the legacy site has been partially phased out. Updated to a working link.