### PR TITLE
PEP 590: Base update

### DIFF
--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -138,7 +138,7 @@ The following functions or macros are added to the C API:
   This uses either the vectorcall protocol or ``tp_call`` internally;
   if neither is supported, an exception is raised.
 
-- ``PyObject *PyCall_Vectorcall(PyObject *obj, PyObject *tuple, PyObject *dict)``:
+- ``PyObject *PyVectorcall_Call(PyObject *obj, PyObject *tuple, PyObject *dict)``:
   Call the object (which must support vectorcall) with the old
   ``*args`` and ``**kwargs`` calling convention.
   This is mostly meant to put in the ``tp_call`` slot.
@@ -223,7 +223,7 @@ To enable call performance on a par with Python functions and built-in functions
 third-party callables should include a ``vectorcallfunc`` function pointer,
 set ``tp_vectorcall_offset`` to the correct value and add the ``Py_TPFLAGS_HAVE_VECTORCALL`` flag.
 Any class that does this must implement the ``tp_call`` function and make sure its behaviour is consistent with the ``vectorcallfunc`` function.
-Setting ``tp_call`` to ``PyCall_Vectorcall`` is sufficient.
+Setting ``tp_call`` to ``PyVectorcall_Call`` is sufficient.
 
 
 Performance implications of these changes

--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -69,7 +69,7 @@ which must be set for any class that uses the vectorcall protocol.
 
 If ``Py_TPFLAGS_HAVE_VECTORCALL`` is set, then ``tp_vectorcall_offset`` must be a positive integer.
 It is the offset into the object of the vectorcall function pointer of type ``vectorcallfunc``.
