### PR TITLE
PEP 570: Demonstrate a corner case

### DIFF
--- a/pep-0570.rst
+++ b/pep-0570.rst
@@ -88,7 +88,7 @@ There are functions with other interesting semantics:
 
 * ``dict()``, whose mapping/iterator parameter is optional and semantically
   must be positional-only. Any externally visible name for this parameter
-would occlude that name going into the ``**kwarg`` keyword variadic parameter
+  would occlude that name going into the ``**kwarg`` keyword variadic parameter
   dict. [#DICT]_
 
 One can emulate these semantics in Python code by accepting

--- a/pep-0570.rst
+++ b/pep-0570.rst
@@ -88,7 +88,7 @@ There are functions with other interesting semantics:
 
 * ``dict()``, whose mapping/iterator parameter is optional and semantically
   must be positional-only. Any externally visible name for this parameter
-  would occlude that name going into the ``**kwarg`` keyword variadic parameter
+would occlude that name going into the ``**kwarg`` keyword variadic parameter
   dict. [#DICT]_
 
 One can emulate these semantics in Python code by accepting
@@ -513,6 +513,36 @@ and for ``varargslist`` would be::
       | '*' [vfpdef] (',' vfpdef ['=' test])* [',' ['**' vfpdef [',']]]
       | '**' vfpdef [',']
     )
+
+--------------------
+Semantic Corner Case
+--------------------
+
+The following is an interesting corollary of the specification.
+Consider this function definition::
+
+    def foo(name, **kwds):
+        return 'name' in kwds
+
+There is no possible call that will make it return ``True``.
+For example::
+
+    >>> foo(1, **{'name': 2})
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+    TypeError: foo() got multiple values for argument 'name'
+    >>>
+
+But using ``/`` we can support this::
+
+    def foo(name, /, **kwds):
+        return 'name' in kwds
+
+Now the above call will return ``True``.
+
+In other words, the names of positional-only parameters can be used in
+``**kwds`` without ambiguity.  (An another example, this benefits the
+signatures of ``dict()`` and ``dict.update()``.)
 
 ----------------------------
 Origin of "/" as a Separator

--- a/pep-0570.rst
+++ b/pep-0570.rst
@@ -541,7 +541,7 @@ But using ``/`` we can support this::
 Now the above call will return ``True``.
 
 In other words, the names of positional-only parameters can be used in
-``**kwds`` without ambiguity.  (An another example, this benefits the
+``**kwds`` without ambiguity.  (As another example, this benefits the
 signatures of ``dict()`` and ``dict.update()``.)
 
 ----------------------------


### PR DESCRIPTION
The name of a positional-only parameter can occur in `**kwds`.

(This is not really an addition to the specification, it just clarifies a corollary.)

This was brought up in https://github.com/python/cpython/pull/12637#issuecomment-480481885