### PR TITLE
PEP 469: Fix #852 by removing typo iter(d.iteritems()) -> iter(d.items())

### DIFF
--- a/pep-0469.txt
+++ b/pep-0469.txt
@@ -126,7 +126,7 @@ in order to iterate again.
 In Python 3, direct iteration over mappings works the same way as it does
 in Python 2. There are no method based equivalents - the semantic equivalents
 of ``d.itervalues()`` and ``d.iteritems()`` in Python 3 are
-``iter(d.values())`` and ``iter(d.iteritems())``.
+``iter(d.values())`` and ``iter(d.items())``.
 
 The ``six`` and ``future.utils`` compatibility modules also both provide
 ``iterkeys()``, ``itervalues()`` and ``iteritems()`` helper functions that


### PR DESCRIPTION
Fix #852 by updating line 129 in PEP469

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
