### PR TITLE
PEP 8100: a PEP to track details of the steering council election

### DIFF
--- a/pep-0013.rst
+++ b/pep-0013.rst
@@ -23,6 +23,8 @@ The current steering council consists of:
 
 * to be determined
 
+The current steering council vote is tracked in PEP 584.
+
 The core team consists of:
 
 [TODO: we need a canonical list somewhere, in order to hold votes and
@@ -299,6 +301,9 @@ votes cast in a core team vote.
 History
 =======
 
+Creation of this document
+-------------------------
+
 The Python project was started by Guido van Rossum, who served as its
 Benevolent Dictator for Life (BDFL) from inception until July 2018,
 when he `stepped down
@@ -317,6 +322,19 @@ reference (and in particular, PEP 8016 contains additional rationale
 and links to contemporary discussions), but this PEP is now the
 official reference, and will evolve following the rules described
 herein.
+
+
+History of council elections
+----------------------------
+
+* January 2019: PEP 584
+
+
+History of amendments
+---------------------
+
+None yet.
+
 
 
 Acknowledgements

--- a/pep-0013.rst
+++ b/pep-0013.rst
@@ -23,7 +23,7 @@ The current steering council consists of:
 
 * to be determined
 
-The current steering council vote is tracked in PEP 584.
+The current steering council vote is tracked in PEP 8100.
 
 The core team consists of:
 
@@ -327,7 +327,7 @@ herein.
 History of council elections
 ----------------------------
 
-* January 2019: PEP 584
+* January 2019: PEP 8100
 
 
 History of amendments

--- a/pep-0584.rst
+++ b/pep-0584.rst
@@ -2,8 +2,7 @@ PEP: 584
 Title: January 2019 steering council election
 Version: $Revision$
 Last-Modified: $Date$
-Author: Ernest W. Durbin III <ewdurbin@gmail.com>, Nathaniel J. Smith
-  <njs@pobox.com>
+Author: Ernest W. Durbin III <ewdurbin@gmail.com>, Nathaniel J. Smith <njs@pobox.com>
 Status: Active
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0584.rst
+++ b/pep-0584.rst
@@ -47,7 +47,7 @@ is a core team member, they may nominate themselves.
 
 Once the nomination period opens, candidates will be listed here:
 
-* *Candidate (nominated by)*
+1. *Candidate (nominated by)*
 
 
 Results

--- a/pep-0584.rst
+++ b/pep-0584.rst
@@ -13,7 +13,7 @@ Abstract
 ========
 
 This document describes the schedule and other details of the January
-2019 election for the CPython steering council, as specified in
+2019 election for the Python steering council, as specified in
 PEP 13. This is the first steering council election.
 
 

--- a/pep-0584.rst
+++ b/pep-0584.rst
@@ -1,0 +1,74 @@
+PEP: 584
+Title: January 2019 steering council election
+Version: $Revision$
+Last-Modified: $Date$
+Author: Ernest W. Durbin III <ewdurbin@gmail.com>, Nathaniel J. Smith
+  <njs@pobox.com>
+Status: Active
+Type: Informational
+Content-Type: text/x-rst
+Created: 3-Jan-2019
+
+
+Abstract
+========
+
+This document describes the schedule and other details of the January
+2019 election for the CPython steering council, as specified in
+PEP 13. This is the first steering council election.
+
+
+Returns officer
+===============
+
+In future elections, the returns officer will be appointed by the
+outgoing steering council. Since this is the first election, we have
+no outgoing steering council, and PEP 13 says that the returns officer
+is instead appointed by the PSF Executive Director, Ewa Jodlowska.
+`She appointed Ernest W. Durbin III
+<https://discuss.python.org/t/officially-appointing-the-returns-officer-for-the-steering-council-election/603>`__.
+
+
+Schedule
+========
+
+There will be a two-week nomination period, followed by a two-week
+vote.
+
+The nomination period is: January 7, 2019 through January 20, 2019
+
+The voting period is: January 21, 2019 through Febuary 3, 2019
+
+
+Candidates
+==========
+
+Candidates must be nominated by a core team member. If the candidate
+is a core team member, they may nominate themselves.
+
+Once the nomination period opens, candidates will be listed here:
+
+* *Candidate (nominated by)*
+
+
+Results
+=======
+
+There are no results yet, but when there are, they'll be listed here.
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+
+..
+  Local Variables:
+  mode: indented-text
+  indent-tabs-mode: nil
+  sentence-end-double-space: t
+  fill-column: 70
+  coding: utf-8
+  End:

--- a/pep-0584.rst
+++ b/pep-0584.rst
@@ -2,7 +2,7 @@ PEP: 584
 Title: January 2019 steering council election
 Version: $Revision$
 Last-Modified: $Date$
-Author: Ernest W. Durbin III <ewdurbin@gmail.com>, Nathaniel J. Smith <njs@pobox.com>
+Author: Nathaniel J. Smith <njs@pobox.com>, Ernest W. Durbin III <ewdurbin@gmail.com>
 Status: Active
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-8100.rst
+++ b/pep-8100.rst
@@ -1,4 +1,4 @@
-PEP: 584
+PEP: 8100
 Title: January 2019 steering council election
 Version: $Revision$
 Last-Modified: $Date$


### PR DESCRIPTION
Inspired by this thread:

  https://discuss.python.org/t/how-do-we-want-to-collect-nominees/590

@EWDurbin: I listed you as an author, similar to how release managers
are the official authors of release schedule PEPs. Is that OK?