### PR TITLE
PEP 0508: change identifer_end rule to identifier_end

### DIFF
--- a/pep-0508.txt
+++ b/pep-0508.txt
@@ -387,7 +387,7 @@ The complete parsley grammar::
                       | marker_and:m -> m
     marker        = marker_or
     quoted_marker = ';' wsp* marker
-    identifer_end = letterOrDigit | (('-' | '_' | '.' )* letterOrDigit)
+    identifier_end = letterOrDigit | (('-' | '_' | '.' )* letterOrDigit)
     identifier    = < letterOrDigit identifier_end* >
     name          = identifier
     extras_list   = identifier:i (wsp* ',' wsp* identifier)*:ids -> [i] + ids


### PR DESCRIPTION
fixed typo in identifier_end rule that was resulting in attribute error when trying to run the grammar.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
