### PR TITLE
PEP 484: Fixed typos, IOW, apply PEP8 inline comment space

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -2062,7 +2062,7 @@ Convenience definitions:
 
 * TYPE_CHECKING, ``False`` at runtime but ``True`` to  type checkers
 
-I/O releated types:
+I/O related types:
 
 * IO (generic over ``AnyStr``)
 

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -1188,8 +1188,8 @@ type checker will infer the correct type of the result::
   joe = new_user(BasicUser)  # Inferred type is BasicUser
 
 The value corresponding to ``Type[C]`` must be an actual class object
-that's a subtype of ``C``, not a special form.  IOW, in the above
-example calling e.g. ``new_user(Union[BasicUser, ProUser])`` is
+that's a subtype of ``C``, not a special form.  In other words, in the
+above example calling e.g. ``new_user(Union[BasicUser, ProUser])`` is
 rejected by the type checker (in addition to failing at runtime
 because you can't instantiate a union).
 

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -267,7 +267,7 @@ arguments of the callback are completely unconstrained in this case
 Since using callbacks with keyword arguments is not perceived as a
 common use case, there is currently no support for specifying keyword
 arguments with ``Callable``.  Similarly, there is no support for
-specifying callback signatures with a variable number of argument of a
+specifying callback signatures with a variable number of arguments of a
 specific type.
 
 Because ``typing.Callable`` does double-duty as a replacement for

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -470,11 +470,11 @@ However, there are some special cases in the static typechecking context:
 
     T = TypeVar('T')
 
-    def fun_1(x: T) -> T: ... # T here
-    def fun_2(x: T) -> T: ... # and here could be different
+    def fun_1(x: T) -> T: ...  # T here
+    def fun_2(x: T) -> T: ...  # and here could be different
 
-    fun_1(1)                  # This is OK, T is inferred to be int
-    fun_2('a')                # This is also OK, now T is str
+    fun_1(1)                   # This is OK, T is inferred to be int
+    fun_2('a')                 # This is also OK, now T is str
 
 * A type variable used in a method of a generic class that coincides
   with one of the variables that parameterize this class is always bound
@@ -485,12 +485,12 @@ However, there are some special cases in the static typechecking context:
     T = TypeVar('T')
 
     class MyClass(Generic[T]):
-        def meth_1(self, x: T) -> T: ... # T here
-        def meth_2(self, x: T) -> T: ... # and here are always the same
+        def meth_1(self, x: T) -> T: ...  # T here
+        def meth_2(self, x: T) -> T: ...  # and here are always the same
 
-    a = MyClass() # type: MyClass[int]
-    a.meth_1(1)   # OK
-    a.meth_2('a') # This is an error!
+    a = MyClass()  # type: MyClass[int]
+    a.meth_1(1)    # OK
+    a.meth_2('a')  # This is an error!
 
 * A type variable used in a method that does not match any of the variables
   that parameterize the class makes this method a generic function in that
@@ -502,8 +502,8 @@ However, there are some special cases in the static typechecking context:
         def method(self, x: T, y: S) -> S:
             ...
 
-    x = Foo() # type: Foo[int]
-    y = x.method(0, "abc") # inferred type of y is str
+    x = Foo()               # type: Foo[int]
+    y = x.method(0, "abc")  # inferred type of y is str
 
 * Unbound type variables should not appear in the bodies of generic functions,
   or in the class bodies apart from method definitions::
@@ -513,15 +513,15 @@ However, there are some special cases in the static typechecking context:
 
     def a_fun(x: T) -> None:
         # this is OK
-        y = [] # type: List[T]
+        y = []  # type: List[T]
         # but below is an error!
-        y = [] # type: List[S]
+        y = []  # type: List[S]
 
     class Bar(Generic[T]):
         # this is also an error
-        an_attr = [] # type: List[S]
+        an_attr = []  # type: List[S]
 
-        def do_something(x: S) -> S: # this is OK though
+        def do_something(x: S) -> S:  # this is OK though
             ...
 
 * A generic class definition that appears inside a generic function
@@ -532,7 +532,7 @@ However, there are some special cases in the static typechecking context:
     def a_fun(x: T) -> None:
 
         # This is OK
-        a_list = [] # type: List[T]
+        a_list = []  # type: List[T]
         ...
 
         # This is however illegal
@@ -547,14 +547,14 @@ However, there are some special cases in the static typechecking context:
     S = TypeVar('S')
 
     class Outer(Generic[T]):
-        class Bad(Iterable[T]):      # Error
+        class Bad(Iterable[T]):       # Error
             ...
         class AlsoBad:
-            x = None # type: List[T] # Also an error
+            x = None  # type: List[T] # Also an error
 
-        class Inner(Iterable[S]):    # OK
+        class Inner(Iterable[S]):     # OK
             ...
-        attr = None # type: Inner[T] # Also OK
+        attr = None  # type: Inner[T] # Also OK
 
 
 Instantiating generic classes and type erasure
@@ -583,7 +583,7 @@ argument(s) is substituted.  Otherwise, ``Any`` is assumed.  Example::
   T = TypeVar('T')
 
   class Node(Generic[T]):
-      x = None  # type: T  # Instance attribute (see below)
+      x = None  # type: T # Instance attribute (see below)
       def __init__(self, label: T = None) -> None:
           ...
 
@@ -730,7 +730,7 @@ be a subtype of the boundary type. A common example is the definition of a
   class Comparable(metaclass=ABCMeta):
       @abstractmethod
       def __lt__(self, other: Any) -> bool: ...
-      ... # __gt__ etc. as well
+      ...  # __gt__ etc. as well
 
   CT = TypeVar('CT', bound=Comparable)
 
@@ -740,8 +740,8 @@ be a subtype of the boundary type. A common example is the definition of a
       else:
           return y
 
-  min(1, 2) # ok, return type int
-  min('x', 'y') # ok, return type str
+  min(1, 2)      # ok, return type int
+  min('x', 'y')  # ok, return type str
 
 (Note that this is not ideal -- for example ``min('x', 1)`` is invalid
 at runtime but a type checker would simply infer the return type
@@ -844,7 +844,7 @@ while the following is prohibited::
 
   B_co = TypeVar('B_co', covariant=True)
 
-  def bad_func(x: B_co) -> B_co: # Flagged as error by a type checker
+  def bad_func(x: B_co) -> B_co:  # Flagged as error by a type checker
       ...
 
 
@@ -1409,11 +1409,11 @@ correspond to those of ``Generator``, namely ``Coroutine[T_co, T_contra, V_co]``
 for example::
 
   from typing import List, Coroutine
-  c = None # type: Coroutine[List[str], str, int]
+  c = None  # type: Coroutine[List[str], str, int]
   ...
-  x = c.send('hi') # type: List[str]
+  x = c.send('hi')  # type: List[str]
   async def bar() -> None:
-      x = await c # type: int
+      x = await c  # type: int
 
 The module also provides generic ABCs ``Awaitable``,
 ``AsyncIterable``, and ``AsyncIterator`` for situations where more precise
@@ -2176,11 +2176,11 @@ Notes:
 
     def f():
         '''Docstring'''
-        # type: () -> None # Error!
+        # type: () -> None  # Error!
 
     def g():
         '''Docstring'''
-        # # type: () -> None # This is OK
+        # # type: () -> None  # This is OK
 
 When checking Python 2.7 code, type checkers should treat the ``int`` and
 ``long`` types as equivalent. For parameters typed as ``Text``, arguments of


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
## Fixed Typos
[Link](https://www.python.org/dev/peps/pep-0484/#callable)
"Similarly, there is no support for specifying callback signatures with a variable number of **argument** of a specific type."
Changed to:
**arguments**

[Link](https://www.python.org/dev/peps/pep-0484/#the-typing-module)
"I/O **releated** types:"
Changed to:
**related**


## Replaced IOW -> In other words

[Link](https://www.python.org/dev/peps/pep-0484/#the-type-of-class-objects)

"... that's a subtype of ``C``, not a special form.  **IOW**, in the above example calling e.g. ``new_user(Union[BasicUser, ProUser])`` is ..."
Changed to:
**In other words**

### Reasoning

I'm reasonably sure **IOW** is intended to mean **In other words** (i.e. [UrbanDictionary:IOW](https://www.urbandictionary.com/define.php?term=IOW) instead of one of [Wikipedia:IOW](https://en.wikipedia.org/wiki/IOW)) in this context, so have optimistically suggested this replacement.

See [PEP 20](https://www.python.org/dev/peps/pep-0020/): Explicit is better than implicit.

## Applied PEP 8: Inline comments

(Note this occurred in many places, please review the diff or individual commits for details)
e.g. 
```
        class AlsoBad:
-           x = None # type: List[T] # Also an error
+           x = None  # type: List[T] # Also an error
                     ^
```

### Reasoning

- [PEP8: "Inline comments should be separated by at least *two spaces* from the statement."](https://www.python.org/dev/peps/pep-0008/#inline-comments)

- Also, as noted in this [PEP484 Type comments](https://www.python.org/dev/peps/pep-0484/#type-comments) section, type comments should be at the start, and can then be followed by a comment, separated with a *single* space as it is a comment within a comment, i.e.

```
  # type: ignore # <comment or other marker>
```

<hr/>
@Mariatta @johnsonb2 Thank you for the inspiration in #914