### PR TITLE
[DO-NOT-MERGE][WIP] Remove "Legacy C Locale" section

### DIFF
--- a/pep-0011.txt
+++ b/pep-0011.txt
@@ -144,18 +144,6 @@ patches will be accepted. Such build files will be removed from the
 source tree 3 years after the extended support for the compiler has
 ended (but continue to remain available in revision control).
 
-Legacy C Locale
----------------
-
-Starting with CPython 3.7.0, \*nix platforms are expected to provide
-at least one of ``C.UTF-8`` (full locale), ``C.utf8`` (full locale) or
-``UTF-8`` (``LC_CTYPE``-only locale) as an alternative to the legacy ``C``
-locale.
-
-Any Unicode-related integration problems that occur only in the legacy ``C``
-locale and cannot be reproduced in an appropriately configured non-ASCII
-locale will be closed as "won't fix".
-
 No-longer-supported platforms
 -----------------------------
 


### PR DESCRIPTION
FreeBSD 11 does not provide a C locale with UTF-8 encoding, but it's
still supported. The UTF-8 Mode is now enabled if the LC_CTYPE locale
is "C" or "POSIX". Moreover, the UTF-8 Mode can also be used on
Windows.