### PR TITLE
PEP 554: Change target version to 3.9.

### DIFF
--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -6,7 +6,7 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 2017-09-05
-Python-Version: 3.8
+Python-Version: 3.9
 Post-History: 07-Sep-2017, 08-Sep-2017, 13-Sep-2017, 05-Dec-2017,
               09-May-2018
 


### PR DESCRIPTION
There is too little time left before the 3.8 release and I don't want Antoine to feel rushed to pronounce.  The implementation is mostly complete, so we *could* land it for 3.8.  However, the experience in 3.8 wouldn't be nearly as good, in part because we're still sharing the GIL.  Plus, we need more confidence that extension modules won't be severely impacted by the wide-spread use of subinterpreters.  Waiting for 3.9 will allow us to address both issues, as well improve performance (especially startup).