### PR TITLE
PEP 590: Clarify the use of PY_VECTORCALL_ARGUMENTS_OFFSET.

### DIFF
--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -88,12 +88,19 @@ The call takes the form ``((vectorcall)(((char *)o)+offset))(o, n, args, kwnames
 ``offset`` is ``TYPE(o)->tp_vectorcall``
 The caller is responsible for creating the ``kwnames`` tuple and ensuring that there are no duplicates in it.
 ``n`` is the number of postional arguments plus ``PY_VECTORCALL_ARGUMENTS_OFFSET`` if the argument vector pointer points to argument 1 in the
-allocated vector.
+allocated vector and the callee is allowed to mutate the contents of the ``args`` vector.
 ``n = number_postional_args | (offset ? PY_VECTORCALL_ARGUMENTS_OFFSET: 0))``.
 
-Example of how ``PY_VECTORCALL_ARGUMENTS_OFFSET`` is used by a callee to avoid allocation [3]_
+PY_VECTORCALL_ARGUMENTS_OFFSET
+------------------------------
 
-Whenever they can do so cheaply (without allocation) callers are encouraged to offset the arguments. 
+When a caller sets the ``PY_VECTORCALL_ARGUMENTS_OFFSET`` it is indicating that the ``args`` pointer points to item 1 (counting from 0) of the allocated array
+and that the contents of the allocated array can be safely mutated by the callee. The callee still needs to make sure that the reference counts of any objects
+in the array remain correct.
+
+Example of how ``PY_VECTORCALL_ARGUMENTS_OFFSET`` is used by a callee is safely used to avoid allocation [3]_
+
+Whenever they can do so cheaply (without allocation) callers are encouraged to offset the arguments.
 Doing so will allow callables such as bound-methods to make their onward calls cheaply.
 The interpreter already allocates space on the stack for the callable, so it can offset its arguments for no additional cost.
 

--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -230,7 +230,7 @@ References
 .. [2] tp_call/PyObject_Call calling convention
    https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_call
 .. [3] Using PY_VECTORCALL_ARGUMENTS_OFFSET in callee
-   https://github.com/markshannon/cpython/blob/60e87d3a1978b38da40e7f9b6065e4b6a8f31b7f/Objects/classobject.c#L53
+   https://github.com/markshannon/cpython/blob/vectorcall-minimal/Objects/classobject.c#L53
 .. [4] Argument Clinic
    https://docs.python.org/3/howto/clinic.html
 .. [5] PEP 576


### PR DESCRIPTION
Clarifies the use of `PY_VECTORCALL_ARGUMENTS_OFFSET`.
The minimal implementation has also been updated to use `const` arguments.
https://github.com/python/cpython/commit/46e9b77d4b2dfd9f2dcb86842e217a40b243835f