### PR TITLE
Upgrade to release version on Py37 and run flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: python
 python:
-    - "3.7-dev"
+    - "3.7"
 
-sudo: false
+dist: xenial    # required for Python 3.7
+sudo: required  # travis-ci/travis-ci#9069
 cache: pip
 
 before_install:
-    - pip install docutils
+    - pip install docutils flake8
+before_script:
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 script:
     - make -j

--- a/pep-0418/clockutils.py
+++ b/pep-0418/clockutils.py
@@ -211,7 +211,7 @@ if os.name == "nt":
         def now(self):
             # convert 100-nanosecond intervals since 1601 to UNIX style seconds
             return ( _time._GetSystemTimeAsFileTime() / 10000000
-                   + NT_GetSystemTimeAsFileTimeClock.epoch
+                   + _NT_GetSystemTimeAsFileTimeClock.epoch
                    )
     ALL_CLOCKS.append( _SingletonClockEntry(_NT_GetSystemTimeAsFileTimeClock) )
 

--- a/pep-0418/clockutils.py
+++ b/pep-0418/clockutils.py
@@ -73,7 +73,7 @@ def monotonic():
     if _global_monotonic is None:
         _global_monotonic = monotonic_clock()
         if _global_monotonic is None:
-            raise RunTimeError("no monotonic clock available")
+            raise RuntimeError("no monotonic clock available")
     return _global_monotonic.now()
 
 _global_hires = None
@@ -85,7 +85,7 @@ def highres():
     if _global_hires is None:
         _global_hires = highres()
         if _global_hires is None:
-            raise RunTimeError("no highres clock available")
+            raise RuntimeError("no highres clock available")
     return _global_hires.now()
 
 _global_steady = None
@@ -97,7 +97,7 @@ def steady():
     if _global_steady is None:
         _global_steady = steady()
         if _global_steady is None:
-            raise RunTimeError("no steady clock available")
+            raise RuntimeError("no steady clock available")
     return _global_steady.now()
 
 class _Clock_Flags(int):

--- a/pep2pyramid.py
+++ b/pep2pyramid.py
@@ -36,6 +36,7 @@ import getopt
 import errno
 import random
 import time
+import traceback
 import shutil
 
 REQUIRES = {'python': '2.2',

--- a/pep2pyramid.py
+++ b/pep2pyramid.py
@@ -136,9 +136,9 @@ def fixanchor(current, match):
                 ltext.append(c)
                 break
         link = EMPTYSTRING.join(ltext)
-    elif text.endswith('.txt') and text <> current:
+    elif text.endswith('.txt') and text != current:
         link = PEPDIRURL + os.path.splitext(text)[0] + '/' + text
-    elif text.startswith('pep-') and text <> current:
+    elif text.startswith('pep-') and text != current:
         link = os.path.splitext(text)[0] + ".html"
     elif text.startswith('PEP'):
         pepnum = int(match.group('pepnum'))
@@ -350,7 +350,7 @@ def get_input_lines(inpath):
     try:
         infile = codecs.open(inpath, 'r', 'utf-8')
     except IOError, e:
-        if e.errno <> errno.ENOENT: raise
+        if e.errno != errno.ENOENT: raise
         print >> sys.stderr, 'Error: Skipping missing PEP file:', e.filename
         sys.stderr.flush()
         return None, None

--- a/pep2pyramid.py
+++ b/pep2pyramid.py
@@ -241,7 +241,7 @@ def fixfile(inpath, input_lines, outfile):
                 try:
                     url = PEPCVSURL % int(pep)
                     v = '<a href="%s">%s</a> ' % (url, cgi.escape(date))
-                except ValueError, error:
+                except ValueError as error:
                     v = date
         elif k.lower() == 'content-type':
             url = PEPURL % 9
@@ -349,7 +349,7 @@ def get_pep_type(input_lines):
 def get_input_lines(inpath):
     try:
         infile = codecs.open(inpath, 'r', 'utf-8')
-    except IOError, e:
+    except IOError as e:
         if e.errno != errno.ENOENT: raise
         print >> sys.stderr, 'Error: Skipping missing PEP file:', e.filename
         sys.stderr.flush()
@@ -532,7 +532,7 @@ def main(argv=None):
         opts, args = getopt.getopt(
             argv, 'hd:fkq',
             ['help', 'destdir=', 'force', 'keep-going', 'quiet'])
-    except getopt.error, msg:
+    except getopt.error as msg:
         usage(1, msg)
 
     for opt, arg in opts:


### PR DESCRIPTION

flake8 testing of https://github.com/python/peps on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
/home/travis/virtualenv/python3.7.0/lib/python3.7/site-packages/pycodestyle.py:113: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
./pep2pyramid.py:139:42: E999 SyntaxError: invalid syntax
    elif text.endswith('.txt') and text <> current:
                                         ^
./pep-0418/clockutils.py:76:19: F821 undefined name 'RunTimeError'
            raise RunTimeError("no monotonic clock available")
                  ^
./pep-0418/clockutils.py:88:19: F821 undefined name 'RunTimeError'
            raise RunTimeError("no highres clock available")
                  ^
./pep-0418/clockutils.py:100:19: F821 undefined name 'RunTimeError'
            raise RunTimeError("no steady clock available")
                  ^
./pep-0418/clockutils.py:207:17: F821 undefined name 'EPOCH_16010101T000000'
        epoch = EPOCH_16010101T000000   # 01jan1601
                ^
./pep-0418/clockutils.py:214:22: F821 undefined name 'NT_GetSystemTimeAsFileTimeClock'
                   + NT_GetSystemTimeAsFileTimeClock.epoch
                     ^
./pep-0418/clockutils.py:315:57: F821 undefined name '_CLOCK_PROCESS_CPUTIME_ID'
                ALL_CLOCKS.append( _SingletonClockEntry(_CLOCK_PROCESS_CPUTIME_ID) )
                                                        ^
./pep-0418/clockutils.py:335:57: F821 undefined name '_CLOCK_CLOCK_THREAD_CPUTIME_ID'
                ALL_CLOCKS.append( _SingletonClockEntry(_CLOCK_CLOCK_THREAD_CPUTIME_ID) )
                                                        ^
1     E999 SyntaxError: invalid syntax
7     F821 undefined name 'RunTimeError'
8
```