### PR TITLE
PEP 8001: Use CVIS instead of a github repository

### DIFF
--- a/pep-8001.rst
+++ b/pep-8001.rst
@@ -77,14 +77,43 @@ to November 30 (Anywhere-on-Earth).
 Where is the vote?
 ------------------
 
-The vote will happen through a private GitHub repository named
-"vote-governance" within the Python organization.  Every committer
-will push a single file named after their GitHub username.  Inside the
-file, preferences should be stated one PEP per line.
+The vote will happen using a "private" poll on the
+`Condorcet Internet Voting Service <https://civs.cs.cornell.edu/>`_. Every committer
+will recieve an email with a link allowing them to rank the PEPs in their order of
+preference.
 
-Committers are allowed to change their vote while voting is open.
+The election wil be supervised by Ernest Durbin.
 
-The repository will be made read-only and public on December 1st.
+The results of the election, including anonymized ballots, will be made public on
+December 1st, after the election has closed.
+
+The following settings will be used for the vote in the CIVS system::
+
+    [x] Private
+    [ ] Make this a test poll: read all votes from a file.
+    [ ] Do not release results to all voters.
+    [x] Enable detailed ballot reporting.
+        [ ] In detailed ballot report, also reveal the identity of the voter with each ballot.
+    [ ] Allow voters to write in new choices.
+    [ ] Present choices on voting page in exactly the given order.
+    [ ] Allow voters to select “no opinion” for some choices.
+    [ ] Enforce proportional representation
+
+Which will have the effect of:
+
+* Making the election "private", or in other words, invite only.
+* The results of the election will be released to all voters.
+* The contents of every ballot will be released to the public, along
+  with a detailed report going over how the winner was elected.
+* The detailed ballots will *not* include any identifying information
+  and the email addresses of the voters will be thrown away by the CIVS
+  system as soon as the email with their voting link has been sent.
+* Voters will *not* be able to write in new choices, and will be limited
+  only to the options specified in the election.
+* The default ordering for each ballot will be randomized to remove
+  any influence that the order of the ballot may have on the election.
+* Voters will have to rank all choices somehow, but may rank multiple
+  choices as equal.
 
 Voting mechanics
 ----------------
@@ -94,30 +123,20 @@ orders all candidate PEPs from the most preferred to the least
 preferred. The vote will be tallied and a winner chosen using the
 `Condorcet method <https://en.wikipedia.org/wiki/Condorcet_method>`_.
 
+While the CIVS system does not provide an option for a "Pure"
+Condorcet election, any Condorcet method will select the "Pure"
+Condorcet winner if one exists and otherwise only vary if one
+doesn't exist. The CIVS system differentiates between a Condorcet
+winner and a non Condorcet winner by stating if the winner was a
+Condorcet winner, or if it merely wasn't defeated versus any other
+option. So a winner in the CIVS system will only be accepted if
+it states it was a Condorcet winner.
+
 In the unlikely case of a tie (or cycle as is possible under the
-Condorcet method), voting will be re-opened for another week to allow
-voters to change their ballots. This re-opening and allowing of vote
-changing for a week will continue until a winner is determined.
-
-An example ballot is::
-
-    Please rank **every** choice -- starting at 1 and ending at 6 by entering your rankings
-    between the square brackets (e.g. `[1]`, with 1 being your most preferred choice and
-    6 being your least preferred).
-
-    If you are currently an inactive core developer *who intends to remain inactive*,
-    please abstain from voting.
-
-    **DO NOT LEAVE ANY BRACKETS BLANK!**
-    **DO NOT REPEAT A RANKING/NUMBER!**
-
-    [] PEP 8010: The BDFL Governance Model (Warsaw)
-    [] PEP 8011: Python Governance Model Lead by Trio of Pythonistas (Wijaya, Warsaw)
-    [] PEP 8012: The Community Governance Model (Langa)
-    [] PEP 8013: The External Council Governance Model (Dower)
-    [] PEP 8014: The Commons Governance Model (Jansen)
-    [] PEP 8015: Organization of the Python community (Stinner)
-    [] Further discussion
+Condorcet method), a new election will be opened, limited to the
+options involved in the tie or cycle, to select a new winner from
+amongst the tied options. This new election will be open for a
+week, and will be repeated until a single winner is determined.
 
 
 Questions and Answers
@@ -152,15 +171,34 @@ developers to assess their skin in the game.
 Note: this is not an edict and will not be policed.  We trust all
 members of the core team to act in the best interest of Python.
 
-Why should the vote be public?
-------------------------------
+Why should the vote be private?
+-------------------------------
 
-The population of Python core developers is very small.  With an
-important decision like governance, we owe it to ourselves and the wider
-Python community to be transparent about how the choice was made.
-This removes ambiguity around *who* voted and *how*, as well as allows
-people to confirm whether any "tactical voting" occurred (which instant
-run-off ranked voting is criticized for; see below).
+When discussing the election system, a number of core developers expressed
+concerns with the idea of having public ballots, with at least one core
+developer stating that they were planning on abstaining from voting
+altogether due to the use of a public ballot.
+
+A secret ballot is considered by many to be a requirement for a free and
+fair election, allowing members to vote their true preferences without
+worry about social pressure or possible fallout for how they may have
+voted.
+
+
+Why the use of CIVS?
+--------------------
+
+In the resulting discussion of this PEP, it was determined that core
+developers wished to have a secret ballot. Unfortunately a secret ballot
+requires either novel cryptography or a trusted party to anonymize the
+ballots. Since there is not known to be any existing novel cryptographic
+systems for Condorcet ballots, the CIVS system was chosen to act as a
+trusted party.
+
+More information about the security and privacy afforded by CIVS, including
+how a malicous voter, election supervisor, or CIVS administrator can
+influence the election can be be found
+`here <https://civs.cs.cornell.edu/sec_priv.html>_`.
 
 Are there any deficiencies in the Condorcet method?
 ------------------------------------------------------------


### PR DESCRIPTION
Suggested change to use CVIS instead of a github repository to enable private ballots.