### PR TITLE
PEP 590: Correct sign of return value of PyVectorcall_NARGS().

### DIFF
--- a/pep-0590.rst
+++ b/pep-0590.rst
@@ -129,7 +129,7 @@ so it can use this trick at no additional cost.
 See [3]_ for an example of how ``PY_VECTORCALL_ARGUMENTS_OFFSET`` is used by a callee to avoid allocation.
 
 For getting the actual number of arguments from the parameter ``n``,
-the macro ``PyVectorcall_NARGS(n)`` must be used.
+the inline function ``PyVectorcall_NARGS(n)`` must be used.
 This allows for future changes or extensions.
 
 
@@ -152,7 +152,7 @@ The following functions or macros are added to the C API:
   ``*args`` and ``**kwargs`` calling convention.
   This is mostly meant to put in the ``tp_call`` slot.
 
-- ``Py_ssize_t PyVectorcall_NARGS(size_t nargs)``: Given a vectorcall ``nargs`` argument,
+- ``size_t PyVectorcall_NARGS(size_t nargs)``: Given a vectorcall ``nargs`` argument,
   return the actual number of arguments.
   Currently equivalent to ``nargs & ~PY_VECTORCALL_ARGUMENTS_OFFSET``.
 


### PR DESCRIPTION
The return type of `PyVectorcall_NARGS()` is documented at `Py_ssize_t` but it makes no sense for this to be a signed value, for two reasons.
1. The number of arguments must be a non-negative number; you cannot have a negative number of arguments.
2. The input value is an unsigned number. The conversion to a signed value may add some overhead. While the version returning a signed integer will probably be as efficient as the version returning a unsigned integer, there is no guarantee that it will be.