### PR TITLE
PEP 590: no longer mention tp_descr_set

### DIFF
--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -164,8 +164,7 @@ Extension types inherit the type flag ``Py_TPFLAGS_HAVE_VECTORCALL``
 and the value ``tp_vectorcall_offset`` from the base class,
 provided that they implement ``tp_call`` the same way as the base class.
 Additionally, the flag ``Py_TPFLAGS_METHOD_DESCRIPTOR``
-is inherited if ``tp_descr_get`` and ``tp_descr_set`` are implemented the
-same way as the base class.
+is inherited if ``tp_descr_get`` is implemented the same way as the base class.
 
 Heap types never inherit the vectorcall protocol because
 that would not be safe (heap types can be changed dynamically).


### PR DESCRIPTION
Since `__set__` and `__delete__` are no longer mentioned in the description of `Py_TPFLAGS_METHOD_DESCRIPTOR`, also `tp_descr_set` shouldn't be mentioned in the section about subclassing.