### PR TITLE
PEP 8: minor grammar improvement

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -810,7 +810,7 @@ underscores are recognized (these can generally be combined with any
 case convention):
 
 - ``_single_leading_underscore``: weak "internal use" indicator.
-  E.g. ``from M import *`` does not import objects whose name starts
+  E.g. ``from M import *`` does not import objects whose names start
   with an underscore.
 
 - ``single_trailing_underscore_``: used by convention to avoid


### PR DESCRIPTION
From 
> does not import objects whose name starts with an underscore.

into

> does not import objects whose names start with an underscore.

Closes https://github.com/python/pythondotorg/issues/1387
