### PR TITLE
PEP 8100: Add hyperlink to discussion topic for David Mertz.

### DIFF
--- a/pep-8100.rst
+++ b/pep-8100.rst
@@ -55,7 +55,7 @@ Once the nomination period opens, candidates will be listed here:
 4. `Guido van Rossum <https://discuss.python.org/t/steering-council-nomination-guido-van-rossum/628>`__ (``self``)
 5. `Victor Stinner <https://discuss.python.org/t/steering-council-nomination-victor-stinner/635>`_ (``Christian Heimes``)
 6. `Yury Selivanov <https://discuss.python.org/t/steering-council-nomination-yury-selivanov/645>`_ (``Christian Heimes``)
-7. David Mertz (``Chris Jerdonek``)
+7. `David Mertz <https://discuss.python.org/t/steering-council-nomination-david-mertz/647>`_ (``Chris Jerdonek``)
 
 
 Voter Roll


### PR DESCRIPTION
This adds the hyperlink to the Discourse discussion.