### PR TITLE
PEP 590: Use size_t for "number of arguments + flag"

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -1515,10 +1515,10 @@ error refers to::
       'not_found': http.client.NOT_FOUND  # type: ignore
   }
 
-A ``# type: ignore`` comment on a line by itself is equivalent to
-adding an inline ``# type: ignore`` to each line until the end of
-the current indented block. At top indentation level this has
-effect of disabling type checking until the end of file.
+A ``# type: ignore`` comment on a line by itself at the top of a file,
+before any docstrings, imports, or other executable code, silences all
+errors in the file. Blank lines and other comments, such as shebang
+lines and coding cookies, may precede the ``# type: ignore`` comment.
 
 In some cases, linting tools or other comments may be needed on the same
 line as a type comment. In these cases, the type comment should be before
@@ -1527,7 +1527,8 @@ other comments and linting markers:
   # type: ignore # <comment or other marker>
 
 If type hinting proves useful in general, a syntax for typing variables
-may be provided in a future Python version.
+may be provided in a future Python version. (**UPDATE**: This syntax
+was added in Python 3.6 through PEP 526.)
 
 Casts
 =====

--- a/pep-0544.txt
+++ b/pep-0544.txt
@@ -5,11 +5,12 @@ Last-Modified: $Date$
 Author: Ivan Levkivskyi <levkivskyi@gmail.com>, Jukka Lehtosalo <jukka.lehtosalo@iki.fi>, Łukasz Langa <lukasz@python.org>
 BDFL-Delegate: Guido van Rossum <guido@python.org>
 Discussions-To: Python-Dev <python-dev@python.org>
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 05-Mar-2017
-Python-Version: 3.7
+Python-Version: 3.8
+Resolution: https://mail.python.org/archives/list/typing-sig@python.org/message/FDO4KFYWYQEP3U2HVVBEBR3SXPHQSHYR/
 
 
 Abstract

--- a/pep-0544.txt
+++ b/pep-0544.txt
@@ -611,6 +611,32 @@ The self-types in protocols follow the corresponding specification
   c = Other()  # Also OK
 
 
+Callback protocols
+------------------
+
+Protocols can be used to define flexible callback types that are hard
+(or even impossible) to express using the ``Callable[...]`` syntax
+specified by PEP 484, such as variadic, overloaded, and complex generic
+callbacks. They can be defined as protocols with a ``__call__`` member::
+
+  from typing import Optional, List, Protocol
+
+  class Combiner(Protocol):
+      def __call__(self, *vals: bytes,
+                   maxlen: Optional[int] = None) -> List[bytes]: ...
+
+  def good_cb(*vals: bytes, maxlen: Optional[int] = None) -> List[bytes]:
+      ...
+  def bad_cb(*vals: bytes, maxitems: Optional[int]) -> List[bytes]:
+      ...
+
+  comb: Combiner = good_cb  # OK
+  comb = bad_cb  # Error! Argument 2 has incompatible type because of
+                 # different name and kind in the callback
+
+Callback protocols and ``Callable[...]`` types can be used interchangeably.
+
+
 Using Protocols
 ===============
 
@@ -930,7 +956,7 @@ effects on the core interpreter and standard library except in the
 ``typing`` module, and a minor update to ``collections.abc``:
 
 * Define class ``typing.Protocol`` similar to ``typing.Generic``.
-* Implement metaclass functionality to detect whether a class is
+* Implement functionality to detect whether a class is
   a protocol or not. Add a class attribute ``_is_protocol = True``
   if that is the case. Verify that a protocol class only has protocol
   base classes in the MRO (except for object).

--- a/pep-0558.rst
+++ b/pep-0558.rst
@@ -6,7 +6,7 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 2017-09-08
-Python-Version: 3.7
+Python-Version: 3.8
 Post-History: 2017-09-08
 
 
@@ -34,7 +34,7 @@ up to and including replication of local variable mutation bugs that
 can arise when a trace hook is installed [1]_.
 
 While this PEP considers CPython's current behaviour when no trace hooks are
-installed to be acceptable (and even desirable), it considers the current
+installed to be acceptable (and largely desirable), it considers the current
 behaviour when trace hooks are installed to be problematic, as it causes bugs
 like [1]_ *without* even reliably enabling the desired functionality of allowing
 debuggers like ``pdb`` to mutate local variables [3]_.
@@ -70,6 +70,10 @@ For tracing mode, this PEP proposes changes to CPython's behaviour at function
 scope that bring the ``locals()`` builtin semantics closer to those used in
 regular operation, while also making the related frame API semantics clearer
 and easier for interactive debuggers to rely on.
+
+The proposed tracing mode changes also affect the semantics of frame object
+references obtained through other means, such as via a traceback, or via the
+``sys._getframe()`` API.
 
 
 New ``locals()`` documentation
@@ -259,81 +263,36 @@ defined ``locals()`` builtin, trace functions necessarily use the implementation
 dependent ``frame.f_locals`` interface, as a frame reference is what gets
 passed to hook implementations.
 
-In regular operation, nothing will change - ``frame.f_locals`` will be a direct
-reference to the dynamic snapshot, and ``locals()`` will return a reference to
-that snapshot. This reflects the fact that it's only CPython's tracing mode
-semantics that are currently problematic.
-
-In tracing mode, however, we will change ``frame.f_locals`` to instead return
-a dedicated proxy type (implemented as a private subclass of the existing
+Instead of being a direct reference to the dynamic snapshot returned by
+``locals()``, ``frame.f_locals`` will be updated to instead return a dedicated
+proxy type (implemented as a private subclass of the existing
 ``types.MappingProxyType``) that has two internal attributes not exposed as
 part of either the Python or public C API:
 
-* *mapping*: the dynamic snapshot that would be returned by ``frame.f_locals``
-  during regular operation
+* *mapping*: the dynamic snapshot that is returned by the ``locals()`` builtin
 * *frame*: the underlying frame that the snapshot is for
 
-The ``locals()`` builtin would be aware of this proxy type, and continue to
-return a reference to the dynamic snapshot even when in tracing mode.
+``__setitem__`` and ``__delitem__`` operations on the proxy will affect not only
+the dynamic snapshot, but *also* the corresponding fast local or cell reference
+on the underlying frame.
 
-As long as the process remains in tracing mode, then ``__setitem__`` and
-``__delitem__`` operations on the proxy will affect not only the dynamic
-snapshot, but *also* the corresponding fast local or cell reference on the
-underlying frame.
-
-If the process leaves tracing mode (i.e. all previously installed trace hooks
-are uninstalled), then any already created proxy objects will remain in place,
-but their ``__setitem__`` and ``__delitem__`` methods will skip mutating
-the underlying frame.
+The ``locals()`` builtin will be made aware of this proxy type, and continue to
+return a reference to the dynamic snapshot rather than to the write-through
+proxy.
 
 At the C API layer, ``PyEval_GetLocals()`` will implement the same semantics
 as the Python level ``locals()`` builtin, and a new ``PyFrame_GetLocals(frame)``
 accessor API will be provided to allow the proxy bypass logic to be encapsulated
 entirely inside the frame implementation. The C level equivalent of accessing
 ``pyframe.f_locals`` in Python will be to access ``cframe->f_locals`` directly
-(the one difference is that the Python descriptor will continue to include an
-implicit snapshot refresh).
+(the one difference is that accessing ``pyframe.f_locals`` will continue to
+implicitly refresh the dynamic snapshot, whereas C code will need to explicitly
+call ``PyFrame_GetLocals(frame)`` to refresh the snapshot).
 
 The ``PyFrame_LocalsToFast()`` function will be changed to always emit
 ``RuntimeError``, explaining that it is no longer a supported operation, and
 affected code should be updated to rely on the write-through tracing mode
 proxy instead.
-
-
-Open Questions
-==============
-
-Is it necessary to restrict frame semantic changes to tracing mode?
--------------------------------------------------------------------
-
-It would be possible to say that ``frame.f_locals`` should *always* return a
-write-through proxy, even in regular operation.
-
-This PEP currently avoids that option for a couple of key reasons, one pragmatic
-and one more philosophical:
-
-* Object allocations and method wrappers aren't free, and tracing functions
-  aren't the only operations that access frame locals from outside the function.
-  Restricting the changes to tracing mode means that the additional memory and
-  execution time overhead of these changes are going to be as close to zero in
-  regular operation as we can possibly make them.
-* "Don't change what isn't broken": the current tracing mode problems are caused
-  by a requirement that's specific to tracing mode (support for external
-  rebinding of function local variable references), so it makes sense to also
-  restrict any related fixes to tracing mode
-
-The counter-argument to this is that it makes for a really subtle behavioural
-runtime state dependent distinction in how ``frame.f_locals`` works, and creates
-some new edge cases around how ``f_locals`` behaves as trace functions are added
-and removed. If the design adopted were instead "``frame.f_locals`` is always a
-write-through proxy, while ``locals()`` is always a dynamic snapshot", that
-would likely be both simpler to implement and easier to explain, suggesting
-that it may be a good idea.
-
-Regardless of how the CPython reference implementation chooses to handle this,
-optimising compilers and interpreters can potentially impose additional
-restrictions on debuggers, by making local variable mutation through frame
-objects an opt-in behaviour that may disable some optimisations.
 
 
 Design Discussion
@@ -375,6 +334,45 @@ These are formally defined as inheriting ``globals()`` and ``locals()`` from
 the calling scope by default.
 
 There doesn't seem to be any reason for the PEP to change this.
+
+
+Changing the frame API semantics in regular operation
+-----------------------------------------------------
+
+Earlier versions of this PEP proposed having the semantics of the frame
+``f_locals`` attribute depend on whether or not a tracing hook was currently
+installed - only providing the write-through proxy behaviour when a tracing hook
+was active, and otherwise behaving the same as the ``locals()`` builtin.
+
+That was adopted as the original design proposal for a couple of key reasons,
+one pragmatic and one more philosophical:
+
+* Object allocations and method wrappers aren't free, and tracing functions
+  aren't the only operations that access frame locals from outside the function.
+  Restricting the changes to tracing mode meant that the additional memory and
+  execution time overhead of these changes would as close to zero in regular
+  operation as we can possibly make them.
+* "Don't change what isn't broken": the current tracing mode problems are caused
+  by a requirement that's specific to tracing mode (support for external
+  rebinding of function local variable references), so it made sense to also
+  restrict any related fixes to tracing mode
+
+However, actually attempting to implement and document that dynamic approach
+highlighted the fact that it makes for a really subtle runtime state dependent
+behaviour distinction in how ``frame.f_locals`` works, and creates several
+new edge cases around how ``f_locals`` behaves as trace functions are added
+and removed.
+
+Accordingly, the design was switched to the current one, where
+``frame.f_locals`` is always a write-through proxy, and ``locals()`` is always
+a dynamic snapshot, which is both simpler to implement and easier to explain.
+
+Regardless of how the CPython reference implementation chooses to handle this,
+optimising compilers and interpreters also remain free to impose additional
+restrictions on debuggers, by making local variable mutation through frame
+objects an opt-in behaviour that may disable some optimisations (just as the
+emulation of CPython's frame API is already an opt-in flag in some Python
+implementations).
 
 
 Historical semantics at function scope

--- a/pep-0558.rst
+++ b/pep-0558.rst
@@ -206,12 +206,11 @@ may not affect the values of local and free variables used by the interpreter."
 This PEP proposes to change that text to instead say:
 
     At function scope (including for generators and coroutines), [this function]
-    returns a
-    dynamic snapshot of the function's local variables and any nonlocal cell
-    references. In this case, changes made via the snapshot are *not* written
-    back to the corresponding local variables or nonlocal cell references, and
-    any such changes to the snapshot will be overwritten if the snapshot is
-    subsequently refreshed (e.g. by another call to ``locals()``).
+    returns a dynamic snapshot of the function's local variables and any
+    nonlocal cell references. In this case, changes made via the snapshot are
+    *not* written back to the corresponding local variables or nonlocal cell
+    references, and any such changes to the snapshot will be overwritten if the
+    snapshot is subsequently refreshed (e.g. by another call to ``locals()``).
 
     CPython implementation detail: the dynamic snapshot for the currently
     executing frame will be implicitly refreshed before each call to the trace
@@ -281,13 +280,15 @@ return a reference to the dynamic snapshot rather than to the write-through
 proxy.
 
 At the C API layer, ``PyEval_GetLocals()`` will implement the same semantics
-as the Python level ``locals()`` builtin, and a new ``PyFrame_GetLocals(frame)``
-accessor API will be provided to allow the proxy bypass logic to be encapsulated
-entirely inside the frame implementation. The C level equivalent of accessing
-``pyframe.f_locals`` in Python will be to access ``cframe->f_locals`` directly
-(the one difference is that accessing ``pyframe.f_locals`` will continue to
-implicitly refresh the dynamic snapshot, whereas C code will need to explicitly
-call ``PyFrame_GetLocals(frame)`` to refresh the snapshot).
+as the Python level ``locals()`` builtin, and a new
+``PyFrame_GetPyLocals(frame)`` accessor API will be provided to allow the
+function level proxy bypass logic to be encapsulated entirely inside the frame
+implementation.
+
+The C level equivalent of accessing ``pyframe.f_locals`` in Python will be a
+new ``PyFrame_GetLocalsAttr(frame)`` API. Like the Python level descriptor, the
+new API will implicitly refresh the dynamic snapshot at function scope before
+returning a reference to the write-through proxy.
 
 The ``PyFrame_LocalsToFast()`` function will be changed to always emit
 ``RuntimeError``, explaining that it is no longer a supported operation, and
