### PR TITLE
PEP 8001: Add draft of vote details

### DIFF
--- a/pep-8001.rst
+++ b/pep-8001.rst
@@ -97,7 +97,76 @@ The election will be supervised by Ernest W. Durbin III, The PSF Director of Inf
 The results of the election, including anonymized ballots, will be made public on
 December 17th, after the election has closed.
 
-The following settings will be used for the vote in the CIVS system::
+The following settings will be used for the vote in the CIVS system:
+
+Name of the poll: ``Python governance vote (December 2018)``
+
+Description of the poll::
+
+    This is the vote to choose how the CPython project will govern
+    itself, now that Guido has announced his retirement as BDFL. For
+    full details, see <a
+    href="https://www.python.org/dev/peps/pep-8001/">PEP
+    8001</a>. Many discussions have occurred under <a
+    href="https://discuss.python.org/tags/governance">the "governance"
+    tag</a> on discuss.python.org.
+    <p>
+    All votes must be received <b>by the end of December 16th, 2018, <a
+    href="https://en.wikipedia.org/wiki/Anywhere_on_Earth">Anywhere on
+    Earth</a></b>. All CPython core developers are eligible to vote.
+    <p>
+    <b>Note: You can only vote once, and all votes are final.</b> Once
+    you click "Submit ranking", it's too late to change your mind.
+    <p>
+    All ballots will be published at the end of voting, but <b>without
+    any names attached</b>. No-one associated with the Python project or
+    the PSF will know how you voted, or even whether you voted.
+    <p>
+    If you have any questions, you can post in <a
+    href="https://discuss.python.org/c/committers">the Committers
+    topic</a>, on <a href="mailto:python-committers@python.org">the
+    python-committers list</a>, or <a
+    href="mailto:ewdurbin@gmail.com">contact the vote administrator
+    directly</a>.
+    <p>
+    <h1>Options</h1>
+    <p>
+    We're selecting between seven PEPs, each proposing a different
+    governance model.
+    <p>
+    The options below include links to the text of each PEP, as well
+    as their complete change history. The text of these PEPs was
+    frozen on December 1, when the vote started. But if you looked at
+    the PEPs before that, they might have changed. For convenience,
+    the following is a complete list of changes since the official
+    review period started on November 16:
+    <p>
+    <ul>
+      <li><i>(no changes)</i></li>
+    </ul>
+    <p>
+    A "Further discussion" option is also included. It represents the
+    option of not making a choice at all at this time, and continuing
+    the discussion instead. Including this option lets us demonstrate
+    the core team's readiness to move forward.
+    <p>
+    If you think a proposal is a particularly bad idea, you can
+    express that by ranking it below "Further discussion". If you
+    think all of the proposals are better than further discussion,
+    then you should rank "Further discussion" last.
+
+Candidates (note: linebreaks are significant here)::
+
+    <a href="https://www.python.org/dev/peps/pep-8010/">PEP 8010: The Technical Leader Governance Model</a> (Warsaw) (<a href="https://github.com/python/peps/commits/master/pep-8010.rst">changelog</a>)
+    <a href="https://www.python.org/dev/peps/pep-8011/">PEP 8011: Python Governance Model Lead by Trio of Pythonistas</a> (Wijaya, Warsaw) (<a href="https://github.com/python/peps/commits/master/pep-8011.rst">changelog</a>)
+    <a href="https://www.python.org/dev/peps/pep-8012/">PEP 8012: The Community Governance Model</a> (Langa) (<a href="https://github.com/python/peps/commits/master/pep-8012.rst">changelog</a>)
+    <a href="https://www.python.org/dev/peps/pep-8013/">PEP 8013: The External Council Governance Model</a> (Dower) (<a href="https://github.com/python/peps/commits/master/pep-8013.rst">changelog</a>)
+    <a href="https://www.python.org/dev/peps/pep-8014/">PEP 8014: The Commons Governance Model</a> (Jansen) (<a href="https://github.com/python/peps/commits/master/pep-8014.rst">changelog</a>)
+    <a href="https://www.python.org/dev/peps/pep-8015/">PEP 8015: Organization of the Python community</a> (Stinner) (<a href="https://github.com/python/peps/commits/master/pep-8015.rst">changelog</a>)
+    <a href="https://www.python.org/dev/peps/pep-8016/">PEP 8016: The Steering Council Model</a> (Smith, Stufft) (<a href="https://github.com/python/peps/commits/master/pep-8016.rst">changelog</a>)
+    Further discussion
+
+Options::
 
     [x] Private
     [ ] Make this a test poll: read all votes from a file.
@@ -109,7 +178,7 @@ The following settings will be used for the vote in the CIVS system::
     [ ] Allow voters to select “no opinion” for some choices.
     [ ] Enforce proportional representation
 
-Which will have the effect of:
+These options will have the effect of:
 
 * Making the election "private", or in other words, invite only.
 * The results of the election will be released to all voters.

--- a/pep-8001.rst
+++ b/pep-8001.rst
@@ -113,7 +113,10 @@ Description of the poll::
     <p>
     All votes must be received <b>by the end of December 16th, 2018, <a
     href="https://en.wikipedia.org/wiki/Anywhere_on_Earth">Anywhere on
-    Earth</a></b>. All CPython core developers are eligible to vote.
+    Earth</a></b>. All CPython core developers are <a
+    href="https://github.com/python/voters">eligible to vote</a>.
+    It is asked that inactive core developers <i>who intend to remain
+    inactive</i> abstain from voting.
     <p>
     <b>Note: You can only vote once, and all votes are final.</b> Once
     you click "Submit ranking", it's too late to change your mind.
@@ -137,13 +140,9 @@ Description of the poll::
     The options below include links to the text of each PEP, as well
     as their complete change history. The text of these PEPs was
     frozen on December 1, when the vote started. But if you looked at
-    the PEPs before that, they might have changed. For convenience,
-    the following is a complete list of changes since the official
-    review period started on November 16:
-    <p>
-    <ul>
-      <li><i>(no changes)</i></li>
-    </ul>
+    the PEPs before that, they might have changed. Please take the
+    time to check the current text of the PEPs if you read an older
+    draft.
     <p>
     A "Further discussion" option is also included. It represents the
     option of not making a choice at all at this time, and continuing


### PR DESCRIPTION
The vote's supposed to start in a few days, so I figured it would be
good to get out ahead of any last-minute futzing with the text. Here's
a fully-fleshed-out proposal for the vote instructions and options, so
everyone can review.

I also set up a test vote on CIVS, using the text in my initial
commit, so you can see how it will actually look in context:
https://civs.cs.cornell.edu/cgi-bin/vote.pl?id=E_f3dd3ec110515d32&akey=add219018ca56843

I'll post these links on python-committers too.

CC: @ewdurbin