### PR TITLE
PEP 599: Updates

### DIFF
--- a/pep-0599.rst
+++ b/pep-0599.rst
@@ -197,17 +197,6 @@ converted to ``manylinux2014`` wheels. This image will come with a
 full compiler suite installed (``gcc``, ``g++``, and ``gfortran``
 4.8.5) as well as the latest releases of Python and ``pip``.
 
-Compatibility with kernels that lack ``vsyscall``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Similar to CentOS 6, CentOS 7 includes a version of ``glibc`` that
-depends on the ``vsyscall`` page. As described in :pep:`571`, this
-breaks the assumption that a Docker containers userland is compatible
-wtih its host's kernel. Similar to ``manylinux2010``, Docker images
-for ``manylinux2014`` require patching ``glibc`` to remove all
-dependencies on ``vsyscall`` in the version of ``glibc`` included with
-our Docker image.
-
 Auditwheel
 ----------
 

--- a/pep-0599.rst
+++ b/pep-0599.rst
@@ -265,8 +265,14 @@ PyPI Support
 
 PyPI should permit wheels containing the ``manylinux2014`` platform
 tag to be uploaded in the same way that it permits ``manylinux2010``.
-It should not attempt to verify the compatibility of ``manylinux2014``
-wheels.
+
+If technically feasible, PyPI should attempt to verify the
+compatibility of ``manylinux2014`` wheels, but that capability is not
+a requirement for adoption of this PEP.
+
+Package authors should not upload non-compliant ``manylinux2014``
+wheels to PyPI, and should be aware that PyPI may begin blocking
+non-compliant wheels from being uploaded.
 
 References
 ==========


### PR DESCRIPTION
* The vsyscall usage in glibc was removed in the 2.14 release, so this is not relevant for manylinux2014.
* Update PyPI support section to allow for blocking non-compliant uploads
