### PR TITLE
PEP 594: Update 2

### DIFF
--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -13,8 +13,29 @@ Abstract
 ========
 
 This PEP proposed a list of standard library modules to be removed from the
-standard library. The modules are mostly historic data formats and APIs that
-have been superseded a long time ago, e.g. Mac OS 9 and Commodore.
+standard library. The modules are mostly historic data formats (e.g. Commodore
+and SUN file formats), APIs and operating systems that have been superseded a
+long time ago (e.g. Mac OS 9), or modules that have security implications and
+better alternatives (e.g. password and login).
+
+The PEP follows in the foot steps of other PEPS like :pep:`3818`. The
+*Standard Library Reorganization* proposal removed a bunch of modules from
+Python 3.0. In 2007, the PEP referred to maintenance burden as:
+
+   "Over the years, certain modules have become a heavy burden upon python-dev
+   to maintain. In situations like this, it is better for the module to be
+   given to the community to maintain to free python-dev to focus more on
+   language support and other modules in the standard library that do not take
+   up an undue amount of time and effort."
+
+The withdrawn :pep:`206` from 2000 expresses issues with the Python standard
+library unvarnished and fortright:
+
+   "[...] the standard library modules aren't always the best choices for a
+   job. Some library modules were quick hacks (e.g. ``calendar``,
+   ``commands``), some were designed poorly and are now near-impossible to
+   fix (``cgi``), and some have been rendered obsolete by other, more complete
+   modules [...]."
 
 
 Rationale
@@ -91,7 +112,9 @@ just be *documented* as deprecated. Optionally modules may emit a
 `PendingDeprecationWarning`.
 
 All deprecated modules will also undergo a feature freeze. No additional
-features should be added. Bug should still be fixed.
+features should be added *unless* python-dev agrees that the deprecation of
+the module is reverted and the code will not be removed. Bug should still be
+fixed.
 
 3.9
 ---
@@ -144,13 +167,13 @@ audio processing.
    :header: "Module", "Deprecated in", "To be removed", "Added in", "Has maintainer?", "Replacement"
    :widths: 2, 1, 1, 1, 1, 2
 
-    aifc,3.8,3.10,1993,**yes (inactive)**,\-
-    asynchat,**3.6**,3.10,1999,**yes**,asyncio
-    asyncore,**3.6**,3.10,1999,**yes**,asyncio
-    audioop,3.8,3.10,1992,**yes**,\-
+    aifc,3.8 (3.0\*),3.10,1993,**yes (inactive)**,\-
+    asynchat,**3.6** (3.0\*),3.10,1999,**yes**,asyncio
+    asyncore,**3.6** (3.0\*),3.10,1999,**yes**,asyncio
+    audioop,3.8 (3.0\*),3.10,1992,**yes**,\-
     binhex,3.8,3.10,1995,no,\-
-    cgi,3.8,3.10,1995,no,\-
-    cgitb,3.8,3.10,1995,no,\-
+    cgi,3.8 (2.0\*\*),3.10,1995,no,\-
+    cgitb,3.8 (2.0\*\*),3.10,1995,no,\-
     chunk,3.8,3.10,1999,no,\-
     crypt,3.8,3.10,1994,**yes (inactive)**,"bcrypt, argon2cffi, hashlib, passlib"
     email.message.Message,3.3,3.10,2001,yes,email.message.EmailMessage
@@ -163,20 +186,21 @@ audio processing.
     macpath,**3.7**,**3.8**,1990,n/a,\-
     msilib,3.8,3.10,2006,no,\-
     nntplib,3.8,3.10,1992,no,\-
-    nis,3.8,3.10,1992,no,\-
+    nis,3.8 (3.0\*),3.10,1992,no,\-
     ossaudiodev,3.8,3.10,2002,no,\-
     parser,**2.5**,**3.9**,1993,**yes**,"ast, lib2to3.pgen2"
     pipes,3.8,3.10,1992,no,subprocess
     smtpd,"**3.4.7**, **3.5.4**",3.10,2001,**yes**,aiosmtpd
     sndhdr,3.8,3.10,1994,no,"filetype, puremagic, python-magic"
     spwd,3.8,3.10,2005,no,"python-pam, simplepam"
-    sunau,3.8,3.10,1993,no,\-
-    telnetlib,3.8,3.10,1997,no,"telnetlib3, Exscript"
+    sunau,3.8 (3.0\*),3.10,1993,no,\-
+    telnetlib,3.8 (3.0\*),3.10,1997,no,"telnetlib3, Exscript"
     uu,3.8,3.10,1994,no,\-
     xdrlib,3.8,3.10,1992/1996,no,\-
 
