### PR TITLE
PEP 343: Update link to Raymond Chen's blog post

### DIFF
--- a/pep-0343.txt
+++ b/pep-0343.txt
@@ -921,7 +921,7 @@ References
 ==========
 
 .. [1] Raymond Chen's article on hidden flow control
-       http://blogs.msdn.com/oldnewthing/archive/2005/01/06/347666.aspx
+       https://devblogs.microsoft.com/oldnewthing/20050106-00/?p=36783
 
 .. [2] Guido suggests some generator changes that ended up in PEP 342
        https://mail.python.org/pipermail/python-dev/2005-May/053885.html


### PR DESCRIPTION
I was reading this PEP and tried to click the link, but it was dead. A quick Google search for `raymond chen control flow macros` gave me the new link.

I have signed the Contributor License Agreement.