### PR TITLE
PEP 590: kwnames should be non-empty tuple (or NULL)

### DIFF
--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -55,7 +55,7 @@ Calls are made through a function pointer taking the following parameters:
 * ``PyObject *callable``: The called object
 * ``PyObject *const *args``: A vector of arguments
 * ``Py_ssize_t nargs``: The number of arguments plus the optional flag ``PY_VECTORCALL_ARGUMENTS_OFFSET`` (see below)
-* ``PyObject *kwnames``: Either ``NULL`` or a tuple with the names of the keyword arguments
+* ``PyObject *kwnames``: Either ``NULL`` or a non-empty tuple with the names of the keyword arguments
 
 This is implemented by the function pointer type:
 ``typedef PyObject *(*vectorcallfunc)(PyObject *callable, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames);``
@@ -99,6 +99,8 @@ The call
 The call takes the form ``((vectorcallfunc)(((char *)o)+offset))(o, args, n, kwnames)`` where
 ``offset`` is ``Py_TYPE(o)->tp_vectorcall_offset``.
 The caller is responsible for creating the ``kwnames`` tuple and ensuring that there are no duplicates in it.
+For efficiently dealing with the common case of no keywords,
+``kwnames`` must be ``NULL`` if there are no keyword arguments.
 
 ``n`` is the number of postional arguments plus possibly the ``PY_VECTORCALL_ARGUMENTS_OFFSET`` flag.
 


### PR DESCRIPTION
For simplifying the code of the vectorcall callee, do not allow an empty tuple to be passed as `kwnames`. This way, there is a unique way to specify "no keyword arguments", namely passing a `NULL` pointer.

CC @encukou @markshannon @scoder 