### PR TITLE
PEP 590: Remove unnecessary PyObject_VectorCall function.

### DIFF
--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -114,15 +114,12 @@ If callables could be sub-classed then any call to a ``function`` or a ``method_
 New C API and changes to CPython
 ================================
 
-``PyObject *PyObject_VectorCallWithCallable(PyObject *obj, PyObject **args, Py_ssize_t nargs, PyTupleObject *kwnames)``
-Calls ``obj`` with the given arguments.
-Note that ``nargs`` is the number of positional arguments; no offsetting is allowed.
+``PyObject *PyObject_VectorCall(PyObject *obj, PyObject **args, Py_ssize_t nargs, PyTupleObject *kwnames)``
 
-``PyObject *PyObject_VectorCall(PyObject **args, Py_ssize_t n, PyTupleObject *kwnames)``
-Calls ``args[0]`` with the remaining arguments.
-Note that ``nargs`` is the number of positional arguments, including the callable; no offsetting is allowed.
+Calls ``obj`` with the given arguments. Note that ``nargs`` may include the flag ``PY_VECTORCALL_ARGUMENTS_OFFSET``.
+``nargs & ~PY_VECTORCALL_ARGUMENTS_OFFSET`` is the number of positional arguments.
 
-Both functions raise an exception if ``obj`` is not callable.
+``PyObject_VectorCall`` raises an exception if ``obj`` is not callable.
 
 Two utility functions are provided to call the new calling convention from the old one, or vice-versa.
 These functions are ``PyObject *PyCall_MakeVectorCall(PyObject *obj, PyObject *tuple, PyObject **dict)`` and
@@ -141,9 +138,9 @@ Internal CPython changes
 
 In order to conform to the specification, the only changes required are:
 
-* Using the new calling convention in the interpreter.
-* Implementing the ``PyObject_Vector`` and ``PyObject_VectorCallWithCallable``.
-* Implementing the ``PyCall_MakeVectorCall`` and ``PyCall_MakeTpCall`` convenience functions.
+* To use the new calling convention in the interpreter.
+* An implementation of the ``PyObject_VectorCall`` function.
+* An implementation of the ``PyCall_MakeVectorCall`` and ``PyCall_MakeTpCall`` convenience functions.
 
 To gain the promised performance advantage, the following classes will need to implement the new calling convention:
 * Python functions


### PR DESCRIPTION
Rather than just removing `PyObject_VectorCall`, I've also renamed the clumsily named `PyOject_VectorCallWithCallable` to `PyObject_VectorCall` and corrected the note about the  use of `PY_VECTORCALL_ARGUMENTS_OFFSET` in `PyObject_VectorCall`. 

Also corrects the section on internal CPython changes.