@@ -324,7 +325,59 @@ The proposal in this PEP aims to retain the first two properties (to maintain
 backwards compatibility with as much code as possible) while ensuring that
 simply installing a trace hook can't enable rebinding of function locals via
 the ``locals()`` builtin (whereas enabling rebinding via
-``inspect.currentframe().f_locals`` is fully intended).
+``frame.f_locals`` inside the tracehook implementation is fully intended).
+
+
+Keeping ``locals()`` as a dynamic snapshot at function scope
+------------------------------------------------------------
+
+It would theoretically be possible to change the semantics of the ``locals()``
+builtin to return the write-through proxy at function scope, rather than
+continuing to return a dynamic snapshot.
+
+This PEP doesn't (and won't) propose this as it's a backwards incompatible
+change in practice, even though code that relies on the current behaviour is
+technically operating in an undefined area of the language specification.
+
+Consider the following code snippet::
+
+    def example():
+        x = 1
+        locals()["x"] = 2
+        print(x)
+
+Even with a trace hook installed, that function will consistently print ``1``
+on the current reference interpreter implementation::
+
+    >>> example()
+    1
+    >>> import sys
+    >>> def basic_hook(*args):
+    ...     return basic_hook
+    ...
+    >>> sys.settrace(basic_hook)
+    >>> example()
+    1
+
+Similarly, ``locals()`` can be passed to the ``exec()`` and ``eval()`` builtins
+at function scope without risking unexpected rebinding of local variables.
+
+Provoking the reference interpreter into incorrectly mutating the local variable
+state requires a more complex setup where a nested function closes over a
+variable being rebound in the outer function, and due to the use of either
+threads, generators, or coroutines, it's possible for a trace function to start
+running for the nested function before the rebinding operation in the outer
+function, but finish running after the rebinding operation has taken place (in
+which case the rebinding will be reverted, which is the bug reported in [1]_).
+
+In addition to preserving the de facto semantics which have been in place since
+PEP 227 introduced nested scopes in Python 2.1, the other benefit of restricting
+the write-through proxy support to the implementation-defined frame object API
+is that it means that only interpreter implementations which emulate the full
+frame API need to offer the write-through capability at all, and that
+JIT-compiled implementations only need to enable it when a frame introspection
+API is invoked, or a trace hook is installed, not whenever ``locals()`` is
+accessed at function scope.
 
 
 What happens with the default args for ``eval()`` and ``exec()``?
@@ -333,7 +386,7 @@ What happens with the default args for ``eval()`` and ``exec()``?
 These are formally defined as inheriting ``globals()`` and ``locals()`` from
 the calling scope by default.
 
-There doesn't seem to be any reason for the PEP to change this.
+There isn't any need for the PEP to change these defaults, so it doesn't.
 
 
 Changing the frame API semantics in regular operation

--- a/pep-0574.rst
+++ b/pep-0574.rst
@@ -4,10 +4,11 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Antoine Pitrou <solipsis@pitrou.net>
 BDFL-Delegate: Nick Coghlan
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 23-Mar-2018
+Python-Version: 3.8
 Post-History: 28-Mar-2018, 30-Apr-2019
 Resolution: https://mail.python.org/pipermail/python-dev/2019-May/157284.html
 
