### PR TITLE
PEP 581: mention that bpo tickets can be automatically closed.

### DIFF
--- a/pep-0581.rst
+++ b/pep-0581.rst
@@ -68,7 +68,7 @@ these aren't readily available on Roundup / bpo.
 
 - Ability to automatically close issues when a PR has been merged [#]_.
 
-  - Note: This ability been added to bpo after PEP 581's acceptance.
+  - Note that this feature exists in bpo too.
 
 - Lower barrier to contribution. With more than 28 million users, an open
   source contributor is more likely to already have an account and be familiar


### PR DESCRIPTION
bpo tickets can be automatically closed by using special keyword.

Not sure how many core devs are aware of this. It would be great to document it in devguide.
See related issue: https://github.com/python/devguide/issues/502