### PR TITLE
Initial crop of governance model PEPs

### DIFF
--- a/pep-0013.rst
+++ b/pep-0013.rst
@@ -1,0 +1,37 @@
+PEP: 13
+Title: Python Language Governance
+Author: Barry Warsaw <barry@python.org>
+Status: Active
+Type: Informational
+Content-Type: text/x-rst
+Created: 2018-08-24
+
+
+Abstract
+========
+
+This PEP is a placeholder for the Python language governance model voted on
+and selected by representatives from the Python community.  The process for
+selecting a new governance model in the wake of `Guido's retirement
+<https://mail.python.org/pipermail/python-committers/2018-July/005664.html>`_
+is outlined in PEP 8000.
+
+This PEP both describes the new model and names duly elected officeholders.
+It maintains the history of those officeholders.
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/pep-8000.rst
+++ b/pep-8000.rst
@@ -1,0 +1,88 @@
+PEP: 8000
+Title: Python Language Governance Proposal Overview
+Author: Barry Warsaw <barry@python.org>
+Status: Active
+Type: Informational
+Content-Type: text/x-rst
+Created: 2018-08-24
+
+
+Abstract
+========
+
+This PEP provides an overview of the Python language governance selection
+process in the wake of `Guido's retirement
+<https://mail.python.org/pipermail/python-committers/2018-July/005664.html>`_.
+Once the governance model is selected, it will be codified in PEP 13.
+
+Here is a list of PEPs related to the governance model selection process.
+PEPs in the lower 8000s describe the general process for selecting a
+governance model.
+
+* PEP 8001 - Python Governance Voting Process
+
+  This PEP describes how the vote for the new governance model will be
+  conducted.  It outlines the voting method, timeline, criteria for
+  participation, and explicit list of eligible voters
+
+* PEP 8002 - Open Source Governance Survey
+
+  Surveys will be conducted of similar open source and free software project
+  governance models, and summaries of these models are outlined in this PEP.
+  These surveys will serve as useful barometers for how such projects can be
+  successfully governed, and may serve as inspiration for Python's own
+  governance model.  Python is unique, so it's expected that we will have our
+  own spin on governance, rather than directly adopting any of those
+  surveyed.
+
+PEPs in the 8010s describe the actual proposals for Python governance.  It is
+expected that these PEPs will cover the broad scope of governance, and that
+differences in details (such as the size of a governing council) will be
+covered in the same PEP, rather than in potentially vote-splitting individual
+PEPs.
+
+* PEP 8010 - The BDFL Governance Model
+
+  This is a placeholder PEP for the continuation of the `Benevolent Dictator
+  For Life <https://en.wikipedia.org/wiki/Benevolent_dictator_for_life>`_
+  model.  The name is an homage to Guido's title and does not necessarily
+  imply that the next BDFL will be required to serve without time limit.  Also
+  within scope is whether an advisory council aids or supports the BDFL.  This
+  PEP does *not* name either the next BDFL, nor members of such an advisory
+  council.  For that, see PEP 13.
+
+* PEP 8011 - The Council Goverance Model
+
+  This is a placeholder PEP for a new model of Python governance based on a
+  small Council of Pythonistas (COP)y.  It describes the size and role of the
+  council, but it differs from PEP 8010 in that it does not propose a leader
+  to whom the council answers.  The governing council makes the final
+  decisions for the Python language.  This PEP does *not* name members of the
+  council; for that, see PEP 13.
+
+* PEP 8012 - The Community Governance Model
+
+  This is a placeholder PEP for a new model of Python governance based on
+  consensus and voting, without the role of a centralized singular leader or a
+  governing council.  It describes how, when, and why votes are conducted for
+  decisions affecting the Python language.  It also describes the criteria for
+  voting eligibility.
+
+Additional governance models may be added before the final selection.
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/pep-8001.rst
+++ b/pep-8001.rst
@@ -1,0 +1,34 @@
+PEP: 8001
+Title: Python Governance Voting Process
+Author: Barry Warsaw <barry@python.org>
+Status: Active
+Type: Process
+Content-Type: text/x-rst
+Created: 2018-08-24
+
+
+Abstract
+========
+
+This PEP outlines the process for how the new Python language governance model
+is selected, in the wake of `Guido's retirement
+<https://mail.python.org/pipermail/python-committers/2018-July/005664.html>`_.
+Once the model is chosen by the procedures outlined here, it will be codified
+in PEP 13.
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/pep-8002.rst
+++ b/pep-8002.rst
@@ -1,0 +1,37 @@
+PEP: 8002
+Title: Open Source Governance Survey
+Author: Barry Warsaw <barry@python.org>
+Status: Active
+Type: Informational
+Content-Type: text/x-rst
+Created: 2018-08-24
+
+
+Abstract
+========
+
+This PEP surveys existing and similar open source and free software projects
+for their governance models, providing summaries that will serve as useful
+references for Python's own selection of a new governance model in the wake of
+`Guido's retirement
+<https://mail.python.org/pipermail/python-committers/2018-July/005664.html>`_.
+
+Rather than an individual PEP for each of these community surveys, they will
+all be collected here in this PEP.
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/pep-8010.rst
+++ b/pep-8010.rst
@@ -1,0 +1,39 @@
+PEP: 8010
+Title: The BDFL Governance Model
+Author: Barry Warsaw <barry@python.org>
+Status: Active
+Type: Informational
+Content-Type: text/x-rst
+Created: 2018-08-24
+
+
+Abstract
+========
+
+This PEP proposes a continuation of the `Benevolent Dictator For Life
+<https://en.wikipedia.org/wiki/Benevolent_dictator_for_life>`_ (BDFL) model of
+Python governance.  While currently a placeholder, it will describe such
+processes as how the Guido+1 BDFL will be selected, how future successors will
+be chosen, the role of the BDFL, and the role and size of any advisory
+council.
+
+This PEP does *not* name a new BDFL.  Should this model be adopted, it will be
+codified in PEP 13 along with the names of all officeholders described in this
+PEP.
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/pep-8010.rst
+++ b/pep-8010.rst
@@ -7,6 +7,11 @@ Content-Type: text/x-rst
 Created: 2018-08-24
 
 