-The *added in* column illustrates, when a module was originally designed and
-added to the standard library. The *has maintainer* colum refers to the
+Some module deprecations proposed by :pep:`3108` for 3.0 and :pep:`206` for
+2.0. The *added in* column illustrates, when a module was originally designed
+and added to the standard library. The *has maintainer* colum refers to the
 `expert index <https://devguide.python.org/experts/>`_, a list of domain
 experts and maintainers in the DevGuide.
 
@@ -254,8 +278,15 @@ File Format is an old audio format from 1988 based on Amiga IFF. It was most
 commonly used on the Apple Macintosh. These days only few specialized
 application use AIFF.
 
+A user disclosed [8]_ that the post production film industry makes heavy
+use of the AIFC file format. The usage of the ``aifc`` module in closed source
+and internal software was unknown prior to the first posting of this PEP. This
+may be a compelling argument to keep the ``aifc`` module in the standard
+library. The file format is stable and the module does not require much
+maintenance. The strategic benefits for Python may outmatch the burden.
+
 Module type
-  pure Python (depends on `audioop`_ C extension)
+  pure Python (depends on some functions from `audioop`_ C extension)
 Deprecated in
   3.8
 To be removed in
@@ -272,8 +303,13 @@ The `audioop <https://docs.python.org/3/library/audioop.html>`_ module
 contains helper functions to manipulate raw audio data and adaptive
 differential pulse-code modulated audio data. The module is implemented in
 C without any additional dependencies. The `aifc`_, `sunau`_, and `wave`_
-module depend on `audioop`_ for some operations. The byteswap operation in
-the `wave`_ module can be substituted with little work.
+module depend on `audioop`_ for some operations.
+
+The byteswap operation in the ``wave`` module can be substituted with little
+extra work. In case ``aifc`` is not deprecated as well, a reduced version of
+the ``audioop`` module is converted into a private implementation detail,
+e.g. ``_audioop`` with ``byteswap``, ``alaw2lin``, ``ulaw2lin``, ``lin2alaw``,
+``lin2ulaw``, and ``lin2adpcm``.
 
 Module type
   C extension
@@ -335,6 +371,17 @@ playback and capture devices. OSS was initially free software, but later
 support for newer sound devices and improvements were proprietary. Linux
 community abandoned OSS in favor of ALSA [1]_. Some operation systems like
 OpenBSD and NetBSD provide an incomplete [2]_ emulation of OSS.
+
+To best of my knowledge, FreeBSD is the only widespread operating system
+that Open Sound System as of today. The ``ossaudiodev`` hasn't seen any
+improvements or new features since 2003. All commits since 2003 are
+project-wide code cleanups and a couple of bug fixes. It would be beneficial
+for both FreeBSD community and core development, if the module would be
+maintained and distributed by people that care for it and use it.
+
+The standard library used to have more audio-related modules. The other
+audio device interface (``audiodev``, ``linuxaudiodev``, ``sunaudiodev``)
+were removed in 2007 as part of the :pep:`3108` stdlib re-organization.
 
 Module type
   C extension
@@ -436,9 +483,10 @@ cgi
 
 The `cgi <https://docs.python.org/3/library/cgi.html>`_ module is a support
 module for Common Gateway Interface (CGI) scripts. CGI is deemed as
-inefficient because every incoming request is handled in a new process. PEP
-206 considers the module as *designed poorly and are now near-impossible
-to fix*.
+inefficient because every incoming request is handled in a new process.
+:pep:`206` considers the module as:
+
+   "[...] designed poorly and are now near-impossible to fix (``cgi``) [...]"
 
 Several people proposed to either keep the cgi module for features like
 `cgi.parse_qs()` or move `cgi.escape()` to a different module. The
@@ -451,7 +499,7 @@ with secure default values.
 Module type
   pure Python
 Deprecated in
-  3.8
+  3.8 (originally proposed for 2.0 by :pep:`206`)
 To be removed in
   3.10
 Has a designated expert
@@ -473,7 +521,7 @@ optional debugging middleware.
 Module type
   pure Python
 Deprecated in
-  3.8
+  3.8 (originally proposed for 2.0 by :pep:`206`)
 To be removed in
   3.10
 Has a designated expert
