### PR TITLE
PEP 394: refresh recomandations for python command target

### DIFF
--- a/pep-0394.txt
+++ b/pep-0394.txt
@@ -23,10 +23,11 @@ Python interpreter (i.e. the version invoked by the ``python`` command).
 
 * ``python2`` will refer to some version of Python 2.x.
 * ``python3`` will refer to some version of Python 3.x.
-* for the time being, all distributions *should* ensure that ``python``,
-  if installed, refers to the same target as ``python2``, unless the user
-  deliberately overrides this or a virtual environment is active.
-* however, end users should be aware that ``python`` refers to ``python3``
+* all distributions *should* ensure that ``python``, if installed, refers to
+  the currently installed python version, historically ``python2`` or
+  ``python3`` for newer ones, unless the user deliberately overrides this
+  or a virtual environment is active.
+* end users should be aware that ``python`` refers to ``python3``
   on at least Arch Linux (that change is what prompted the creation of this
   PEP), so ``python`` should be used in the shebang line only for scripts
   that are source compatible with both Python 2 and 3.
@@ -45,8 +46,8 @@ Recommendation
 * When  invoked, ``python2`` should run some version of the Python 2
   interpreter, and ``python3`` should run some version of the Python 3
   interpreter.
-* If the ``python`` command is installed, it should invoke the same version of
-  Python as the ``python2`` command (however, note that some distributions
+* If the ``python`` command is installed, it should invoke that version
+  of python that is officially supported by that distro. Some distributions
   have already chosen to have ``python`` implement the ``python3``
   command; see the `Rationale`_ and `Migration Notes`_ below).
 * The Python 2.x ``idle``, ``pydoc``, and ``python-config`` commands should


### PR DESCRIPTION
This changes the recommandation for making ``python`` command to
point to either python2 or python3 based on the official python
version of the distribution.

This solves issue where distributions avoided to create a ``python``
symlink even when they had only python3 installed, thus breaking lots
of scripts that were correctly using cross compatibility
recommandations of using the `python`.

As of 2018, is it far worse not to have a ``python`` command installed
than having it pointed to ``python3``.

One notable example are Fedora 27 or newer which has only python3
installed by default and is missing a symlink. See
https://bugzilla.redhat.com/show_bug.cgi?id=1630882
