### PR TITLE
PEP 517: Clarify expected front end handling of setup.py based trees

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -697,6 +697,9 @@ implementation was released in pip 19.0.
 * Support for in-tree backends and self-hosting of backends was added by
   the introduction of the ``backend-path`` key in the ``[build-system]``
   table.
+* Clarified that the ``setuptools.build_meta:__legacy__`` PEP 517 backend is
+  an acceptable alternative to directly invoking ``setup.py`` for source trees
+  that don't specify ``build-backend`` explicitly.
 
 
 ===================================

--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -159,7 +159,9 @@ not be affected by this.
 
 If the ``pyproject.toml`` file is absent, or the ``build-backend``
 key is missing, the source tree is not using this specification, and
-tools should fall back to running ``setup.py``.
+tools should revert to the legacy behaviour of running ``setup.py`` (either
+directly, or by implicitly invoking the ``setuptools.build_meta:__legacy__``
+backend).
 
 Where the ``build-backend`` key exists, this takes precedence and the source tree follows the format and
 conventions of the specified backend (as such no ``setup.py`` is needed unless the backend requires it).


### PR DESCRIPTION
The previous wording could be taken as suggesting that frontends should opt
out of their PEP 517 processing entirely if `build-backend` was not defined,
whereas it's actually fine to just use the `setuptools` provided backend that
implements the legacy build semantics.