### PR TITLE
Multiple PEPs: Fix dead links for issues

### DIFF
--- a/pep-0042.txt
+++ b/pep-0042.txt
@@ -70,7 +70,7 @@ Core Language / Builtins
   be raised or removed.  Removal would be hard because the current
   compiler can overflow the C stack if the nesting is too deep.
 
-  http://www.python.org/sf/215555
+  https://bugs.python.org/issue215555
 
 * Non-accidental IEEE-754 support (Infs, NaNs, settable traps, etc).
   Big project.
@@ -80,11 +80,11 @@ Core Language / Builtins
   bug in the OSes, but some apps try to shield users from it.  When
   it happens, the symptoms are very confusing.
 
-  Hang using files named prn.txt, etc http://www.python.org/sf/481171
+  Hang using files named prn.txt, etc https://bugs.python.org/issue481171
 
 * eval and free variables: It might be useful if there was a way to
   pass bindings for free variables to eval when a code object with
-  free variables is passed. http://www.python.org/sf/443866
+  free variables is passed. https://bugs.python.org/issue443866
 
 Standard Library
 ================
@@ -92,14 +92,14 @@ Standard Library
 * The urllib module should support proxies which require
   authentication.  See SourceForge bug #210619 for information:
 
-  http://www.python.org/sf/210619
+  https://bugs.python.org/issue210619
 
 * os.rename() should be modified to handle EXDEV errors on platforms
   that don't allow rename() to operate across filesystem boundaries
   by copying the file over and removing the original. Linux is one
   system that requires this treatment.
 
-  http://www.python.org/sf/212317
+  https://bugs.python.org/issue212317
 
 * signal handling doesn't always work as expected.  E.g. if
   sys.stdin.readline() is interrupted by a (returning) signal
@@ -108,31 +108,31 @@ Standard Library
   changes would have to applied to all places that can do blocking
   interruptable I/O.  So it's a big project.
 
-  http://www.python.org/sf/210599
+  https://bugs.python.org/issue210599
 
 * Extend Windows utime to accept directory paths.
 
-  http://www.python.org/sf/214245
+  https://bugs.python.org/issue214245
 
 * Extend copy.py to module & function types.
 
-  http://www.python.org/sf/214553
+  https://bugs.python.org/issue214553
 
 * Better checking for bad input to ``marshal.load*().``
 
-  http://www.python.org/sf/214754
+  https://bugs.python.org/issue214754
 
 * rfc822.py should be more lenient than the spec in the types of
   address fields it parses.  Specifically, an invalid address of the
   form "From: Amazon.com <delivers-news2@amazon.com>" should be
   parsed correctly.
 
-  http://www.python.org/sf/210678
+  https://bugs.python.org/issue210678
 
 * cgi.py's FieldStorage class should be more conservative with memory
   in the face of large binary file uploads.
 
-  http://www.python.org/sf/210674
+  https://bugs.python.org/issue210674
 
   There are two issues here: first, because
   read_lines_to_outerboundary() uses readline() it is possible that a
@@ -143,17 +143,17 @@ Standard Library
   The second issue was related to the self.lines attribute, which was
   removed in revision 1.56 of cgi.py (see also):
 
-  http://www.python.org/sf/219806
+  https://bugs.python.org/issue219806
 
 * urllib should support proxy definitions that contain just the host
   and port
 
-  http://www.python.org/sf/210849
+  https://bugs.python.org/issue210849
 
 * urlparse should be updated to comply with RFC 2396, which defines
   optional parameters for each segment of the path.
 
