### PR TITLE
PEP 594: deprecate telnetlib

### DIFF
--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -168,6 +168,7 @@ audio processing.
     sndhdr,3.8,3.10,no,"filetype, puremagic, python-magic"
     spwd,3.8,3.10,no,"python-pam, simplepam"
     sunau,3.8,3.10,no,\-
+    telnetlib,3.8,3.10,no,"telnetlib3, Exscript"
     uu,3.8,3.10,no,\-
     xdrlib,3.8,3.10,no,\-
 
@@ -520,6 +521,22 @@ Has a designated expert
    no
 Substitute
   **none**
+
+telnetlib
+~~~~~~~~~
+
+The `telnetlib <https://docs.python.org/3/library/telnetlib.html>`_ module
+provides a Telnet class that implements the Telnet protocol.
+
+Module type
+  pure Python
+Deprecated in
+  3.8
+To be removed in
+  3.10
+Substitute
+  `telnetlib3 <https://pypi.org/project/telnetlib3>`_,
+  `Exscript <https://pypi.org/project/Exscript/>`_
 
 
 Operating system interface


### PR DESCRIPTION
- [ ] explain why to deprecate the module
