### PR TITLE
Amend misleading withdrawal notice on PEP 577

### DIFF
--- a/pep-0577.rst
+++ b/pep-0577.rst
@@ -19,21 +19,28 @@ consequences (most notably, allowing ``>>=` and ``<<=`` as inline augmented
 assignment operators that meant something entirely different from the ``>=``
 and ``<=`` comparison operators).
 
-I also realised that even without dedicated syntax of their own, PEP 572 allows
-inline augmented assignments to be written using the ``operator`` module::
+I also realised that even without dedicated syntax of their own, PEP 572
+technically allows inline augmented assignments to be written using the
+``operator`` module::
 
     from operator import iadd
     if (target := iadd(target, value)) < limit:
         ...
 
-(The restriction to simple names as inline assignment targets means that the
-target expession can always be repeated without side effects)
+The restriction to simple names as inline assignment targets means that the
+target expession can always be repeated without side effects, and thus avoids
+the ambiguity that would arise from allowing actual embedded augmented
+assignments (it's still a bad idea, since it would almost certainly be hard
+for humans to read, this note is just about the theoretical limits of language
+level expressiveness).
 
-Accordingly, I'm withdrawing this PEP without submitting it for pronouncement,
-and will instead be writing a replacement PEP that focuses specifically on the
-handling of assignment targets which haven't already been declared as local
+Accordingly, I withdrew this PEP without submitting it for pronouncement. At
+the time I also started writing a replacement PEP that focused specifically on
+the handling of assignment targets which hadn't already been declared as local
 variables in the current scope (for both regular block scopes, and for scoped
-expressions).
+expressions), but that draft never even reached a stage where *I* liked it
+better than the ultimately accepted proposal in PEP 572, so it was never
+posted anywhere, nor assigned a PEP number.
 
 
 Abstract


### PR DESCRIPTION
When I withdrew PEP 577, I intended to write up a new alternative
to both it and PEP 572, but the replacement never reached a state
where I liked it enough to post it.

So this amends the withdrawal notice to make it clear that there's
no further alternative planned.