-  http://www.python.org/sf/210834
+  https://bugs.python.org/issue210834
 
 * The exceptions raised by pickle and cPickle are currently
   different; these should be unified (probably the exceptions should
@@ -164,7 +164,7 @@ Standard Library
   example, urllib.quote() could convert Unicode strings to UTF-8 and
   then do the usual %HH conversion.  But this is not the only one!
 
-  http://www.python.org/sf/216716
+  https://bugs.python.org/issue216716
 
 * There should be a way to say that you don't mind if ``str()`` or
   ``__str__()`` return a Unicode string object.  Or a different function
@@ -175,11 +175,11 @@ Standard Library
 * Killing a thread from another thread.  Or maybe sending a signal.
   Or maybe raising an asynchronous exception.
 
-  http://www.python.org/sf/221115
+  https://bugs.python.org/issue221115
 
 * The debugger (pdb) should understand packages.
 
-  http://www.python.org/sf/210631
+  https://bugs.python.org/issue210631
 
 * Jim Fulton suggested the following:
 
@@ -195,7 +195,7 @@ Standard Library
     Then the cgi module (and other apps) could use this thing in a
     uniform way.
 
-  http://www.python.org/sf/415692
+  https://bugs.python.org/issue415692
 
 * Jim Fulton pointed out that binascii's b2a_base64() function has
   situations where it makes sense not to append a newline, or to
@@ -209,30 +209,30 @@ Standard Library
   - possibly special-case None as the delimiter string to avoid adding
     the pad bytes too???
 
-  http://www.python.org/sf/415694
+  https://bugs.python.org/issue415694
 
 * pydoc should be integrated with the HTML docs, or at least be able
   to link to them.
 
-  http://www.python.org/sf/405554
+  https://bugs.python.org/issue405554
 
 * Distutils should deduce dependencies for .c and .h files.
 
-  http://www.python.org/sf/472881
+  https://bugs.python.org/issue472881
 
 * asynchat is buggy in the face of multithreading.
 
-  http://www.python.org/sf/595217
+  https://bugs.python.org/issue595217
 
 * It would be nice if the higher level modules (httplib, smtplib,
   nntplib, etc.) had options for setting socket timeouts.
 
-  http://www.python.org/sf/723287
+  https://bugs.python.org/issue723287
 
 * The curses library is missing two important calls: newterm() and
   delscreen()
 
-  http://www.python.org/sf/665572, http://bugs.debian.org/175590
+  https://bugs.python.org/issue665572, http://bugs.debian.org/175590
 
 * It would be nice if the built-in SSL socket type could be used for
   non-blocking SSL I/O.  Currently packages such as Twisted which
@@ -243,7 +243,7 @@ Standard Library
 
 * The import lock could use some redesign.
 
-  http://www.python.org/sf/683658
+  https://bugs.python.org/issue683658
 
 * A nicer API to open text files, replacing the ugly (in some
   people's eyes) "U" mode flag.  There's a proposal out there to have
@@ -256,7 +256,7 @@ Standard Library
   "outer.inner", and pickling should work.  (GvR is no longer certain
   this is easy or even right.)
 
-  http://www.python.org/sf/633930
+  https://bugs.python.org/issue633930
 
 * Decide on a clearer deprecation policy (especially for modules) and
   act on it.
@@ -276,7 +276,7 @@ Standard Library
 * Lazily tracking tuples?
 
   https://mail.python.org/pipermail/python-dev/2002-May/023926.html
-  http://www.python.org/sf/558745
+  https://bugs.python.org/issue558745
 
 * Make 'as' a keyword.  It has been a pseudo-keyword long enough.
   (It's deprecated in 2.5, and will become a keyword in 2.6.)
@@ -289,7 +289,7 @@ C API wishes
   applications where the FILE \* structure does not match the FILE \*
   the interpreter was compiled with.
 
-  http://www.python.org/sf/210821
+  https://bugs.python.org/issue210821
 
   See this bug report for a specific suggestion that will allow a
   Borland C++ builder application to interact with a python.dll build
@@ -301,7 +301,7 @@ Tools
 
 * Python could use a GUI builder.
 
-  http://www.python.org/sf/210820
+  https://bugs.python.org/issue210820
 
 
 Building and Installing
@@ -312,7 +312,7 @@ Building and Installing
   module names with characters that are not allowable in Python or C
   identifiers.
 
-  http://www.python.org/sf/216326
+  https://bugs.python.org/issue216326
 
 * Building from source should not attempt to overwrite the
   Include/graminit.h and Parser/graminit.c files, at least for people
@@ -320,7 +320,7 @@ Building and Installing
   snapshots.  Some people find this a problem in unusual build
   environments.
 
-  http://www.python.org/sf/219221
+  https://bugs.python.org/issue219221
 
 * The configure script has probably grown a bit crufty with age and
   may not track autoconf's more recent features very well.  It should

--- a/pep-0262.txt
+++ b/pep-0262.txt
@@ -319,7 +319,7 @@ References
 
 .. [2] A patch to implement this PEP will be tracked as
        patch #562100 on SourceForge.
-       http://www.python.org/sf/562100 .
+       https://bugs.python.org/issue562100 .
        Code implementing the installation database is currently in
        Python CVS in the nondist/sandbox/pep262 directory.
 

--- a/pep-0277.txt
+++ b/pep-0277.txt
@@ -106,7 +106,7 @@ References
 .. [1] Microsoft Windows APIs
        http://msdn.microsoft.com/
 
-.. [2] http://python.org/sf/594001
+.. [2] https://bugs.python.org/issue594001
 
 
 Copyright

--- a/pep-0278.txt
+++ b/pep-0278.txt
@@ -192,7 +192,7 @@ Reference Implementation
 ========================
 
 A reference implementation is available in SourceForge patch
-#476814: http://www.python.org/sf/476814
+#476814: https://bugs.python.org/issue476814
 
 
 References

--- a/pep-0283.txt
+++ b/pep-0283.txt
@@ -65,10 +65,10 @@ for more, and of course ``Misc/NEWS`` for the full list.
   by Michael Hudson is now all checked in.
 
 - Speed up list iterations by filling ``tp_iter`` and other tweaks.
-  See http://www.python.org/sf/560736; also done for ``xrange`` and
+  See https://bugs.python.org/issue560736; also done for ``xrange`` and
   tuples.
 
-- Timeout sockets.  http://www.python.org/sf/555085
+- Timeout sockets.  https://bugs.python.org/issue555085
 
 - Stage B0 of the ``int``/``long`` integration (PEP 237).  This means
   issuing a ``FutureWarning`` about situations where ``hex`` or ``oct``
@@ -78,7 +78,7 @@ for more, and of course ``Misc/NEWS`` for the full list.
 
 - Nuke ``SET_LINENO`` from all code objects (providing a different way
   to set debugger breakpoints).  This can boost ``pystone`` by >5%.
-  http://www.python.org/sf/587993, now checked in.  (Unfortunately
+  https://bugs.python.org/issue587993, now checked in.  (Unfortunately
   the ``pystone`` boost didn't happen.  What happened?)
 
 - Write a ``pymemcompat.h`` that people can bundle with their
@@ -92,7 +92,7 @@ for more, and of course ``Misc/NEWS`` for the full list.
   few things use this at this time.
 
 - Warn when an extension type's ``tp_compare`` returns anything except
-  -1, 0 or 1.  http://www.python.org/sf/472523
+  -1, 0 or 1.  https://bugs.python.org/issue472523
 
 - Warn for assignment to ``None`` (in various forms).
 
@@ -113,11 +113,11 @@ for more, and of course ``Misc/NEWS`` for the full list.
 
   Vinay Sajip's implementation has been packagized and imported.
   (Documentation and unit tests still pending.)
-  http://www.python.org/sf/578494
+  https://bugs.python.org/issue578494
 
 - A modified MRO (Method Resolution Order) algorithm.  Consensus
   is that we should adopt C3.  Samuele Pedroni has contributed a
-  draft implementation in C, see http://www.python.org/sf/619475
+  draft implementation in C, see https://bugs.python.org/issue619475
   This has now been checked in.
 
 - A new command line option parser.  Greg Ward's Optik package
@@ -301,7 +301,7 @@ Features that did not make it into Python 2.3
 - Lazily tracking tuples?
 
   - https://mail.python.org/pipermail/python-dev/2002-May/023926.html
-  - http://www.python.org/sf/558745
+  - https://bugs.python.org/issue558745
 
   Not much enthusiasm I believe.
 

--- a/pep-0285.txt
+++ b/pep-0285.txt
@@ -438,7 +438,7 @@ Implementation
 ==============
 
 A complete implementation in C has been uploaded to the
-SourceForge patch manager: http://python.org/sf/528022
+SourceForge patch manager: https://bugs.python.org/issue528022
 
 This will soon be checked into CVS for python 2.3a0.
 

--- a/pep-0289.txt
+++ b/pep-0289.txt
@@ -298,13 +298,13 @@ References
 
 .. [4] Jeff Epler had worked up a patch demonstrating
        the previously proposed bracket and yield syntax
-       http://python.org/sf/795947
+       https://bugs.python.org/issue795947
 
 .. [5] Discussion over the relative merits of early versus late binding
        https://mail.python.org/pipermail/python-dev/2004-April/044555.html
 
 .. [6] Patch discussion and alternative patches on Source Forge
-       http://www.python.org/sf/872326
+       https://bugs.python.org/issue872326
 
 
 Copyright

--- a/pep-0293.txt
+++ b/pep-0293.txt
@@ -417,10 +417,10 @@ References
 
 .. [1] SF feature request #403100
        "Multicharacter replacements in PyUnicode_TranslateCharmap"
-       http://www.python.org/sf/403100
+       https://bugs.python.org/issue403100
 
 .. [2] SF patch #432401 "unicode encoding error callbacks"
-       http://www.python.org/sf/432401
+       https://bugs.python.org/issue432401
 
 
 Copyright

--- a/pep-0298.txt
+++ b/pep-0298.txt
@@ -161,7 +161,7 @@ Reference Implementation
 ========================
 
 An implementation has been uploaded to the SourceForge patch
-manager as http://www.python.org/sf/652857.
+manager as https://bugs.python.org/issue652857.
 
 
 Additional Notes/Comments

--- a/pep-0304.txt
+++ b/pep-0304.txt
@@ -333,7 +333,7 @@ References
 ==========
 
 .. [1] patch 602345, Option for not writing py.[co] files, Klose
-   (http://www.python.org/sf/602345)
+   (https://bugs.python.org/issue602345)
 
 .. [2] python-dev thread, Disable writing .py[co], Norwitz
    (https://mail.python.org/pipermail/python-dev/2003-January/032270.html)
@@ -348,7 +348,7 @@ References
    (http://www.python.org/dev/peps/pep-0302)
 
 .. [6] patch 677103, PYTHONBYTECODEBASE patch (PEP 304), Montanaro
-   (http://www.python.org/sf/677103)
+   (https://bugs.python.org/issue677103)
 
 
 Copyright

--- a/pep-0306.txt
+++ b/pep-0306.txt
@@ -96,7 +96,7 @@ References
        http://cpython-devguide.readthedocs.io/en/latest/grammar.html
 
 .. [2] SF Bug #676521, parser module validation failure
-       http://www.python.org/sf/676521
+       https://bugs.python.org/issue676521
 
 
 Copyright

--- a/pep-0309.txt
+++ b/pep-0309.txt
@@ -289,9 +289,9 @@ References
 
 .. [3] http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/52549
 
-.. _931005: http://www.python.org/sf/931005
-.. _931007: http://www.python.org/sf/931007
-.. _931010: http://www.python.org/sf/931010
+.. _931005: https://bugs.python.org/issue931005
+.. _931007: https://bugs.python.org/issue931007
+.. _931010: https://bugs.python.org/issue931010
 
 
 Copyright

--- a/pep-0311.txt
+++ b/pep-0311.txt
@@ -230,7 +230,7 @@ Implementation
 ==============
 
 An implementation of this proposal can be found at
-http://www.python.org/sf/684256
+https://bugs.python.org/issue684256
 
 
 References

--- a/pep-0318.txt
+++ b/pep-0318.txt
@@ -626,7 +626,7 @@ decorator per line.
 A `previous patch`_ from Michael Hudson which implements the
 list-after-def syntax is also still kicking around.
 
-.. _patch: http://www.python.org/sf/979728
+.. _patch: https://bugs.python.org/issue979728
 .. _previous patch: http://starship.python.net/crew/mwh/hacks/meth-syntax-sugar-3.diff
 
 After 2.4a2 was released, in response to community reaction, Guido
@@ -699,7 +699,7 @@ Sparks produced `a patch`_.
 .. _detailed proposal:
     http://www.aminus.org/rbre/python/pydec.html
 .. _a patch:
-    http://www.python.org/sf/1013835
+    https://bugs.python.org/issue1013835
 
 As noted previously, Guido rejected this form, outlining his problems
 with it in `a message`_ to python-dev and comp.lang.python.

--- a/pep-0322.txt
+++ b/pep-0322.txt
@@ -77,7 +77,7 @@ The implementation could be as simple as::
 No language syntax changes are needed.  The proposal is fully backwards
 compatible.
 
-A C implementation and unit tests are at:  http://www.python.org/sf/834422
+A C implementation and unit tests are at:  https://bugs.python.org/issue834422
 
 BDFL Pronouncement
 ==================

--- a/pep-0338.txt
+++ b/pep-0338.txt
@@ -309,7 +309,7 @@ References
    (http://www.python.org/dev/peps/pep-0299/)
 
 .. [2] PEP 338 implementation (runpy module and ``-m`` update)
-   (http://www.python.org/sf/1429601)
+   (https://bugs.python.org/issue1429601)
 
 .. [3] execmodule Python Cookbook Recipe
    (http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/307772)
@@ -318,7 +318,7 @@ References
    (http://www.python.org/dev/peps/pep-0302/)
 
 .. [5] PEP 338 documentation (for runpy module)
-   (http://www.python.org/sf/1429605)
+   (https://bugs.python.org/issue1429605)
 
 Copyright
 =========

--- a/pep-0339.txt
+++ b/pep-0339.txt
@@ -570,7 +570,7 @@ References
    (http://bytecodehacks.sourceforge.net/bch-docs/bch/index.html)
 
 .. [#CALL_ATTR] CALL_ATTR opcode
-   (http://www.python.org/sf/709744)
+   (https://bugs.python.org/issue709744)
 
 
 

--- a/pep-0341.txt
+++ b/pep-0341.txt
@@ -111,7 +111,7 @@ References
 ==========
 
 .. [1] https://mail.python.org/pipermail/python-dev/2005-May/053319.html
-.. [2] http://python.org/sf/1355913
+.. [2] https://bugs.python.org/issue1355913
 .. [3] https://mail.python.org/pipermail/python-checkins/2005-December/048457.html
 
 

--- a/pep-0342.txt
+++ b/pep-0342.txt
@@ -119,7 +119,7 @@ multitasking.  These methods and adjustments are:
 
 A prototype patch implementing all of these changes against the current Python
 CVS HEAD is available as SourceForge patch #1223381
-(http://python.org/sf/1223381).
+(https://bugs.python.org/issue1223381).
 
 
 Specification: Sending Values into Generators
@@ -535,7 +535,7 @@ Examples
                    yield nonblocking_write(sock, data)
                except ConnectionLost:
                    pass  # exit normally if connection lost
-    
+
        # coroutine function that listens for connections on a
        # socket, and then launches a service "handler" coroutine
        # to service the connection
@@ -544,23 +544,23 @@ Examples
            while True:
                # get the next incoming connection
                connected_socket = yield nonblocking_accept(sock)
-    
+
                # start another coroutine to handle the connection
                trampoline.add( handler(connected_socket) )
-    
+
        # Create a scheduler to manage all our coroutines
        t = Trampoline()
-    
+
        # Create a coroutine instance to run the echo_handler on
        # incoming connections
        #
        server = listen_on(
            t, listening_socket("localhost","echo"), echo_handler
        )
-    
+
        # Add the coroutine to the scheduler
        t.add(server)
-    
+
        # loop forever, accepting connections and servicing them
        # "in parallel"
        #
@@ -571,7 +571,7 @@ Reference Implementation
 ========================
 
 A prototype patch implementing all of the features described in this PEP is
-available as SourceForge patch #1223381 (http://python.org/sf/1223381).
+available as SourceForge patch #1223381 (https://bugs.python.org/issue1223381).
 
 This patch was committed to CVS 01-02 August 2005.
 

--- a/pep-0349.txt
+++ b/pep-0349.txt
@@ -133,7 +133,7 @@ behaviour for an abstract base type.
 References
 ==========
 
-.. [1] http://www.python.org/sf/1266570
+.. [1] https://bugs.python.org/issue1266570
 
 
 Copyright

--- a/pep-0352.txt
+++ b/pep-0352.txt
@@ -279,7 +279,7 @@ References
    http://www.python.org/dev/summary/2004-08-01_2004-08-15.html#an-exception-is-an-exception-unless-it-doesn-t-inherit-from-exception
 
 .. [#SF_1104669] SF patch #1104669 (new-style exceptions)
-   http://www.python.org/sf/1104669
+   https://bugs.python.org/issue1104669
 
 .. [#pycon2007-sprint-email]  python-3000 email ("How far to go with cleaning up exceptions")
     https://mail.python.org/pipermail/python-3000/2007-March/005911.html

--- a/pep-0356.txt
+++ b/pep-0356.txt
@@ -164,12 +164,12 @@ Open issues
 
 - Bugs deferred until 2.5.1 (or later):
 
-  * http://python.org/sf/1544279 - ``Socket`` module is not thread-safe
-  * http://python.org/sf/1541420 - tools and demo missing from windows
-  * http://python.org/sf/1542451 - crash with continue in nested try/finally
-  * http://python.org/sf/1475523 - gettext.py bug (owner: Martin v. Loewis)
-  * http://python.org/sf/1467929 - %-formatting and dicts
-  * http://python.org/sf/1446043 - ``unicode()`` does not raise ``LookupError``
+  * https://bugs.python.org/issue1544279 - ``Socket`` module is not thread-safe
+  * https://bugs.python.org/issue1541420 - tools and demo missing from windows
+  * https://bugs.python.org/issue1542451 - crash with continue in nested try/finally
+  * https://bugs.python.org/issue1475523 - gettext.py bug (owner: Martin v. Loewis)
+  * https://bugs.python.org/issue1467929 - %-formatting and dicts
+  * https://bugs.python.org/issue1446043 - ``unicode()`` does not raise ``LookupError``
 
 - The PEP 302 changes to (at least) ``pkgutil``, ``runpy`` and ``pydoc`` must
   be documented.
@@ -187,7 +187,7 @@ References
 ==========
 
 .. [1] Shadow Password Support Module
-       http://python.org/sf/579435
+       https://bugs.python.org/issue579435
 
 .. [2] Joe Smith, bdist_* to stdlib?
        https://mail.python.org/pipermail/python-dev/2006-February/060926.html

--- a/pep-0361.txt
+++ b/pep-0361.txt
@@ -173,7 +173,7 @@ discussed on python-dev.  Other enhancements include:
 New modules in the standard library:
 
 - ``winerror``
-  http://python.org/sf/1505257
+  https://bugs.python.org/issue1505257
   (Patch rejected, module should be written in C)
 
 - ``setuptools``
@@ -263,8 +263,8 @@ Open issues
 How should import warnings be handled?
 
 - https://mail.python.org/pipermail/python-dev/2006-June/066345.html
-- http://python.org/sf/1515609
-- http://python.org/sf/1515361
+- https://bugs.python.org/issue1515609
+- https://bugs.python.org/issue1515361
 
 
 References

--- a/pep-0366.txt
+++ b/pep-0366.txt
@@ -125,7 +125,7 @@ References
 ==========
 
 .. [1] Absolute/relative import not working?
-   (http://www.python.org/sf/1510172)
+   (https://bugs.python.org/issue1510172)
 
 .. [2] c.l.p. question about modules and relative imports
    (http://groups.google.com/group/comp.lang.python/browse_thread/thread/c44c769a72ca69fa/)

--- a/pep-3100.txt
+++ b/pep-3100.txt
@@ -332,7 +332,7 @@ References
    https://mail.python.org/pipermail/python-3000/2006-May/001735.html
 
 .. [22] SF patch "sys.id() and sys.intern()"
-   http://www.python.org/sf/1601678
+   https://bugs.python.org/issue1601678
 
 .. [23] python-3000 email ("__nonzero__ vs. __bool__")
    https://mail.python.org/pipermail/python-3000/2006-November/004524.html
@@ -413,10 +413,10 @@ References
    https://mail.python.org/pipermail/python-dev/2007-November/075388.html
 
 .. [#exitfunc-patch] Patch to remove sys.exitfunc
-   http://www.python.org/sf/1680961
+   https://bugs.python.org/issue1680961
 
 .. [#remove-operator-funcs] Remove deprecated functions from operator
-   http://www.python.org/sf/1516309
+   https://bugs.python.org/issue1516309
 
 Copyright
 =========

--- a/pep-3119.txt
+++ b/pep-3119.txt
@@ -856,7 +856,7 @@ References
    (http://www-128.ibm.com/developerworks/library/l-cppeak2/)
 
 .. [6] Implementation of @abstractmethod
-   (http://python.org/sf/1706989)
+   (https://bugs.python.org/issue1706989)
 
 .. [7] Unifying types and classes in Python 2.2, by GvR
    (http://www.python.org/download/releases/2.2.3/descrintro/)
@@ -875,7 +875,7 @@ References
    (http://en.wikipedia.org/wiki/Finite_set)
 
 .. [12] Make isinstance/issubclass overloadable
-   (http://python.org/sf/1708353)
+   (https://bugs.python.org/issue1708353)
 
 .. [13] ABCMeta sample implementation
    (http://svn.python.org/view/sandbox/trunk/abc/xyz.py)

--- a/pep-3129.txt
+++ b/pep-3129.txt
@@ -119,7 +119,7 @@ References
    http://www.python.org/dev/peps/pep-0318/#design-goals
 
 .. [#implementation]
-   http://python.org/sf/1671208
+   https://bugs.python.org/issue1671208
 
 
 

--- a/pep-3132.txt
+++ b/pep-3132.txt
@@ -178,7 +178,7 @@ were:
 References
 ==========
 
-.. [SFPATCH] http://python.org/sf/1711529
+.. [SFPATCH] https://bugs.python.org/issue1711529
 .. [1] https://mail.python.org/pipermail/python-3000/2007-May/007198.html
 
 


### PR DESCRIPTION
`http://www.python.org/sf/<issue-num>` or `http://python.org/sf/<issue-num>` redirects to `https://legacy.python.org/sf/<issue-num>`. This returns a 403 as the legacy site has been partially phased out.

Any reference to `http://www.python.org/sf/<issue-num>` or `http://python.org/sf/<issue-num>` has been changed to `https://bugs.python.org/issue<issue-num>`