### PR TITLE
PEP-0581: use auto-numbering for footnotes.

### DIFF
--- a/pep-0581.rst
+++ b/pep-0581.rst
@@ -311,6 +311,15 @@ References
 .. [#] bugs.python.org
    (https://bugs.python.org/)
 
+.. [#] miss-islington
+   (https://github.com/python/miss-islington)
+
+.. [#] bedevere
+   (https://github.com/python/bedevere)
+
+.. [#] the-knights-who-say-ni
+   (https://github.com/python/the-knights-who-say-ni)
+
 .. [#] Getting permanent links to files
    (https://help.github.com/articles/getting-permanent-links-to-files/)
 
@@ -348,15 +357,6 @@ References
 
 .. [#] CPython GitHub pull request 1505
    (https://github.com/python/cpython/pull/1505)
-
-.. [#] miss-islington
-   (https://github.com/python/miss-islington)
-
-.. [#] bedevere
-   (https://github.com/python/bedevere)
-
-.. [#] the-knights-who-say-ni
-   (https://github.com/python/the-knights-who-say-ni)
 
 
 Copyright

--- a/pep-0581.rst
+++ b/pep-0581.rst
@@ -22,7 +22,7 @@ Rationale
 
 CPython's development moved to GitHub on February 2017. All other projects
 within the PSF's organization are hosted on GitHub and are using GitHub issues.
-CPython is still using Roundup as the issue tracker on bugs.python.org (bpo) [1]_.
+CPython is still using Roundup as the issue tracker on bugs.python.org (bpo) [#]_.
 
 Why GitHub
 ----------
@@ -34,7 +34,7 @@ not currently available on Roundup / bpo.
   existing integrations and applications available from GitHub Marketplace to
   help with the workflow. New applications are easily installed and enabled.
   In addition, we've had great success with building our own GitHub bots, like
-  miss-islington [14]_, bedevere [15]_, and the-knights-who-say-ni [16]_.
+  miss-islington [#]_, bedevere [#]_, and the-knights-who-say-ni [#]_.
 
 - Ability to embed/drag and drop screenshots and debug log files into GitHub
   pull requests and issues.
@@ -52,19 +52,19 @@ not currently available on Roundup / bpo.
 
 - Support for voting via reactions.
 
-- Support for permalinks [2]_, allowing easy quoting and copying & pasting of
+- Support for permalinks [#]_, allowing easy quoting and copying & pasting of
   source code.
 
 - Core developers don't have to maintain the issue infrastructure/site, giving
   us more time to focus on the development of Python.
 
-- Ability to automatically close issues when a PR has been merged [3]_.
+- Ability to automatically close issues when a PR has been merged [#]_.
 
 - Lower barrier to contribution. With more than 28 million users, an open
   source contributor is more likely to already have an account and be familiar
   with GitHub's interface, making it easier to start contributing.
 
-- Email notifications containing metadata [4]_, integrated with Gmail, allowing
+- Email notifications containing metadata [#]_, integrated with Gmail, allowing
   systematic filtering of emails.
 
 - Additional privacy, such as offering the user a choice to hide an
@@ -82,7 +82,7 @@ Issues with Roundup / bpo
   people who aren't already familiar with the code base.
 
 - The upstream Roundup is in Mercurial. There is an open discussion about
-  moving the source code of bpo to GitHub [5]_. If the source code of
+  moving the source code of bpo to GitHub [#]_. If the source code of
   bpo does move to GitHub, it will become difficult to update patches from
   upstream. But as long as it is in Mercurial, it is difficult to maintain
   and onboard new contributors.
@@ -93,13 +93,13 @@ Issues with Roundup / bpo
 - Email address is exposed. There is no choice to mask it.
 
 - There is no REST API available. There is an open issue in Roundup for adding
-  REST API  [6]_. Last activity was in 2016.
+  REST API  [#]_. Last activity was in 2016.
 
 - It sends a number of unnecessary emails and notifications, and it is
   difficult, if not impossible, to configure. An example is the nosy email,
   where email notifications are sent whenever someone adds themselves as "nosy".
   An issue has been filed in upstream Roundup about this since 2012 with
-  little traction [7]_.
+  little traction [#]_.
 
 - Creating an account has been a hassle. There have been reports of people
   having trouble creating accounts or logging in.
@@ -145,7 +145,7 @@ Backup of GitHub data
 ---------------------
 
 This effort has been started and is being tracked as an issue in core-workflow
-[8]_. We're using GitHub's Migrations API [9]_ to download GitHub data for 
+[#]_. We're using GitHub's Migrations API [#]_ to download GitHub data for
 CPython on a daily basis. The archives will be dropped in a S3 bucket.
 
 Thanks to Ernest W. Durbin III for working on this.
@@ -258,7 +258,7 @@ A GitHub account should not be a requirement
 --------------------------------------------
 
 Back when moving the CPython codebase from Mercurial to GitHub was being
-discussed [10]_ [11]_, it was brought up that we still needed to allow uploading
+discussed [#]_ [#]_, it was brought up that we still needed to allow uploading
 of patches on bpo, and that a GitHub account should not be a requirement in
 order to contribute to Python.
 
@@ -266,11 +266,11 @@ If bpo is made read-only, we'll need to come up with a different solution to
 allow people to contribute when they don't have a GitHub account.
 
 One solution is to create a new "python-issues" mailing list, similar to the
-docs@python.org [12]_ mailing list, to allow people to submit their issues
+docs@python.org [#]_ mailing list, to allow people to submit their issues
 there.
 
 Related to this, since the migration to GitHub in 2017, I recall one case
-[13]_ where there was a contributor, who submitted a patch to Mercurial and
+[#]_ where there was a contributor, who submitted a patch to Mercurial and
 refused to create a GitHub account. Because of this, our bot was unable to
 detect whether they had signed the CLA. Another person had volunteered to upload
 their patch to GitHub. But it was still required that both people sign the CLA.
@@ -308,54 +308,54 @@ and ideas have been valuable.
 References
 ==========
 
-.. [1] bugs.python.org
+.. [#] bugs.python.org
    (https://bugs.python.org/)
 
-.. [2] Getting permanent links to files
+.. [#] Getting permanent links to files
    (https://help.github.com/articles/getting-permanent-links-to-files/)
 
-.. [3] Closing issues using keywords
+.. [#] Closing issues using keywords
    (https://help.github.com/articles/closing-issues-using-keywords/)
 
-.. [4] About GitHub email notifications
+.. [#] About GitHub email notifications
    (https://help.github.com/articles/about-email-notifications/)
 
-.. [5] Consider whether or not to migrate bugs.python.org source code
+.. [#] Consider whether or not to migrate bugs.python.org source code
    to GitHub repo
    (https://github.com/python/bugs.python.org/issues/2)
 
-.. [6] Roundup issue 2550734: Expose roundup via a RESTful interface
+.. [#] Roundup issue 2550734: Expose roundup via a RESTful interface
    (http://issues.roundup-tracker.org/issue2550734)
 
-.. [7] Roundup issue 2550742: Do not send email by default when adding
+.. [#] Roundup issue 2550742: Do not send email by default when adding
    or removing oneself from the Nosy list
    (http://issues.roundup-tracker.org/issue2550742)
 
-.. [8] Backup GitHub information
+.. [#] Backup GitHub information
    (https://github.com/python/core-workflow/issues/20)
 
-.. [9] GitHub's Migrations API
+.. [#] GitHub's Migrations API
    (https://developer.github.com/v3/migrations/orgs/)
 
-.. [10] Python-committers email
+.. [#] Python-committers email
    (https://mail.python.org/pipermail/python-committers/2015-December/003642.html)
 
-.. [11] Python-committers email
+.. [#] Python-committers email
    (https://mail.python.org/pipermail/python-committers/2015-December/003645.html)
 
-.. [12] docs mailing list
+.. [#] docs mailing list
    (https://mail.python.org/mailman/listinfo/docs)
 
-.. [13] CPython GitHub pull request 1505
+.. [#] CPython GitHub pull request 1505
    (https://github.com/python/cpython/pull/1505)
 
-.. [14] miss-islington
+.. [#] miss-islington
    (https://github.com/python/miss-islington)
 
-.. [15] bedevere
+.. [#] bedevere
    (https://github.com/python/bedevere)
 
-.. [16] the-knights-who-say-ni
+.. [#] the-knights-who-say-ni
    (https://github.com/python/the-knights-who-say-ni)
 
 


### PR DESCRIPTION
Use auto-numbering for footnotes to make it easier to add/remove notes.
