### PR TITLE
PEP 494/537: 3.7.2rc1 and 3.6.8rc1 released

### DIFF
--- a/pep-0494.txt
+++ b/pep-0494.txt
@@ -110,7 +110,7 @@ Release Schedule
 
 Final maintenance mode release, final binary releases.
 
-- 3.6.8 candidate: 2018-12-11 (expected)
+- 3.6.8 candidate: 2018-12-11
 - 3.6.8 final: 2018-12-20 (expected)
 
 3.6.9 and beyond schedule

--- a/pep-0537.txt
+++ b/pep-0537.txt
@@ -71,7 +71,7 @@ Release Schedule
 3.7.2 schedule
 --------------
 
-- 3.7.2 candidate 1: 2018-12-11 (expected)
+- 3.7.2 candidate 1: 2018-12-11
 - 3.7.2 final: 2018-12-20 (expected)
 
 


### PR DESCRIPTION
https://blog.python.org/2018/12/python-372rc1-and-368rc1-now-available.html