### PR TITLE
PEP 590: Swap tp_vectorcall_offset and tp_vectorcall slots.

### DIFF
--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -68,6 +68,10 @@ into the object of the ``vectorcall`` function-pointer.
 A new slot ``tp_vectorcall`` is added so that classes can support the vectorcall calling convention.
 It has the type ``vectorcall``.
 
+The ``tp_print`` slot is reused as the ``tp_vectorcall_offset`` slot to make it easier for for external projects to backport the vectorcall protocol to earlier Python versions.
+In particular, the Cython project has shown interest in doing that (see https://mail.python.org/pipermail/python-dev/2018-June/153927.html).
+
+
 Additional flags
 ----------------
 

--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -58,15 +58,15 @@ This is implemented by the function pointer type:
 Changes to the ``PyTypeObject``
 -------------------------------
 
-The a new slot called ``tp_vectorcall_offset`` is added. It has the type ``uint32_t``.
-A new flag is added, ``Py_TPFLAGS_HAVE_VECTORCALL``, which is set for any new PyTypeObjects that include the
+The unused slot ``printfunc tp_print`` is replaced with ``tp_vectorcall_offset``. It has the type ``uintptr_t``.
+
+A new flag is added, ``Py_TPFLAGS_HAVE_VECTORCALL``, which is set for any new PyTypeObjects that use the
 ``tp_vectorcall_offset`` member.
 
 If ``Py_TPFLAGS_HAVE_VECTORCALL`` is set then ``tp_vectorcall_offset`` is the offset
 into the object of the ``vectorcall`` function-pointer.
-
-The unused slot ``printfunc tp_print`` is replaced with ``vectorcall tp_vectorcall``, so that classes
-can support the vectorcall calling convention.
+A new slot ``tp_vectorcall`` is added so that classes can support the vectorcall calling convention.
+It has the type ``vectorcall``.
 
 Additional flags
 ----------------


### PR DESCRIPTION
Will allow Cython to use vectorcall in versions before 3.8.
