### PR TITLE
PEP 508: Update definition of python_version

### DIFF
--- a/pep-0508.txt
+++ b/pep-0508.txt
@@ -277,7 +277,7 @@ error like all other unknown variables.
        ``Java HotSpot(TM) 64-Bit Server VM, 25.51-b03, Oracle Corporation``
        ``Darwin Kernel Version 14.5.0: Wed Jul 29 02:18:53 PDT 2015; root:xnu-2782.40.9~2/RELEASE_X86_64``
    * - ``python_version``
-     - ``platform.python_version()[:3]``
+     - ``'.'.join(platform.python_version_tuple()[:2]``
      - ``3.4``, ``2.7``
    * - ``python_full_version``
      - ``platform.python_version()``
@@ -516,7 +516,7 @@ A test program - if the grammar is in a string ``grammar``::
         'platform_system': platform.system(),
         'platform_version': platform.version(),
         'python_full_version': platform.python_version(),
-        'python_version': platform.python_version()[:3],
+        'python_version': '.'.join(platform.python_version_tuple()[:2]),
         'sys_platform': sys.platform,
     }
 
@@ -524,6 +524,20 @@ A test program - if the grammar is in a string ``grammar``::
     for test in tests:
         parsed = compiled(test).specification()
         print("%s -> %s" % (test, parsed))
+
+
+Summary of changes to PEP 508
+=============================
+
+The following changes were made to this PEP based on feedback after its initial
+implementation:
+
+- The definition of ``python_version`` was changed from
+  ``platform.python_version()[:3]`` to
+  ``'.'.join(platform.python_version_tuple()[:2]``, to accommodate potential
+  future versions of Python with 2-digit major and minor versions
+  (e.g. 3.10). [#future_versions]_
+
 
 References
 ==========
@@ -545,6 +559,10 @@ References
 
 .. [#parsley] The parsley PEG library.
    (https://pypi.python.org/pypi/parsley/)
+
+.. [#future_versions] Future Python versions might be problematic with the
+   definition of Environment Marker Variable ``python_version``
+   (https://github.com/python/peps/issues/560)
 
 Copyright
 =========


### PR DESCRIPTION
Per #560, the current definition of `python_version` is not compatible with a 2+ digit major or minor version. There were no objections to changing the definition to more accurately reflect the semantic content intended to be conveyed (i.e. the major and minor version).

CC @finefoot