@@ -487,7 +535,7 @@ email (legacy API)
 The `email <https://docs.python.org/3/library/email.html>`_ package is a
 library for managing email messages. The email package contains several
 legacy modules, legacy functions, and legacy classes, that provide backwards
-compatibility to Python 3.2 and 2.7.
+compatibility to Python 3.2 and 2.7:
 
  * ``email.message.Message`` (replaced by ``email.message.EmailMessage``)
  * ``email.mime`` (replaced by ``email.contentmanager``)
@@ -497,6 +545,11 @@ compatibility to Python 3.2 and 2.7.
  * ``email.utils`` (new API performs parsing and formatting automatically)
  * ``email.iterators``
  * ``email.policy.Compat32``
+
+The classes ``email.mime.audio.MIMEAudio`` and ``email.mime.image.MIMEImage``
+depend on the ``sndhdr`` and ``imghdr`` modules. In case the ``email.mime``
+package is not removed, the auto-detection of file formats must be deprecated
+and ``_subtype`` argument a required argument.
 
 Module type
   pure Python
@@ -1031,6 +1084,8 @@ Update 2
 * Deprecate `telnetlib`_
 * Deprecate compat32 policy of email package
 * Add creation year to overview table
+* Mention :pep:`206` and :pep:`3108`
+* Update sections for ``aifc``, ``audioop``, ``cgi``, and ``wave``.
 
 
 References
@@ -1043,6 +1098,7 @@ References
 .. [5] https://twitter.com/dabeaz/status/1130278844479545351
 .. [6] https://mail.python.org/pipermail/python-dev/2019-May/157464.html
 .. [7] https://discuss.python.org/t/switch-pythons-parsing-tech-to-something-more-powerful-than-ll-1/379
+.. [8] https://mail.python.org/pipermail/python-dev/2019-May/157634.html
 
 
 Copyright

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -168,6 +168,7 @@ audio processing.
     sndhdr,3.8,3.10,no,"filetype, puremagic, python-magic"
     spwd,3.8,3.10,no,"python-pam, simplepam"
     sunau,3.8,3.10,no,\-
+    telnetlib,3.8,3.10,no,"telnetlib3, Exscript"
     uu,3.8,3.10,no,\-
     xdrlib,3.8,3.10,no,\-
 
@@ -520,6 +521,22 @@ Has a designated expert
    no
 Substitute
   **none**
+
+telnetlib
+~~~~~~~~~
+
+The `telnetlib <https://docs.python.org/3/library/telnetlib.html>`_ module
+provides a Telnet class that implements the Telnet protocol.
+
+Module type
+  pure Python
+Deprecated in
+  3.8
+To be removed in
+  3.10
+Substitute
+  `telnetlib3 <https://pypi.org/project/telnetlib3>`_,
+  `Exscript <https://pypi.org/project/Exscript/>`_
 
 
 Operating system interface
@@ -975,7 +992,7 @@ Update 2
 * Keep ``colorsys`` module
 * Add experts
 * Redirect discussions to discuss.python.org
-
+* Deprecate `telnetlib`_
 
 References
 ==========

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -141,39 +141,44 @@ PyPI, e.g. Pillow for image processing or NumPy-based projects to deal with
 audio processing.
 
 .. csv-table:: Table 1: Proposed modules deprecations
-   :header: "Module", "Deprecated in", "To be removed", "Has expert?", "Replacement"
-   :widths: 1, 1, 1, 1, 2
+   :header: "Module", "Deprecated in", "To be removed", "Added in", "Has maintainer?", "Replacement"
+   :widths: 2, 1, 1, 1, 1, 2
 
