### PR TITLE
[WIP: new PEP] Use SPDX license expressions in Core package metadata

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -41,10 +41,12 @@ distribution using a well defined syntax and well known license ids from SPDX.
 
 This PEP was started based on several discussions and in particular:
 
--  `<https://github.com/pypa/warehouse/issues/2996>`_
--  `<https://github.com/pypa/interoperability-peps/issues/46>`_
--  `<https://github.com/pypa/wheel/issues/138>`_
--  `<https://github.com/pombredanne/spdx-pypi-pep/issues/1#issuecomment-281343077>`_
+- `<https://github.com/pypa/warehouse/issues/2996>`_
+- `<https://github.com/pypa/interoperability-peps/issues/46>`_
+- `<https://github.com/pypa/packaging-problems/issues/41>`_
+- `<https://github.com/pypa/wheel/issues/138>`_
+- `<https://github.com/pombredanne/spdx-pypi-pep/issues/1#issuecomment-281343077>`_
+
 
 Fields
 ======

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -1,0 +1,155 @@
+PEP: 9999
+Title: Metadata for Python Software Packages 2.2
+Version: $Revision$
+Last-Modified: $Date$
+Author: Philippe Ombredanne <pombredanne@nexb.com>
+BDFL-Delegate: 
+Discussions-To: distutils-sig <distutils-sig at python.org>
+Status: 
+Type: Standards Track
+Content-Type: text/x-rst
+Created: 15-Aug-2018
+Python-Version: 3.x
+Post-History:
+Replaces: 566
+Resolution: 
+
+Abstract
+========
+
+This PEP describes the changes between versions 2.1 and 2.2 of the core
+metadata specification for Python packages. Version 2.1 is specified in PEP
+566.
+
+The key and only change introduced in this PEP is how license is documented in
+package medata.
+
+Software is licensed and providing accurate licensing information to Python
+packages users is an important matter.  Yet, license metadata are limited often
+leading to some confusion. 
+
+- There are two overlapping places where a license can be documented leading to
+  confusion for packagers: license-related `Classifiers` and the `License`
+  attribute.
+
+- Furthermore, it is difficult to convey anything but simple licensing using
+  these two fields. License information expressiveness and clarity when creating
+  packages will help packagers and users alike.
+
+License expressions provide a better way to express the license of a
+distribution using a well defined syntax and well known license ids from SPDX.
+
+This PEP was started based on several discussions and in particular:
+
+-  `<https://github.com/pypa/warehouse/issues/2996>`_
+-  `<https://github.com/pypa/interoperability-peps/issues/46>`_
+-  `<https://github.com/pypa/wheel/issues/138>`_
+-  `<https://github.com/pombredanne/spdx-pypi-pep/issues/1#issuecomment-281343077>`_
+
+Fields
+======
+
+The canonical source for the names and semantics of each of the supported
+metadata fields is the `Core Metadata Specification`_ document.
+
+The details for the update to the `Core Metadata Specification`_ document are 
+in this `Core Metadata Specification pull request`_.
+
+
+New in Version 2.2
+------------------
+
+License-Expression (optional)
+:::::::::::::::::::::::::::::
+
+A string containing a license expression using the SPDX license expression
+syntax and SPDX-listed license identifiers so that user can express accurately
+the licensing of a package in a way that is both easy to read for humans and
+easy to process automatically by tools.
+
+A string containing a license expression using `SPDX license expression syntax and
+identifiers <https://spdx.org/ids>`__ that indicates the license(s) covering the
+distribution. The license expressions are specified in the `SPDX specification 
+<https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60>`_.
+SPDX also publishes a companion `list of license ids <https://spdx.org/license-list>`_
+for use in license expressions. 
+
+Note: this field is not case sensitive though the normalized representation of
+an SPDX license expression has a well defined case.
+
+Examples::
+
+    License-Expression: BSD-3-Clause
+
+    License-Expression: MIT OR GPL-2.0-or-later AND (FSFUL AND BSD-2-Clause)
+
+    License-Expression: GPL-3.0-or-later WITH Classpath-Exception-2.0 OR BSD-3-Clause
+
+
+Tools `should` validate that this field contains a valid license expression
+and `should` report a warning if the field contains an invalid expression.
+
+
+Changed in Version 2.2
+----------------------
+
+License
+:::::::
+
+This field will be deprecated in the future and its documentation has been
+updated accordingly. Tools are encouraged to provide a warning when this field
+is used.
+
+Classifiers
+:::::::::::
+
+The use of license-related classifiers in this field will be deprecated in the
+future and its documentation has been updated accordingly. Tools are encouraged
+to provide a warning when this field is used with license-related classifiers.
+
+
+Summary of Differences From PEP 566
+===================================
+
+* Metadata-Version is now 2.2.
+
+* Added one new field: ``License-Expression``
+
+* Updated the documentation of two fields:  ``License`` and ``Classifiers``
+
+
+References
+==========
+
+This document specifies version 2.2 of the metadata format.
+Version 1.0 is specified in PEP 241.
+Version 1.1 is specified in PEP 314.
+Version 1.2 is specified in PEP 345.
+Version 2.0, while not formally accepted, was specified in PEP 426.
+Version 2.1 is specified in PEP 566.
+
+.. _`Core Metadata Specification`:
+   https://packaging.python.org/specifications/core-metadata/
+
+.. _`Core Metadata Specification pull request`:
+   https://github.com/pypa/packaging.python.org/pull/635/
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+Acknowledgements
+================
+
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 80
+   End:

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Philippe Ombredanne <pombredanne@nexb.com>
 BDFL-Delegate: 
-Discussions-To: distutils-sig <distutils-sig at python.org>
+Discussions-To: https://discuss.python.org/t/improving-license-clarity-with-better-package-metadata
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -5,7 +5,7 @@ Last-Modified: $Date$
 Author: Philippe Ombredanne <pombredanne@nexb.com>
 BDFL-Delegate: 
 Discussions-To: distutils-sig <distutils-sig at python.org>
-Status: 
+Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 15-Aug-2018

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -2,8 +2,8 @@ PEP: 9999
 Title: Metadata for Python Software Packages 2.2
 Version: $Revision$
 Last-Modified: $Date$
-Author: Philippe Ombredanne <pombredanne@nexb.com>
-BDFL-Delegate: 
+Author: Philippe Ombredanne <pombredanne at nexb.com>
+BDFL-Delegate: Paul Moore <p.f.moore at gmail.com>
 Discussions-To: https://discuss.python.org/t/improving-license-clarity-with-better-package-metadata
 Status: Draft
 Type: Standards Track
@@ -22,7 +22,7 @@ metadata specification for Python packages. Version 2.1 is specified in PEP
 566.
 
 The key and only change introduced in this PEP is how license is documented in
-package medata.
+package metadata.
 
 Software is licensed and providing accurate licensing information to Python
 packages users is an important matter.  Yet, license metadata are limited often

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -140,7 +140,8 @@ Version 2.1 is specified in PEP 566.
 Copyright
 =========
 
-This document has been placed in the public domain.
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.
 
 
 Acknowledgements


### PR DESCRIPTION
This is a WIP PR for discussion around a PEP to add a new Core metadata field to document license in packages and eventually retire the use of the `License` and `Classifiers`.

This has been triggered by several recent or older discussions in particular:

- https://github.com/pypa/warehouse/issues/2996
- https://github.com/pypa/interoperability-peps/issues/46
- https://github.com/pypa/packaging-problems/issues/41
- https://github.com/pypa/wheel/issues/138
- https://github.com/pombredanne/spdx-pypi-pep/issues/1#issuecomment-281343077


Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>