+.. note:: This is just a placeholder until the actual governance PEPs are
+          written.  It is possible that the title, content, model proposed,
+          and  authorship will change once the PEP is actually written.
+
+
 Abstract
 ========
 

--- a/pep-8011.rst
+++ b/pep-8011.rst
@@ -1,0 +1,39 @@
+PEP: 8011
+Title: The Council Governance Model
+Author: Barry Warsaw <barry@python.org>
+Status: Active
+Type: Informational
+Content-Type: text/x-rst
+Created: 2018-08-24
+
+
+Abstract
+========
+
+This PEP proposes a new Python language governance model based on a Council of
+Pythonistas (COP) tasked with making final decisions for the language.  It
+differs from PEP 8010 by specifically not proposing a central singular leader.
+It describes the size and role of the council, how the initial group of
+council members will be chosen, any term limits of the councilmembers, and how
+successors will be elected.
+
+This PEP does *not* name the council members.  Should this model be adopted,
+it will be codified in PEP 13 along with the names of all officeholders
+described in this PEP.
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/pep-8011.rst
+++ b/pep-8011.rst
@@ -7,6 +7,11 @@ Content-Type: text/x-rst
 Created: 2018-08-24
 
 
+.. note:: This is just a placeholder until the actual governance PEPs are
+          written.  It is possible that the title, content, model proposed,
+          and  authorship will change once the PEP is actually written.
+
+
 Abstract
 ========
 

--- a/pep-8012.rst
+++ b/pep-8012.rst
@@ -7,6 +7,11 @@ Content-Type: text/x-rst
 Created: 2018-08-24
 
 
+.. note:: This is just a placeholder until the actual governance PEPs are
+          written.  It is possible that the title, content, model proposed,
+          and  authorship will change once the PEP is actually written.
+
+
 Abstract
 ========
 

--- a/pep-8012.rst
+++ b/pep-8012.rst
@@ -1,0 +1,37 @@
+PEP: 8012
+Title: The Community Governance Model
+Author: Barry Warsaw <barry@python.org>
+Status: Active
+Type: Informational
+Content-Type: text/x-rst
+Created: 2018-08-24
+
+
+Abstract
+========
+
+This PEP proposes a new model of Python governance based on consensus and
+voting by the Python community, without the role of a centralized singular or
+a governing council.  It describes how, when, and why votes are conducted for
+decisions affecting the Python language.  It also describes the criteria for
+voting eligibility.
+
+Should this model be adopted, it will be codified in PEP 13 along with the
+names of all officeholders described in this PEP.
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:


### PR DESCRIPTION
These are the placeholder PEPs for the selection of a new Python language governance model.  We are reserving PEPs in the lower 8000s for the supporting material, and PEP 13 for the final, codified model PEP.