-    aifc,3.8,3.10,**yes (inactive)**,\-
-    asynchat,**3.6**,3.10,**yes**,asyncio
-    asyncore,**3.6**,3.10,**yes**,asyncio
-    audioop,3.8,3.10,**yes**,\-
-    binhex,3.8,3.10,no,\-
-    cgi,3.8,3.10,no,\-
-    cgitb,3.8,3.10,no,\-
-    chunk,3.8,3.10,no,\-
-    crypt,3.8,3.10,**yes (inactive)**,"bcrypt, argon2cffi, hashlib, passlib"
-    email.message.Message,3.3,3.10,no,email.message.EmailMessage
-    email.mime,3.3,3.10,no,email.contentmanager
-    email.policy.Compat32,3.3,3.10,email.policy.EmailPolicy
-    formatter,3.4,3.10,no,\-
-    fpectl,**3.7**,**3.7**,n/a,\-
-    imghdr,3.8,3.10,no,"filetype, puremagic, python-magic"
-    imp,**3.4**,3.10,**yes**,importlib
-    macpath,**3.7**,**3.8**,n/a,\-
-    msilib,3.8,3.10,no,\-
-    nntplib,3.8,3.10,no,\-
-    nis,3.8,3.10,no,\-
-    ossaudiodev,3.8,3.10,no,\-
-    parser,**2.5**,**3.9**,**yes**,"ast, lib2to3.pgen2"
-    pipes,3.8,3.10,no,subprocess
-    smtpd,"**3.4.7**, **3.5.4**",3.10,**yes**,aiosmtpd
-    sndhdr,3.8,3.10,no,"filetype, puremagic, python-magic"
-    spwd,3.8,3.10,no,"python-pam, simplepam"
-    sunau,3.8,3.10,no,\-
-    telnetlib,3.8,3.10,no,"telnetlib3, Exscript"
-    uu,3.8,3.10,no,\-
-    xdrlib,3.8,3.10,no,\-
+    aifc,3.8,3.10,1993,**yes (inactive)**,\-
+    asynchat,**3.6**,3.10,1999,**yes**,asyncio
+    asyncore,**3.6**,3.10,1999,**yes**,asyncio
+    audioop,3.8,3.10,1992,**yes**,\-
+    binhex,3.8,3.10,1995,no,\-
+    cgi,3.8,3.10,1995,no,\-
+    cgitb,3.8,3.10,1995,no,\-
+    chunk,3.8,3.10,1999,no,\-
+    crypt,3.8,3.10,1994,**yes (inactive)**,"bcrypt, argon2cffi, hashlib, passlib"
+    email.message.Message,3.3,3.10,2001,yes,email.message.EmailMessage
+    email.mime,3.3,3.10,2001,yes,email.contentmanager
+    email.policy.Compat32,3.3,3.10,2011,yes,email.policy.EmailPolicy
+    formatter,3.4,3.10,1995,no,\-
+    fpectl,**3.7**,**3.7**,1997,n/a,\-
+    imghdr,3.8,3.10,1992,no,"filetype, puremagic, python-magic"
+    imp,**3.4**,3.10,1990/1995,**yes**,importlib
+    macpath,**3.7**,**3.8**,1990,n/a,\-
+    msilib,3.8,3.10,2006,no,\-
+    nntplib,3.8,3.10,1992,no,\-
+    nis,3.8,3.10,1992,no,\-
+    ossaudiodev,3.8,3.10,2002,no,\-
+    parser,**2.5**,**3.9**,1993,**yes**,"ast, lib2to3.pgen2"
+    pipes,3.8,3.10,1992,no,subprocess
+    smtpd,"**3.4.7**, **3.5.4**",3.10,2001,**yes**,aiosmtpd
+    sndhdr,3.8,3.10,1994,no,"filetype, puremagic, python-magic"
+    spwd,3.8,3.10,2005,no,"python-pam, simplepam"
+    sunau,3.8,3.10,1993,no,\-
+    telnetlib,3.8,3.10,1997,no,"telnetlib3, Exscript"
+    uu,3.8,3.10,1994,no,\-
+    xdrlib,3.8,3.10,1992/1996,no,\-
+
+The *added in* column illustrates, when a module was originally designed and
+added to the standard library. The *has maintainer* colum refers to the
+`expert index <https://devguide.python.org/experts/>`_, a list of domain
+experts and maintainers in the DevGuide.
 
 
 Data encoding modules
@@ -1008,9 +1013,9 @@ Update 1
 
 * Deprecate `parser`_ module
 * Keep `fileinput`_ module
-* Elaborate why `crypt`_ and `spwd`_ are dangerous and bad
+* Elaborate why ``crypt`` and ``spwd`` are dangerous and bad
 * Improve sections for `cgitb`_, `colorsys`_, `nntplib`_, and `smtpd`_ modules
-* The `colorsys`_, `crypt`_, `imghdr`_, `sndhdr`_, and `spwd`_ sections now
+* The `colorsys`_, ``crypt``, `imghdr`_, `sndhdr`_, and ``spwd`` sections now
   list suitable substitutions.
 * Mention that ``socketserver`` is going to stay for ``http.server`` and
   ``xmlrpc.server``
@@ -1025,6 +1030,7 @@ Update 2
 * Redirect discussions to discuss.python.org
 * Deprecate `telnetlib`_
 * Deprecate compat32 policy of email package
