### PR TITLE
PEP 484: Follow PEP8 to concatenate String

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -35,7 +35,7 @@ For example, here is a simple function whose argument and return type
 are declared in the annotations::
 
   def greeting(name: str) -> str:
-      return 'Hello ' + name
+      return 'Hello '.join(name)
 
 While these annotations are available at runtime through the usual
 ``__annotations__`` attribute, *no type checking happens at runtime*.


### PR DESCRIPTION
If applied this PR, will do change example `def greeting(name: str) -> str:` to follow PEP8 recomendations. In PEP8 in the [Programming Recommendations](https://www.python.org/dev/peps/pep-0008/#id51) section, it is recommended to use `` '.join () `to concatenate strings.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
