### PR TITLE
Change specification for `# type: ignore`

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -1516,7 +1516,9 @@ error refers to::
   }
 
 A ``# type: ignore`` comment on a line by itself at the top of a file,
-before any docstrings or imports, silences all errors in the file.
+before any docstrings, imports, or other executable code, silences all
+errors in the file. Blank lines and other comments, such as shebang
+lines and coding cookies, may precede the ``# type: ignore`` comment.
 
 In some cases, linting tools or other comments may be needed on the same
 line as a type comment. In these cases, the type comment should be before

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -1515,10 +1515,8 @@ error refers to::
       'not_found': http.client.NOT_FOUND  # type: ignore
   }
 
-A ``# type: ignore`` comment on a line by itself is equivalent to
-adding an inline ``# type: ignore`` to each line until the end of
-the current indented block. At top indentation level this has
-effect of disabling type checking until the end of file.
+A ``# type: ignore`` comment on a line by itself at the top of a file,
+before any docstrings or imports, silences all errors in the file.
 
 In some cases, linting tools or other comments may be needed on the same
 line as a type comment. In these cases, the type comment should be before
@@ -1527,7 +1525,8 @@ other comments and linting markers:
   # type: ignore # <comment or other marker>
 
 If type hinting proves useful in general, a syntax for typing variables
-may be provided in a future Python version.
+may be provided in a future Python version. (**UPDATE**: This syntax
+was added in Python 3.6 through PEP 526.)
 
 Casts
 =====


### PR DESCRIPTION
As discussed on the typing-sig mailing list, the currently specified behavior for `# type: ignore` on a line by itself has remained mostly unimplemented and doesn't seem useful. Instead, the PEP now mandates a syntax for ignoring all errors in a specific file, which is more obviously useful.

I considered adding a sentence like "Individual type checkers may add additional syntax for silencing errors", but it didn't seem particularly useful since type checkers in general are free to add extensions to what PEP 484 specifies.

While I was at it I added a reference to PEP 526 to an out-of-date sentence adjacent to the modified paragraph.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
