### PR TITLE
PEP 13: Add info about the limited access to members list

### DIFF
--- a/pep-0013.rst
+++ b/pep-0013.rst
@@ -284,7 +284,8 @@ and commit access.
 
 The initial active core team members will consist of everyone
 currently listed in the `"Python core" team on Github
-<https://github.com/orgs/python/teams/python-core/members>`__, and the
+<https://github.com/orgs/python/teams/python-core/members>`__ (access
+granted for core members only), and the
 initial inactive members will consist of everyone else who has been a
 committer in the past.
 


### PR DESCRIPTION
The core team members list is only available for core members. Otherwise a 404 error is displayed so people will try to fix what seems to be a broken link (like me).

This PR is done to close #863

I already signed the CLA to contribute to cpython.

Of course, feel free to rewrite it; english is not my native tongue.
