### PR TITLE
PEP 0517: Remove misleading ".zip" example sdist

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -70,7 +70,7 @@ interface for installing from this format, to support usages like
 ``pip install some-directory/``.
 
 A *source distribution* is a static snapshot representing a particular
-release of some source code, like ``lxml-3.4.4.zip``. Source
+release of some source code, like ``lxml-3.4.4.tar.gz``. Source
 distributions serve many purposes: they form an archival record of
 releases, they provide a stupid-simple de facto standard for tools
 that want to ingest and process large corpora of code, possibly


### PR DESCRIPTION
Later on in the same PEP, it says that the `.zip` example can't possibly work:

> [source distributions] will be gzipped tar archives, with the .tar.gz extension. Zip archives, or other compression formats for tarballs, are not allowed at present.

This, and other documentation issues not fixed here, was noted in a blog post I was reading: https://blog.schuetze.link/2018/07/21/a-dive-into-packaging-native-python-extensions.html. Full credit to @konstin.