### PR TITLE
PEP-8 To be consistent with operator-after-line-break style

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -135,14 +135,14 @@ conditional lines from the nested suite inside the ``if``-statement.
 Acceptable options in this situation include, but are not limited to::
 
     # No extra indentation.
-    if (this_is_one_thing and
-        that_is_another_thing):
+    if (this_is_one_thing
+        and that_is_another_thing):
         do_something()
 
     # Add a comment, which will provide some distinction in editors
     # supporting syntax highlighting.
-    if (this_is_one_thing and
-        that_is_another_thing):
+    if (this_is_one_thing
+        and that_is_another_thing):
         # Since both conditions are true, we can frobnicate.
         do_something()
 


### PR DESCRIPTION
Fixed some code examples which where using the binary operator before line break contrary to the general rule of binary operator after line break https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator
