### PR TITLE
PEP 8100: Nominate David Mertz for steering council

### DIFF
--- a/pep-8100.rst
+++ b/pep-8100.rst
@@ -55,6 +55,7 @@ Once the nomination period opens, candidates will be listed here:
 4. `Guido van Rossum <https://discuss.python.org/t/steering-council-nomination-guido-van-rossum/628>`__ (``self``)
 5. `Victor Stinner <https://discuss.python.org/t/steering-council-nomination-victor-stinner/635>`_ (``Christian Heimes``)
 6. `Yury Selivanov <https://discuss.python.org/t/steering-council-nomination-yury-selivanov/645>`_ (``Christian Heimes``)
+7. David Mertz (``Chris Jerdonek``)
 
 
 Voter Roll


### PR DESCRIPTION
I'm nominating David Mertz to the steering council because of his interest expressed in this Python-Dev thread here (and after consulting with him):
https://mail.python.org/pipermail/python-dev/2019-January/155988.html

After merging this, I'll create a topic on Discourse and add to the PEP a hyperlink to the topic, like there is for the other nominees.
