### PR TITLE
PEP 8015: Committee has 5 members

### DIFF
--- a/pep-8015.rst
+++ b/pep-8015.rst
@@ -250,6 +250,12 @@ is responsible to select the elected member(s).
 If a committee member steps down, a new vote is organized to replace
 them.
 
+If the situation of a committee member changes in a way that no longer
+satisfies the committee constraint (ex: they move to the same company as
+two other committee members), they have to resign. If the employer of a
+member is acquired by the employer of two other members, the member with
+the mandate ending earlier has to resign once the acquisition completes.
+
 Election Creating the Python Steering Committee Members
 -------------------------------------------------------
 
@@ -583,8 +589,6 @@ History of this PEP:
   * The Steering Committee is now made of 5 people instead of 3.
   * There are no term limits (instead of a limit of 2 mandates:
     6 years in total).
-  * When a Steering Committee member moves to the same company than
-    other members, they don't have to resign anymore.
   * A committee member can now be a PEP delegate.
 
 * Version 6: Adjust votes

--- a/pep-8015.rst
+++ b/pep-8015.rst
@@ -15,11 +15,11 @@ proposes 3 main changes:
 * Formalize the existing concept of "Python teams";
 * Give more autonomy to Python teams;
 * Replace the BDFL (Guido van Rossum) with a new "Python Steering
-  Committee" of 3 members which have limited roles. Their key role is
-  mostly to decide how a PEP is approved (or rejected or deferred),
-  but not to approve PEPs.
+  Committee" of 5 members which has limited roles: basically decide how
+  decisions are taken, but don't take decisions.
 
-Note: the "BDFL-delegate" role is renamed to "PEP delegate".
+PEPs are approved by a PEP delegate or by a vote (reserved to core
+developers, need ``>= 2/3`` majority).
 
 
 Rationale
@@ -180,9 +180,24 @@ developers since it has the most decision power. The roles of this group
 are strictly limited to ensure that Python keeps its autonomy and
 remains open.
 
-Steering Committee members are elected for 3 years, a member is replaced
-every year. This way, a member will stay for one full Python release and
-the committee composition will be updated frequently.
+The Python Steering Committee is composed of 5 members. They are elected
+for 3 years and 1/3 is replaced every year (first year: 1, second year:
+2, third year: 2). This way, a member will stay for one full Python
+release and the committee composition will be updated frequently. A
+committee member can be a candidate for the seat they are leaving.
+There are no term limits.
+
+Committee members must be Python core developers. It is important that
+the members of the committee reflect the diversity of Python' users and
+contributors. A small step to ensure that is to enforce that only 2
+members (strictly less than 50% of the 5 members) can work for the same
+employer (same company or subsidiaries of the same company). If a
+committee member moves to same company than other committee members,
+they don't have to resign.
+
+The size of 5 members has been chosen for the members diversity and to
+ensure that the committee can continue to work even if a member becomes
+unavailable for an unknown duration.
 
 Python Steering Committee Roles
 -------------------------------
@@ -213,19 +228,6 @@ delegates is meant to help them to achieve that goal.
 Election of Python Steering Committee Members
 ---------------------------------------------
 
-The Python Steering Committee is composed of 3 members. They are elected
-for three year terms, and each year a member is replaced. A committee
-member can be a candidate for the seat they are leaving (with a total
-limit of 2 mandates, see below).
-
-Committee members must be Python core developers. It is important that
-the members of the committee reflect the diversity of Python' users and
-contributors. A small step to ensure that is to enforce that two members
-cannot work for the same company (or subsidiaries of the same company).
-In addition, to encourage more people to get involved, a core developer
-can only be a committee member twice in their whole life (up to 6 years
-total), it can be two mandates in a row.
-
 The vote is organized by the Steering Committee. It is announced 3 weeks
 in advance: candidates have to apply during this period. The vote is
 reserved to core developers and is open for 1 week. To avoid
@@ -243,27 +245,23 @@ creation of the committee.
 In case of tie, a new vote is organized immediately between candidates
 involved in the tie using the same voting method and also during 1 week.
 If the second vote leads to a tie again, the current Steering Committee
-is responsible to seleect the elected member.
+is responsible to select the elected member(s).
 
