### PR TITLE
PEP 554: add a deferred idea (priority channels)

### DIFF
--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -1235,6 +1235,11 @@ pattern::
 This would be made even simpler if there existed a ``__reraise__``
 protocol.
 
+Support prioritization in channels
+----------------------------------
+
+A simple example is ``queue.PriorityQueue`` in the stdlib.
+
 
 Rejected Ideas
 ==============


### PR DESCRIPTION
The idea (from private correspondence with Christopher Lozinski) is reasonable but falls outside the minimalist scope of the PEP.