### PR TITLE
PEP 566: Support for direct references and permit public index servers to add restrictions

### DIFF
--- a/pep-0566.rst
+++ b/pep-0566.rst
@@ -93,13 +93,16 @@ Version Specifiers
 ==================
 
 Version numbering requirements and the semantics for specifying comparisons
-between versions are defined in PEP 440.
+between versions are defined in :pep:`440`. Direct references as defined in
+:pep:`440` are also permitted as an alternative to version specifiers.
 
 Following :pep:`508`, version specifiers no longer need to be surrounded by
 parentheses in the fields Requires-Dist, Provides-Dist, Obsoletes-Dist or
 Requires-External, so e.g. ``requests >= 2.8.1`` is now a valid value.
 The recommended format is without parentheses, but tools parsing metadata should
-also be able to handle version specifiers in parentheses.
+also be able to handle version specifiers in parentheses. Further, public index
+servers MAY prohibit strict version matching clauses or direct references in
+these fields.
 
 Usage of version specifiers is otherwise unchanged from PEP 345.
 


### PR DESCRIPTION
- Permit direct references as an alternative to version specifiers
- Permit public index servers to prohibit strict matching specifiers
  and direct references

Closes #763 

/cc @di @pfmoore 