### PR TITLE
Talk about line length instead of window size

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -218,10 +218,9 @@ lines. Some web based tools may not offer dynamic line wrapping at all.
 
 Some teams strongly prefer a longer line length.  For code maintained
 exclusively or primarily by a team that can reach agreement on this
-issue, it is okay to increase the nominal line length from 80 to
-100 characters (effectively increasing the maximum length to 99
-characters), provided that comments and docstrings are still wrapped
-at 72 characters.
+issue, it is okay to increase the line length limit up to 99 characters,
+provided that comments and docstrings are still wrapped at 72
+characters.
 
 The Python standard library is conservative and requires limiting
 lines to 79 characters (and docstrings/comments to 72).


### PR DESCRIPTION
Avoid unnecessary mixing of line length and window width, as it can be confusing.