### PR TITLE
PEP 594: miswording fix

### DIFF
--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -60,7 +60,7 @@ This PEP also designates some modules as not scheduled for removal. Some
 modules have been deprecated for several releases or seem unnecessary at
 first glance. However it is beneficial to keep the modules in the standard
 library, mostly for environments where installing a package from PyPI is not
-an option. This can be cooperate environments or class rooms where external
+an option. This can be corporate environments or class rooms where external
 code is not permitted without legal approval.
 
 * The usage of FTP is declining, but some files are still provided over

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -20,7 +20,7 @@ Rationale
 =========
 
 Back in the early days of Python, the interpreter came with a large set of
-useful modules. This was often refrained to as "batteries included"
+useful modules. This was often referred to as "batteries included"
 philosophy and was one of the corner stones to Python's success story.
 Users didn't have to figure out how to download and install separate
 packages in order to write a simple web server or parse email.


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
Change 

> This was often refrained to as "batteries included"

 to

>  This was often referred to as "batteries included"