### PR TITLE
PEP 590: Add "Vectorcall" and "fastcall" keywords

### DIFF
--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -1,5 +1,5 @@
 PEP: 590
-Title: A new calling convention for CPython
+Title: Vectorcall: A new calling convention for CPython
 Author: Mark Shannon <mark@hotpy.org>
 Status: Draft
 Type: Standards Track
@@ -12,7 +12,7 @@ Abstract
 ========
 
 This PEP introduces a new calling convention [1]_ for use by CPython and other software and tools in the CPython ecosystem.
-The new calling convention is a formalisation and extension of a calling convention already used internally by CPython.
+The new calling convention is a formalisation and extension of "fastcall", a calling convention already used internally by CPython.
 
 Rationale
 =========


### PR DESCRIPTION
- Add "Vectorcall" to the PEP title to make it easier to reference
- Mention "fastcall" in the abstract, for people familiar with the term

@markshannon, are you OK with renaming the PEP like this?