### PR TITLE
PEP 569: Python 3.8.0b3 released

### DIFF
--- a/pep-0569.rst
+++ b/pep-0569.rst
@@ -58,10 +58,10 @@ Actual:
   (No new features beyond this point.)
 
 - 3.8.0 beta 2: Monday, 2019-07-04
+- 3.8.0 beta 3: Monday, 2019-07-29
 
 Expected:
 
-- 3.8.0 beta 3: Monday, 2019-07-29
 - 3.8.0 beta 4: Monday, 2019-08-26
 - 3.8.0 candidate 1: Monday, 2019-09-30
 - 3.8.0 candidate 2: Monday, 2019-10-07 (if necessary)


### PR DESCRIPTION
https://mail.python.org/archives/list/python-announce-list@python.org/thread/BCIHRB5N6AKPCBVO4TQYSYSPOBMV3GXL/