### PR TITLE
PEP 578: Rename open_for_import to io.open_code

### DIFF
--- a/pep-0578.rst
+++ b/pep-0578.rst
@@ -192,31 +192,33 @@ The new public C API for the verified open hook is::
 
    # Set the handler
    typedef PyObject *(*hook_func)(PyObject *path, void *userData)
-   int PyImport_SetOpenForImportHook(hook_func handler, void *userData)
+   int PyFile_SetOpenCodeHook(hook_func handler, void *userData)
 
    # Open a file using the handler
-   PyObject *PyImport_OpenForImport(const char *path)
+   PyObject *PyFile_OpenCode(const char *path)
 
 The new public Python API for the verified open hook is::
 
    # Open a file using the handler
-   importlib.util.open_for_import(path : str) -> io.IOBase
+   io.open_code(path : str) -> io.IOBase
 
 
-The ``importlib.util.open_for_import()`` function is a drop-in
-replacement for ``open(str(pathlike), 'rb')``. Its default behaviour is
-to open a file for raw, binary access. To change the behaviour a new
+The ``io.open_code()`` function is a drop-in replacement for
+``open(abspath(str(pathlike)), 'rb')``. Its default behaviour is to
+open a file for raw, binary access. To change the behaviour a new
 handler should be set. Handler functions only accept ``str`` arguments.
-The C API ``PyImport_OpenForImport`` function assumes UTF-8 encoding.
+The C API ``PyFile_OpenCode`` function assumes UTF-8 encoding. Paths
+must be absolute, and it is the responsibility of the caller to ensure
+the full path is correctly resolved.
 
-A custom handler may be set by calling ``PyImport_SetOpenForImportHook()``
-from C at any time, including before ``Py_Initialize()``. However, if a
-hook has already been set then the call will fail. When
-``open_for_import()`` is called with a hook set, the hook will be passed
-the path and its return value will be returned directly. The returned
-object should be an open file-like object that supports reading raw
-bytes. This is explicitly intended to allow a ``BytesIO`` instance if
-the open handler has already read the entire file into memory.
+A custom handler may be set by calling ``PyFile_SetOpenCodeHook()`` from
+C at any time, including before ``Py_Initialize()``. However, if a hook
+has already been set then the call will fail. When ``open_code()`` is
+called with a hook set, the hook will be passed the path and its return
+value will be returned directly. The returned object should be an open
+file-like object that supports reading raw bytes. This is explicitly
+intended to allow a ``BytesIO`` instance if the open handler has already
+read the entire file into memory.
 
 Note that these hooks can import and call the ``_io.open()`` function on
 CPython without triggering themselves. They can also use ``_io.BytesIO``
@@ -227,13 +229,13 @@ raise an exception of its choice, as well as performing any other
 logging.
 
 All import and execution functionality involving code from a file will
-be changed to use ``open_for_import()`` unconditionally. It is important
-to note that calls to ``compile()``, ``exec()`` and ``eval()`` do not go
+be changed to use ``open_code()`` unconditionally. It is important to
+note that calls to ``compile()``, ``exec()`` and ``eval()`` do not go
 through this function - an audit hook that includes the code from these
 calls is the best opportunity to validate code that is read from the
 file. Given the current decoupling between import and execution in
-Python, most imported code will go through both ``open_for_import()``
-and the log hook for ``compile``, and so care should be taken to avoid
+Python, most imported code will go through both ``open_code()`` and the
+log hook for ``compile``, and so care should be taken to avoid
 repeating verification steps.
 
 There is no Python API provided for changing the open hook. To modify
@@ -256,10 +258,10 @@ call will have any effect. (Including existence tests in
 security-critical code allows another vector to bypass auditing, so it
 is preferable that the function always exist.)
 
-``importlib.util.open_for_import(path)`` should at a minimum always
-return ``_io.open(path, 'rb')``. Code using the function should make no
-further assumptions about what may occur, and implementations other than
-CPython are not required to let developers override the behavior of this
+``io.open_code(path)`` should at a minimum always return
+``_io.open(path, 'rb')``. Code using the function should make no further
+assumptions about what may occur, and implementations other than CPython
+are not required to let developers override the behavior of this
 function with a hook.
 
 Suggested Audit Hook Locations
@@ -287,14 +289,14 @@ see which operations provide audit events.
    ``PySys_AddAuditHook``, ``sys.addaudithook``, "", "Detect when new
    audit hooks are being added.
    "
-   ``PyImport_SetOpenForImportHook``, ``setopenforimporthook``, "", "
-   Detects any attempt to set the ``open_for_import`` hook.
+   ``PyFile_SetOpenCodeHook``, ``setopencodehook``, "", "
+   Detects any attempt to set the ``open_code`` hook.
    "
    "``compile``, ``exec``, ``eval``, ``PyAst_CompileString``,
    ``PyAST_obj2mod``", ``compile``, "``(code, filename_or_none)``", "
    Detect dynamic code compilation, where ``code`` could be a string or
    AST. Note that this will be called for regular imports of source
-   code, including those that were opened with ``open_for_import``.
+   code, including those that were opened with ``open_code``.
    "
    "``exec``, ``eval``, ``run_mod``", ``exec``, "``(code_object,)``", "
    Detect dynamic execution of code objects. This only occurs for
@@ -454,14 +456,14 @@ have been added and modify their behaviour appropriately.
 Currently, we are not aware of any legitimate reasons for a program to
 behave differently in the presence of audit hooks.
 
-Both application-level APIs ``sys.audit`` and
-``importlib.util.open_for_import`` are always present and functional,
-regardless of whether the regular ``python`` entry point or some
-alternative entry point is used. Callers cannot determine whether any
-hooks have been added (except by performing side-channel analysis), nor
-do they need to. The calls should be fast enough that callers do not
-need to avoid them, and the program is responsible for ensuring that
-any added hooks are fast enough to not affect application performance.
+Both application-level APIs ``sys.audit`` and ``io.open_code`` are
+always present and functional, regardless of whether the regular
+``python`` entry point or some alternative entry point is used. Callers
+cannot determine whether any hooks have been added (except by performing
+side-channel analysis), nor do they need to. The calls should be fast
+enough that callers do not need to avoid them, and the program is
+responsible for ensuring that any added hooks are fast enough to not
+affect application performance.
 
 The argument that this is "security by obscurity" is valid, but
 irrelevant. Security by obscurity is only an issue when there are no


### PR DESCRIPTION
Haven't implemented these changes yet, and I want to do that before committing this, but at least getting the new proposed names out there early.