### PR TITLE
PEP 590: Remove Py_TPFLAGS_HAVE_VECTORCALL flag.

### DIFF
--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -58,20 +58,17 @@ This is implemented by the function pointer type:
 Changes to the ``PyTypeObject``
 -------------------------------
 
-The a new slot called ``tp_vectorcall_offset`` is added. It has the type ``uint32_t``.
-A new flag is added, ``Py_TPFLAGS_HAVE_VECTORCALL``, which is set for any new PyTypeObjects that include the
-``tp_vectorcall_offset`` member.
+The a new slot called ``tp_vectorcall_offset`` is added. It has the type ``uintptr_t``.
 
-If ``Py_TPFLAGS_HAVE_VECTORCALL`` is set then ``tp_vectorcall_offset`` is the offset
-into the object of the ``vectorcall`` function-pointer.
+If ``tp_vectorcall_offset`` is non-zero, it is the offset into the object of the ``vectorcall`` function-pointer.
 
 The unused slot ``printfunc tp_print`` is replaced with ``vectorcall tp_vectorcall``, so that classes
 can support the vectorcall calling convention.
 
-Additional flags
-----------------
+New type flag
+-------------
 
-One additional flag is specified: ``Py_TPFLAGS_METHOD_DESCRIPTOR``.
+One new ``tp_flags`` flag is specified: ``Py_TPFLAGS_METHOD_DESCRIPTOR``.
 
 ``Py_TPFLAGS_METHOD_DESCRIPTOR`` should be set if the the callable uses the descriptor protocol to create a method or method-like object.
 This is used by the interpreter to avoid creating temporary objects when calling methods.


### PR DESCRIPTION
Remove the `Py_TPFLAGS_HAVE_VECTORCALL` flag, and use `tp_vectorcall_offset` unconditionally.

From the discussion in https://bugs.python.org/issue32388. 
It is OK to unconditionally add fields without breaking the ABI.