-This pointer must not be ``NULL``.
+This pointer may be ``NULL``, in which case the behavior is the same as if ``Py_TPFLAGS_HAVE_VECTORCALL`` was not set.
 
 The ``tp_print`` slot is reused as the ``tp_vectorcall_offset`` slot to make it easier for for external projects to backport the vectorcall protocol to earlier Python versions.
 In particular, the Cython project has shown interest in doing that (see https://mail.python.org/pipermail/python-dev/2018-June/153927.html).
@@ -142,6 +142,10 @@ The following functions or macros are added to the C API:
   Call the object (which must support vectorcall) with the old
   ``*args`` and ``**kwargs`` calling convention.
   This is mostly meant to put in the ``tp_call`` slot.
+
+- ``vectorcallfunc PyVectorcall_FUNC(PyObject *obj)``: If ``obj`` does not support vectorcall,
+  return ``NULL``.
+  Otherwise, return the vectorcall pointer in the instance ``obj`` (which may be ``NULL``).
 
 - ``Py_ssize_t PyVectorcall_NARGS(Py_ssize nargs)``: Given a vectorcall ``nargs`` argument,
   return the actual number of arguments.

--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -63,7 +63,7 @@ This is implemented by the function pointer type:
 Changes to the ``PyTypeObject`` struct
 --------------------------------------
 
-The unused slot ``printfunc tp_print`` is replaced with ``tp_vectorcall_offset``. It has the type ``uint32_t``.
+The unused slot ``printfunc tp_print`` is replaced with ``tp_vectorcall_offset``. It has the type ``Py_ssize_t``.
 A new ``tp_flags`` flag is added, ``Py_TPFLAGS_HAVE_VECTORCALL``,
 which must be set for any class that uses the vectorcall protocol.
 

--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -54,11 +54,11 @@ Calls are made through a function pointer taking the following parameters:
 
 * ``PyObject *callable``: The called object
 * ``Py_ssize_t n``: The number of arguments plus the optional flag ``PY_VECTORCALL_PREPEND`` (see below)
-* ``PyObject **args``: A vector of arguments
+* ``PyObject *const *args``: A vector of arguments
 * ``PyObject *kwnames``: Either ``NULL`` or a non-empty tuple of the names of the keyword arguments
 
 This is implemented by the function pointer type:
-``typedef PyObject *(*vectorcallfunc)(PyObject *callable, Py_ssize_t n, PyObject **args, PyObject *kwnames);``
+``typedef PyObject *(*vectorcallfunc)(PyObject *callable, Py_ssize_t n, PyObject *const *args, PyObject *kwnames);``
 
 Changes to the ``PyTypeObject`` struct
 --------------------------------------
@@ -129,7 +129,7 @@ New C API and changes to CPython
 
 The following functions or macros are added to the C API:
 
-- ``PyObject *PyObject_Vectorcall(PyObject *obj, PyObject **args, Py_ssize_t nargs, PyObject *kwargs)``:
+- ``PyObject *PyObject_Vectorcall(PyObject *obj, PyObject *const *args, Py_ssize_t nargs, PyObject *kwargs)``:
   Calls ``obj`` with the given arguments.
   Note that ``nargs`` may include the flag ``PY_VECTORCALL_PREPEND``.
   The actual number of positional arguments is given by ``PyVectorcall_NARGS(nargs)``.
@@ -138,7 +138,7 @@ The following functions or macros are added to the C API:
   This uses either the vectorcall protocol or ``tp_call`` internally;
   if neither is supported, an exception is raised.
 
-- ``PyObject *PyCall_Vectorcall(PyObject *obj, PyObject *tuple, PyObject **dict)``:
+- ``PyObject *PyCall_Vectorcall(PyObject *obj, PyObject *tuple, PyObject *dict)``:
   Call the object (which must support vectorcall) with the old
   ``*args`` and ``**kwargs`` calling convention.
   This is mostly meant to put in the ``tp_call`` slot.

--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -1,6 +1,6 @@
 PEP: 590
-Title: Vectorcall: A new calling convention for CPython
-Author: Mark Shannon <mark@hotpy.org>
+Title: Vectorcall: a fast calling protocol for CPython
+Author: Mark Shannon <mark@hotpy.org>, Jeroen Demeyer <J.Demeyer@UGent.be>
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
@@ -11,11 +11,17 @@ Post-History:
 Abstract
 ========
 
-This PEP introduces a new calling convention [1]_ for use by CPython and other software and tools in the CPython ecosystem.
-The new calling convention is a formalisation and extension of "fastcall", a calling convention already used internally by CPython.
+This PEP introduces a new C API to optimize calls of objects.
+It introduces a new "vectorcall" protocol and calling convention.
+This is based on the "fastcall" convention, which is already used internally by CPython.
+The new features can be used by any user-defined extension class.
 
-Rationale
-=========
+**NOTE**: This PEP deals only with the Python/C API,
+it does not affect the Python language or standard library.
+
+
+Motivation
+==========
 
 The choice of a calling convention impacts the performance and flexibility of code on either side of the call.
 Often there is tension between performance and flexibility.
@@ -23,21 +29,20 @@ Often there is tension between performance and flexibility.
 The current ``tp_call`` [2]_ calling convention is sufficiently flexible to cover all cases, but its performance is poor.
 The poor performance is largely a result of having to create intermediate tuples, and possibly intermediate dicts, during the call.
 This is mitigated in CPython by including special-case code to speed up calls to Python and builtin functions.
-Unfortunately this means that other callables such as classes and third party extension objects are called using the
+Unfortunately, this means that other callables such as classes and third party extension objects are called using the
 slower, more general ``tp_call`` calling convention.
 
 This PEP proposes that the calling convention used internally for Python and builtin functions is generalized and published
 so that all calls can benefit from better performance.
-
-Improved Performance
---------------------
-
-The current ``tp_call`` calling convention requires creation of a tuple and, if there are any named arguments, a dictionary for every call.
-This is expensive. The proposed calling convention removes the need to create almost all of these temporary objects.
-Another source of inefficiency in the ``tp_call`` convention is that it has one function pointer per-class, rather than per-object. This is inefficient for calls to classes as several intermediate objects need to be created. For a user defined class, ``UserClass``, at least one intermediate object is created for each call in the sequence ``type.__call__``, ``object.__new__``, ``UserClass.__init__``.
-
 The new proposed calling convention is not fully general, but covers the large majority of calls.
 It is designed to remove the overhead of temporary object creation and multiple indirections.
+
+Another source of inefficiency in the ``tp_call`` convention is that it has one function pointer per class,
+rather than per object.
+This is inefficient for calls to classes as several intermediate objects need to be created.
+For a class ``cls``, at least one intermediate object is created for each call in the sequence
+``type.__call__``, ``cls.__new__``, ``cls.__init__``.
+
 
 Specification
 =============
@@ -48,144 +53,205 @@ The function pointer type
 Calls are made through a function pointer taking the following parameters:
 
 * ``PyObject *callable``: The called object
-* ``Py_ssize_t n``: The number of arguments plus an optional offset flag for the first argument in vector.
+* ``Py_ssize_t n``: The number of arguments plus the optional flag ``PY_VECTORCALL_PREPEND`` (see below)
 * ``PyObject **args``: A vector of arguments
-* ``PyTupleObject *kwnames``: A tuple of the names of the named arguments.
+* ``PyObject *kwnames``: Either ``NULL`` or a non-empty tuple of the names of the keyword arguments
 
 This is implemented by the function pointer type:
-``typedef PyObject *(*vectorcall)(PyObject *callable, Py_ssize_t n, PyObject** args, PyTupleObject *kwnames);``
+``typedef PyObject *(*vectorcallfunc)(PyObject *callable, Py_ssize_t n, PyObject **args, PyObject *kwnames);``
 
-Changes to the ``PyTypeObject``
--------------------------------
+Changes to the ``PyTypeObject`` struct
+--------------------------------------
 
-The unused slot ``printfunc tp_print`` is replaced with ``tp_vectorcall_offset``. It has the type ``uintptr_t``.
+The unused slot ``printfunc tp_print`` is replaced with ``tp_vectorcall_offset``. It has the type ``Py_ssize_t``.
+A new ``tp_flags`` flag is added, ``Py_TPFLAGS_HAVE_VECTORCALL``,
+which must be set for any class that uses the vectorcall protocol.
 
-A new flag is added, ``Py_TPFLAGS_HAVE_VECTORCALL``, which is set for any new PyTypeObjects that use the
-``tp_vectorcall_offset`` member.
-
-If ``Py_TPFLAGS_HAVE_VECTORCALL`` is set then ``tp_vectorcall_offset`` is the offset
-into the object of the ``vectorcall`` function-pointer.
-A new slot ``tp_vectorcall`` is added so that classes can support the vectorcall calling convention.
-It has the type ``vectorcall``.
+If ``Py_TPFLAGS_HAVE_VECTORCALL`` is set, then ``tp_vectorcall_offset`` must be a positive integer.
+It is the offset into the object of the vectorcall function pointer of type ``vectorcallfunc``.
+This pointer must not be ``NULL``.
 
 The ``tp_print`` slot is reused as the ``tp_vectorcall_offset`` slot to make it easier for for external projects to backport the vectorcall protocol to earlier Python versions.
 In particular, the Cython project has shown interest in doing that (see https://mail.python.org/pipermail/python-dev/2018-June/153927.html).
 
+Descriptor behavior
+-------------------
 
-Additional flags
-----------------
+One additional type flag is specified: ``Py_TPFLAGS_METHOD_DESCRIPTOR``.
 
-One additional flag is specified: ``Py_TPFLAGS_METHOD_DESCRIPTOR``.
+``Py_TPFLAGS_METHOD_DESCRIPTOR`` should be set if the the callable uses the descriptor protocol to create a bound method-like object.
+This is used by the interpreter to avoid creating temporary objects when calling methods
+(see ``_PyObject_GetMethod`` and the ``LOAD_METHOD``/``CALL_METHOD`` opcodes).
 
-``Py_TPFLAGS_METHOD_DESCRIPTOR`` should be set if the the callable uses the descriptor protocol to create a method or method-like object.
-This is used by the interpreter to avoid creating temporary objects when calling methods.
+Concretely, if ``Py_TPFLAGS_METHOD_DESCRIPTOR`` is set for ``type(func)``, then:
 
-If this flag is set for a class ``F``, then instances of that class are expected to behave the same as a Python function when used as a class attribute.
-Specifically, this means that the value of ``c.m`` where ``C.m`` is an instance of the class ``F`` (and ``c`` is an instance of ``C``)
-must be an object that acts like a bound method binding ``C.m`` and ``c``.
-This flag is necessary if custom callables are to be able to behave like Python functions *and* be called as efficiently as Python or built-in functions.
+- ``func.__get__(obj, cls)(*args, **kwds)`` (with ``obj`` not None)
+  must be equivalent to ``func(obj, *args, **kwds)``.
+
+- ``func.__get__(None, cls)(*args, **kwds)`` must be equivalent to ``func(*args, **kwds)``.
+
+There are no restrictions on the object ``func.__get__(obj, cls)``.
+The latter is not required to implement the vectorcall protocol.
 
 The call
 --------
 
-The call takes the form ``((vectorcall)(((char *)o)+offset))(o, n, args, kwnames)`` where
+The call takes the form ``((vectorcallfunc)(((char *)o)+offset))(o, n, args, kwnames)`` where
 ``offset`` is ``Py_TYPE(o)->tp_vectorcall_offset``.
 The caller is responsible for creating the ``kwnames`` tuple and ensuring that there are no duplicates in it.
-``n`` is the number of postional arguments plus ``PY_VECTORCALL_ARGUMENTS_OFFSET`` if the argument vector pointer points to argument 1 in the
-allocated vector and the callee is allowed to mutate the contents of the ``args`` vector.
-``n = number_postional_args | (offset ? PY_VECTORCALL_ARGUMENTS_OFFSET: 0))``.
+For efficiently dealing with the common case of no keywords,
+``kwnames`` must be ``NULL`` if there are no keyword arguments.
 
-PY_VECTORCALL_ARGUMENTS_OFFSET
-------------------------------
+``n`` is the number of postional arguments plus possibly the ``PY_VECTORCALL_PREPEND`` flag.
 
-When a caller sets the ``PY_VECTORCALL_ARGUMENTS_OFFSET`` it is indicating that the ``args`` pointer points to item 1 (counting from 0) of the allocated array
-and that the contents of the allocated array can be safely mutated by the callee. The callee still needs to make sure that the reference counts of any objects
-in the array remain correct.
+PY_VECTORCALL_PREPEND
+---------------------
 
-Example of how ``PY_VECTORCALL_ARGUMENTS_OFFSET`` is used by a callee is safely used to avoid allocation [3]_
+The flag ``PY_VECTORCALL_PREPEND`` should be added to ``n``
+if the callee is allowed to temporarily change ``args[-1]``.
+In other words, this can be used if ``args`` points to argument 1 in the allocated vector.
+The callee must restore the value of ``args[-1]`` before returning.
 
-Whenever they can do so cheaply (without allocation) callers are encouraged to offset the arguments.
+Whenever they can do so cheaply (without allocation), callers are encouraged to use ``PY_VECTORCALL_PREPEND``.
 Doing so will allow callables such as bound methods to make their onward calls cheaply.
-The interpreter already allocates space on the stack for the callable, so it can offset its arguments for no additional cost.
+The bytecode interpreter already allocates space on the stack for the callable,
+so it can use this trick at no additional cost.
 
-Continued prohibition of callable classes as base classes
----------------------------------------------------------
+See [3]_ for an example of how ``PY_VECTORCALL_PREPEND`` is used by a callee to avoid allocation.
 
-Currently any attempt to use ``function``, ``method`` or ``method_descriptor`` as a base class for a new class will fail with a ``TypeError``.
-This behaviour is desirable as it prevents errors when a subclass overrides the ``__call__`` method.
-If callables could be sub-classed then any call to a ``function`` or a ``method_descriptor`` would need an additional check that the ``__call__`` method had not been overridden. By exposing an additional call mechanism, the potential for errors  becomes greater. As a consequence, any third-party class implementing the new call interface will not be usable as a base class.
+For getting the actual number of arguments from the parameter ``n``,
+the macro ``PyVectorcall_NARGS(n)`` must be used.
+This allows for future changes or extensions.
+
 
 New C API and changes to CPython
 ================================
 
-``PyObject *PyObject_VectorCall(PyObject *obj, PyObject **args, Py_ssize_t nargs, PyTupleObject *kwnames)``
+The following functions or macros are added to the C API:
 
-Calls ``obj`` with the given arguments. Note that ``nargs`` may include the flag ``PY_VECTORCALL_ARGUMENTS_OFFSET``.
-``nargs & ~PY_VECTORCALL_ARGUMENTS_OFFSET`` is the number of positional arguments.
+- ``PyObject *PyObject_Vectorcall(PyObject *obj, PyObject **args, Py_ssize_t nargs, PyObject *kwargs)``:
+  Calls ``obj`` with the given arguments.
+  Note that ``nargs`` may include the flag ``PY_VECTORCALL_PREPEND``.
+  The actual number of positional arguments is given by ``PyVectorcall_NARGS(nargs)``.
+  The argument ``kwargs`` is either a dict, a tuple of keyword names or ``NULL``.
+  An empty dict or empty tuple has the same effect as passing ``NULL``.
+  This uses either the vectorcall protocol or ``tp_call`` internally;
+  if neither is supported, an exception is raised.
 
-``PyObject_VectorCall`` raises an exception if ``obj`` is not callable.
+- ``PyObject *PyCall_Vectorcall(PyObject *obj, PyObject *tuple, PyObject **dict)``:
+  Call the object (which must support vectorcall) with the old
+  ``*args`` and ``**kwargs`` calling convention.
+  This is mostly meant to put in the ``tp_call`` slot.
 
-Two utility functions are provided to call the new calling convention from the old one, or vice-versa.
-These functions are ``PyObject *PyCall_MakeVectorCall(PyObject *obj, PyObject *tuple, PyObject **dict)`` and
-``PyObject *PyCall_MakeTpCall(PyObject *obj, PyObject **args, Py_ssize_t nargs, PyTupleObject *kwnames)``, respectively.
+- ``Py_ssize_t PyVectorcall_NARGS(Py_ssize nargs)``: Given a vectorcall ``nargs`` argument,
+  return the actual number of arguments.
+  Currently equivalent to ``nargs & ~PY_VECTORCALL_PREPEND``.
 
-Both functions raise an exception if ``obj`` does not support the relevant protocol.
+New ``METH_VECTORCALL`` flag
+----------------------------
 
-``METH_FASTCALL`` and ``METH_VECTORCALL`` flags
------------------------------------------------
+A new constant ``METH_VECTORCALL`` is added for specifying ``PyMethodDef`` structs.
+It means that the C function has the signature ``vectorcallfunc``.
+This should be the preferred flag for new functions, as this avoids a wrapper function.
 
-A new ``METH_VECTORCALL`` flag is added for specifying ``PyMethodDef`` structs. It is equivalent to the currently undocumented ``METH_FASTCALL | METH_KEYWORD`` flags.
-The new flag specifies that the function has the type ``PyObject *(*call) (PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwname)``
+**NOTE**: the numerical value of ``METH_VECTORCALL`` is unspecified
+and it may have more than 1 bit set.
+It must not combined with any of the existing flags
+``METH_VARARGS``, ``METH_FASTCALL``, ``METH_NOARGS``, ``METH_O`` or ``METH_KEYWORDS``.
+
+Subclassing
+-----------
+
+Extension types inherit the type flag ``Py_TPFLAGS_HAVE_VECTORCALL``
+and the value ``tp_vectorcall_offset`` from the base class,
+provided that they implement ``tp_call`` the same way as the base class.
+Additionally, the flag ``Py_TPFLAGS_METHOD_DESCRIPTOR``
+is inherited if ``tp_descr_get`` and ``tp_descr_set`` are implemented the
+same way as the base class.
+
+Heap types never inherit the vectorcall protocol because
+that would not be safe (heap types can be changed dynamically).
+This restriction may be lifted in the future, but that would require
+special-casing ``__call__`` in ``type.__setattribute__``.
+
 
 Internal CPython changes
 ========================
 
-In order to conform to the specification, the only changes required are:
+Changes to existing classes
+---------------------------
 
-* To use the new calling convention in the interpreter.
-* An implementation of the ``PyObject_VectorCall`` function.
-* An implementation of the ``PyCall_MakeVectorCall`` and ``PyCall_MakeTpCall`` convenience functions.
+The ``function``, ``builtin_function_or_method``, ``method_descriptor``, ``method``, ``wrapper_descriptor``, ``method-wrapper``
+classes will use the vectorcall protocol
+(not all of these will be changed in the initial implementation).
 
-To gain the promised performance advantage, the following classes will need to implement the new calling convention:
-* Python functions
-* Builtin functions and methods
-* Bound methods
-* Method descriptors
-* A few of the most commonly used classes, probably ``range``, ``list``, ``str``, and ``type``.
+For ``builtin_function_or_method`` and ``method_descriptor``
+(which use the ``PyMethodDef`` data structure),
+one could implement a specific vectorcall wrapper for every existing calling convention.
+Whether or not it is worth doing that remains to be seen.
 
-Changes to existing C structs
------------------------------
+Using the vectorcall protocol for classes
+-----------------------------------------
 
-The ``function``, ``builtin_function_or_method``, ``method_descriptor`` and ``method`` classes will have their corresponding structs changed to
-include a ``vectorcall`` pointer.
-
-Third-party built-in classes using the new extended call interface
-------------------------------------------------------------------
-
-To enable call performance on a par with Python functions and built-in functions, third-party callables should include a ``vectorcall`` function pointer
-and set ``tp_vectorcall_offset`` to the correct value.
-Any class that sets ``tp_vectorcall_offset`` to non-zero should also implement the ``tp_call`` function and make sure its behaviour is consistent with the ``vectorcall`` function.
-Setting ``tp_call`` to ``PyCall_MakeVectorCall`` will suffice.
+For a class ``cls``, creating a new instance using ``cls(xxx)``
+requires multiple calls.
+At least one intermediate object is created for each call in the sequence
+``type.__call__``, ``cls.__new__``, ``cls.__init__``.
+So it makes a lot of sense to use vectorcall for calling classes.
+This really means implementing the vectorcall protocol for ``type``.
+Some of the most commonly used classes will use this protocol,
+probably ``range``, ``list``, ``str``, and ``type``.
 
 The ``PyMethodDef`` protocol and Argument Clinic
-================================================
+------------------------------------------------
 
 Argument Clinic [4]_ automatically generates wrapper functions around lower-level callables, providing safe unboxing of primitive types and
 other safety checks.
-Argument Clinic could be extended to generate wrapper objects conforming to the new ``vectorcall`` protocol.
+Argument Clinic could be extended to generate wrapper objects with the ``METH_VECTORCALL`` signature.
 This will allow execution to flow from the caller to the Argument Clinic generated wrapper and
 thence to the hand-written code with only a single indirection.
+
+
+Third-party extension classes using vectorcall
+==============================================
+
+To enable call performance on a par with Python functions and built-in functions,
+third-party callables should include a ``vectorcallfunc`` function pointer,
+set ``tp_vectorcall_offset`` to the correct value and add the ``Py_TPFLAGS_HAVE_VECTORCALL`` flag.
+Any class that does this must implement the ``tp_call`` function and make sure its behaviour is consistent with the ``vectorcallfunc`` function.
+Setting ``tp_call`` to ``PyCall_Vectorcall`` is sufficient.
+
 
 Performance implications of these changes
 =========================================
 
-Initial experiments, implementing the new calling convention for Python  functions, builtin functions and method-descriptors showed a
-speedup of around 2%. A full implementation involving other callables and adding support for the new calling convention to argument
-clinic would, in the author's estimation, yield a speedup of between 3% and 4% for the standard benchmark suite.
+This PEP should not have much impact on the performance of existing code
+(neither in the positive nor the negative sense).
+It is mainly meant to allow efficient new code to be written,
+not to make existing code faster.
+
+Nevertheless, this PEP optimizes for ``METH_FASTCALL`` functions.
+Performance of functions using ``METH_VARARGS`` will become slightly worse.
+
+
+Stable ABI
+==========
+
+Nothing from this PEP is added to the stable ABI (PEP 384).
 
 
 Alternative Suggestions
 =======================
+
+bpo-29259
+---------
+
+PEP 590 is close to what was proposed in bpo-29259 [#bpo29259]_.
+The main difference is that this PEP stores the function pointer
+in the instance rather than in the class.
+This makes more sense for implementing functions in C,
+where every instance corresponds to a different C function.
+It also allows optimizing ``type.__call__``, which is not possible with bpo-29259.
 
 PEP 576 and PEP 580
 -------------------
@@ -213,30 +279,25 @@ Removing any special cases and making all calls use the ``tp_call`` form was als
 However, unless a much more efficient way was found to create and destroy tuples, and to a lesser extent dictionaries,
 then it would be too slow.
 
+
 Acknowledgements
 ================
 
-Victor Stinner for developing the original "vector call" calling convention internally to CPython (where is it is called "fast call")
-this PEP codifies and extends his work.
+Victor Stinner for developing the original "fastcall" calling convention internally to CPython.
+This PEP codifies and extends his work.
 
-Jeroen Demeyer for authoring PEP 575 and PEP 580 which helped motivate this PEP.
 
 References
 ==========
 
-.. [1] Calling conventions
-   https://en.wikipedia.org/wiki/Calling_convention
+.. [#bpo29259] Add tp_fastcall to PyTypeObject: support FASTCALL calling convention for all callable objects,
+               https://bugs.python.org/issue29259
 .. [2] tp_call/PyObject_Call calling convention
    https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_call
-.. [3] Using PY_VECTORCALL_ARGUMENTS_OFFSET in callee
+.. [3] Using PY_VECTORCALL_PREPEND in callee
    https://github.com/markshannon/cpython/blob/vectorcall-minimal/Objects/classobject.c#L53
 .. [4] Argument Clinic
    https://docs.python.org/3/howto/clinic.html
-.. [5] PEP 576
-   https://www.python.org/dev/peps/pep-0576/
-.. [6] PEP 580
-   https://www.python.org/dev/peps/pep-0580/
-
 
 
 Reference implementation

--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -53,7 +53,7 @@ The function pointer type
 Calls are made through a function pointer taking the following parameters:
 
 * ``PyObject *callable``: The called object
-* ``Py_ssize_t n``: The number of arguments plus the optional flag ``PY_VECTORCALL_PREPEND`` (see below)
+* ``Py_ssize_t n``: The number of arguments plus the optional flag ``PY_VECTORCALL_ARGUMENTS_OFFSET`` (see below)
 * ``PyObject *const *args``: A vector of arguments
 * ``PyTupleObject *kwnames``: A tuple of the names of the named arguments.
 
@@ -100,22 +100,22 @@ The call takes the form ``((vectorcallfunc)(((char *)o)+offset))(o, n, args, kwn
 ``offset`` is ``Py_TYPE(o)->tp_vectorcall_offset``.
 The caller is responsible for creating the ``kwnames`` tuple and ensuring that there are no duplicates in it.
 
-``n`` is the number of postional arguments plus possibly the ``PY_VECTORCALL_PREPEND`` flag.
+``n`` is the number of postional arguments plus possibly the ``PY_VECTORCALL_ARGUMENTS_OFFSET`` flag.
 
-PY_VECTORCALL_PREPEND
+PY_VECTORCALL_ARGUMENTS_OFFSET
 ---------------------
 
-The flag ``PY_VECTORCALL_PREPEND`` should be added to ``n``
+The flag ``PY_VECTORCALL_ARGUMENTS_OFFSET`` should be added to ``n``
 if the callee is allowed to temporarily change ``args[-1]``.
 In other words, this can be used if ``args`` points to argument 1 in the allocated vector.
 The callee must restore the value of ``args[-1]`` before returning.
 
-Whenever they can do so cheaply (without allocation), callers are encouraged to use ``PY_VECTORCALL_PREPEND``.
+Whenever they can do so cheaply (without allocation), callers are encouraged to use ``PY_VECTORCALL_ARGUMENTS_OFFSET``.
 Doing so will allow callables such as bound methods to make their onward calls cheaply.
 The bytecode interpreter already allocates space on the stack for the callable,
 so it can use this trick at no additional cost.
 
-See [3]_ for an example of how ``PY_VECTORCALL_PREPEND`` is used by a callee to avoid allocation.
+See [3]_ for an example of how ``PY_VECTORCALL_ARGUMENTS_OFFSET`` is used by a callee to avoid allocation.
 
 For getting the actual number of arguments from the parameter ``n``,
 the macro ``PyVectorcall_NARGS(n)`` must be used.
@@ -129,7 +129,7 @@ The following functions or macros are added to the C API:
 
 - ``PyObject *PyObject_Vectorcall(PyObject *obj, PyObject *const *args, Py_ssize_t nargs, PyObject *keywords)``:
   Calls ``obj`` with the given arguments.
-  Note that ``nargs`` may include the flag ``PY_VECTORCALL_PREPEND``.
+  Note that ``nargs`` may include the flag ``PY_VECTORCALL_ARGUMENTS_OFFSET``.
   The actual number of positional arguments is given by ``PyVectorcall_NARGS(nargs)``.
   The argument ``keywords`` is either a dict, a tuple of keyword names or ``NULL``.
   An empty dict or empty tuple has the same effect as passing ``NULL``.
@@ -143,7 +143,7 @@ The following functions or macros are added to the C API:
 
 - ``Py_ssize_t PyVectorcall_NARGS(Py_ssize nargs)``: Given a vectorcall ``nargs`` argument,
   return the actual number of arguments.
-  Currently equivalent to ``nargs & ~PY_VECTORCALL_PREPEND``.
+  Currently equivalent to ``nargs & ~PY_VECTORCALL_ARGUMENTS_OFFSET``.
 
 New ``METH_VECTORCALL`` flag
 ----------------------------
@@ -292,7 +292,7 @@ References
                https://bugs.python.org/issue29259
 .. [2] tp_call/PyObject_Call calling convention
    https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_call
-.. [3] Using PY_VECTORCALL_PREPEND in callee
+.. [3] Using PY_VECTORCALL_ARGUMENTS_OFFSET in callee
    https://github.com/markshannon/cpython/blob/vectorcall-minimal/Objects/classobject.c#L53
 .. [4] Argument Clinic
    https://docs.python.org/3/howto/clinic.html

--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -103,7 +103,7 @@ The caller is responsible for creating the ``kwnames`` tuple and ensuring that t
 ``n`` is the number of postional arguments plus possibly the ``PY_VECTORCALL_ARGUMENTS_OFFSET`` flag.
 
 PY_VECTORCALL_ARGUMENTS_OFFSET
----------------------
+------------------------------
 
 The flag ``PY_VECTORCALL_ARGUMENTS_OFFSET`` should be added to ``n``
 if the callee is allowed to temporarily change ``args[-1]``.

--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -129,11 +129,11 @@ New C API and changes to CPython
 
 The following functions or macros are added to the C API:
 
-- ``PyObject *PyObject_Vectorcall(PyObject *obj, PyObject *const *args, Py_ssize_t nargs, PyObject *kwargs)``:
+- ``PyObject *PyObject_Vectorcall(PyObject *obj, PyObject *const *args, Py_ssize_t nargs, PyObject *keywords)``:
   Calls ``obj`` with the given arguments.
   Note that ``nargs`` may include the flag ``PY_VECTORCALL_PREPEND``.
   The actual number of positional arguments is given by ``PyVectorcall_NARGS(nargs)``.
-  The argument ``kwargs`` is either a dict, a tuple of keyword names or ``NULL``.
+  The argument ``keywords`` is either a dict, a tuple of keyword names or ``NULL``.
   An empty dict or empty tuple has the same effect as passing ``NULL``.
   This uses either the vectorcall protocol or ``tp_call`` internally;
   if neither is supported, an exception is raised.

--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -143,7 +143,7 @@ The following functions or macros are added to the C API:
   ``*args`` and ``**kwargs`` calling convention.
   This is mostly meant to put in the ``tp_call`` slot.
 
-- ``vectorcallfunc PyVectorcall_FUNC(PyObject *obj)``: If ``obj`` does not support vectorcall,
+- ``vectorcallfunc PyVectorcall_Function(PyObject *obj)``: If ``obj`` does not support vectorcall,
   return ``NULL``.
   Otherwise, return the vectorcall pointer in the instance ``obj`` (which may be ``NULL``).
 

--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -131,8 +131,8 @@ The following functions or macros are added to the C API:
   Calls ``obj`` with the given arguments.
   Note that ``nargs`` may include the flag ``PY_VECTORCALL_ARGUMENTS_OFFSET``.
   The actual number of positional arguments is given by ``PyVectorcall_NARGS(nargs)``.
-  The argument ``keywords`` is either a dict, a tuple of keyword names or ``NULL``.
-  An empty dict or empty tuple has the same effect as passing ``NULL``.
+  The argument ``keywords`` is a tuple of keyword names or ``NULL``.
+  An empty tuple has the same effect as passing ``NULL``.
   This uses either the vectorcall protocol or ``tp_call`` internally;
   if neither is supported, an exception is raised.
 

--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -55,7 +55,7 @@ Calls are made through a function pointer taking the following parameters:
 * ``PyObject *callable``: The called object
 * ``Py_ssize_t n``: The number of arguments plus the optional flag ``PY_VECTORCALL_PREPEND`` (see below)
 * ``PyObject *const *args``: A vector of arguments
-* ``PyObject *kwnames``: Either ``NULL`` or a non-empty tuple of the names of the keyword arguments
+* ``PyTupleObject *kwnames``: A tuple of the names of the named arguments.
 
 This is implemented by the function pointer type:
 ``typedef PyObject *(*vectorcallfunc)(PyObject *callable, Py_ssize_t n, PyObject *const *args, PyObject *kwnames);``
@@ -63,7 +63,7 @@ This is implemented by the function pointer type:
 Changes to the ``PyTypeObject`` struct
 --------------------------------------
 
-The unused slot ``printfunc tp_print`` is replaced with ``tp_vectorcall_offset``. It has the type ``Py_ssize_t``.
+The unused slot ``printfunc tp_print`` is replaced with ``tp_vectorcall_offset``. It has the type ``uint32_t``.
 A new ``tp_flags`` flag is added, ``Py_TPFLAGS_HAVE_VECTORCALL``,
 which must be set for any class that uses the vectorcall protocol.
 
@@ -99,8 +99,6 @@ The call
 The call takes the form ``((vectorcallfunc)(((char *)o)+offset))(o, n, args, kwnames)`` where
 ``offset`` is ``Py_TYPE(o)->tp_vectorcall_offset``.
 The caller is responsible for creating the ``kwnames`` tuple and ensuring that there are no duplicates in it.
-For efficiently dealing with the common case of no keywords,
-``kwnames`` must be ``NULL`` if there are no keyword arguments.
 
 ``n`` is the number of postional arguments plus possibly the ``PY_VECTORCALL_PREPEND`` flag.
 
@@ -138,14 +136,10 @@ The following functions or macros are added to the C API:
   This uses either the vectorcall protocol or ``tp_call`` internally;
   if neither is supported, an exception is raised.
 
-- ``PyObject *PyVectorcall_Call(PyObject *obj, PyObject *tuple, PyObject *dict)``:
+- ``PyObject *PyCall_MakeVectorCall(PyObject *obj, PyObject *tuple, PyObject *dict)``:
   Call the object (which must support vectorcall) with the old
   ``*args`` and ``**kwargs`` calling convention.
   This is mostly meant to put in the ``tp_call`` slot.
-
-- ``vectorcallfunc PyVectorcall_Function(PyObject *obj)``: If ``obj`` does not support vectorcall,
-  return ``NULL``.
-  Otherwise, return the vectorcall pointer in the instance ``obj`` (which may be ``NULL``).
 
 - ``Py_ssize_t PyVectorcall_NARGS(Py_ssize nargs)``: Given a vectorcall ``nargs`` argument,
   return the actual number of arguments.
@@ -155,7 +149,7 @@ New ``METH_VECTORCALL`` flag
 ----------------------------
 
 A new constant ``METH_VECTORCALL`` is added for specifying ``PyMethodDef`` structs.
-It means that the C function has the signature ``vectorcallfunc``.
+It means that the C function has the type ``PyObject *(*call) (PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwname)``.
 This should be the preferred flag for new functions, as this avoids a wrapper function.
 
 **NOTE**: the numerical value of ``METH_VECTORCALL`` is unspecified
@@ -211,7 +205,7 @@ The ``PyMethodDef`` protocol and Argument Clinic
 
 Argument Clinic [4]_ automatically generates wrapper functions around lower-level callables, providing safe unboxing of primitive types and
 other safety checks.
-Argument Clinic could be extended to generate wrapper objects with the ``METH_VECTORCALL`` signature.
+Argument Clinic could be extended to generate wrapper objects conforming to the new ``vectorcall`` protocol.
 This will allow execution to flow from the caller to the Argument Clinic generated wrapper and
 thence to the hand-written code with only a single indirection.
 
@@ -223,7 +217,7 @@ To enable call performance on a par with Python functions and built-in functions
 third-party callables should include a ``vectorcallfunc`` function pointer,
 set ``tp_vectorcall_offset`` to the correct value and add the ``Py_TPFLAGS_HAVE_VECTORCALL`` flag.
 Any class that does this must implement the ``tp_call`` function and make sure its behaviour is consistent with the ``vectorcallfunc`` function.
-Setting ``tp_call`` to ``PyVectorcall_Call`` is sufficient.
+Setting ``tp_call`` to ``PyCall_MakeVectorCall`` is sufficient.
 
 
 Performance implications of these changes


### PR DESCRIPTION
The discussion on GH-1028 got out of hand.
This PR attempts to collect the "uncontroversial" changes, and also to collect the unresolved issues.

If there's something here you don't agree with, point it out.
I'll add it to the following list of things to hash out (and, if feasible, revert the change here).

Please don't discuss any of these in this PR.

cc @markshannon @jdemeyer 

### The vectorcall function's kwname argument:

* [ ] `PyTupleObject` or `PyObject`?
* [ ] Can be `NULL`?
* [ ] Can the tuple be empty?


### `vectorcall` → `vectorcallfunc`

I'm not sure this was settled.


### `tp_vectorcall_offset` type

* `uintptr_t` (original)
* `Py_ssize_t` (matches type of `offsetof` and existing practice)
* `ptrdiff_t` (actual "difference of pointers" type)

This is probalby pointless bikeshedding.


### `METH_VECTORCALL` function type

* `PyObject *(*call) (PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwname)`
* `vectorcallfunc`

(There is a discussion on what code is "trusted".)


### `PyCall_MakeVectorCall` name

* `PyCall_MakeVectorcall` (original)
* `PyCall_Vectorcall`
* `PyVectorcall_Call`


### `PyVectorcall_Function`

Do we need this one?

```
- ``vectorcallfunc PyVectorcall_Function(PyObject *obj)``: If ``obj`` does not support vectorcall,
  return ``NULL``.
  Otherwise, return the vectorcall pointer in the instance ``obj`` (which may be ``NULL``).
```

### `PyCall_MakeTpCall`

Do we need to add this one back?


### `PY_VECTORCALL_ARGUMENTS_OFFSET` vs. `PY_VECTORCALL_PREPEND`

### Passing a dict to `PyObject_Vectorcall`
