### PR TITLE
PEP 432: Direct discussions to capi-sig

### DIFF
--- a/pep-0432.txt
+++ b/pep-0432.txt
@@ -61,7 +61,7 @@ set to ``capi-sig@python.org``. Once a coherent and feasible proposal for a new
 public API has been developed, then that PEP header will be removed, and the
 PEP will be submitted back to ``python-dev`` for further review and discussion.
 (Python 3.9 currently seems like a more plausible time frame for that than
-PEP 3.8 - if that changes, then the target Python version in the PEP will be
+Python 3.8 - if that changes, then the target Python version in the PEP will be
 adjusted accordingly)
 
 

--- a/pep-0432.txt
+++ b/pep-0432.txt
@@ -3,11 +3,12 @@ Title: Restructuring the CPython startup sequence
 Version: $Revision$
 Last-Modified: $Date$
 Author: Nick Coghlan <ncoghlan@gmail.com>
+Discussions-To: capi-sig@python.org
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 28-Dec-2012
-Python-Version: 3.8
+Python-Version: 3.9
 Post-History: 28-Dec-2012, 2-Jan-2013
 
 
@@ -45,6 +46,23 @@ initialization.
 Note: TBC = To Be Confirmed, TBD = To Be Determined. The appropriate
 resolution for most of these should become clearer as the reference
 implementation is developed.
+
+
+PEP Status
+==========
+
+As described further below, the practical constraints on improving the public
+API used to configure an embedded CPython interpreter are currently being
+explored by way of private updates to the initialisation API used by the main
+CPython CLI application.
+
+As long as that is the case, the Discussions-To header in the PEP will remain
+set to ``capi-sig@python.org``. Once a coherent and feasible proposal for a new
+public API has been developed, then that PEP header will be removed, and the
+PEP will be submitted back to ``python-dev`` for further review and discussion.
+(Python 3.9 currently seems like a more plausible time frame for that than
+PEP 3.8 - if that changes, then the target Python version in the PEP will be
+adjusted accordingly)
 
 
 Proposal


### PR DESCRIPTION
Also update the tentative target Python version to 3.9.