### PR TITLE
PEP-573: Rewrite section on passing the "defining class" into C methods.

### DIFF
--- a/pep-0573.rst
+++ b/pep-0573.rst
@@ -299,15 +299,18 @@ through ``f_globals`` will also break the new cycles through ``ht_module``.
 Passing the defining class to extension methods
 -----------------------------------------------
 
-A new style of C-level functions will be added to the current selection of
-``PyCFunction`` and ``PyCFunctionWithKeywords``::
+Since PEP 590 [#pep-590]_ was accepted for Python 3.8, ``PyCFunction``
+implements the vectorcall protocol.
+This PEP builds on top of PEP 590 to provide C implemented methods with
+context about their defining class (and thus their defining module).
+
+A new C signature ``PyCMethod`` is added to the ``PyCFunction`` set of
+signatures, together with a corresponding signature flag ``METH_METHOD``::
 
     PyObject *PyCMethod(PyObject *self,
                         PyTypeObject *defining_class,
-                        PyObject *args, PyObject *kwargs)
-
-A new method object flag, ``METH_METHOD``, will be added to signal that
-the underlying C function is ``PyCMethod``.
+                        PyObject *const *args, size_t n_args,
+                        PyObject *kwnames)
 
 To hold the extra information, a new structure extending ``PyCFunctionObject``
 will be added::
@@ -317,15 +320,14 @@ will be added::
         PyTypeObject *mm_class; /* Passed as 'defining_class' arg to the C func */
     } PyCMethodObject;
 
-To allow passing the defining class to the underlying C function, a change
-to private API is required, now ``_PyMethodDef_RawFastCallDict`` and
-``_PyMethodDef_RawFastCallKeywords`` will receive ``PyTypeObject *cls``
-as one of their arguments.
+The ``PyCFunction`` implementation will pass this class object into a
+``PyCMethod`` C function when it finds the ``METH_METHOD`` flag being set.
+A new macro ``PyCFunction_GET_CLASS(cls)`` will be added for easier access
+to ``mm_class``.
 
-A new macro ``PyCFunction_GET_CLASS(cls)`` will be added for easier access to mm_class.
-
-Method construction and calling code and will be updated to honor
-``METH_METHOD``.
+C methods may continue to use the other ``METH_*`` signatures if they do
+not require access to their defining class/module.
+In that case, trying to access the ``mm_class`` field is invalid.
 
 
 Argument Clinic
@@ -550,6 +552,9 @@ References
 
 .. [#gh-patch]
    https://github.com/Traceur759/cpython/compare/master...Traceur759:pep-c.patch
+
+.. [#pep-590]
+   https://www.python.org/dev/peps/pep-0590/
 
 
 Copyright


### PR DESCRIPTION
The main change is the signature, but I took the liberty to reword the paragraphs while I was matching them with PEP-590.