### PR TITLE
PEP 0551: change title of "Rejected Advice" section

### DIFF
--- a/pep-0551.rst
+++ b/pep-0551.rst
@@ -292,7 +292,7 @@ the use of cached bytecode), and will raise a custom audit event
 ``spython.open_for_import`` containing ``(filename, True_if_allowed)``.
 
 After opening the file, the entire contents is read into memory in a
-single buffer and the file is closed. 
+single buffer and the file is closed.
 
 Compilation will later trigger a ``compile`` event, so there is no need
 to validate the contents now using mechanisms that also apply to
@@ -417,8 +417,8 @@ Since ``importlib``'s use of ``open_for_import`` may be easily bypassed
 with monkeypatching, an audit hook **should** be used to detect
 attribute changes on type objects.
 
-Rejected Advice
-===============
+Things not to do
+================
 
 This section discusses common or "obviously good" recommendations that
 we are specifically *not* making. These range from useless or incorrect


### PR DESCRIPTION
"Rejected Advice" sounds like the section will contain false
statements that should not be followed, instead it contains true
statements about things you should not do.

Change the title to "Things not to do" to be clearer that these are
correct advice but of a negative sense.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
