### PR TITLE
PEP 8016: remove confusing term "strict majority"

### DIFF
--- a/pep-8016.rst
+++ b/pep-8016.rst
@@ -109,8 +109,8 @@ committee than to rule on individual cases. And so on.
 
 To use its powers, the council votes. Every council member must either
 vote or explicitly abstain. Members with conflicts of interest on a
-particular vote must abstain. Passing requires a strict majority of
-non-abstaining council members.
+particular vote must abstain. Passing requires support from a majority
+of non-abstaining council members.
 
 Whenever possible, the council's deliberations and votes shall be held
 in public.


### PR DESCRIPTION
This doesn't change the meaning at all; just removes a confusing term.

Thanks to Xiang Zhang for pointing this out here:
https://discuss.python.org/t/pep-8016-the-steering-council-model/394/36