### PR TITLE
PEP 590: update

### DIFF
--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -55,7 +55,7 @@ Calls are made through a function pointer taking the following parameters:
 * ``PyObject *callable``: The called object
 * ``PyObject *const *args``: A vector of arguments
 * ``Py_ssize_t nargs``: The number of arguments plus the optional flag ``PY_VECTORCALL_ARGUMENTS_OFFSET`` (see below)
-* ``PyObject *kwnames``: Either ``NULL`` or a tuple with the names of the keyword arguments
+* ``PyObject *kwnames``: Either ``NULL`` or a non-empty tuple with the names of the keyword arguments
 
 This is implemented by the function pointer type:
 ``typedef PyObject *(*vectorcallfunc)(PyObject *callable, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames);``
@@ -99,6 +99,8 @@ The call
 The call takes the form ``((vectorcallfunc)(((char *)o)+offset))(o, args, n, kwnames)`` where
 ``offset`` is ``Py_TYPE(o)->tp_vectorcall_offset``.
 The caller is responsible for creating the ``kwnames`` tuple and ensuring that there are no duplicates in it.
+For efficiently dealing with the common case of no keywords,
+``kwnames`` must be ``NULL`` if there are no keyword arguments.
 
 ``n`` is the number of postional arguments plus possibly the ``PY_VECTORCALL_ARGUMENTS_OFFSET`` flag.
 
@@ -131,8 +133,8 @@ The following functions or macros are added to the C API:
   Calls ``obj`` with the given arguments.
   Note that ``nargs`` may include the flag ``PY_VECTORCALL_ARGUMENTS_OFFSET``.
   The actual number of positional arguments is given by ``PyVectorcall_NARGS(nargs)``.
-  The argument ``keywords`` is a tuple of keyword names or ``NULL``.
-  An empty tuple has the same effect as passing ``NULL``.
+  The argument ``keywords`` is either a dict, a tuple of keyword names or ``NULL``.
+  An empty dict or empty tuple has the same effect as passing ``NULL``.
   This uses either the vectorcall protocol or ``tp_call`` internally;
   if neither is supported, an exception is raised.
 
@@ -149,7 +151,7 @@ New ``METH_VECTORCALL`` flag
 ----------------------------
 
 A new constant ``METH_VECTORCALL`` is added for specifying ``PyMethodDef`` structs.
-It means that the C function has the type ``PyObject *(*call) (PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwname)``.
+It means that the C function has the signature ``vectorcallfunc``.
 This should be the preferred flag for new functions, as this avoids a wrapper function.
 
 **NOTE**: the numerical value of ``METH_VECTORCALL`` is unspecified


### PR DESCRIPTION
Rewrites/clarify some parts of PEP 590 and change some details, adding myself as author.

Main changes:

- Specify that ``kwnames`` must be either ``NULL`` or a non-empty tuple (this is easier for the callee to detect the case of no keyword arguments).
- Allow subclassing the same way as PEP 580.
- Remove ``PyCall_MakeTpCall`` (what's the use case for making this public API?)
- Change ``METH_VECTORCALL`` to mean that the signature is of type ``vectorcall`` (using the actual ``vectorcall`` signature is more natural and faster since you don't need a wrapper at all)
- In ``PyObject_Vectorcall``, allow passing a keyword dict (better to do conversion from dict to tuple in one place, instead of requiring every caller to do that)
- Pass argument vector as `PyObject *const *args` (it's already like that in the implementation)

Details:

- Change the type of ``tp_vectorcall_offset`` to ``Py_ssize_t`` (why ``uintptr_t``? every other offset also has type ``Py_ssize_t``)
- New macro ``PyVectorcall_NARGS(n)`` for ``n & ~PY_VECTORCALL_ARGUMENTS_OFFSET`` (cleaner and more future-proof in case we ever add more special bits)
- New inline function ``PyVectorcall_Function(obj)`` to return the ``vectorcallfunc`` pointer stored in ``obj`` (or `NULL`).
- Change ``PyTupleObject`` in signature to ``PyObject`` (it's already like that in the implementation, passing a specific struct in the Python/C API is normally not done)
- Rename ``PY_VECTORCALL_ARGUMENTS_OFFSET`` -> ``PY_VECTORCALL_PREPEND`` (I didn't like the word "offset" for that, while "prepend" refers to `_PyObject_Call_Prepend`)
- Rename ``vectorcall`` -> ``vectorcallfunc`` (analogous to other function pointer typedefs like `binaryfunc`)
- Rename ``PyCall_MakeVectorCall`` -> ``PyVectorcall_Call``

CC @encukou @markshannon

See also the new implementation at https://github.com/python/cpython/pull/13185