### PR TITLE
PEP 541: Add section on how to request a name transfer

### DIFF
--- a/pep-0541.txt
+++ b/pep-0541.txt
@@ -283,10 +283,10 @@ these are the steps to follow:
    are more stringent than for `continuing maintenance of the same project
    <continue-maintenance_>`_ - although it's not easy to get a name transferred
    in either case.
-3. Search the `Warehouse issues <https://github.com/pypa/warehouse/issues>`_
+3. Search the `PyPI Support issues <https://github.com/pypa/pypi-support/issues>`_
    to see if anyone else is already requesting the same name.
 4. If all the criteria are met to transfer ownership of the name,
-   open a new `issue on Warehouse <https://github.com/pypa/warehouse/issues>`_
+   `open a new issue  <https://github.com/pypa/pypi-support/issues/new?labels=PEP+541&template=pep541-request.md>`_
    to request it, detailing why you believe each relevant criterion is
    satisfied.
 

--- a/pep-0541.txt
+++ b/pep-0541.txt
@@ -122,6 +122,7 @@ A project is considered *abandoned* when ALL of the following are met:
 
 All other projects are considered *active*.
 
+.. _continue-maintenance:
 
 Continued maintenance of an abandoned project
 ---------------------------------------------
@@ -144,6 +145,7 @@ are met:
 Under no circumstances will a name be reassigned against the wishes of
 a reachable owner.
 
+.. _reclaim-name:
 
 Removal of an abandoned project
 -------------------------------
@@ -267,6 +269,26 @@ can decide to reassign or remove a project from the Package Index after
 careful consideration even when not all requirements listed
 here are met.
 
+How to request a name transfer
+==============================
+
+If you want to take over an existing project name on PyPI,
+these are the steps to follow:
+
+1. Try to contact the current owner(s) directly: email them and open an issue
+   if you can find a related repository. The processes described here are meant
+   as a last resort if the owner cannot be contacted.
+2. Check the criteria above to see when a transfer is allowed. In particular,
+   the criteria for `reusing a name for a different project <reclaim-name_>`_
+   are more stringent than for `continuing maintenance of the same project
+   <continue-maintenance_>`_ - although it's not easy to get a name transferred
+   in either case.
+3. Search the `Warehouse issues <https://github.com/pypa/warehouse/issues>`_
+   to see if anyone else is already requesting the same name.
+4. If all the criteria are met to transfer ownership of the name,
+   open a new `issue on Warehouse <https://github.com/pypa/warehouse/issues>`_
+   to request it, detailing why you believe each relevant criterion is
+   satisfied.
 
 Prior art
 =========


### PR DESCRIPTION
PEP 541 details the rules for transferring ownership of abandoned PyPI projects whose owners cannot be reached. Understandably, this is a common starting point for people who want to claim such projects.

This PR adds explicit information on how to go about getting an abandoned name. In particular, it points people to the Warehouse issues as the place to request a transfer - this [seems to be the de-facto standard approach](https://github.com/pypa/warehouse/search?q=PEP+541&unscoped_q=PEP+541&type=Issues). It also tries to emphasise that this should be a last resort, to hopefully prevent a flood of requests.

I'm happy to change this if a Github issue is not the preferred way to request an ownership transfer. Arguably sending an email doesn't tie it to having a Github account, but on the other hand, a Github issue feels more publicly visible, and is convenient for @ mentioning project owners who are on Github as an additional attempt to contact them. But there should be some pointer for people, whatever the best option is.