### PR TITLE
PEPs 576, 579, 580: Appoint Petr Viktorin as BDFL-Delegate

### DIFF
--- a/pep-0576.rst
+++ b/pep-0576.rst
@@ -1,6 +1,7 @@
 PEP: 576
 Title: Rationalize Built-in function classes
 Author: Mark Shannon <mark@hotpy.org>
+BDFL-Delegate: Petr Viktorin
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0579.rst
+++ b/pep-0579.rst
@@ -1,6 +1,7 @@
 PEP: 579
 Title: Refactoring C functions and methods
 Author: Jeroen Demeyer <J.Demeyer@UGent.be>
+BDFL-Delegate: Petr Viktorin
 Status: Draft
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0580.rst
+++ b/pep-0580.rst
@@ -1,6 +1,7 @@
 PEP: 580
 Title: The C call protocol
 Author: Jeroen Demeyer <J.Demeyer@UGent.be>
+BDFL-Delegate: Petr Viktorin
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst


### PR DESCRIPTION
Petr had been mentioned as a potential delegate prior to the governance
changes, and with Petr's agreement, the Steering Council is appointing
him to review the competing proposals in these PEPs, and make the
decision on which approach to pursue to resolve the issues with the
status quo.