### PR TITLE
PEP 594: Fix reference to prior PEP

### DIFF
--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -18,7 +18,7 @@ and SUN file formats), APIs and operating systems that have been superseded a
 long time ago (e.g. Mac OS 9), or modules that have security implications and
 better alternatives (e.g. password and login).
 
-The PEP follows in the foot steps of other PEPS like :pep:`3818`. The
+The PEP follows in the foot steps of other PEPS like :pep:`3108`. The
 *Standard Library Reorganization* proposal removed a bunch of modules from
 Python 3.0. In 2007, the PEP referred to maintenance burden as:
 


### PR DESCRIPTION
The context refers to 'Standard Library Reorganization', which is PEP
3108. This change updates the nearby link

Fixes #1160