### PR TITLE
PEP 257: Relax the requirement for a blank line after docstrings

### DIFF
--- a/pep-0257.txt
+++ b/pep-0257.txt
@@ -138,10 +138,10 @@ the same line as the opening quotes or on the next line.  The entire
 docstring is indented the same as the quotes at its first line (see
 example below).
 
-Insert a blank line after all docstrings (one-line or multi-line) that
-document a class -- generally speaking, the class's methods are
-separated from each other by a single blank line, and the docstring
-needs to be offset from the first method by a blank line.
+A blank line may be inserted after all docstrings (one-line or
+multi-line) that document a class -- generally speaking, the class's
+methods are separated from each other by a single blank line, and the
+docstring can be offset from the first method by a blank line.
 
 The docstring of a script (a stand-alone program) should be usable as
 its "usage" message, printed when the script is invoked with incorrect


### PR DESCRIPTION
Blank lines after docstrings should not be required.  In many cases, this just causes unnecessary extra vertical whitespace.  Relax this requirement.