### PR TITLE
PEP 557: Fix typo

### DIFF
--- a/pep-0557.rst
+++ b/pep-0557.rst
@@ -236,7 +236,7 @@ The parameters to ``dataclass`` are:
   mutated. This is a specialized use case and should be considered
   carefully.
 
-  If a class already has an explicitely defined ``__hash__`` the
+  If a class already has an explicitly defined ``__hash__`` the
   behavior when adding ``__hash__`` is modified.  An expicitely
   defined ``__hash__`` is defined when:
 
@@ -249,10 +249,10 @@ The parameters to ``dataclass`` are:
     - ``__eq__`` is not defined on the class, and any ``__hash__`` is
       defined.
 
-  If ``unsafe_hash`` is true and an explicitely defined ``__hash__``
+  If ``unsafe_hash`` is true and an explicitly defined ``__hash__``
   is present, then ``ValueError`` is raised.
 
-  If ``unsafe_hash`` is false and an explicitely defined ``__hash__``
+  If ``unsafe_hash`` is false and an explicitly defined ``__hash__``
   is present, then no ``__hash__`` is added.
 
   See the Python documentation [#]_ for more information.


### PR DESCRIPTION
Corrects spelling of “explicitly”.