### PR TITLE
PEP 4: remove the part about about "should be a patch to bpo".

### DIFF
--- a/pep-0004.txt
+++ b/pep-0004.txt
@@ -34,8 +34,7 @@ Procedure for declaring a module deprecated
 
 Since the status of module deprecation is recorded in this PEP,
 proposals for deprecating modules MUST be made by providing a change
-to the text of this PEP, which SHOULD be a patch posted to
-bugs.python.org.
+to the text of this PEP.
 
 A proposal for deprecation of the module MUST include the date of the
 proposed deprecation and a rationale for deprecating it.  In addition,


### PR DESCRIPTION
Remove the part about `".., which SHOULD be a patch posted to
bugs.python.org."`

I think that is referring to the old way where changes to the PEP has to be a patch uploaded to bpo.
Nowadays it is as GitHub pull request, but I'm not sure if we need to be specific about it.

Alternatively it can ends with: `", which SHOULD be a GitHub pull request."`