### PR TITLE
PEP 594: asyncore and asynchat are deprecated since 3.6

### DIFF
--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -144,8 +144,8 @@ audio processing.
    :widths: 1, 1, 1, 2
 
     aifc,3.8,3.10,\-
-    asynchat,3.8,3.10,asyncio
-    asyncore,3.8,3.10,asyncio
+    asynchat,**3.6**,3.10,asyncio
+    asyncore,**3.6**,3.10,asyncio
     audioop,3.8,3.10,\-
     binhex,3.8,3.10,\-
     cgi,3.8,3.10,\-


### PR DESCRIPTION
The information in the table was wrong.
