### PR TITLE
PEP 257: replaced "triple-quoted strings" to "triple double quotes"

### DIFF
--- a/pep-0257.txt
+++ b/pep-0257.txt
@@ -75,7 +75,7 @@ detailed description of attribute and additional docstrings.
 For consistency, always use ``"""triple double quotes"""`` around
 docstrings.  Use ``r"""raw triple double quotes"""`` if you use any
 backslashes in your docstrings.  For Unicode docstrings, use
-``u"""Unicode triple-quoted strings"""``.
+``u"""Unicode triple double quotes"""``.
 
 There are two forms of docstrings: one-liners and multi-line
 docstrings.


### PR DESCRIPTION
For consistency, I replaced "triple-quoted strings" to "triple double quotes", like used before, which make more sense.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
