### PR TITLE
PEP 484: Remove mention of typing.io and .re

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -2057,7 +2057,7 @@ Convenience definitions:
 
 * TYPE_CHECKING, ``False`` at runtime but ``True`` to  type checkers
 
-Types available in the ``typing.io`` submodule:
+I/O releated types:
 
 * IO (generic over ``AnyStr``)
 
@@ -2065,7 +2065,7 @@ Types available in the ``typing.io`` submodule:
 
 * TextIO (a simple subtype of ``IO[str]``)
 
-Types available in the ``typing.re`` submodule:
+Types related to regular expressions and the ``re`` module:
 
 * Match and Pattern, types of ``re.match()`` and ``re.compile()``
   results (generic over ``AnyStr``)


### PR DESCRIPTION
Per discussion in python/typeshed#1652 and python/typing#589.