### PR TITLE
PEP 517: Add build-backend-location

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -157,6 +157,13 @@ specified in PYTHONPATH). Although Python automatically adds the working
 directory to ``sys.path`` in some situations, code to resolve the backend should
 not be affected by this.
 
+In order to allow build backends to build themselves, it is possible to supply
+an additional location to search for build backends with the
+``build-backend-location`` option. If specified, this must be a path relative
+to the root of the source tree which will be added to ``sys.path`` while the
+build backend is imported. Build frontends must remove this location from the
+module search path before executing the build backend hooks.
+
 If the ``pyproject.toml`` file is absent, or the ``build-backend``
 key is missing, the source tree is not using this specification, and
 tools should fall back to running ``setup.py``.


### PR DESCRIPTION
This is a provisional wording changing the PEP 517 spec to allow backends to build themselves from a backend in the source tree, using @takluyver's suggested mechanism.

A proof of concept implementation from @takluyver in the `pep517` library is available [here](https://github.com/pypa/pep517/pull/42).

CC: @gaborbernat @pfmoore 

@takluyver Gave you push access to my branch if you want to update the wording.