### PR TITLE
PEP 590: remove METH_VECTORCALL flag

### DIFF
--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -145,18 +145,6 @@ The following functions or macros are added to the C API:
   return the actual number of arguments.
   Currently equivalent to ``nargs & ~PY_VECTORCALL_ARGUMENTS_OFFSET``.
 
-New ``METH_VECTORCALL`` flag
-----------------------------
-
-A new constant ``METH_VECTORCALL`` is added for specifying ``PyMethodDef`` structs.
-It means that the C function has the type ``PyObject *(*call) (PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwname)``.
-This should be the preferred flag for new functions, as this avoids a wrapper function.
-
-**NOTE**: the numerical value of ``METH_VECTORCALL`` is unspecified
-and it may have more than 1 bit set.
-It must not combined with any of the existing flags
-``METH_VARARGS``, ``METH_FASTCALL``, ``METH_NOARGS``, ``METH_O`` or ``METH_KEYWORDS``.
-
 Subclassing
 -----------
 


### PR DESCRIPTION
I suggest to keep the flag `METH_FASTCALL` for now instead of adding a new flag `METH_VECTORCALL`. First of all, this allows compatibility with all Python versions starting from 3.6 (at least, if not combined with `METH_KEYWORDS`). Second, it makes a clear separation between the vectorcall protocol and the `PyMethodDef` struct, which are more or less orthogonal. Third, using the name `METH_VECTORCALL` for a calling convention which is not the `vectorcallfunc` calling convention would be confusing.

CC @encukou @markshannon @scoder 