### PR TITLE
PEP 590: new function PyObject_VectorcallDict

### DIFF
--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -127,14 +127,22 @@ New C API and changes to CPython
 
 The following functions or macros are added to the C API:
 
-- ``PyObject *PyObject_Vectorcall(PyObject *obj, PyObject *const *args, Py_ssize_t nargs, PyObject *keywords)``:
-  Calls ``obj`` with the given arguments.
+- ``PyObject *PyObject_Vectorcall(PyObject *obj, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)``:
+  Call ``obj`` with the given arguments.
   Note that ``nargs`` may include the flag ``PY_VECTORCALL_ARGUMENTS_OFFSET``.
   The actual number of positional arguments is given by ``PyVectorcall_NARGS(nargs)``.
-  The argument ``keywords`` is a tuple of keyword names or ``NULL``.
+  The argument ``kwnames`` is a tuple of keyword names or ``NULL``.
   An empty tuple has the same effect as passing ``NULL``.
-  This uses either the vectorcall protocol or ``tp_call`` internally;
-  if neither is supported, an exception is raised.
+  Internally, this uses the vectorcall protocol if supported;
+  otherwise, it uses ``tp_call``.
+  If neither is supported, an exception is raised.
+  This replaces the existing private function ``_PyObject_FastCallKeywords``.
+
+- ``PyObject *PyObject_VectorcallDict(PyObject *obj, PyObject *const *args, Py_ssize_t nargs, PyObject *kwdict)``:
+  Call ``obj`` with the given arguments.
+  Same as ``PyObject_Vectorcall`` except that the keyword arguments are given
+  as a dict (which may be ``NULL`` if there are no keyword arguments).
+  This replaces the existing private function ``_PyObject_FastCallDict``.
 
 - ``PyObject *PyVectorcall_Call(PyObject *obj, PyObject *tuple, PyObject *dict)``:
   Call the object (which must support vectorcall) with the old


### PR DESCRIPTION
Add a new public function for doing a call with an argument vector and a dict. As @markshannon suggested, this is a cleaner API than having a single function with two meanings.

CC @encukou @scoder 