### PR TITLE
PEP 581: Mention GitHub's new feature wrt issue template

### DIFF
--- a/pep-0581.rst
+++ b/pep-0581.rst
@@ -205,7 +205,8 @@ issue. If the issue creator did not supply the above headers, the bot will apply
 the ``needs triage`` label. At that point, it will require a core developer to
 properly label the issue.
 
-We can also take advantage of GitHub's multiple issue template feature.
+We can also take advantage of GitHub's multiple issue template feature, and the
+ability to automatically set issue assignee and labels.
 
 Updates to bedevere
 -------------------

--- a/pep-0581.rst
+++ b/pep-0581.rst
@@ -206,7 +206,7 @@ the ``needs triage`` label. At that point, it will require a core developer to
 properly label the issue.
 
 We can also take advantage of GitHub's multiple issue template feature, and the
-ability to automatically set issue assignee and labels.
+ability to automatically set issue assignee and labels by using issue templates.
 
 Updates to bedevere
 -------------------


### PR DESCRIPTION
It is now possible to automate issue assignee and labels via templates.
https://blog.github.com/changelog/2018-12-05-issue-template-automation-improvements/
