### PR TITLE
PEP 0591: Fix a broken reference

### DIFF
--- a/pep-0591.rst
+++ b/pep-0591.rst
@@ -291,7 +291,7 @@ References
 
 .. [#mypy] http://www.mypy-lang.org/
 
-.. [#typing_extensions] https://github.com/python/typing/typing_extensions
+.. [#typing_extensions] https://github.com/python/typing/tree/master/typing_extensions
 
 Copyright
 =========


### PR DESCRIPTION
Reference implementation was linked incorrectly in the "References" section.