### PR TITLE
PEP 457: Better distinguish this PEP from PEP 570

### DIFF
--- a/pep-0457.txt
+++ b/pep-0457.txt
@@ -20,10 +20,11 @@ name; when a function accepting positional-only parameters is called,
 positional arguments are mapped to these parameters based solely on
 their position.
 
-This PEP is an Informational PEP describing the notation for use when describing
-APIs that use positional-only parameters (e.g. in Argument Clinic, or in the
-string representation of `inspect.Signature` objects). A separate PEP, PEP 570,
-proposes elevation of this notation to full Python syntax.
+This PEP is an Informational PEP describing the notation for use when
+describing APIs that use positional-only parameters (e.g. in Argument
+Clinic, or in the string representation of `inspect.Signature`
+objects). A separate PEP, PEP 570, proposes elevation of this notation
+to full Python syntax.
 
 =========
 Rationale
@@ -46,9 +47,9 @@ positional-only parameters.  Put another way, there are
 many builtin functions whose signatures are simply not
 expressable with Python syntax.
 
-This PEP proposes a notation for such signatures that could form the basis of a
-backwards-compatible syntax that should permit implementing any builtin in pure
-Python code (see PEP 570 for that proposal).
+This PEP proposes a notation for such signatures that could form the
+basis of a backwards-compatible syntax that should permit implementing
+any builtin in pure Python code (see PEP 570 for that proposal).
 
 -----------------------------------------------------
 Positional-Only Parameter Semantics In Current Python

--- a/pep-0457.txt
+++ b/pep-0457.txt
@@ -1,5 +1,5 @@
 PEP: 457
-Title: Syntax For Positional-Only Parameters
+Title: Notation For Positional-Only Parameters
 Version: $Revision$
 Last-Modified: $Date$
 Author: Larry Hastings <larry@hastings.org>
@@ -14,11 +14,16 @@ Created: 08-Oct-2013
 Overview
 ========
 
-This PEP proposes a syntax for positional-only parameters in Python.
+This PEP proposes a notation for positional-only parameters in Python.
 Positional-only parameters are parameters without an externally-usable
 name; when a function accepting positional-only parameters is called,
 positional arguments are mapped to these parameters based solely on
 their position.
+
+This PEP is an Informational PEP describing the notation for use when describing
+APIs that use positional-only parameters (e.g. in Argument Clinic, or in the
+string representation of `inspect.Signature` objects). A separate PEP, PEP 570,
+proposes elevation of this notation to full Python syntax.
 
 =========
 Rationale
@@ -41,8 +46,9 @@ positional-only parameters.  Put another way, there are
 many builtin functions whose signatures are simply not
 expressable with Python syntax.
 
-This PEP proposes a backwards-compatible syntax that should
-permit implementing any builtin in pure Python code.
+This PEP proposes a notation for such signatures that could form the basis of a
+backwards-compatible syntax that should permit implementing any builtin in pure
+Python code (see PEP 570 for that proposal).
 
 -----------------------------------------------------
 Positional-Only Parameter Semantics In Current Python


### PR DESCRIPTION
This PEP: shorthand notation to describe positional-only arguments
PEP 570: Elevating that notation to actual Python syntax

