### PR TITLE
PEP 8011: Provide explanation of PSF membership

### DIFF
--- a/pep-8011.rst
+++ b/pep-8011.rst
@@ -55,7 +55,7 @@ Roles and responsibilities of the leadership trio
 - Understand their own limitation, and seek advice whenever necessary.
 - Provide mentorship to the next generation of leaders.
 - Be a Python core developer
-- Be a voting member of The PSF (one of Contributing / Manager / Fellow / Supporter).
+- Be a voting member of The PSF (one of Contributing / Manager / Fellow / Supporter). [2]
 - Understand that Python is not just a language but also a community. They need
   to be aware of issues in Python not just the technical aspects, but also
   other issues in the community.
@@ -119,9 +119,9 @@ active eligible core devs can vote for one group of three.
 Qualities desired out of the trio:
 
 - Be a Python core developer.
-- Be a voting PSF member (one of Contributing / Manager / Fellow / Supporter).
+- Be a voting PSF member (one of Contributing / Manager / Fellow / Supporter). [2]
 - Be a member of the community with good standing.
-- Adhere to The PSF's code of conduct (Be open, considerate, and respectful).
+- Adhere to The PSF's code of conduct (Be open, considerate, and respectful). [1]
 - Be willing to accept the said roles and responsibilities.
 - Able to communicate and articulate their thoughts effectively.
 
@@ -309,7 +309,7 @@ Ideally, the workgroup members should include and reflect the diversity of
 the wider Python community.
 
 Members of this workgroup do not need to be a Python core developer, but they
-need to be at least a basic member of the PSF.
+need to be at least a basic member of the PSF [2].
 
 These workgroup are active as long as the trio are active.
 
@@ -335,6 +335,19 @@ Why these workgroups are necessary
 
 This is an effort to 'refactor the large role' of the previous Python BDFL.
 
+Affirmation as being a member of the PSF
+========================================
+
+This PEP proposes that core developers and the trio members self-certify
+themselves as being a member of The PSF.
+
+Being part of the PSF means being part of the Python community, and support
+The PSF's mission and diversity statement.
+
+By being a member of The PSF, Python core developers declare their support for
+Python and agree to the community Code of Conduct.
+
+For more details of The PSF membership, see: PSF Membership FAQ [2].
 
 Reasoning for choosing the name trio
 ====================================
@@ -344,6 +357,14 @@ Not to be confused with Python trio (an async library).
 The "trio" is short and easy to pronounce, unlike other words that are
 long and can have negative interpretations, like triad, trinity, triumvirate,
 threesome, etc.
+
+
+References
+==========
+
+.. [1] The PSF's Code of Conduct (https://www.python.org/psf/codeofconduct/)
+
+.. [2] PSF Membership FAQ (https://www.python.org/psf/membership/)
 
 
 Copyright


### PR DESCRIPTION
Provide links to The PSF's membership FAQ page, and PSF Community Code of Conduct.
