### PR TITLE
PEP 517: Improve wording on including setup.py in the source distribution

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -161,11 +161,9 @@ If the ``pyproject.toml`` file is absent, or the ``build-backend``
 key is missing, the source tree is not using this specification, and
 tools should fall back to running ``setup.py``.
 
-Where the ``build-backend`` key exists, it takes precedence over
-``setup.py``, and source trees need not include ``setup.py`` at all
-if the build backend does not require it.
-Projects may still wish to include a ``setup.py`` for compatibility
-with tools that do not use this spec.
+Where the ``build-backend`` key exists, this takes precedence and the source tree follows the format and
+conventions of the specified backend (as such no ``setup.py`` is needed unless the backend requires it).
+Projects may still wish to include a ``setup.py`` for compatibility with tools that do not use this spec.
 
 =========================
  Build backend interface

--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -162,7 +162,8 @@ key is missing, the source tree is not using this specification, and
 tools should fall back to running ``setup.py``.
 
 Where the ``build-backend`` key exists, it takes precedence over
-``setup.py``, and source trees need not include ``setup.py`` at all.
+``setup.py``, and source trees need not include ``setup.py`` at all
+if the build backend does not require it.
 Projects may still wish to include a ``setup.py`` for compatibility
 with tools that do not use this spec.
 


### PR DESCRIPTION
Make it explicit that including a ``setup.py`` is still needed if the build backend tool uses it (aka dropping the setup.py) is not mandatory.

The current wording could mislead someone to think that the ``build_backend`` keyword and ``setup.py`` are mutually exclusive (aka need not - could be interpreted as must not).