### PR TITLE
PEP 590: allow passing a dict to PyObject_Vectorcall

### DIFF
--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -131,8 +131,8 @@ The following functions or macros are added to the C API:
   Calls ``obj`` with the given arguments.
   Note that ``nargs`` may include the flag ``PY_VECTORCALL_ARGUMENTS_OFFSET``.
   The actual number of positional arguments is given by ``PyVectorcall_NARGS(nargs)``.
-  The argument ``keywords`` is a tuple of keyword names or ``NULL``.
-  An empty tuple has the same effect as passing ``NULL``.
+  The argument ``keywords`` is either a dict, a tuple of keyword names or ``NULL``.
+  An empty dict or empty tuple has the same effect as passing ``NULL``.
   This uses either the vectorcall protocol or ``tp_call`` internally;
   if neither is supported, an exception is raised.
 


### PR DESCRIPTION
Allow passing a dict as `keywords` argument to `PyObject_Vectorcall`. Since checking for a `tuple` or `dict` is very fast, this costs almost nothing in terms of performance.

The fact that `_PyObject_FastCallDict` (which does vectorcall with a dict) exists and is used in various places in CPython shows that such functionality is useful.

CC @encukou @markshannon 