### PR TITLE
PEP 0008: Clarify self-contradictory =-spacing rules

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -552,19 +552,6 @@ Other Recommendations
       hypot2 = x * x + y * y
       c = (a + b) * (a - b)
 
-- Don't use spaces around the ``=`` sign when used to indicate a
-  keyword argument or a default parameter value.
-
-  Yes::
-
-      def complex(real, imag=0.0):
-          return magic(r=real, i=imag)
-
-  No::
-
-      def complex(real, imag = 0.0):
-          return magic(r = real, i = imag)
-
 - Function annotations should use the normal rules for colons and
   always have spaces around the ``->`` arrow if present.  (See
   `Function Annotations`_ below for more about function annotations.)
@@ -579,9 +566,23 @@ Other Recommendations
       def munge(input:AnyStr): ...
       def munge()->PosInt: ...
 
-- When combining an argument annotation with a default value, use
-  spaces around the ``=`` sign (but only for those arguments that have
-  both an annotation and a default).
+- Don't use spaces around the ``=`` sign when used to indicate a
+  keyword argument, or when used to indicate a default value for an
+  *unannotated* function parameter.
+
+  Yes::
+
+      def complex(real, imag=0.0):
+          return magic(r=real, i=imag)
+
+  No::
+
+      def complex(real, imag = 0.0):
+          return magic(r = real, i = imag)
+
+
+  When combining an argument annotation with a default value, however, do use
+  spaces around the ``=`` sign:
 
   Yes::
 


### PR DESCRIPTION
Previously, the PEP contained roughly the following three rules, in sequence:

1. Never use spaces around `=` when used to indicate a parameter default
2. Something unrelated
3. DO use spaces around `=` when used to indicate a parameter default if there is also a parameter annotation present

This was, in my opinion, confusing, since rules 1 and 3 contradict each other. If you read both, it's not too hard to deduce the intended meaning (don't use spaces for default parameters of unannotated parameters, but do use them for annotated parameters), but it's still technically a contradiction as written, and somebody scan-reading the document could easily just see the first rule and walk away misled.

This commit attempts to clarify this part of the PEP by:
* Combining the first and third rules listed above into a single rule that addresses both annotated and unannotated parameters
* Rephrasing the first rule to indicate that it applies only to unannotated parameters, to eliminate the logical contradiction

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
