### PR TITLE
PEP 544: Remove additional error from error example

### DIFF
--- a/pep-0544.txt
+++ b/pep-0544.txt
@@ -368,6 +368,9 @@ Examples::
       def __init__(self, name: str, value: int) -> None:
           self.name = name
           self.value = value
+      
+      def method(self) -> None:
+          return
 
   var: Template = Concrete('value', 42)  # OK
 


### PR DESCRIPTION
The example with `Concrete` and `Template` is supposed to highlight that adding properties to a protocol in the implementation of a method is not supported, and does not add to the required signature of the protocol.
However, this also has the problem of `Concrete` not being a `Template` anyway because it is missing that `method`.
