### PR TITLE
PEP 586: Make backwards compatibility best-effort

### DIFF
--- a/pep-0586.rst
+++ b/pep-0586.rst
@@ -322,29 +322,19 @@ Backwards compatibility
 -----------------------
 
 When type checkers add support for Literal, it's important they do so
-in a way that preserves backwards-compatibility. Code that used to
-type check **must** continue to type check after support for Literal
-is added.
+in a way that maximizes backwards-compatibility. Type checkers should
+ensure that code that used to type check continues to do so after support
+for Literal is added on a best-effort basis.
 
 This is particularly important when performing type inference. For
 example, given the statement ``x = "blue"``, should the inferred
 type of ``x`` be ``str`` or ``Literal["blue"]``?
 
-This PEP does not require any particular strategy for cases like this,
-apart from requiring that backwards compatibility is maintained.
-
-For example, one simple strategy for meeting this requirement would be
-to always assume expressions are *not* Literal types unless they are
-explicitly annotated otherwise. A type checker using this strategy would
-always infer that ``x`` is of type ``str`` in the above example.
-
-If type checkers choose to use more sophisticated inference strategies,
-they should avoid being too over-zealous while doing so.
-
-For example, one strategy that does *not* work is always assuming
-literal values occurring in expressions have the corresponding Literal
-type.  This naive strategy would cause programs like the
-following to start failing when they previously did not::
+One naive strategy would be to always assume expressions are intended
+to be Literal types. So, ``x`` would always have an inferred type of
+``Literal["blue"]`` in the example above. This naive strategy is almost
+certainly too disruptive -- it would cause programs like the following
+to start failing when they previously did not::
 
     # If a type checker infers 'var' has type Literal[3]
     # and my_list has type List[Literal[3]]...
@@ -366,6 +356,15 @@ in objects::
 
     # ...this assignment would no longer type check
     m.field = 4      
+
+An alternative strategy that *does* maintain compatibility in every case would
+be to always assume expressions are *not* Literal types unless they are
+explicitly annotated otherwise. A type checker using this strategy would
+always infer that ``x`` is of type ``str`` in the first example above.
+
+This is not the only viable strategy: type checkers should feel free to experiment
+with more sophisticated inference techniques. This PEP does not mandate any
+particular strategy; it only emphasizes the importance of backwards compatibility.
 
 Using non-Literals in Literal contexts
 --------------------------------------


### PR DESCRIPTION
This pull request relaxes PEP 586 so that type checkers are now expected to maintain backwards compatibility on a best-effort basis, rather than a mandatory basis (as per the earlier discussion on typing-sig).

It also rearranges the order in which information is presented: the section now opens with and focuses on an example of what a too-disruptive inference strategy would look like.
