### PR TITLE
PEP 590: Use PyObject *kwnames, which may be NULL

### DIFF
--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -55,7 +55,7 @@ Calls are made through a function pointer taking the following parameters:
 * ``PyObject *callable``: The called object
 * ``Py_ssize_t n``: The number of arguments plus the optional flag ``PY_VECTORCALL_ARGUMENTS_OFFSET`` (see below)
 * ``PyObject *const *args``: A vector of arguments
-* ``PyTupleObject *kwnames``: A tuple of the names of the named arguments.
+* ``PyObject *kwnames``: Either ``NULL`` or a tuple with the names of the keyword arguments
 
 This is implemented by the function pointer type:
 ``typedef PyObject *(*vectorcallfunc)(PyObject *callable, Py_ssize_t n, PyObject *const *args, PyObject *kwnames);``

--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -53,12 +53,12 @@ The function pointer type
 Calls are made through a function pointer taking the following parameters:
 
 * ``PyObject *callable``: The called object
-* ``Py_ssize_t n``: The number of arguments plus the optional flag ``PY_VECTORCALL_ARGUMENTS_OFFSET`` (see below)
 * ``PyObject *const *args``: A vector of arguments
+* ``Py_ssize_t nargs``: The number of arguments plus the optional flag ``PY_VECTORCALL_ARGUMENTS_OFFSET`` (see below)
 * ``PyObject *kwnames``: Either ``NULL`` or a tuple with the names of the keyword arguments
 
 This is implemented by the function pointer type:
-``typedef PyObject *(*vectorcallfunc)(PyObject *callable, Py_ssize_t n, PyObject *const *args, PyObject *kwnames);``
+``typedef PyObject *(*vectorcallfunc)(PyObject *callable, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames);``
 
 Changes to the ``PyTypeObject`` struct
 --------------------------------------
@@ -96,7 +96,7 @@ The latter is not required to implement the vectorcall protocol.
 The call
 --------
 
-The call takes the form ``((vectorcallfunc)(((char *)o)+offset))(o, n, args, kwnames)`` where
+The call takes the form ``((vectorcallfunc)(((char *)o)+offset))(o, args, n, kwnames)`` where
 ``offset`` is ``Py_TYPE(o)->tp_vectorcall_offset``.
 The caller is responsible for creating the ``kwnames`` tuple and ensuring that there are no duplicates in it.
 


### PR DESCRIPTION
This simply codifies what's already in the reference implementation, so it should be uncontroversial:

- the `nargs` argument comes after `args` in vectorcall functions.
- `kwnames` is passed as `PyObject *` instead of `PyTupleObject *` (like most other C API functions, the generic `PyObject *` is used instead of a specific struct like `PyTupleObject *`)
- the argument `kwnames` may be `NULL`

CC @encukou @markshannon 