### PR TITLE
PEP 573: Defer to Python 3.9

### DIFF
--- a/pep-0573.rst
+++ b/pep-0573.rst
@@ -11,7 +11,7 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 02-Jun-2016
-Python-Version: 3.8
+Python-Version: 3.9
 Post-History:
 
 


### PR DESCRIPTION
I'd like to target the module state access PEP to Python 3.9, and focus on C calling convention PEPs (580 & 590) for Python 3.8.
cc @ericsnowcurrently @Dormouse759 @ncoghlan 