### PR TITLE
create package target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 pep-0000.txt
 pep-0000.rst
 pep-????.html
+peps.rss
 __pycache__
 *.pyc
 *.pyo
 *~
 *env
 .vscode
+*.swp
+/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ script:
 
 after_success:
   - test $TRAVIS_BRANCH = "master" &&
-    make package
+    make upload

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ before_install:
     - pip install docutils
 script:
     - make -j
+
+after_success:
+  - test $TRAVIS_BRANCH = "master" &&
+    make package

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ clean:
 	-rm pep-0000.rst
 	-rm pep-0000.txt
 	-rm *.html
+	-rm -rf build
 
 update:
 	git pull https://github.com/python/peps.git
@@ -41,3 +42,10 @@ update:
 venv:
 	$(PYTHON) -m venv venv
 	./venv/bin/python -m pip install -U docutils
+
+package: all rss
+	mkdir -p build/peps
+	cp *.html build/peps/
+	cp *.png build/peps/
+	cp *.rss build/peps/
+	tar -C build -czf build/peps.tar.gz peps

--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,8 @@ package: all rss
 	cp *.png build/peps/
 	cp *.rss build/peps/
 	tar -C build -czf build/peps.tar.gz peps
+
+upload:	venv package
+	./venv/bin/python -m pip install awscli
+	./venv/bin/aws s3 cp --acl public-read build/peps.tar.gz s3://pythondotorg-assets-staging/peps.tar.gz
+	./venv/bin/aws s3 cp --acl public-read build/peps.tar.gz s3://pythondotorg-assets/peps.tar.gz


### PR DESCRIPTION
the peps are built... may as well publish a tarball directly from travis.

python.org hosting is being updated and i'm trying to move it away from local
disk storage, which the current pep integration relies on.

this will allow python.org to pull the tarball out of S3 and do it's work.