### PR TITLE
PEP 505: fix code formatting to be literal block

### DIFF
--- a/pep-0505.rst
+++ b/pep-0505.rst
@@ -97,7 +97,7 @@ result in ``None`` can be substituted for a default value without needing
 additional parentheses.
 
 Some examples of how implicit parentheses are placed when evaluating operator
-precedence in the presence of the ``??`` operator.
+precedence in the presence of the ``??`` operator::
 
     a, b = None, None
     def c(): return None


### PR DESCRIPTION
Currently this code is mis-formatted as regular text in block quote, losing line breaks

CLA signed in the past, I'm `cben` on bugs.python.org.