### PR TITLE
PEP 0594: Fix indentation of 'wave'

### DIFF
--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -796,7 +796,7 @@ Substitute
   argparse
 
 wave
-~~~~
+----
 
 The `wave <https://docs.python.org/3/library/wave.html>`_ module provides
 support for the WAV sound format. The module uses one simple function


### PR DESCRIPTION
Was one layer too deep, making it seem like it's part of 'optparse'.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
