### PR TITLE
pep2html: use raw strings where needed

### DIFF
--- a/pep2html.py
+++ b/pep2html.py
@@ -82,10 +82,10 @@ to templates.  DO NOT USE THIS HTML FILE AS YOUR TEMPLATE!
 DTD = ('<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"\n'
        '                      "http://www.w3.org/TR/REC-html40/loose.dtd">')
 
-fixpat = re.compile("((https?|ftp):[-_a-zA-Z0-9/.+~:?#$=&,]+)|(pep-\d+(.txt|.rst)?)|"
-                    "(RFC[- ]?(?P<rfcnum>\d+))|"
-                    "(PEP\s+(?P<pepnum>\d+))|"
-                    ".")
+fixpat = re.compile(r"((https?|ftp):[-_a-zA-Z0-9/.+~:?#$=&,]+)|(pep-\d+(.txt|.rst)?)|"
+                    r"(RFC[- ]?(?P<rfcnum>\d+))|"
+                    r"(PEP\s+(?P<pepnum>\d+))|"
+                    r".")
 
 EMPTYSTRING = ''
 SPACE = ' '
@@ -115,7 +115,7 @@ def fixanchor(current, match):
         ltext = list(text)
         while ltext:
             c = ltext.pop()
-            if c not in '();:,.?\'"<>':
+            if c not in '''();:,.?'"<>''':
                 ltext.append(c)
                 break
         link = EMPTYSTRING.join(ltext)
@@ -221,7 +221,7 @@ def fixfile(inpath, input_lines, outfile):
     for k, v in header:
         if k.lower() in ('author', 'bdfl-delegate', 'discussions-to'):
             mailtos = []
-            for part in re.split(',\s*', v):
+            for part in re.split(r',\s*', v):
                 if '@' in part:
                     realname, addr = parseaddr(part)
                     if k.lower() == 'discussions-to':
@@ -237,7 +237,7 @@ def fixfile(inpath, input_lines, outfile):
             v = COMMASPACE.join(mailtos)
         elif k.lower() in ('replaces', 'superseded-by', 'requires'):
             otherpeps = ''
-            for otherpep in re.split(',?\s+', v):
+            for otherpep in re.split(r',?\s+', v):
                 otherpep = int(otherpep)
                 otherpeps += '<a href="pep-%04d.html">%i</a> ' % (otherpep,
                                                                   otherpep)


### PR DESCRIPTION
Running with latest CPython master gives several warnings like
```
pep2html.py:87: SyntaxWarning: invalid escape sequence \s
  "(PEP\s+(?P<pepnum>\d+))|"
```