### PR TITLE
PEP 590: Record BDFL delegate

### DIFF
--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -1,6 +1,7 @@
 PEP: 590
 Title: Vectorcall: a fast calling protocol for CPython
 Author: Mark Shannon <mark@hotpy.org>, Jeroen Demeyer <J.Demeyer@UGent.be>
+BDFL-Delegate: Petr Viktorin <encukou@gmail.com>
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst


### PR DESCRIPTION
In the Steering Council discussions leading up to the [2019-04-26 update], I was appointed BDFL delegate for PEPs 576, 579, 580, and 590.
PEP 590 was still just a draft on the mailing list when the SC updated the PEPs themselves, so it wasn't updated then.

[2019-04-26 update]: https://github.com/python/steering-council/blob/master/updates/2019-04-26_steering-council-update.md#peps
