### PR TITLE
PEP 574: update

### DIFF
--- a/pep-0574.rst
+++ b/pep-0574.rst
@@ -420,6 +420,11 @@ This mechanism has two drawbacks:
   such as ints and strings) triggers a call to the user's ``persistent_id()``
   method, leading to a possible performance drop compared to nominal.
 
+  (the Python 2 ``cPickle`` module supported an undocumented
+  ``inst_persistent_id()`` hook that was only called on non-built-in types;
+  it was added in 1997 in order to alleviate the performance issue of
+  calling ``persistent_id``, presumably at ZODB's request)
+
 Passing a sequence of buffers in ``buffer_callback``
 ----------------------------------------------------
 

--- a/pep-0574.rst
+++ b/pep-0574.rst
@@ -212,10 +212,20 @@ PickleBuffer objects:
    Release the ``PickleBuffer`` instance's underlying buffer.
 
 
+Buffer requirements
+-------------------
+
 ``PickleBuffer`` can wrap any kind of buffer, including non-contiguous
-buffers.  It's up to consumers to decide how best to handle different kinds
-of buffers (for example, some consumers may find it acceptable to make a
-contiguous copy of non-contiguous buffers).
+buffers.  However, it is required that ``__reduce__`` only returns a
+contiguous ``PickleBuffer`` (*contiguity* here is meant in the PEP 3118
+sense: either C-ordered or Fortran-ordered).  Non-contiguous buffers
+will raise an error when pickled.
+
+This restriction is primarily an ease-of-implementation issue for the
+``pickle`` module but also other consumers of out-of-band buffers.
+The simplest solution on the provider side is to return a contiguous
+copy of a non-contiguous buffer; a sophisticated provider, though, may
+decide instead to return a sequence of contiguous sub-buffers.
 
 
 Consumer API


### PR DESCRIPTION
Make it a requirement that buffers are contiguous. Efficient tooling for non-contiguous buffers is not available from CPython currently, and consumers shouldn't be required to implement their own handling.

Also add a bit of trivia about an undocumented ZODB-specific `cPickle` hook.