### PR TITLE
PEP 569: Python 3.8.0b4 released

### DIFF
--- a/pep-0569.rst
+++ b/pep-0569.rst
@@ -59,10 +59,10 @@ Actual:
 
 - 3.8.0 beta 2: Monday, 2019-07-04
 - 3.8.0 beta 3: Monday, 2019-07-29
+- 3.8.0 beta 4: Thursday, 2019-08-29
 
 Expected:
 
-- 3.8.0 beta 4: Monday, 2019-08-26
 - 3.8.0 candidate 1: Monday, 2019-09-30
 - 3.8.0 candidate 2: Monday, 2019-10-07 (if necessary)
 - 3.8.0 final: Monday, 2019-10-21


### PR DESCRIPTION
https://www.python.org/downloads/release/python-380b4/
https://blog.python.org/2019/08/python-380b4-is-now-available-for.html
https://mail.python.org/archives/list/python-dev@python.org/thread/AP7O65CDZWNWGCLJBRYLW3AP5H4L3MRK/