@@ -481,9 +482,10 @@ advantage of the best path for each protocol (or at least treat protocol
 Implementation
 ==============
 
-A first implementation is available in the author's GitHub fork [#pickle5-git]_.
+The PEP was initially implemented in the author's GitHub fork [#pickle5-git]_.
+It was later merged into Python 3.8 [#pickle5-pr]_.
 
-An experimental backport for Python 3.6 and 3.7 is downloadable from PyPI
+A backport for Python 3.6 and 3.7 is downloadable from PyPI
 [#pickle5-pypi]_.
 
 Support for pickle protocol 5 and out-of-band buffers was added to Numpy
@@ -544,6 +546,9 @@ References
 
 .. [#pickle5-git] ``pickle5`` branch on GitHub
    https://github.com/pitrou/cpython/tree/pickle5
+
+.. [#pickle5-pr] PEP 574 Pull Request on GitHub
+   https://github.com/python/cpython/pull/7076
 
 .. [#pickle5-pypi] ``pickle5`` project on PyPI
    https://pypi.org/project/pickle5/

--- a/pep-0586.rst
+++ b/pep-0586.rst
@@ -3,12 +3,14 @@ Title: Literal Types
 Author: Michael Lee <michael.lee.0x2a@gmail.com>, Ivan Levkivskyi <levkivskyi@gmail.com>, Jukka Lehtosalo <jukka.lehtosalo@iki.fi>
 BDFL-Delegate: Guido van Rossum <guido@python.org>
 Discussions-To: Typing-Sig <typing-sig@python.org>
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 14-Mar-2018
 Python-Version: 3.8
 Post-History: 14-Mar-2018
+Resolution: https://mail.python.org/archives/list/typing-sig@python.org/message/FDO4KFYWYQEP3U2HVVBEBR3SXPHQSHYR/
+
 
 Abstract
 ========

--- a/pep-0587.rst
+++ b/pep-0587.rst
@@ -101,14 +101,13 @@ and adopted as private APIs for us in the native CPython CLI.
 Python Initialization C API
 ===========================
 
-This PEP proposes to add the following new structures, functions and
-macros.
+This PEP proposes to add the following new structures and functions.
 
 New structures:
 
 * ``PyConfig``
-* ``PyStatus``
 * ``PyPreConfig``
+* ``PyStatus``
 * ``PyWideStringList``
 
 New functions:
@@ -258,12 +257,12 @@ Example using the preinitialization to enable the UTF-8 Mode::
     /* ... use Python API here ... */
     Py_Finalize();
 
-Function to initialize a pre-configuration:
+Function to initialize a preconfiguration:
 
 * ``void PyPreConfig_InitIsolatedConfig(PyPreConfig *preconfig)``
 * ``void PyPreConfig_InitPythonConfig(PyPreConfig *preconfig)``
 
-Functions to preinitialization Python:
+Functions to preinitialize Python:
 
 * ``PyStatus Py_PreInitialize(const PyPreConfig *preconfig)``
 * ``PyStatus Py_PreInitializeFromBytesArgs(const PyPreConfig *preconfig, int argc, char * const *argv)``
@@ -272,7 +271,8 @@ Functions to preinitialization Python:
 The caller is responsible to handle exceptions (error or exit) using
 ``PyStatus_Exception()`` and ``Py_ExitStatusException()``.
 
-If Python is initialized with command line arguments, the command line
+For `Python Configuration`_ (``PyPreConfig_InitPythonConfig()``),
+if Python is initialized with command line arguments, the command line
 arguments must also be passed to preinitialize Python, since they have
 an effect on the pre-configuration like encodings. For example, the
 ``-X utf8`` command line option enables the UTF-8 Mode.
@@ -363,7 +363,7 @@ Example setting the program name::
 
         /* Set the program name. Implicitly preinitialize Python. */
         status = PyConfig_SetString(&config, &config.program_name,
-                                 L"/path/to/my_program");
+                                    L"/path/to/my_program");
         if (PyStatus_Exception(status)) {
             goto fail;
         }
@@ -451,13 +451,16 @@ exceptions (error or exit) using ``PyStatus_Exception()`` and
   equal or greater to 2, raise a ``BytesWarning`` exception.
 * ``check_hash_pycs_mode`` (``wchar_t*``):
   ``--check-hash-based-pycs`` command line option value (see PEP 552).
+  Valid values: ``always``, ``never`` and ``default``. The default value
+  is ``default``.
 * ``configure_c_stdio`` (``int``):
   If non-zero, configure C standard streams (``stdio``, ``stdout``,
   ``stdout``).  For example, set their mode to ``O_BINARY`` on Windows.
 * ``dev_mode`` (``int``):
   Development mode
 * ``dump_refs`` (``int``):
-  If non-zero, dump all objects which are still alive at exit
+  If non-zero, dump all objects which are still alive at exit.
+  Require a special Python build with ``Py_REF_DEBUG`` macro defined.
 * ``exec_prefix`` (``wchar_t*``):
   ``sys.exec_prefix``.
 * ``executable`` (``wchar_t*``):
@@ -495,17 +498,24 @@ exceptions (error or exit) using ``PyStatus_Exception()`` and
   If non-zero, use ``io.FileIO`` instead of ``WindowsConsoleIO`` for
   ``sys.stdin``, ``sys.stdout`` and ``sys.stderr``.
 * ``malloc_stats`` (``int``):
-  If non-zero, dump memory allocation statistics at exit.
+  If non-zero, dump statistics on ``pymalloc`` memory allocator at exit.
+  The option is ignored if Python is built using ``--without-pymalloc``.
 * ``pythonpath_env`` (``wchar_t*``):
-  Module search paths as a string separated by DELIM (usually ``:``).
+  Module search paths as a string separated by DELIM (usually ``:``
+  character).
   Initialized from ``PYTHONPATH`` environment variable value by default.
 * ``module_search_paths_set`` (``int``),
   ``module_search_paths`` (``PyWideStringList``):
   ``sys.path``. If ``module_search_paths_set`` is equal to 0, the
-  ``module_search_paths`` is replaced by the function computing the
-  `Path Configuration`.
+  ``module_search_paths`` is overridden by the function computing the
+  `Path Configuration`_.
 * ``optimization_level`` (``int``):
-  Compilation optimization level.
+  Compilation optimization level:
+
+  * 0: Peephole optimizer (and ``__debug__`` is set to ``True``)
+  * 1: Remove assertions, set ``__debug__`` to ``False``
+  * 2: Strip docstrings
+
 * ``parse_argv`` (``int``):
   If non-zero, parse ``argv`` the same way the regular Python command
   line arguments, and strip Python arguments from ``argv``: see `Command
@@ -527,15 +537,18 @@ exceptions (error or exit) using ``PyStatus_Exception()`` and
   Quiet mode. For example, don't display the copyright and version
   messages even in interactive mode.
 * ``run_command`` (``wchar_t*``):
-  ``-c COMMAND`` argument.
+  ``python3 -c COMMAND`` argument.
 * ``run_filename`` (``wchar_t*``):
-  ``python3 SCRIPT`` argument.
+  ``python3 FILENAME`` argument.
 * ``run_module`` (``wchar_t*``):
   ``python3 -m MODULE`` argument.
 * ``show_alloc_count`` (``int``):
   Show allocation counts at exit?
+  Need a special Python build with ``COUNT_ALLOCS`` macro defined.
 * ``show_ref_count`` (``int``):
   Show total reference count at exit?
+  Need a debug build of Python (``Py_REF_DEBUG`` macro should be
+  defined).
 * ``site_import`` (``int``):
   Import the ``site`` module at startup?
 * ``skip_source_first_line`` (``int``):
@@ -617,7 +630,7 @@ configuration, and then override some parameters::
 
         /* Override executable computed by PyConfig_Read() */
         status = PyConfig_SetString(&config, &config.executable,
-                                 L"/path/to/my_executable");
+                                    L"/path/to/my_executable");
         if (PyStatus_Exception(status)) {
             goto done;
         }
@@ -736,8 +749,8 @@ equal to 0, ``module_search_paths`` is overriden and
 
 It is possible to completely ignore the function computing the default
 path configuration by setting explicitly all path configuration output
-fields listed above. A string is considered as set even if it's an empty
-string. ``module_search_paths`` is considered as set if
+fields listed above. A string is considered as set even if it is non-empty.
+``module_search_paths`` is considered as set if
 ``module_search_paths_set`` is set to 1. In this case, path
 configuration input fields are ignored as well.
 
@@ -829,7 +842,7 @@ Private provisional API:
 
 No module is imported during the "Core" phase and the ``importlib``
 module is not configured: the `Path Configuration`_ is only applied
-during the "Main" phase. It allows to customize Python in Python to
+during the "Main" phase. It may allow to customize Python in Python to
 override or tune the `Path Configuration`_, maybe install a custom
 sys.meta_path importer or an import hook, etc.
 
@@ -840,7 +853,7 @@ after the Core phase and before the Main phase, which is one of the PEP
 The "Core" phase is not properly defined: what should be and what should
 not be available at this phase is not specified yet. The API is marked
 as private and provisional: the API can be modified or even be removed
-anytime until a proper public API is design.
+anytime until a proper public API is designed.
 
 Example running Python code between "Core" and "Main" initialization
 phases::
@@ -856,7 +869,9 @@ phases::
             Py_ExitStatusException(status);
         }
 
-        /* ... set 'config' configuration ... */
+        config._init_main = 0;
+
+        /* ... customize 'config' configuration ... */
 
         status = Py_InitializeFromConfig(&config);
         PyConfig_Clear(&config);
@@ -1065,7 +1080,7 @@ Option                            ``PyConfig`` field
 ``-b``                            ``bytes_warning++``
 ``-B``                            ``write_bytecode = 0``
 ``-c COMMAND``                    ``run_command = COMMAND``
-``--check-hash-based-pycs=MODE``  ``_check_hash_pycs_mode = MODE``
+``--check-hash-based-pycs=MODE``  ``check_hash_pycs_mode = MODE``
 ``-d``                            ``parser_debug++``
 ``-E``                            ``use_environment = 0``
 ``-i``                            ``inspect++`` and ``interactive++``

--- a/pep-0587.rst
+++ b/pep-0587.rst
@@ -107,7 +107,7 @@ macros.
 New structures:
 
 * ``PyConfig``
-* ``PyInitError``
+* ``PyStatus``
 * ``PyPreConfig``
 * ``PyWideStringList``
 
@@ -121,19 +121,19 @@ New functions:
 * ``PyConfig_SetBytesArgv(config, argc, argv)``
 * ``PyConfig_SetBytesString(config, config_str, str)``
 * ``PyConfig_SetString(config, config_str, str)``
-* ``PyInitError_Error(err_msg)``
-* ``PyInitError_Exit(exitcode)``
-* ``PyInitError_Failed(err)``
-* ``PyInitError_IsError(err)``
-* ``PyInitError_IsExit(err)``
-* ``PyInitError_NoMemory()``
-* ``PyInitError_Ok()``
 * ``PyPreConfig_InitIsolatedConfig(preconfig)``
 * ``PyPreConfig_InitPythonConfig(preconfig)``
+* ``PyStatus_Error(err_msg)``
+* ``PyStatus_Exception(status)``
+* ``PyStatus_Exit(exitcode)``
+* ``PyStatus_IsError(status)``
+* ``PyStatus_IsExit(status)``
+* ``PyStatus_NoMemory()``
+* ``PyStatus_Ok()``
 * ``PyWideStringList_Append(list, item)``
 * ``PyWideStringList_Insert(list, index, item)``
 * ``Py_BytesMain(argc, argv)``
-* ``Py_ExitInitError(err)``
+* ``Py_ExitStatusException(status)``
 * ``Py_InitializeFromConfig(config)``
 * ``Py_PreInitialize(preconfig)``
 * ``Py_PreInitializeFromArgs(preconfig, argc, argv)``
@@ -159,45 +159,45 @@ PyWideStringList
 
 Methods:
 
-* ``PyInitError PyWideStringList_Append(PyWideStringList *list, const wchar_t *item)``:
+* ``PyStatus PyWideStringList_Append(PyWideStringList *list, const wchar_t *item)``:
   Append *item* to *list*.
-* ``PyInitError PyWideStringList_Insert(PyWideStringList *list, Py_ssize_t index, const wchar_t *item)``:
+* ``PyStatus PyWideStringList_Insert(PyWideStringList *list, Py_ssize_t index, const wchar_t *item)``:
   Insert *item* into *list* at *index*. If *index* is greater than
   *list* length, just append *item* to *list*.
 
 If *length* is non-zero, *items* must be non-NULL and all strings must
 be non-NULL.
 
-PyInitError
------------
+PyStatus
+--------
 
-``PyInitError`` is a structure to store an error message or an exit code
-for the Python Initialization. For an error, it stores the C function
-name which created the error.
+``PyStatus`` is a structure to store the status of an initialization
+function: success, error or exit. For an error, it can store the C
+function name which created the error.
 
 Example::
 
-    PyInitError alloc(void **ptr, size_t size)
+    PyStatus alloc(void **ptr, size_t size)
     {
         *ptr = PyMem_RawMalloc(size);
         if (*ptr == NULL) {
-            return PyInitError_NoMemory();
+            return PyStatus_NoMemory();
         }
-        return PyInitError_Ok();
+        return PyStatus_Ok();
     }
 
     int main(int argc, char **argv)
     {
         void *ptr;
-        PyInitError err = alloc(&ptr, 16);
-        if (PyInitError_Failed(err)) {
-            Py_ExitInitError(err);
+        PyStatus status = alloc(&ptr, 16);
+        if (PyStatus_Exception(status)) {
+            Py_ExitStatusException(status);
         }
         PyMem_Free(ptr);
         return 0;
     }
 
-``PyInitError`` fields:
+``PyStatus`` fields:
 
 * ``exitcode`` (``int``):
   Argument passed to ``exit()``.
@@ -207,22 +207,29 @@ Example::
   Name of the function which created an error, can be ``NULL``.
 * private ``_type`` field: for internal usage only.
 
-Functions to create an error:
+Functions to create a status:
 
-* ``PyInitError_Ok()``: Success.
-* ``PyInitError_Error(err_msg)``: Initialization error with a message.
-* ``PyInitError_NoMemory()``: Memory allocation failure (out of memory).
-* ``PyInitError_Exit(exitcode)``: Exit Python with the specified exit code.
+* ``PyStatus_Ok()``: Success.
+* ``PyStatus_Error(err_msg)``: Initialization error with a message.
+* ``PyStatus_NoMemory()``: Memory allocation failure (out of memory).
+* ``PyStatus_Exit(exitcode)``: Exit Python with the specified exit code.
 
-Functions to handle an error:
+Functions to handle a status:
 
-* ``PyInitError_Failed(err)``: Is the result an error or an exit?
-* ``PyInitError_IsError(err)``: Is the result an error?
-* ``PyInitError_IsExit(err)``: Is the result an exit?
-* ``Py_ExitInitError(err)``: Call ``exit(exitcode)`` if *err* is an
-  exit, print the error and exit if *err* is an error. Must only be
-  called with an error and an exit: if ``PyInitError_Failed(err)`` is
-  true.
+* ``PyStatus_Exception(status)``: Is the result an error or an exit?
+  If true, the exception must be handled; by calling
+  ``Py_ExitStatusException(status)`` for example.
+* ``PyStatus_IsError(status)``: Is the result an error?
+* ``PyStatus_IsExit(status)``: Is the result an exit?
+* ``Py_ExitStatusException(status)``: Call ``exit(exitcode)`` if *status*
+  is an exit. Print the error messageand exit with a non-zero exit code
+  if *status* is an error.  Must only be called if
+  ``PyStatus_Exception(status)`` is true.
+
+.. note::
+   Internally, Python uses macros which set ``PyStatus.func``,
+   whereas functions to create a status set ``func`` to ``NULL``.
+
 
 Preinitialization with PyPreConfig
 ----------------------------------
@@ -240,9 +247,9 @@ Example using the preinitialization to enable the UTF-8 Mode::
 
     preconfig.utf8_mode = 1;
 
-    PyInitError err = Py_PreInitialize(&preconfig);
-    if (PyInitError_Failed(err)) {
-        Py_ExitInitError(err);
+    PyStatus status = Py_PreInitialize(&preconfig);
+    if (PyStatus_Exception(status)) {
+        Py_ExitStatusException(status);
     }
 
     /* at this point, Python will speak UTF-8 */
@@ -258,12 +265,12 @@ Function to initialize a pre-configuration:
 
 Functions to preinitialization Python:
 
-* ``PyInitError Py_PreInitialize(const PyPreConfig *preconfig)``
-* ``PyInitError Py_PreInitializeFromBytesArgs(const PyPreConfig *preconfig, int argc, char * const *argv)``
-* ``PyInitError Py_PreInitializeFromArgs(const PyPreConfig *preconfig, int argc, wchar_t * const * argv)``
+* ``PyStatus Py_PreInitialize(const PyPreConfig *preconfig)``
+* ``PyStatus Py_PreInitializeFromBytesArgs(const PyPreConfig *preconfig, int argc, char * const *argv)``
+* ``PyStatus Py_PreInitializeFromArgs(const PyPreConfig *preconfig, int argc, wchar_t * const * argv)``
 
-The caller is responsible to handle error or exit using
-``PyInitError_Failed()`` and ``Py_ExitInitError()``.
+The caller is responsible to handle exceptions (error or exit) using
+``PyStatus_Exception()`` and ``Py_ExitStatusException()``.
 
 If Python is initialized with command line arguments, the command line
 arguments must also be passed to preinitialize Python, since they have
@@ -279,11 +286,14 @@ an effect on the pre-configuration like encodings. For example, the
   * ``PYMEM_ALLOCATOR_NOT_SET`` (``0``): don't change memory allocators
     (use defaults)
   * ``PYMEM_ALLOCATOR_DEFAULT`` (``1``): default memory allocators
-  * ``PYMEM_ALLOCATOR_DEBUG`` (``2``): enable debug hooks
+  * ``PYMEM_ALLOCATOR_DEBUG`` (``2``): default memory allocators with
+    debug hooks
   * ``PYMEM_ALLOCATOR_MALLOC`` (``3``): force usage of ``malloc()``
-  * ``PYMEM_ALLOCATOR_MALLOC_DEBUG`` (``4``): ``malloc()`` with debug hooks
+  * ``PYMEM_ALLOCATOR_MALLOC_DEBUG`` (``4``): force usage of
+    ``malloc()`` with debug hooks
   * ``PYMEM_ALLOCATOR_PYMALLOC`` (``5``): Python "pymalloc" allocator
-  * ``PYMEM_ALLOCATOR_PYMALLOC_DEBUG`` (``6``): pymalloc with debug hooks
+  * ``PYMEM_ALLOCATOR_PYMALLOC_DEBUG`` (``6``): Python "pymalloc"
+    allocator with debug hooks
   * Note: ``PYMEM_ALLOCATOR_PYMALLOC`` and
     ``PYMEM_ALLOCATOR_PYMALLOC_DEBUG`` are not supported if Python is
     configured using ``--without-pymalloc``
@@ -300,7 +310,7 @@ an effect on the pre-configuration like encodings. For example, the
   See ``PyConfig.dev_mode``.
 * ``isolated`` (``int``):
   See ``PyConfig.isolated``.
-* ``legacy_windows_fs_encoding`` (``int``):
+* ``legacy_windows_fs_encoding`` (``int``, Windows only):
   If non-zero, disable UTF-8 Mode, set the Python filesystem encoding to
   ``mbcs``, set the filesystem error handler to ``replace``.
 * ``parse_argv`` (``int``):
@@ -313,11 +323,15 @@ an effect on the pre-configuration like encodings. For example, the
 * ``utf8_mode`` (``int``):
   If non-zero, enable the UTF-8 mode.
 
-The ``legacy_windows_fs_encoding`` is only available on Windows.
+The ``legacy_windows_fs_encoding`` field is only available on Windows.
+``#ifdef MS_WINDOWS`` macro can be used for Windows specific code.
 
-There is also a private field, for internal use only,
-``_config_version`` (``int``): the configuration version, used
-for ABI compatibility.
+``PyPreConfig`` private fields, for internal use only:
+
+* ``_config_version`` (``int``):
+  Configuration version, used for ABI compatibility.
+* ``_config_init`` (``int``):
+  Function used to initalize ``PyConfig``, used for preinitialization.
 
 ``PyMem_SetAllocator()`` can be called after ``Py_PreInitialize()`` and
 before ``Py_InitializeFromConfig()`` to install a custom memory
@@ -339,23 +353,23 @@ Example setting the program name::
 
     void init_python(void)
     {
-        PyInitError err;
+        PyStatus status;
         PyConfig config;
 
-        err = PyConfig_InitPythonConfig(&config);
-        if (PyInitError_Failed(err)) {
+        status = PyConfig_InitPythonConfig(&config);
+        if (PyStatus_Exception(status)) {
             goto fail;
         }
 
         /* Set the program name. Implicitly preinitialize Python. */
-        err = PyConfig_SetString(&config, &config.program_name,
+        status = PyConfig_SetString(&config, &config.program_name,
                                  L"/path/to/my_program");
-        if (PyInitError_Failed(err)) {
+        if (PyStatus_Exception(status)) {
             goto fail;
         }
 
-        err = Py_InitializeFromConfig(&config);
-        if (PyInitError_Failed(err)) {
+        status = Py_InitializeFromConfig(&config);
+        if (PyStatus_Exception(status)) {
             goto fail;
         }
         PyConfig_Clear(&config);
@@ -363,29 +377,29 @@ Example setting the program name::
 
     fail:
         PyConfig_Clear(&config);
-        Py_ExitInitError(err);
+        Py_ExitStatusException(status);
     }
 
 ``PyConfig`` methods:
 
-* ``PyInitError PyConfig_InitPythonConfig(PyConfig *config)``
+* ``PyStatus PyConfig_InitPythonConfig(PyConfig *config)``
   Initialize configuration with `Python Configuration`_.
-* ``PyInitError PyConfig_InitIsolatedConfig(PyConfig *config)``:
+* ``PyStatus PyConfig_InitIsolatedConfig(PyConfig *config)``:
   Initialize configuration with `Isolated Configuration`_.
-* ``PyInitError PyConfig_SetString(PyConfig *config, wchar_t * const *config_str, const wchar_t *str)``:
+* ``PyStatus PyConfig_SetString(PyConfig *config, wchar_t * const *config_str, const wchar_t *str)``:
   Copy the wide character string *str* into ``*config_str``.
   Preinitialize Python if needed.
-* ``PyInitError PyConfig_SetBytesString(PyConfig *config, wchar_t * const *config_str, const char *str)``:
+* ``PyStatus PyConfig_SetBytesString(PyConfig *config, wchar_t * const *config_str, const char *str)``:
   Decode *str* using ``Py_DecodeLocale()`` and set the result into
   ``*config_str``.
   Preinitialize Python if needed.
-* ``PyInitError PyConfig_SetArgv(PyConfig *config, int argc, wchar_t * const *argv)``:
+* ``PyStatus PyConfig_SetArgv(PyConfig *config, int argc, wchar_t * const *argv)``:
   Set command line arguments from wide character strings.
   Preinitialize Python if needed.
-* ``PyInitError PyConfig_SetBytesArgv(PyConfig *config, int argc, char * const *argv)``:
+* ``PyStatus PyConfig_SetBytesArgv(PyConfig *config, int argc, char * const *argv)``:
   Set command line arguments: decode bytes using ``Py_DecodeLocale()``.
   Preinitialize Python if needed.
-* ``PyInitError PyConfig_Read(PyConfig *config)``:
+* ``PyStatus PyConfig_Read(PyConfig *config)``:
   Read all Python configuration. Fields which are already initialized
   are left unchanged.
   Preinitialize Python if needed.
@@ -409,11 +423,13 @@ preinitialization configuration depends on command line arguments (if
 
 Functions to initialize Python:
 
-* ``PyInitError Py_InitializeFromConfig(const PyConfig *config)``:
+* ``PyStatus Py_InitializeFromConfig(const PyConfig *config)``:
   Initialize Python from *config* configuration.
 
-The caller of these methods and functions is responsible to handle error
-or exit using ``PyInitError_Failed()`` and ``Py_ExitInitError()``.
+The caller of these methods and functions is responsible to handle
+exceptions (error or exit) using ``PyStatus_Exception()`` and
+``Py_ExitStatusException()``.
+
 
 ``PyConfig`` fields:
 
@@ -465,6 +481,16 @@ or exit using ``PyInitError_Failed()`` and ``Py_ExitInitError()``.
   Install signal handlers?
 * ``interactive`` (``int``):
   Interactive mode.
+* ``isolated`` (``int``):
+  If greater than 0, enable isolated mode:
+
+  * ``sys.path`` contains neither the script's directory (computed from
+    ``argv[0]`` or the current directory) nor the user's site-packages
+    directory.
+  * Python REPL doesn't import ``readline`` nor enable default readline
+    configuration on interactive prompts.
+  * Set ``use_environment`` and ``user_site_directory`` are set to 0.
+
 * ``legacy_windows_stdio`` (``int``, Windows only):
   If non-zero, use ``io.FileIO`` instead of ``WindowsConsoleIO`` for
   ``sys.stdin``, ``sys.stdout`` and ``sys.stderr``.
@@ -531,6 +557,9 @@ or exit using ``PyInitError_Failed()`` and ``Py_ExitInitError()``.
 * ``xoptions`` (``PyWideStringList``):
   ``sys._xoptions``.
 
+The ``legacy_windows_stdio`` field is only available on Windows.
+``#ifdef MS_WINDOWS`` macro can be used for Windows specific code.
+
 If ``parse_argv`` is non-zero, ``argv`` arguments are parsed the same
 way the regular Python parses command line arguments, and Python
 arguments are stripped from ``argv``: see `Command Line Arguments`_.
@@ -553,13 +582,13 @@ Options`_.
 More complete example modifying the default configuration, read the
 configuration, and then override some parameters::
 
-    PyInitError init_python(const char *program_name)
+    PyStatus init_python(const char *program_name)
     {
-        PyInitError err;
+        PyStatus status;
         PyConfig config;
 
-        err = PyConfig_InitPythonConfig(&config);
-        if (PyInitError_Failed(err)) {
+        status = PyConfig_InitPythonConfig(&config);
+        if (PyStatus_Exception(status)) {
             goto done;
         }
 
@@ -567,44 +596,44 @@ configuration, and then override some parameters::
            (decode byte string from the locale encoding).
 
            Implicitly preinitialize Python. */
-        err = PyConfig_SetBytesString(&config, &config.program_name,
+        status = PyConfig_SetBytesString(&config, &config.program_name,
                                       program_name);
-        if (PyInitError_Failed(err)) {
+        if (PyStatus_Exception(status)) {
             goto done;
         }
 
         /* Read all configuration at once */
-        err = PyConfig_Read(&config);
-        if (PyInitError_Failed(err)) {
+        status = PyConfig_Read(&config);
+        if (PyStatus_Exception(status)) {
             goto done;
         }
 
         /* Append our custom search path to sys.path */
-        err = PyWideStringList_Append(&config.module_search_paths,
+        status = PyWideStringList_Append(&config.module_search_paths,
                                       L"/path/to/more/modules");
-        if (PyInitError_Failed(err)) {
+        if (PyStatus_Exception(status)) {
             goto done;
         }
 
         /* Override executable computed by PyConfig_Read() */
-        err = PyConfig_SetString(&config, &config.executable,
+        status = PyConfig_SetString(&config, &config.executable,
                                  L"/path/to/my_executable");
-        if (PyInitError_Failed(err)) {
+        if (PyStatus_Exception(status)) {
             goto done;
         }
 
-        err = Py_InitializeFromConfig(&config);
+        status = Py_InitializeFromConfig(&config);
 
     done:
         PyConfig_Clear(&config);
-        return err;
+        return status;
     }
 
 .. note::
    ``PyImport_FrozenModules``, ``PyImport_AppendInittab()`` and
    ``PyImport_ExtendInittab()`` functions are still relevant and
-   continue to work as previously. They should be set or called
-   before the Python initialization.
+   continue to work as previously. They should be set or called after
+   Python preinitialization and before the Python initialization.
 
 
 Isolated Configuration
@@ -644,10 +673,10 @@ Example of customized Python always running in isolated mode::
     int main(int argc, char **argv)
     {
         PyConfig config;
-        PyInitError err;
+        PyStatus status;
 
-        err = PyConfig_InitPythonConfig(&config);
-        if (PyInitError_Failed(err)) {
+        status = PyConfig_InitPythonConfig(&config);
+        if (PyStatus_Exception(status)) {
             goto fail;
         }
 
@@ -655,13 +684,13 @@ Example of customized Python always running in isolated mode::
 
         /* Decode command line arguments.
            Implicitly preinitialize Python (in isolated mode). */
-        err = PyConfig_SetBytesArgv(&config, argc, argv);
-        if (PyInitError_Failed(err)) {
+        status = PyConfig_SetBytesArgv(&config, argc, argv);
+        if (PyStatus_Exception(status)) {
             goto fail;
         }
 
-        err = Py_InitializeFromConfig(&config);
-        if (PyInitError_Failed(err)) {
+        status = Py_InitializeFromConfig(&config);
+        if (PyStatus_Exception(status)) {
             goto fail;
         }
         PyConfig_Clear(&config);
@@ -670,12 +699,12 @@ Example of customized Python always running in isolated mode::
 
     fail:
         PyConfig_Clear(&config);
-        if (!PyInitError_IsExit(err)) {
-            /* Display the error message and exit the process with
-               non-zero exit code */
-            Py_ExitInitError(err);
+        if (PyStatus_IsExit(status)) {
+            return status.exitcode;
         }
-        return err.exitcode;
+        /* Display the error message and exit the process with
+           non-zero exit code */
+        Py_ExitStatusException(status);
     }
 
 This example is a basic implementation of the "System Python Executable"
@@ -700,6 +729,11 @@ Path Configuration
   * ``prefix``
   * ``module_search_paths_set``, ``module_search_paths``
 
+If at least one "output field" is not set, Python computes the path
+configuration to fill unset fields. If ``module_search_paths_set`` is
+equal to 0, ``module_search_paths`` is overriden and
+``module_search_paths_set`` is set to 1.
+
 It is possible to completely ignore the function computing the default
 path configuration by setting explicitly all path configuration output
 fields listed above. A string is considered as set even if it's an empty
@@ -713,9 +747,22 @@ path configuration (Unix only, Windows does not log any warning).
 If ``base_prefix`` or ``base_exec_prefix`` fields are not set, they
 inherit their value from ``prefix`` and ``exec_prefix`` respectively.
 
+``Py_RunMain()`` and ``Py_Main()`` modify ``sys.path``:
+
+* If ``run_filename`` is set and is a directory which contains a
+  ``__main__.py`` script, prepend ``run_filename`` to ``sys.path``.
+* If ``isolated`` is zero:
+
+  * If ``run_module`` is set, prepend the current directory to
+    ``sys.path``. Do nothing if the current directory cannot be read.
+  * If ``run_filename`` is set, prepends the directory of the filename
+    to ``sys.path``.
+  * Otherwise, prepends an empty string to ``sys.path``.
+
 If ``site_import`` is non-zero, ``sys.path`` can be modified by the
-``site`` module. For example, if ``user_site_directory`` is non-zero,
-the user site directory is added to ``sys.path`` (if it exists).
+``site`` module. If ``user_site_directory`` is non-zero the user's
+site-package directory exists, the ``site`` module appends the user's
+site-package directory to ``sys.path``.
 
 See also `Configuration Files`_ used by the path configuration.
 
@@ -748,6 +795,94 @@ See `Python Configuration`_ for an example of customized Python always
 running in isolated mode using ``Py_RunMain()``.
 
 
+Multi-Phase Initialization Private Provisional API
+--------------------------------------------------
+
+This section is a private provisional API introducing multi-phase
+initialization, the core feature of the PEP 432:
+
+* "Core" initialization phase, "bare minimum Python":
+
+  * Builtin types;
+  * Builtin exceptions;
+  * Builtin and frozen modules;
+  * The ``sys`` module is only partially initialized
+    (ex: ``sys.path`` doesn't exist yet);
+
+* "Main" initialization phase, Python is fully initialized:
+
+  * Install and configure ``importlib``;
+  * Apply the `Path Configuration`_;
+  * Install signal handlers;
+  * Finish ``sys`` module initialization (ex: create ``sys.stdout`` and
+    ``sys.path``);
+  * Enable optional features like ``faulthandler`` and ``tracemalloc``;
+  * Import the ``site`` module;
+  * etc.
+
+Private provisional API:
+
+* ``PyConfig._init_main``: if set to 0, ``Py_InitializeFromConfig()``
+  stops at the "Core" initialization phase.
+* ``PyStatus _Py_InitializeMain(void)``: move to the "Main"
+  initialization phase, finish the Python initialization.
+
+No module is imported during the "Core" phase and the ``importlib``
+module is not configured: the `Path Configuration`_ is only applied
+during the "Main" phase. It allows to customize Python in Python to
+override or tune the `Path Configuration`_, maybe install a custom
+sys.meta_path importer or an import hook, etc.
+
+It may become possible to compute the `Path Configuration`_ in Python,
+after the Core phase and before the Main phase, which is one of the PEP
+432 motivation.
+
+The "Core" phase is not properly defined: what should be and what should
+not be available at this phase is not specified yet. The API is marked
+as private and provisional: the API can be modified or even be removed
+anytime until a proper public API is design.
+
+Example running Python code between "Core" and "Main" initialization
+phases::
+
+    void init_python(void)
+    {
+        PyStatus status;
+        PyConfig config;
+
+        status = PyConfig_InitPythonConfig(&config);
+        if (PyStatus_Exception(status)) {
+            PyConfig_Clear(&config);
+            Py_ExitStatusException(status);
+        }
+
+        /* ... set 'config' configuration ... */
+
+        status = Py_InitializeFromConfig(&config);
+        PyConfig_Clear(&config);
+        if (PyStatus_Exception(status)) {
+            Py_ExitStatusException(status);
+        }
+
+        /* Use sys.stderr because sys.stdout is only created
+           by _Py_InitializeMain() */
+        int res = PyRun_SimpleString(
+            "import sys; "
+            "print('Run Python code before _Py_InitializeMain', "
+                   "file=sys.stderr)");
+        if (res < 0) {
+            exit(1);
+        }
+
+        /* ... put more configuration code here ... */
+
+        status = _Py_InitializeMain();
+        if (PyStatus_Exception(status)) {
+            Py_ExitStatusException(status);
+        }
+    }
+
+
 Backwards Compatibility
 =======================
 
@@ -776,9 +911,9 @@ PyPreConfig                      Python   Isolated
 ``coerce_c_locale``                   -1         0
 ``configure_locale``               **1**         0
 ``dev_mode``                          -1         0
-``isolated``                          -1     **1**
+``isolated``                           0     **1**
 ``legacy_windows_fs_encoding``        -1         0
-``use_environment``                   -1         0
+``use_environment``                    0         0
 ``parse_argv``                     **1**         0
 ``utf8_mode``                         -1         0
 ===============================  =======  ========
@@ -1025,9 +1160,9 @@ Default Python Configugration
 * ``coerce_c_locale`` = -1
 * ``configure_locale`` = 1
 * ``dev_mode`` = -1
-* ``isolated`` = -1
+* ``isolated`` = 0
 * ``legacy_windows_fs_encoding`` = -1
-* ``use_environment`` = -1
+* ``use_environment`` = 1
 * ``utf8_mode`` = -1
 
 ``PyConfig_InitPythonConfig()``:
@@ -1300,8 +1435,53 @@ Issues related to this PEP:
   standalone) to locate the module path according to the shared library"
 
 
+Discussions
+===========
+
+* May 2019:
+
+  * `[Python-Dev] PEP 587 "Python Initialization Configuration" version 4
+    <https://mail.python.org/pipermail/python-dev/2019-May/157492.html>`_
+  * `[Python-Dev] RFC: PEP 587 "Python Initialization Configuration": 3rd version
+    <https://mail.python.org/pipermail/python-dev/2019-May/157435.html>`_
+  * `Study on applications embedding Python
+    <https://mail.python.org/pipermail/python-dev/2019-May/157385.html>`_
+  * `[Python-Dev] RFC: PEP 587 "Python Initialization Configuration":
+    2nd version
+    <https://mail.python.org/pipermail/python-dev/2019-May/157290.html>`_
+
+* March 2019:
+
+  * `[Python-Dev] PEP 587: Python Initialization Configuration
+    <https://mail.python.org/pipermail/python-dev/2019-March/156892.html>`_
+  * `[Python-Dev] New Python Initialization API
+    <https://mail.python.org/pipermail/python-dev/2019-March/156884.html>`_
+
+* February 2019:
+
+  * `Adding char* based APIs for Unix
+    <https://discuss.python.org/t/adding-char-based-apis-for-unix/916>`_
+
+* July-August 2018:
+
+  * July: `[Python-Dev] New _Py_InitializeFromConfig() function (PEP 432)
+    <https://mail.python.org/pipermail/python-dev/2018-July/154882.html>`__
+  * August: `[Python-Dev] New _Py_InitializeFromConfig() function (PEP 432)
+    <https://mail.python.org/pipermail/python-dev/2018-August/154896.html>`__
+
 Version History
 ===============
+
+* Version 5:
+
+  * Rename ``PyInitError`` to ``PyStatus``
+  * Rename ``PyInitError_Failed()`` to ``PyStatus_Exception()``
+  * Rename ``Py_ExitInitError()`` to ``Py_ExitStatusException()``
+  * Add ``PyPreConfig._config_init`` private field.
+  * Fix Python Configuration default values: isolated=0
+    and use_environment=1, instead of -1.
+  * Add "Multi-Phase Initialization Private Provisional API"
+    and "Discussions" sections
 
 * Version 4:
 

--- a/pep-0589.rst
+++ b/pep-0589.rst
@@ -4,12 +4,13 @@ Author: Jukka Lehtosalo <jukka.lehtosalo@iki.fi>
 Sponsor: Guido van Rossum <guido@python.org>
 BDFL-Delegate: Guido van Rossum <guido@python.org>
 Discussions-To: typing-sig@python.org
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 20-Mar-2019
 Python-Version: 3.8
 Post-History:
+Resolution: https://mail.python.org/archives/list/typing-sig@python.org/message/FDO4KFYWYQEP3U2HVVBEBR3SXPHQSHYR/
 
 
 Abstract

--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -17,6 +17,9 @@ It introduces a new "vectorcall" protocol and calling convention.
 This is based on the "fastcall" convention, which is already used internally by CPython.
 The new features can be used by any user-defined extension class.
 
+Most of the new API is private in CPython 3.8.
+The plan is to finalize semantics and make it public in Python 3.9.
+
 **NOTE**: This PEP deals only with the Python/C API,
 it does not affect the Python language or standard library.
 
@@ -44,6 +47,13 @@ This is inefficient for calls to classes as several intermediate objects need to
 For a class ``cls``, at least one intermediate object is created for each call in the sequence
 ``type.__call__``, ``cls.__new__``, ``cls.__init__``.
 
+This PEP proposes an interface for use by extension modules.
+Such interfaces cannot effectively be tested, or designed, without having the
+consumers in the loop.
+For that reason, we provide private (underscore-prefixed) names.
+The API may change (based on consumer feedback) in Python 3.9, where we expect
+it to be finalized, and the underscores removed.
+
 
 Specification
 =============
@@ -65,12 +75,12 @@ Changes to the ``PyTypeObject`` struct
 --------------------------------------
 
 The unused slot ``printfunc tp_print`` is replaced with ``tp_vectorcall_offset``. It has the type ``Py_ssize_t``.
-A new ``tp_flags`` flag is added, ``Py_TPFLAGS_HAVE_VECTORCALL``,
+A new ``tp_flags`` flag is added, ``_Py_TPFLAGS_HAVE_VECTORCALL``,
 which must be set for any class that uses the vectorcall protocol.
 
-If ``Py_TPFLAGS_HAVE_VECTORCALL`` is set, then ``tp_vectorcall_offset`` must be a positive integer.
+If ``_Py_TPFLAGS_HAVE_VECTORCALL`` is set, then ``tp_vectorcall_offset`` must be a positive integer.
 It is the offset into the object of the vectorcall function pointer of type ``vectorcallfunc``.
-This pointer may be ``NULL``, in which case the behavior is the same as if ``Py_TPFLAGS_HAVE_VECTORCALL`` was not set.
+This pointer may be ``NULL``, in which case the behavior is the same as if ``_Py_TPFLAGS_HAVE_VECTORCALL`` was not set.
 
 The ``tp_print`` slot is reused as the ``tp_vectorcall_offset`` slot to make it easier for for external projects to backport the vectorcall protocol to earlier Python versions.
 In particular, the Cython project has shown interest in doing that (see https://mail.python.org/pipermail/python-dev/2018-June/153927.html).
@@ -80,7 +90,7 @@ Descriptor behavior
 
 One additional type flag is specified: ``Py_TPFLAGS_METHOD_DESCRIPTOR``.
 
-``Py_TPFLAGS_METHOD_DESCRIPTOR`` should be set if the the callable uses the descriptor protocol to create a bound method-like object.
+``Py_TPFLAGS_METHOD_DESCRIPTOR`` should be set if the callable uses the descriptor protocol to create a bound method-like object.
 This is used by the interpreter to avoid creating temporary objects when calling methods
 (see ``_PyObject_GetMethod`` and the ``LOAD_METHOD``/``CALL_METHOD`` opcodes).
 
@@ -128,7 +138,7 @@ New C API and changes to CPython
 
 The following functions or macros are added to the C API:
 
-- ``PyObject *PyObject_Vectorcall(PyObject *obj, PyObject *const *args, Py_ssize_t nargs, PyObject *keywords)``:
+- ``PyObject *_PyObject_Vectorcall(PyObject *obj, PyObject *const *args, Py_ssize_t nargs, PyObject *keywords)``:
   Calls ``obj`` with the given arguments.
   Note that ``nargs`` may include the flag ``PY_VECTORCALL_ARGUMENTS_OFFSET``.
   The actual number of positional arguments is given by ``PyVectorcall_NARGS(nargs)``.
@@ -149,7 +159,7 @@ The following functions or macros are added to the C API:
 Subclassing
 -----------
 
-Extension types inherit the type flag ``Py_TPFLAGS_HAVE_VECTORCALL``
+Extension types inherit the type flag ``_Py_TPFLAGS_HAVE_VECTORCALL``
 and the value ``tp_vectorcall_offset`` from the base class,
 provided that they implement ``tp_call`` the same way as the base class.
 Additionally, the flag ``Py_TPFLAGS_METHOD_DESCRIPTOR``
@@ -159,6 +169,23 @@ Heap types never inherit the vectorcall protocol because
 that would not be safe (heap types can be changed dynamically).
 This restriction may be lifted in the future, but that would require
 special-casing ``__call__`` in ``type.__setattribute__``.
+
+
+Finalizing the API
+==================
+
+The underscore in the names ``_PyObject_Vectorcall`` and
+``_Py_TPFLAGS_HAVE_VECTORCALL`` indicates that this API may change in minor
+Python versions.
+When finalized (which is planned for Python 3.9), they will be renamed to
+``PyObject_Vectorcall`` and ``Py_TPFLAGS_HAVE_VECTORCALL``.
+The old underscore-prefixed names will remain available as aliases.
+
+The new API will be documented as normal, but will warn of the above.
+
+Semantics for the other names introduced in this PEP (``PyVectorcall_NARGS``,
+``PyVectorcall_Call``, ``Py_TPFLAGS_METHOD_DESCRIPTOR``,
+``PY_VECTORCALL_ARGUMENTS_OFFSET``) are final.
 
 
 Internal CPython changes
@@ -203,7 +230,7 @@ Third-party extension classes using vectorcall
 
 To enable call performance on a par with Python functions and built-in functions,
 third-party callables should include a ``vectorcallfunc`` function pointer,
-set ``tp_vectorcall_offset`` to the correct value and add the ``Py_TPFLAGS_HAVE_VECTORCALL`` flag.
+set ``tp_vectorcall_offset`` to the correct value and add the ``_Py_TPFLAGS_HAVE_VECTORCALL`` flag.
 Any class that does this must implement the ``tp_call`` function and make sure its behaviour is consistent with the ``vectorcallfunc`` function.
 Setting ``tp_call`` to ``PyVectorcall_Call`` is sufficient.
 

--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -1,6 +1,7 @@
 PEP: 590
 Title: Vectorcall: a fast calling protocol for CPython
 Author: Mark Shannon <mark@hotpy.org>, Jeroen Demeyer <J.Demeyer@UGent.be>
+BDFL-Delegate: Petr Viktorin <encukou@gmail.com>
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0591.rst
+++ b/pep-0591.rst
@@ -3,11 +3,13 @@ Title: Adding a final qualifier to typing
 Author: Michael J. Sullivan <sully@msully.net>, Ivan Levkivskyi <levkivskyi@gmail.com>
 BDFL-Delegate: Guido van Rossum <guido@python.org>
 Discussions-To: typing-sig@python.org
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 15-Mar-2019
+Python-Version: 3.8
 Post-History:
+Resolution: https://mail.python.org/archives/list/typing-sig@python.org/message/FDO4KFYWYQEP3U2HVVBEBR3SXPHQSHYR/
 
 
 Abstract

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -40,7 +40,7 @@ for several reasons.
   development team. The team has limited resources, reduced maintenance cost
   frees development time for other improvements.
 * Modules in the standard library are generally favored and seen as the
-  de-facto solution for a problem. A majority of users only pick 3rd party
+  de facto solution for a problem. A majority of users only pick 3rd party
   modules to replace a stdlib module, when they have a compelling reason, e.g.
   lxml instead of `xml`. The removal of an unmaintained stdlib module
   increases the chances of a community contributed module to become widely
@@ -61,7 +61,7 @@ This PEP also designates some modules as not scheduled for removal. Some
 modules have been deprecated for several releases or seem unnecessary at
 first glance. However it is beneficial to keep the modules in the standard
 library, mostly for environments where installing a package from PyPI is not
-an option. This can be cooperate environments or class rooms where external
+an option. This can be corporate environments or class rooms where external
 code is not permitted without legal approval.
 
 * The usage of FTP is declining, but some files are still provided over
@@ -500,7 +500,7 @@ groups used to be a dominant platform for online discussions. Over the last
 two decades, news has been slowly but steadily replaced with mailing lists
 and web-based discussion platforms. Twisted is also
 `planning <https://twistedmatrix.com/trac/ticket/9405>`_ to deprecate NNTP
-support and `pynnt <https://github.com/greenbender/pynntp>`_ hasn't seen any
+support and `pynntp <https://github.com/greenbender/pynntp>`_ hasn't seen any
 activity since 2014. This is a good indicator that the public interest in
 NNTP support is declining.
 
@@ -816,8 +816,8 @@ fileinput
 
 The `fileinput <https://docs.python.org/3/library/fileinput.html>`_ module
 implements a helpers to iterate over a list of files from ``sys.argv``. The
-module predates the optparser and argparser module. The same functionality
-can be implemented with the argparser module.
+module predates the optparse and argparse module. The same functionality
+can be implemented with the argparse module.
 
 Several core developers expressed their interest to keep the module in the
 standard library, as it is handy for quick scripts.
@@ -909,7 +909,7 @@ documentation may be moved into a new git repository, so community members
 have a place from which they can pick up and fork code.
 
 A first draft of a `legacylib <https://github.com/tiran/legacylib>`_
-repository is available on my private Github account. The modules could be
+repository is available on my private GitHub account. The modules could be
 made available on PyPI. The Python core team will not publish or maintain
 the packages. It is my hope that members of the Python community will
 adopt, maintain, and perhaps improve the deprecated modules.

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -13,8 +13,29 @@ Abstract
 ========
 
 This PEP proposed a list of standard library modules to be removed from the
-standard library. The modules are mostly historic data formats and APIs that
-have been superseded a long time ago, e.g. Mac OS 9 and Commodore.
+standard library. The modules are mostly historic data formats (e.g. Commodore
+and SUN file formats), APIs and operating systems that have been superseded a
+long time ago (e.g. Mac OS 9), or modules that have security implications and
+better alternatives (e.g. password and login).
+
+The PEP follows in the foot steps of other PEPS like :pep:`3818`. The
+*Standard Library Reorganization* proposal removed a bunch of modules from
+Python 3.0. In 2007, the PEP referred to maintenance burden as:
+
+   "Over the years, certain modules have become a heavy burden upon python-dev
+   to maintain. In situations like this, it is better for the module to be
+   given to the community to maintain to free python-dev to focus more on
+   language support and other modules in the standard library that do not take
+   up an undue amount of time and effort."
+
+The withdrawn :pep:`206` from 2000 expresses issues with the Python standard
+library unvarnished and fortright:
+
+   "[...] the standard library modules aren't always the best choices for a
+   job. Some library modules were quick hacks (e.g. ``calendar``,
+   ``commands``), some were designed poorly and are now near-impossible to
+   fix (``cgi``), and some have been rendered obsolete by other, more complete
+   modules [...]."
 
 
 Rationale
@@ -91,7 +112,9 @@ just be *documented* as deprecated. Optionally modules may emit a
 `PendingDeprecationWarning`.
 
 All deprecated modules will also undergo a feature freeze. No additional
-features should be added. Bug should still be fixed.
+features should be added *unless* python-dev agrees that the deprecation of
+the module is reverted and the code will not be removed. Bug should still be
+fixed.
 
 3.9
 ---
@@ -141,35 +164,45 @@ PyPI, e.g. Pillow for image processing or NumPy-based projects to deal with
 audio processing.
 
 .. csv-table:: Table 1: Proposed modules deprecations
-   :header: "Module", "Deprecated in", "To be removed", "Has expert?", "Replacement"
-   :widths: 1, 1, 1, 1, 2
+   :header: "Module", "Deprecated in", "To be removed", "Added in", "Has maintainer?", "Replacement"
+   :widths: 2, 1, 1, 1, 1, 2
 
-    aifc,3.8,3.10,**yes (inactive)**,\-
-    asynchat,**3.6**,3.10,**yes**,asyncio
-    asyncore,**3.6**,3.10,**yes**,asyncio
-    audioop,3.8,3.10,**yes**,\-
-    binhex,3.8,3.10,no,\-
-    cgi,3.8,3.10,no,\-
-    cgitb,3.8,3.10,no,\-
-    chunk,3.8,3.10,no,\-
-    crypt,3.8,3.10,**yes (inactive)**,"bcrypt, argon2cffi, hashlib, passlib"
-    formatter,3.4,3.10,no,\-
-    fpectl,**3.7**,**3.7**,n/a,\-
-    imghdr,3.8,3.10,no,"filetype, puremagic, python-magic"
-    imp,**3.4**,3.10,**yes**,importlib
-    macpath,**3.7**,**3.8**,n/a,\-
-    msilib,3.8,3.10,no,\-
-    nntplib,3.8,3.10,no,\-
-    nis,3.8,3.10,no,\-
-    ossaudiodev,3.8,3.10,no,\-
-    parser,**2.5**,**3.9**,**yes**,"ast, lib2to3.pgen2"
-    pipes,3.8,3.10,no,subprocess
-    smtpd,"**3.4.7**, **3.5.4**",3.10,**yes**,aiosmtpd
-    sndhdr,3.8,3.10,no,"filetype, puremagic, python-magic"
-    spwd,3.8,3.10,no,"python-pam, simplepam"
-    sunau,3.8,3.10,no,\-
-    uu,3.8,3.10,no,\-
-    xdrlib,3.8,3.10,no,\-
+    aifc,3.8 (3.0\*),3.10,1993,**yes (inactive)**,\-
+    asynchat,**3.6** (3.0\*),3.10,1999,**yes**,asyncio
+    asyncore,**3.6** (3.0\*),3.10,1999,**yes**,asyncio
+    audioop,3.8 (3.0\*),3.10,1992,**yes**,\-
+    binhex,3.8,3.10,1995,no,\-
+    cgi,3.8 (2.0\*\*),3.10,1995,no,\-
+    cgitb,3.8 (2.0\*\*),3.10,1995,no,\-
+    chunk,3.8,3.10,1999,no,\-
+    crypt,3.8,3.10,1994,**yes (inactive)**,"bcrypt, argon2cffi, hashlib, passlib"
+    email.message.Message,3.3,3.10,2001,yes,email.message.EmailMessage
+    email.mime,3.3,3.10,2001,yes,email.contentmanager
+    email.policy.Compat32,3.3,3.10,2011,yes,email.policy.EmailPolicy
+    formatter,**3.4**,3.10,1995,no,\-
+    fpectl,**3.7**,**3.7**,1997,n/a,\-
+    imghdr,3.8,3.10,1992,no,"filetype, puremagic, python-magic"
+    imp,**3.4**,3.10,1990/1995,no,importlib
+    macpath,**3.7**,**3.8**,1990,n/a,\-
+    msilib,3.8,3.10,2006,no,\-
+    nntplib,3.8,3.10,1992,no,\-
+    nis,3.8 (3.0\*),3.10,1992,no,\-
+    ossaudiodev,3.8,3.10,2002,no,\-
+    parser,**2.5**,**3.9**,1993,**yes**,"ast, lib2to3.pgen2"
+    pipes,3.8,3.10,1992,no,subprocess
+    smtpd,"**3.4.7**, **3.5.4**",3.10,2001,**yes**,aiosmtpd
+    sndhdr,3.8,3.10,1994,no,"filetype, puremagic, python-magic"
+    spwd,3.8,3.10,2005,no,"python-pam, simplepam"
+    sunau,3.8 (3.0\*),3.10,1993,no,\-
+    telnetlib,3.8 (3.0\*),3.10,1997,no,"telnetlib3, Exscript"
+    uu,3.8,3.10,1994,no,\-
+    xdrlib,3.8,3.10,1992/1996,no,\-
+
+Some module deprecations proposed by :pep:`3108` for 3.0 and :pep:`206` for
+2.0. The *added in* column illustrates, when a module was originally designed
+and added to the standard library. The *has maintainer* colum refers to the
+`expert index <https://devguide.python.org/experts/>`_, a list of domain
+experts and maintainers in the DevGuide.
 
 
 Data encoding modules
@@ -180,7 +213,7 @@ binhex
 
 The `binhex <https://docs.python.org/3/library/binhex.html>`_ module encodes
 and decodes Apple Macintosh binhex4 data. It was originally developed for
-TSR-80. In the 1980s and early 1990s it was used on classic Mac OS 9 to
+TRS-80. In the 1980s and early 1990s it was used on classic Mac OS 9 to
 encode binary email attachments.
 
 Module type
@@ -245,8 +278,15 @@ File Format is an old audio format from 1988 based on Amiga IFF. It was most
 commonly used on the Apple Macintosh. These days only few specialized
 application use AIFF.
 
+A user disclosed [8]_ that the post production film industry makes heavy
+use of the AIFC file format. The usage of the ``aifc`` module in closed source
+and internal software was unknown prior to the first posting of this PEP. This
+may be a compelling argument to keep the ``aifc`` module in the standard
+library. The file format is stable and the module does not require much
+maintenance. The strategic benefits for Python may outmatch the burden.
+
 Module type
-  pure Python (depends on `audioop`_ C extension)
+  pure Python (depends on some functions from `audioop`_ C extension)
 Deprecated in
   3.8
 To be removed in
@@ -263,8 +303,13 @@ The `audioop <https://docs.python.org/3/library/audioop.html>`_ module
 contains helper functions to manipulate raw audio data and adaptive
 differential pulse-code modulated audio data. The module is implemented in
 C without any additional dependencies. The `aifc`_, `sunau`_, and `wave`_
-module depend on `audioop`_ for some operations. The byteswap operation in
-the `wave`_ module can be substituted with little work.
+module depend on `audioop`_ for some operations.
+
+The byteswap operation in the ``wave`` module can be substituted with little
+extra work. In case ``aifc`` is not deprecated as well, a reduced version of
+the ``audioop`` module is converted into a private implementation detail,
+e.g. ``_audioop`` with ``byteswap``, ``alaw2lin``, ``ulaw2lin``, ``lin2alaw``,
+``lin2ulaw``, and ``lin2adpcm``.
 
 Module type
   C extension
@@ -326,6 +371,17 @@ playback and capture devices. OSS was initially free software, but later
 support for newer sound devices and improvements were proprietary. Linux
 community abandoned OSS in favor of ALSA [1]_. Some operation systems like
 OpenBSD and NetBSD provide an incomplete [2]_ emulation of OSS.
+
+To best of my knowledge, FreeBSD is the only widespread operating system
+that uses Open Sound System as of today. The ``ossaudiodev`` hasn't seen any
+improvements or new features since 2003. All commits since 2003 are
+project-wide code cleanups and a couple of bug fixes. It would be beneficial
+for both FreeBSD community and core development, if the module would be
+maintained and distributed by people that care for it and use it.
+
+The standard library used to have more audio-related modules. The other
+audio device interface (``audiodev``, ``linuxaudiodev``, ``sunaudiodev``)
+were removed in 2007 as part of the :pep:`3108` stdlib re-organization.
 
 Module type
   C extension
@@ -427,9 +483,10 @@ cgi
 
 The `cgi <https://docs.python.org/3/library/cgi.html>`_ module is a support
 module for Common Gateway Interface (CGI) scripts. CGI is deemed as
-inefficient because every incoming request is handled in a new process. PEP
-206 considers the module as *designed poorly and are now near-impossible
-to fix*.
+inefficient because every incoming request is handled in a new process.
+:pep:`206` considers the module as:
+
+   "[...] designed poorly and are now near-impossible to fix (``cgi``) [...]"
 
 Several people proposed to either keep the cgi module for features like
 `cgi.parse_qs()` or move `cgi.escape()` to a different module. The
@@ -442,7 +499,7 @@ with secure default values.
 Module type
   pure Python
 Deprecated in
-  3.8
+  3.8 (originally proposed for 2.0 by :pep:`206`)
 To be removed in
   3.10
 Has a designated expert
@@ -464,13 +521,46 @@ optional debugging middleware.
 Module type
   pure Python
 Deprecated in
-  3.8
+  3.8 (originally proposed for 2.0 by :pep:`206`)
 To be removed in
   3.10
 Has a designated expert
    no
 Substitute
   **none**
+
+email (legacy API)
+~~~~~~~~~~~~~~~~~~
+
+The `email <https://docs.python.org/3/library/email.html>`_ package is a
+library for managing email messages. The email package contains several
+legacy modules, legacy functions, and legacy classes, that provide backwards
+compatibility to Python 3.2 and 2.7:
+
+ * ``email.message.Message`` (replaced by ``email.message.EmailMessage``)
+ * ``email.mime`` (replaced by ``email.contentmanager``)
+ * ``email.header`` (replaced by dict-like API of ``EmailMessage`` class)
+ * ``email.charset``
+ * ``email.encoders`` (replaced by ``EmailMessage.set_content``)
+ * ``email.utils`` (new API performs parsing and formatting automatically)
+ * ``email.iterators``
+ * ``email.policy.Compat32``
+
+The classes ``email.mime.audio.MIMEAudio`` and ``email.mime.image.MIMEImage``
+depend on the ``sndhdr`` and ``imghdr`` modules. In case the ``email.mime``
+package is not removed, the auto-detection of file formats must be deprecated
+and ``_subtype`` argument a required argument.
+
+Module type
+  pure Python
+Deprecated in
+  3.8 (documented as legacy APIs since 3.3 or 3.4)
+To be removed in
+  3.10
+Has a designated expert
+   yes
+Substitute
+  email (non-legacy APIs)
 
 smtpd
 ~~~~~
@@ -520,6 +610,22 @@ Has a designated expert
    no
 Substitute
   **none**
+
+telnetlib
+~~~~~~~~~
+
+The `telnetlib <https://docs.python.org/3/library/telnetlib.html>`_ module
+provides a Telnet class that implements the Telnet protocol.
+
+Module type
+  pure Python
+Deprecated in
+  3.8
+To be removed in
+  3.10
+Substitute
+  `telnetlib3 <https://pypi.org/project/telnetlib3>`_,
+  `Exscript <https://pypi.org/project/Exscript/>`_
 
 
 Operating system interface
@@ -960,9 +1066,9 @@ Update 1
 
 * Deprecate `parser`_ module
 * Keep `fileinput`_ module
-* Elaborate why `crypt`_ and `spwd`_ are dangerous and bad
+* Elaborate why ``crypt`` and ``spwd`` are dangerous and bad
 * Improve sections for `cgitb`_, `colorsys`_, `nntplib`_, and `smtpd`_ modules
-* The `colorsys`_, `crypt`_, `imghdr`_, `sndhdr`_, and `spwd`_ sections now
+* The `colorsys`_, ``crypt``, `imghdr`_, `sndhdr`_, and ``spwd`` sections now
   list suitable substitutions.
 * Mention that ``socketserver`` is going to stay for ``http.server`` and
   ``xmlrpc.server``
@@ -975,6 +1081,11 @@ Update 2
 * Keep ``colorsys`` module
 * Add experts
 * Redirect discussions to discuss.python.org
+* Deprecate `telnetlib`_
+* Deprecate compat32 policy of email package
+* Add creation year to overview table
+* Mention :pep:`206` and :pep:`3108`
+* Update sections for ``aifc``, ``audioop``, ``cgi``, and ``wave``.
 
 
 References
@@ -987,6 +1098,7 @@ References
 .. [5] https://twitter.com/dabeaz/status/1130278844479545351
 .. [6] https://mail.python.org/pipermail/python-dev/2019-May/157464.html
 .. [7] https://discuss.python.org/t/switch-pythons-parsing-tech-to-something-more-powerful-than-ll-1/379
+.. [8] https://mail.python.org/pipermail/python-dev/2019-May/157634.html
 
 
 Copyright

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -140,35 +140,35 @@ PyPI, e.g. Pillow for image processing or NumPy-based projects to deal with
 audio processing.
 
 .. csv-table:: Table 1: Proposed modules deprecations
-   :header: "Module", "Deprecated in", "To be removed", "Replacement"
-   :widths: 1, 1, 1, 2
+   :header: "Module", "Deprecated in", "To be removed", "Has expert?", "Replacement"
+   :widths: 1, 1, 1, 1, 2
 
-    aifc,3.8,3.10,\-
-    asynchat,**3.6**,3.10,asyncio
-    asyncore,**3.6**,3.10,asyncio
-    audioop,3.8,3.10,\-
-    binhex,3.8,3.10,\-
-    cgi,3.8,3.10,\-
-    cgitb,3.8,3.10,\-
-    chunk,3.8,3.10,\-
-    crypt,3.8,3.10,"bcrypt, argon2cffi, hashlib, passlib"
-    formatter,3.4,3.10,\-
-    fpectl,**3.7**,**3.7**,\-
-    imghdr,3.8,3.10,"filetype, puremagic, python-magic"
-    imp,**3.4**,3.10,importlib
-    macpath,**3.7**,**3.8**,\-
-    msilib,3.8,3.10,\-
-    nntplib,3.8,3.10,\-
-    nis,3.8,3.10,\-
-    ossaudiodev,3.8,3.10,\-
-    parser,**2.5**,**3.9**,"ast, lib2to3.pgen2"
-    pipes,3.8,3.10,subprocess
-    smtpd,"**3.4.7**, **3.5.4**",3.10,aiosmtpd
-    sndhdr,3.8,3.10,"filetype, puremagic, python-magic"
-    spwd,3.8,3.10,"python-pam, simplepam"
-    sunau,3.8,3.10,\-
-    uu,3.8,3.10,\-
-    xdrlib,3.8,3.10,\-
+    aifc,3.8,3.10,**yes (inactive)**,\-
+    asynchat,**3.6**,3.10,**yes**,asyncio
+    asyncore,**3.6**,3.10,**yes**,asyncio
+    audioop,3.8,3.10,**yes**,\-
+    binhex,3.8,3.10,no,\-
+    cgi,3.8,3.10,no,\-
+    cgitb,3.8,3.10,no,\-
+    chunk,3.8,3.10,no,\-
+    crypt,3.8,3.10,**yes (inactive)**,"bcrypt, argon2cffi, hashlib, passlib"
+    formatter,3.4,3.10,no,\-
+    fpectl,**3.7**,**3.7**,n/a,\-
+    imghdr,3.8,3.10,no,"filetype, puremagic, python-magic"
+    imp,**3.4**,3.10,**yes**,importlib
+    macpath,**3.7**,**3.8**,n/a,\-
+    msilib,3.8,3.10,no,\-
+    nntplib,3.8,3.10,no,\-
+    nis,3.8,3.10,no,\-
+    ossaudiodev,3.8,3.10,no,\-
+    parser,**2.5**,**3.9**,**yes**,"ast, lib2to3.pgen2"
+    pipes,3.8,3.10,no,subprocess
+    smtpd,"**3.4.7**, **3.5.4**",3.10,**yes**,aiosmtpd
+    sndhdr,3.8,3.10,no,"filetype, puremagic, python-magic"
+    spwd,3.8,3.10,no,"python-pam, simplepam"
+    sunau,3.8,3.10,no,\-
+    uu,3.8,3.10,no,\-
+    xdrlib,3.8,3.10,no,\-
 
 
 Data encoding modules
@@ -188,6 +188,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   **none**
 
@@ -205,6 +207,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   **none**
 
@@ -222,6 +226,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   **none**
 
@@ -244,6 +250,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   yes, but expert is currently inactive.
 Substitute
   **none**
 
@@ -263,6 +271,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   yes
 Substitute
   **none**
 
@@ -280,6 +290,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   **none**
 
@@ -297,6 +309,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   `puremagic <https://pypi.org/project/puremagic/>`_,
   `filetype <https://pypi.org/project/filetype/>`_,
@@ -318,6 +332,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   **none**
 
@@ -336,6 +352,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   `puremagic <https://pypi.org/project/puremagic/>`_,
   `filetype <https://pypi.org/project/filetype/>`_,
@@ -353,6 +371,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   **none**
 
@@ -372,6 +392,8 @@ Deprecated in
   3.6
 Removed in
   3.10
+Has a designated expert
+   yes
 Substitute
   asyncio
 
@@ -393,6 +415,8 @@ Deprecated in
   3.6
 Removed in
   3.10
+Has a designated expert
+   yes
 Substitute
   asyncio
 
@@ -420,6 +444,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   **none**
 
@@ -440,6 +466,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   **none**
 
@@ -454,9 +482,11 @@ deprecation message was added in releases 3.4.7, 3.5.4, and 3.6.1.
 Module type
   pure Python
 Deprecated in
-  **3.7**
+  **3.4.7**, **3.5.4**, **3.6.1**
 To be removed in
   3.10
+Has a designated expert
+   yes
 Substitute
   aiosmtpd
 
@@ -485,6 +515,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   **none**
 
@@ -521,6 +553,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   yes, but expert is currently inactive.
 Substitute
   `bcrypt <https://pypi.org/project/bcrypt/>`_,
   `passlib <https://pypi.org/project/passlib/>`_,
@@ -540,6 +574,8 @@ Deprecated in
   3.7
 Removed in
   3.8
+Has a designated expert
+   n/a
 Substitute
   **none**
 
@@ -559,6 +595,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   **none**
 
@@ -586,6 +624,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   `python-pam <https://pypi.org/project/python-pam/>`_,
   `simpleplam <https://pypi.org/project/simplepam/>`_
@@ -605,6 +645,8 @@ Deprecated in
   3.4
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   *n/a*
 
@@ -623,6 +665,8 @@ Deprecated in
   3.4
 To be removed in
   3.10
+Has a designated expert
+   yes, experts have deprecated the module
 Substitute
   importlib
 
@@ -645,6 +689,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   **none**
 
@@ -674,6 +720,8 @@ Deprecated in
   3.8, documented as deprecated since **2.5**
 To be removed in
   **3.9**
+Has a designated expert
+   yes, experts have deprecated the module.
 Substitute
   ast, lib2to3.pgen2
 
@@ -691,6 +739,8 @@ Deprecated in
   3.8
 To be removed in
   3.10
+Has a designated expert
+   no
 Substitute
   subprocess module
 
@@ -712,6 +762,8 @@ Deprecated in
   3.7
 Removed in
   3.7
+Has a designated expert
+   n/a
 Substitute
   **none**
 
@@ -750,6 +802,8 @@ between color systems.
 
 Module type
   pure Python
+Has a designated expert
+   no
 Substitute
   `colormath <https://pypi.org/project/colormath/>`_,
   `colour <https://pypi.org/project/colour/>`_
@@ -769,6 +823,8 @@ standard library, as it is handy for quick scripts.
 
 Module type
   pure Python
+Has a designated expert
+   no
 
 lib2to3
 -------
@@ -781,6 +837,8 @@ The package is useful for other tasks besides porting code from Python 2 to
 
 Module type
   pure Python
+Has a designated expert
+   no
 
 getopt
 ------
@@ -794,6 +852,8 @@ to write simple Python scripts.
 
 Module type
   pure Python
+Has a designated expert
+   no
 Substitute
   argparse
 
@@ -810,6 +870,8 @@ Module type
   pure Python
 Deprecated in
   3.2
+Has a designated expert
+   yes
 Substitute
   argparse
 
@@ -832,6 +894,8 @@ the ``array`` module could gain support for 24 bit (3 byte) arrays.
 
 Module type
   pure Python (depends on *byteswap* from `audioop`_ C extension)
+Has a designated expert
+   no
 
 
 Future maintenance of removed modules
@@ -908,6 +972,7 @@ Update 2
 --------
 
 * Keep ``colorsys`` module
+* Add experts
 
 
 References

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -506,7 +506,7 @@ NNTP support is declining.
 
 The ``nntplib`` tests have been the cause of additional work in the recent
 past. Python only contains client side of NNTP. The tests connect to
-external news server. The servers are sometimes unavailble, too slow, or do
+external news server. The servers are sometimes unavailable, too slow, or do
 not work correctly over IPv6. The situation causes flaky test runs on
 buildbots.
 
@@ -535,7 +535,7 @@ quality and insecure. Users are discouraged to use them.
 
 * The module is not available on Windows. Cross-platform application need
   an alternative implementation any way.
-* Only DES encryption is guarenteed to be available. DES has an extremely
+* Only DES encryption is guaranteed to be available. DES has an extremely
   limited key space of 2**56.
 * MD5, salted SHA256, salted SHA512, and Blowfish are optional extension.
   SSHA256 and SSHA512 are glibc extensions. Blowfish (bcrypt) is the only

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -21,7 +21,7 @@ Rationale
 =========
 
 Back in the early days of Python, the interpreter came with a large set of
-useful modules. This was often refrained to as "batteries included"
+useful modules. This was often referred to as "batteries included"
 philosophy and was one of the corner stones to Python's success story.
 Users didn't have to figure out how to download and install separate
 packages in order to write a simple web server or parse email.

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -1,6 +1,7 @@
 PEP: 594
 Title: Removing dead batteries from the standard library
 Author: Christian Heimes <christian@python.org>
+Discussions-To: https://discuss.python.org/t/pep-594-removing-dead-batteries-from-the-standard-library/1704
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
@@ -973,6 +974,7 @@ Update 2
 
 * Keep ``colorsys`` module
 * Add experts
+* Redirect discussions to discuss.python.org
 
 
 References

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -144,8 +144,8 @@ audio processing.
    :widths: 1, 1, 1, 2
 
     aifc,3.8,3.10,\-
-    asynchat,3.8,3.10,asyncio
-    asyncore,3.8,3.10,asyncio
+    asynchat,**3.6**,3.10,asyncio
+    asyncore,**3.6**,3.10,asyncio
     audioop,3.8,3.10,\-
     binhex,3.8,3.10,\-
     cgi,3.8,3.10,\-

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -151,20 +151,15 @@ audio processing.
     cgi,3.8,3.10,\-
     cgitb,3.8,3.10,\-
     chunk,3.8,3.10,\-
-    colorsys,3.8,3.10,"colormath, colour, colorspacious, Pillow"
     crypt,3.8,3.10,"bcrypt, argon2cffi, hashlib, passlib"
-    fileinput,\-,**keep**,argparse
     formatter,3.4,3.10,\-
     fpectl,**3.7**,**3.7**,\-
-    getopt,**3.2**,**keep**,"argparse, optparse"
     imghdr,3.8,3.10,"filetype, puremagic, python-magic"
     imp,**3.4**,3.10,importlib
-    lib2to3,\-,**keep**,
     macpath,**3.7**,**3.8**,\-
     msilib,3.8,3.10,\-
     nntplib,3.8,3.10,\-
     nis,3.8,3.10,\-
-    optparse,\-,**keep**,argparse
     ossaudiodev,3.8,3.10,\-
     parser,**2.5**,**3.9**,"ast, lib2to3.pgen2"
     pipes,3.8,3.10,subprocess
@@ -173,7 +168,6 @@ audio processing.
     spwd,3.8,3.10,"python-pam, simplepam"
     sunau,3.8,3.10,\-
     uu,3.8,3.10,\-
-    wave,\-,**keep**,
     xdrlib,3.8,3.10,\-
 
 
@@ -271,29 +265,6 @@ To be removed in
   3.10
 Substitute
   **none**
-
-colorsys
-~~~~~~~~
-
-The `colorsys <https://docs.python.org/3/library/colorsys.html>`_ module
-defines color conversion functions between RGB, YIQ, HSL, and HSV coordinate
-systems.
-
-The PyPI packages *colormath*, *colour*, and *colorspacious* provide more and
-advanced features. The Pillow library is better suited to transform images
-between color systems.
-
-Module type
-  pure Python
-Deprecated in
-  3.8
-To be removed in
-  3.10
-Substitute
-  `colormath <https://pypi.org/project/colormath/>`_,
-  `colour <https://pypi.org/project/colour/>`_
-  `colorspacious <https://pypi.org/project/colorspacious/>`_,
-  `Pillow <https://pypi.org/project/Pillow/>`_
 
 chunk
 ~~~~~
@@ -750,6 +721,41 @@ Modules to keep
 
 Some modules were originally proposed for deprecation.
 
+.. csv-table:: Table 2: Withdrawn deprecations
+   :header: "Module", "Deprecated in", "Replacement"
+   :widths: 1, 1, 2
+
+    colorsys,\-,"colormath, colour, colorspacious, Pillow"
+    fileinput,\-,argparse
+    getopt,\-,"argparse, optparse"
+    lib2to3,\-,
+    optparse,**3.2**,argparse
+    wave,\-,
+
+colorsys
+--------
+
+The `colorsys <https://docs.python.org/3/library/colorsys.html>`_ module
+defines color conversion functions between RGB, YIQ, HSL, and HSV coordinate
+systems.
+
+Walter Dörwald, Petr Viktorin, and others requested to keep ``colorsys``. The
+module is useful to convert CSS colors between coordinate systems. The
+implementation is simple, mature, and does not impose maintenance overhead
+on core development.
+
+The PyPI packages *colormath*, *colour*, and *colorspacious* provide more and
+advanced features. The Pillow library is better suited to transform images
+between color systems.
+
+Module type
+  pure Python
+Substitute
+  `colormath <https://pypi.org/project/colormath/>`_,
+  `colour <https://pypi.org/project/colour/>`_
+  `colorspacious <https://pypi.org/project/colorspacious/>`_,
+  `Pillow <https://pypi.org/project/Pillow/>`_
+
 fileinput
 ---------
 
@@ -826,12 +832,6 @@ the ``array`` module could gain support for 24 bit (3 byte) arrays.
 
 Module type
   pure Python (depends on *byteswap* from `audioop`_ C extension)
-Deprecated in
-  3.8
-To be removed in
-  3.10
-Substitute
-  *n/a*
 
 
 Future maintenance of removed modules
@@ -903,6 +903,12 @@ Update 1
   ``xmlrpc.server``
 * The future maintenance section now states that the deprecated modules
   may be adopted by Python community members.
+
+Update 2
+--------
+
+* Keep ``colorsys`` module
+
 
 References
 ==========

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -99,6 +99,11 @@ Starting with Python 3.9, deprecated modules will start issuing
 `DeprecationWarning`. The `parser`_ module is removed and potentially
 replaced with a new module.
 
+All other deprecated modules are fully supported and will receive security
+updates until Python 3.9 reaches its end of lifetime. Python 3.9.0 will
+be released about 18 months after 3.8.0 (April 2021?) and most likely
+be supported for 5 years after the release. The estimated EOL of Python 3.9
+is in 2026.
 
 3.10
 ----
@@ -493,7 +498,9 @@ groups used to be a dominant platform for online discussions. Over the last
 two decades, news has been slowly but steadily replaced with mailing lists
 and web-based discussion platforms. Twisted is also
 `planning <https://twistedmatrix.com/trac/ticket/9405>`_ to deprecate NNTP
-support.
+support and `pynnt <https://github.com/greenbender/pynntp>`_ hasn't seen any
+activity since 2014. This is a good indicator that the public interest in
+NNTP support is declining.
 
 The ``nntplib`` tests have been the cause of additional work in the recent
 past. Python only contains client side of NNTP. The tests connect to
@@ -773,8 +780,11 @@ getopt
 ------
 
 The `getopt <https://docs.python.org/3/library/getopt.html>`_ module mimics
-C's getopt() option parser. Although users are encouraged to use argparse
-instead, the getopt module is still widely used.
+C's getopt() option parser.
+
+Although users are encouraged to use argparse instead, the getopt module is
+still widely used. The module is small, simple, and handy for C developers
+to write simple Python scripts.
 
 Module type
   pure Python
@@ -785,8 +795,10 @@ optparse
 --------
 
 The `optparse <https://docs.python.org/3/library/optparse.html>`_ module is
-the predecessor of the argparse module. Although it has been deprecated for
-many years, it's still widely used.
+the predecessor of the argparse module.
+
+Although it has been deprecated for many years, it's still too widely used
+to remove it.
 
 Module type
   pure Python
@@ -796,16 +808,21 @@ Substitute
   argparse
 
 wave
-~~~~
+----
 
 The `wave <https://docs.python.org/3/library/wave.html>`_ module provides
-support for the WAV sound format. The module uses one simple function
-from the `audioop`_ module to perform byte swapping between little and big
-endian formats. Before 24 bit WAV support was added, byte swap used to be
-implemented with the ``array`` module. To remove ``wave``'s dependency on the
-``audioop``, the byte swap function could be either be moved to another
-module (e.g. ``operator``) or the ``array`` module could gain support for
-24 bit (3 byte) arrays.
+support for the WAV sound format.
+
+The module is not deprecated, because The WAV format is still relevant these
+days. The ``wave`` module is also used in education, e.g. to show kids how
+to make noise with a computer.
+
+The module uses one simple function from the `audioop`_ module to perform
+byte swapping between little and big endian formats. Before 24 bit WAV
+support was added, byte swap used to be implemented with the ``array``
+module. To remove ``wave``'s dependency on the ``audioop``, the byte swap
+function could be either be moved to another module (e.g. ``operator``) or
+the ``array`` module could gain support for 24 bit (3 byte) arrays.
 
 Module type
   pure Python (depends on *byteswap* from `audioop`_ C extension)
@@ -827,7 +844,10 @@ documentation may be moved into a new git repository, so community members
 have a place from which they can pick up and fork code.
 
 A first draft of a `legacylib <https://github.com/tiran/legacylib>`_
-repository is available on my private Github account.
+repository is available on my private Github account. The modules could be
+made available on PyPI. The Python core team will not publish or maintain
+the packages. It is my hope that members of the Python community will
+adopt, maintain, and perhaps improve the deprecated modules.
 
 It's my hope that some of the deprecated modules will be picked up and
 adopted by users that actually care about them. For example ``colorsys`` and
@@ -881,6 +901,8 @@ Update 1
   list suitable substitutions.
 * Mention that ``socketserver`` is going to stay for ``http.server`` and
   ``xmlrpc.server``
+* The future maintenance section now states that the deprecated modules
+  may be adopted by Python community members.
 
 References
 ==========

--- a/pep-0595.rst
+++ b/pep-0595.rst
@@ -1,0 +1,470 @@
+PEP: 595
+Title: Improving bugs.python.org
+Author: Ezio Melotti <ezio.melotti@gmail.com>, Berker Peksag <berker.peksag@gmail.com>
+Status: Draft
+Type: Process
+Content-Type: text/x-rst
+Created: 12-May-2019
+
+
+Abstract
+========
+
+This PEP proposes a list of improvements to make bugs.python.org
+more usable for contributors and core developers.  This PEP also
+discusses why remaining on Roundup should be preferred over
+switching to GitHub Issues, as proposed by :pep:`581`.
+
+
+Motivation
+==========
+
+On May 14th, 2019 :pep:`581` has been accepted [#]_ without much
+public discussion and without a clear consensus [#]_.  The PEP
+contains factual errors and doesn't address some of the
+issues that the migration to GitHub Issues might present.
+
+Given the scope of the migration, the amount of work required,
+and how it will negatively affect the workflow during the
+transition phase, this decision should be re-evaluated.
+
+.. TODO: add a section with background and terminology?
+   (e.g. roundup, bpo, instances, github issues, pep581/588)
+
+Roundup advantages over GitHub Issues
+=====================================
+
+This section discusses reasons why Roundup should be preferred
+over GitHub Issues and Roundup features that are not available
+on GitHub Issues.
+
+* **Roundup is the status quo.**  Roundup has been an integral
+  part of the CPython workflow for years.  It is a stable product
+  that has been tested and customized to adapt to our needs as the
+  workflow evolved.
+
+  It is possible to gradually improve it and avoid the disruption
+  that a switch to a different system would inevitabily bring to
+  the workflow.
+
+* **Open-source and Python powered.**  Roundup is an open-source
+  project and is written in Python.  By using it and supporting
+  it, we also support the Python ecosystem.  Several features
+  developed for bpo have also been ported to upstream Roundup
+  over the years.
+
+* **Fully customizable.**  Roundup can be (and has been) fully
+  customized to fit our needs.
+
+* **Finer-grained access control.**  Roundup allows the creation
+  of different roles with different permissions (e.g. create,
+  view, edit, etc.) for each individual property, and users can
+  have multiple roles.
+
+* **Flexible UI.**  While Roundup UI might look dated, it is
+  convenient and flexible.
+
+  For example, on the issue page, each field (e.g. title, type,
+  versions, status, linked files and PRs, etc.) have appropriate
+  UI elements (input boxes, dropdowns, tables, etc.) that are
+  easy to set and also provide a convenient way to get info about
+  the issue at a glance.  The number of fields, their values, and
+  the UI element they use is also fully customizable.
+  GitHub only provides labels.
+
+  The issue list page presents the issues in a compact and easy
+  to read table with separate columns for different fields.  For
+  comparison, Roundup lists 50 issues in a screen, whereas GitHub
+  takes two screens to shows 25 issues.
+
+* **Advanced search.**  Roundup provides an accurate way to search
+  and filter by using any combination of issue fields.
+  It is also possible to customize the number of results and the
+  fields displayed in the table, and the sorting and grouping
+  (up to two levels).
+
+  bpo also provides predefined summaries (e.g. "Created by you",
+  "Assigned to you", etc.) and allows the creation of custom
+  search queries that can be conveniently accessed from the sidebar.
+
+* **Nosy list autocomplete.**  The nosy list has an autocomplete
+  feature that suggests maintainers and experts.  The suggestions
+  are automatically updated when the experts index [#]_ changes.
+
+* **Dependencies and Superseders.** Roundup allows to specify
+  dependencies that must be addressed before the current issues
+  can be closed and a superseder issue to easily mark duplicates
+  [#]_.  The list of dependencies can also be used to create
+  meta-issues that references several other sub-issues [#]_.
+
+
+Improving Roundup
+=================
+
+This section lists some of the issues mentioned by :pep:`581`
+and other desired features and discusses how they can be implemented
+by improving Roundup and/or our instance.
+
+* **REST API support.**  A REST API will make integration with other
+  services and the development of new tools and applications easiers.
+
+  Upstream Roundup now supports a REST API. Updating the tracker will
+  make the REST API available.
+
+* **GitHub login support.**  This will allow users to login
+  to bugs.python.org (bpo) without having to create a new account.
+  It will also solve issues with confirmation emails being marked
+  as spam, and provide two-factor authentication.
+
+  A patch to add this functionality is already available and is
+  being integrated at the time of writing [#]_.
+
+* **Markdown support and message preview and editing.**  This feature
+  will allow the use of Markdown in messages and the ability to
+  preview the message before the submission and edit it afterward.
+
+  This can be done, but it will take some work.  Possible solutions
+  have been proposed on the roundup-devel mailing list [#]_.
+
+* **"Remove me from nosy list" button.**  Add a button on issue pages
+  to remove self from the nosy list.
+
+  This feature will be added during GSoC 2019.
+
+* **Mobile friendly theme.**  Current theme of bugs.python.org looks
+  dated and it doesn't work well with mobile browsers.
+
+  A mobile-friendly theme that is more modern but still familiar
+  will be added.
+
+* **Add PR link to BPO emails.**  Currently bpo emails don't include
+  links to the corresponding PRs.
+
+  A patch [#]_ is available to change the content of the bpo emails
+  from::
+
+     components: +Tkinter
+     versions: +Python 3.4
+     pull_requests: +42
+
+  to::
+
+     components: +Tkinter
+     versions: +Python 3.4
+     pull_request: https://github.com/python/cpython/pull/341
+
+* **Python 3 support.**  Using Python 3 will make maintenance easier.
+
+  Upstream Roundup now supports Python 3. Updating the tracker will
+  allow us to switch to Python 3.  The instances will need to be
+  updated as well.
+
+* **Use upstream Roundup.**  We currently use a fork of Roundup with
+  a few modifications, most notably the GitHub integration.  If this
+  is ported upstream, we can start using upstream Roundup without
+  having to maintain our fork.
+
+
+PEP 581 issues
+==============
+
+This section addresses some errors and inaccuracies found in :pep:`581`.
+
+The "Why GitHub?" section of PEP 581 lists features currently
+available on GitHub Issues but not on Roundup.  Some of this features
+are currently supported:
+
+* "Ability to reply to issue and pull request conversations via email."
+
+  * Being able to reply by email has been one of the core features of
+    Roundup since the beginning.  It is also possible to create new
+    issues or close existing ones, set or modify fields, and add
+    attachments.
+
+* "Email notifications containing metadata, integrated with Gmail,
+  allowing systematic filtering of emails."
+
+  * Emails sent by Roundup contains metadata that can be used for
+    filtering.
+
+* "Additional privacy, such as offering the user a choice to hide an
+  email address, while still allowing communication with the user
+  through @-mentions."
+
+  * Email addresses are hidden by default to users that are not
+    registered.  Registered users can see other users' addresses
+    because we configured the tracker to show them.  It can easily
+    be changed if desired.  Users can still be added to the nosy
+    list by using their username even if their address is hidden.
+
+* "Ability to automatically close issues when a PR has been merged."
+
+  * The GitHub integration of Roundup automatically closes issues
+    when a commit that contains "fixes issue <id>" is merged.
+    (Alternative spellings such as "closes" or "bug" are also supported.)
+    See [#]_ for a recent example of this feature.
+
+* "Support for permalinks, allowing easy quoting and copying &
+  pasting of source code."
+
+  * Roundup has permalinks for issues, messages, attachments, etc.
+    In addition, Roundup allows to easily rewrite broken URLs in
+    messages (e.g. if the code hosting changes).
+
+* "Core developers, volunteers, and the PSF don't have to maintain the
+  issue infrastructure/site, giving us more time and resources to focus
+  on the development of Python."
+
+  * While this is partially true, additional resources are required to
+    write and maintain bots.
+
+    In some cases, bots are required to workaround GitHub's lack of
+    features rather than expanding. [#]_ was written
+    specifically to workaround GitHub's email integration.
+
+    Updating our bots to stay up-to-date with changes in the GitHub API
+    has also maintenance cost. [#]_ took two days to be fixed.
+
+    In addition, we will still need to maintain Roundup for bpo (even
+    if it becomes read-only) and for the other trackers
+    we currently host/maintain (Jython [#]_ and Roundup [#]_).
+
+The "Issues with Roundup / bpo" section of :pep:`581` lists some issues
+that have already been fixed:
+
+* "The upstream Roundup code is in Mercurial. Without any CI available,
+  it puts heavy burden on the few existing maintainers in terms of
+  reviewing, testing, and applying patches."
+
+  * While Roundup uses Mercurial by default, there is a git clone
+    available on GitHub [#]_.  Roundup also has CI available [#]_ [#]_.
+
+* "There is no REST API available. There is an open issue in Roundup for
+  adding REST API. Last activity was in 2016."
+
+  * The REST API has been integrated and it's now available in Roundup.
+
+* "Users email addresses are exposed. There is no option to mask it."
+
+  * Exposing addresses to registered and logged in users was a decision
+    taken when our instance was set up.
+
+    This has now been changed to make the email addresses hidden for
+    regular users too (Developers and Coordinators can still see them).
+    The "Email address"" column from the user listing page [#]_ has been
+    removed too.
+
+* "It sends a number of unnecessary emails and notifications, and it is
+  difficult, if not impossible, to configure."
+
+  * This can be configured.
+
+* "Creating an account has been a hassle. There have been reports of people
+  having trouble creating accounts or logging in."
+
+  * The main issue is confirmation emails being marked as spam.  Work has
+    been done to resolve the issue.
+
+  .. TODO: investigate the status of this; when was the last report?
+     See https://mail.python.org/pipermail/tracker-discuss/2018-December/004631.html
+
+
+Migration considerations
+========================
+
+This section describes issues with the migrations that might not
+have been addressed by :pep:`581` and :pep:`588`.
+
+:pep:`588` suggests to add a button to migrate issues to GitHub
+only when someone wants to keep working on them.  This approach
+has several issues:
+
+* bpo will need to be updated in order to add a button that,
+  once pressed, creates a new issue on GitHub, copies over all
+  the messages, attachments, and creates/adds label for the
+  existing fields.  Permissions will also need to be tweaked
+  to make individual issues read-only once they are migrated,
+  and to prevent users to create new accounts.
+
+* The issues will be split between two trackers; searching issues
+  will take significant more effort.
+
+* The conversion from Roundup to GitHub is lossy, unless all
+  the bpo fields are converted into labels or preserved somewhere
+  else.
+
+* bpo converts a number of references into links, including
+  issue, message, and PR IDs, changeset numbers, legacy SVN
+  revision numbers, paths to files in the repo, files in
+  tracebacks (detecting the correct branch), links to devguide
+  pages and sections [#]_.  This happens when messages are
+  requested so it is possible to create the correct link (e.g.
+  all the file links used to point to hg.python.org and now
+  point to GitHub).
+
+  If the links are hardcoded during the migration, it will be
+  difficult (if not impossible) to change them later.  If they
+  aren't, they will either be lost, or a tool to generate the
+  links and updating them will need to be written.
+
+* GitHub doesn't provide a way to set and preserve issue IDs
+  if they are migrated automatically with the use of a button.
+  (Some projects managed to preserve the IDs by contaacting
+  the GitHub staff and migrating the issues *en masse*.)
+
+* On top of the work and changes required to migrate to GitHub
+  issues, we will still need to keep running and maintaining
+  Roundup, for both our instance (read-only) and for the Jython
+  and Roundup trackers (read-write).
+
+
+In addition to the issues listed in the "Open issues" section of
+:pep:`588`, this issues will need to be addressed:
+
+* GitHub is properietary and there is risk of vendor lock-in.
+  Their business model might change and they could shut down
+  altogether.
+
+* Switching to GitHub Issues will likely increase the number of
+  invalid reports and increase the triaging effort.  This concern
+  has been raised in the past in a Zulip topic [#]_.
+
+  There have been already cases where people posted comments on
+  PRs that required moderators to mark them as off-topic or
+  disruptive, delete them altogether, and even lock the
+  conversation [#]_.
+
+* Roundup sends weekly reports to python-dev with a summary that
+  includes new issues, recent issues with no replies, recent
+  issues waiting for review, most discussed issues, closed issues,
+  and deltas for open/closed/total issue counts [#]_.  The report
+  provides an easy way to keep track of the tracker activity and
+  to make sure that issues that require attention are noticed.
+
+  The data collect by the weekly report is also use to generate
+  statistics and graphs that can be used to gain new insights [#]_.
+
+* There are currently two mailing lists where Roundup posts new
+  tracker issues and all messages respectively: new-bugs-announce
+  [#]_ and python-bugs-list [#]_.  A new system will need to be
+  developed to preserve this functionality.  These MLs offer
+  additional ways to keep track of the tracker activity.
+
+
+References
+==========
+
+.. [#] [Python-Dev] PEP 581 (Using GitHub issues for CPython) is accepted
+
+   https://mail.python.org/pipermail/python-dev/2019-May/157399.html
+
+.. [#] [python-committers] [Python-Dev] PEP 581 (Using GitHub issues
+   for CPython) is accepted
+
+   https://mail.python.org/pipermail/python-committers/2019-May/006755.html
+
+.. [#] Experts Index -- Python Devguide
+
+   https://devguide.python.org/experts/
+
+.. [#] An example of superseded issues:
+   "re.sub() replaces only several matches"
+
+   https://bugs.python.org/issue12078
+
+.. [#] An example of meta issue using dependencies to track sub-issues:
+   "Meta-issue: support of the android platform""
+
+   https://bugs.python.org/issue26865
+
+.. [#] Support logging in with GitHub
+
+   https://github.com/python/bugs.python.org/issues/7
+
+.. [#] Re: [Roundup-devel] PEP 581 and Google Summer of Code
+
+   https://sourceforge.net/p/roundup/mailman/message/36667828/
+
+.. [#] [Tracker-discuss] [issue624] bpo emails contain useless non-github
+       pull_request number - users want a link to actual github PR
+
+   https://mail.python.org/pipermail/tracker-discuss/2018-June/004547.html
+
+.. [#] The commit reported in msg342882 closes the issue (see the history below)
+
+   https://bugs.python.org/issue36951#msg342882
+
+.. [#] The cpython-emailer-webhook project
+
+   https://github.com/berkerpeksag/cpython-emailer-webhook
+
+.. [#] A recent incident caused by GitHub
+
+   https://github.com/python/bedevere/pull/163
+
+.. [#] Jython issue tracker
+
+   https://bugs.jython.org/
+
+.. [#] Roundup issue tracker
+
+   https://issues.roundup-tracker.org/
+
+.. [#] GitHub clone of Roundup
+
+   https://github.com/roundup-tracker/roundup
+
+.. [#] Travis-CI for Roundup
+
+   https://travis-ci.org/roundup-tracker/roundup) and codecov
+
+.. [#] Codecov for Roundup
+
+   https://codecov.io/gh/roundup-tracker/roundup/commits
+
+.. [#] User listing -- Python tracker
+
+   https://bugs.python.org/user?@sort=username
+
+.. [#] Generating Special Links in a Comment -- Python Devguide
+
+   https://devguide.python.org/triaging/#generating-special-links-in-a-comment
+
+.. [#] The New-bugs-announce mailing list
+
+   https://mail.python.org/mailman/listinfo/new-bugs-announce
+
+.. [#] The Python-bugs-list mailing list
+
+   https://mail.python.org/mailman/listinfo/python-bugs-list
+
+.. [#] An example of [Python-Dev] Summary of Python tracker Issues
+
+   https://mail.python.org/pipermail/python-dev/2019-May/157483.html
+
+.. [#] Issues stats -- Python tracker
+
+   https://bugs.python.org/issue?@template=stats
+
+.. [#] s/n ratio -- Python -- Zulip
+
+   https://python.zulipchat.com/#narrow/stream/130206-pep581/topic/s.2Fn.20ratio
+
+.. [#] For example this and other related PRs:
+
+   https://github.com/python/cpython/pull/9099
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:


### PR DESCRIPTION
In C, bitwise operations are much better defined on unsigned values.
Since we do `nargs & ~PY_VECTORCALL_ARGUMENTS_OFFSET`, we should do it on an unsigned value.

cc @jdemeyer @markshannon 