-If a committee member steps down, a new vote is organized to replace them.
-If the situation of a committee member changes in a way that no longer
-satisfies the committee constraint (eg: they move to the same company as
-another committee member), they have to resign. If the employer of a
-member is acquired by the employer of another member, the member with
-the mandate ending earlier has to resign once the acquisition completes.
+If a committee member steps down, a new vote is organized to replace
+them.
 
 Election Creating the Python Steering Committee Members
 -------------------------------------------------------
 
-To bootstrap the process, 3 members will be elected at the committee
-creation. The vote follow the same rules than regular committee votes,
-except that the election needs 3 members, and the vote is organized by
+To bootstrap the process, 5 members are elected at the committee
+creation. The vote follows the same rules than regular committee votes,
+except that the election needs 5 members, and the vote is organized by
 the PSF Board.
 
-If two candidates that should be elected are working for the same
-company, only the first in the vote result is elected, the second is not
-elected, but the following candidate in the order of the vote result is
-elected.
+In a council election, if 3 of the top 5 vote-getters work for the
+same employer, then whichever of them ranked lowest is disqualified
+and the 6th-ranking candidate moves up into 5th place; this is
+repeated until a valid council is formed.
 
 In case of tie, a second vote is organized immediately between
 candidates involved in the tie and following candidates to fill the
@@ -272,34 +270,35 @@ committee vote. If the second vote still result in a tie, the PSF Board
 is responsible to elect members and decide their position in the vote
 result.
 
-The order in the vote result must be unique for elected members: the
-first is elected for 3 years, the second for 2 years, and the third for
-1 year.
+The order in the vote result must be unique for elected members: #1 and
+#2 are elected for 3 years, #2 and #3 for 2 years, and #5 for 1 year.
 
 Example of vote result with a tie:
 
 * A
-* B, C
+* B
+* C
 * D
-* E
+* E, F
+* G
 * ...
 
-Candidate A is elected immediately, but a second vote is organized
-between B and C. If A and B are working for the same company, A (1st), C
-(2nd) and D (3rd) are elected, but B is not elected.
+The first 4 candidates (A, B, C and D) are elected immediately. If E
+works for the same employer than two other elected member, F is also
+elected. Otherwise, a second vote is organized for the 5th seat between
+E and F.
 
 Special Case: Steering Committee Members And PEPs
 -------------------------------------------------
 
-A committee member cannot be a PEP delegate.
+A committee member can be a PEP delegate.
 
-A committee member can propose a PEP, but cannot decide how their own PEP
-is approved. In this case, the two other board members decide how this
-PEP is approved.
+A committee member can propose a PEP, but cannot be the PEP delegate of
+their own PEP.
 
 When the committee decides that a PEP must be voted, committee members
 can vote as they are also core developers, but they don't have more
-power than any other core developer.
+power than other core developer.
 
 
 PSF Code of Conduct Workgroup
@@ -476,7 +475,7 @@ the stdlib diverges in newer stable branches).
 Mentorship Team
 ---------------
 
-Becoming a core developer is long and slow process. Mentorship an an
+Becoming a core developer is long and slow process. Mentorship is an
 efficient way to train contributors as future core developers and build
 a trust relationship.
 
@@ -578,6 +577,15 @@ Version History
 ===============
 
 History of this PEP:
+
+* Version 7: Adjust the Steering Committee
+
+  * The Steering Committee is now made of 5 people instead of 3.
+  * There are no term limits (instead of a limit of 2 mandates:
+    6 years in total).
+  * When a Steering Committee member moves to the same company than
+    other members, they don't have to resign anymore.
+  * A committee member can now be a PEP delegate.
 
 * Version 6: Adjust votes
 

--- a/pep-8015.rst
+++ b/pep-8015.rst
@@ -191,9 +191,7 @@ Committee members must be Python core developers. It is important that
 the members of the committee reflect the diversity of Python' users and
 contributors. A small step to ensure that is to enforce that only 2
 members (strictly less than 50% of the 5 members) can work for the same
-employer (same company or subsidiaries of the same company). If a
-committee member moves to same company than other committee members,
-they don't have to resign.
+employer (same company or subsidiaries of the same company).
 
 The size of 5 members has been chosen for the members diversity and to
 ensure that the committee can continue to work even if a member becomes


### PR DESCRIPTION
* The Steering Committee is now made of 5 people instead of 3.
* There are no term limits (instead of a limit of 2 mandates:
  6 years in total).
* A committee member can now be a PEP delegate.