### PR TITLE
PEP 513 & 571: Remove libcrypt.so.1 from whitelist

### DIFF
--- a/pep-0513.txt
+++ b/pep-0513.txt
@@ -136,7 +136,6 @@ included in the following list: ::
     libm.so.6
     libdl.so.2
     librt.so.1
-    libcrypt.so.1
     libc.so.6
     libnsl.so.1
     libutil.so.1
@@ -154,6 +153,9 @@ included in the following list: ::
 
 and, (b) work on a stock CentOS 5.11 [6]_ system that contains the system
 package manager's provided versions of these libraries.
+
+``libcrypt.so.1`` was retrospectively removed from the whitelist after
+Fedora 30 was released with ``libcrypt.so.2`` instead.
 
 Because CentOS 5 is only available for x86_64 and i686 architectures,
 these are the only architectures currently supported by the ``manylinux1``

--- a/pep-0571.rst
+++ b/pep-0571.rst
@@ -90,7 +90,6 @@ the ``manylinux2010`` tag:
        libm.so.6
        libdl.so.2
        librt.so.1
-       libcrypt.so.1
        libc.so.6
        libnsl.so.1
        libutil.so.1
@@ -111,14 +110,16 @@ the ``manylinux2010`` tag:
    ``libpanelw.so.5``. [7]_ ``libpythonX.Y`` remains ineligible for
    inclusion for the same reasons outlined in PEP 513.
 
+   ``libcrypt.so.1`` was retrospectively removed from the whitelist after
+   Fedora 30 was released with ``libcrypt.so.2`` instead.
+
    On Debian-based systems, these libraries are provided by the packages:
 
    ============  =======================================================
    Package       Libraries
    ============  =======================================================
    libc6         libdl.so.2, libresolv.so.2, librt.so.1, libc.so.6,
-                 libpthread.so.0, libm.so.6, libutil.so.1, libcrypt.so.1,
-                 libnsl.so.1
+                 libpthread.so.0, libm.so.6, libutil.so.1, libnsl.so.1
    libgcc1       libgcc_s.so.1
    libgl1        libGL.so.1
    libglib2.0-0  libgobject-2.0.so.0, libgthread-2.0.so.0, libglib-2.0.so.0
@@ -137,8 +138,7 @@ the ``manylinux2010`` tag:
    ============  =======================================================
    glib2         libglib-2.0.so.0, libgthread-2.0.so.0, libgobject-2.0.so.0
    glibc         libresolv.so.2, libutil.so.1, libnsl.so.1, librt.so.1,
-                 libcrypt.so.1, libpthread.so.0, libdl.so.2, libm.so.6,
-                 libc.so.6
+                 libpthread.so.0, libdl.so.2, libm.so.6, libc.so.6
    libICE        libICE.so.6
    libX11        libX11.so.6
    libXext:      libXext.so.6


### PR DESCRIPTION
From https://github.com/pypa/manylinux/issues/305 : `libcrypt.so.1` was one of the whitelisted libraries that wheels could assume would always be on the host system. This appears to be no longer the case, as Fedora 30 has moved to `libcrypt.so.2`, and some wheels fail to load on that platform.

If I have understood correctly, `libcrypto.so.1` must therefore be removed from the whitelist. I'd like @njsmith or someone to confirm that I've got the right idea.

I'm using Fedora 30, and I've yet to have a wheel fail to load myself, so hopefully this means that not many wheels were linking it anyway, and the practical impact isn't too great.