+* Add creation year to overview table
 
 
 References

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -153,6 +153,9 @@ audio processing.
     cgitb,3.8,3.10,no,\-
     chunk,3.8,3.10,no,\-
     crypt,3.8,3.10,**yes (inactive)**,"bcrypt, argon2cffi, hashlib, passlib"
+    email.message.Message,3.3,3.10,no,email.message.EmailMessage
+    email.mime,3.3,3.10,no,email.contentmanager
+    email.policy.Compat32,3.3,3.10,email.policy.EmailPolicy
     formatter,3.4,3.10,no,\-
     fpectl,**3.7**,**3.7**,n/a,\-
     imghdr,3.8,3.10,no,"filetype, puremagic, python-magic"
@@ -472,6 +475,34 @@ Has a designated expert
    no
 Substitute
   **none**
+
+email (legacy API)
+~~~~~~~~~~~~~~~~~~
+
+The `email <https://docs.python.org/3/library/email.html>`_ package is a
+library for managing email messages. The email package contains several
+legacy modules, legacy functions, and legacy classes, that provide backwards
+compatibility to Python 3.2 and 2.7.
+
+ * ``email.message.Message`` (replaced by ``email.message.EmailMessage``)
+ * ``email.mime`` (replaced by ``email.contentmanager``)
+ * ``email.header`` (replaced by dict-like API of ``EmailMessage`` class)
+ * ``email.charset``
+ * ``email.encoders`` (replaced by ``EmailMessage.set_content``)
+ * ``email.utils`` (new API performs parsing and formatting automatically)
+ * ``email.iterators``
+ * ``email.policy.Compat32``
+
+Module type
+  pure Python
+Deprecated in
+  3.8 (documented as legacy APIs since 3.3 or 3.4)
+To be removed in
+  3.10
+Has a designated expert
+   yes
+Substitute
+  email (non-legacy APIs)
 
 smtpd
 ~~~~~
@@ -993,6 +1024,8 @@ Update 2
 * Add experts
 * Redirect discussions to discuss.python.org
 * Deprecate `telnetlib`_
+* Deprecate compat32 policy of email package
+
 
 References
 ==========

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -179,10 +179,10 @@ audio processing.
     email.message.Message,3.3,3.10,2001,yes,email.message.EmailMessage
     email.mime,3.3,3.10,2001,yes,email.contentmanager
     email.policy.Compat32,3.3,3.10,2011,yes,email.policy.EmailPolicy
-    formatter,3.4,3.10,1995,no,\-
+    formatter,**3.4**,3.10,1995,no,\-
     fpectl,**3.7**,**3.7**,1997,n/a,\-
     imghdr,3.8,3.10,1992,no,"filetype, puremagic, python-magic"
-    imp,**3.4**,3.10,1990/1995,**yes**,importlib
+    imp,**3.4**,3.10,1990/1995,no,importlib
     macpath,**3.7**,**3.8**,1990,n/a,\-
     msilib,3.8,3.10,2006,no,\-
     nntplib,3.8,3.10,1992,no,\-
@@ -213,7 +213,7 @@ binhex
 
 The `binhex <https://docs.python.org/3/library/binhex.html>`_ module encodes
 and decodes Apple Macintosh binhex4 data. It was originally developed for
-TSR-80. In the 1980s and early 1990s it was used on classic Mac OS 9 to
+TRS-80. In the 1980s and early 1990s it was used on classic Mac OS 9 to
 encode binary email attachments.
 
 Module type
@@ -373,7 +373,7 @@ community abandoned OSS in favor of ALSA [1]_. Some operation systems like
 OpenBSD and NetBSD provide an incomplete [2]_ emulation of OSS.
 
 To best of my knowledge, FreeBSD is the only widespread operating system
-that Open Sound System as of today. The ``ossaudiodev`` hasn't seen any
+that uses Open Sound System as of today. The ``ossaudiodev`` hasn't seen any
 improvements or new features since 2003. All commits since 2003 are
 project-wide code cleanups and a couple of bug fixes. It would be beneficial
 for both FreeBSD community and core development, if the module would be


### PR DESCRIPTION
- [x] Deprecate telnetlib
- [x] Deprecate compat32 policy of email package
- [x] Add creation year to overview table
- [x] Mention PEP 206 and PEP 3108
- [x] Update sections for ``aifc``, ``audioop``, ``cgi``, and ``wave``
- [ ] Add FAQ