### PR TITLE
PEP 582: Minor formatting fix.

### DIFF
--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -124,7 +124,7 @@ inside of the ``foo`` directory. In both cases, it will **not** use the
 ``__pypackages__`` in the current working directory.
 
 Similarly, if we invoke ``myscript.py`` from the first example, it will use the
-``__pypackages__ `` directory that was in the ``foo`` directory.
+``__pypackages__`` directory that was in the ``foo`` directory.
 
 If we go inside of the ``foo`` directory and start the Python executable (the
 interpreter), it will find the ``__pypackages__`` directory inside of the


### PR DESCRIPTION
Remove extra space prior to closing "``", which was causing the rest of the sentence to appear monospaced.