### PR TITLE
PEP 3141: fix broken numerical tower link

### DIFF
--- a/pep-3141.txt
+++ b/pep-3141.txt
@@ -529,7 +529,7 @@ References
    (http://darcs.haskell.org/numericprelude/docs/html/index.html)
 
 .. [#schemetower] The Scheme numerical tower
-   (http://www.swiss.ai.mit.edu/ftpdir/scheme-reports/r5rs-html/r5rs_8.html#SEC50)
+   (https://groups.csail.mit.edu/mac/ftpdir/scheme-reports/r5rs-html/r5rs_8.html#SEC50)
 
 
 Acknowledgements


### PR DESCRIPTION
Fixed the `The Scheme numerical tower` url

I signed the Contributor Agreement