### PR TITLE
PEP 492: refactor example code.

### DIFF
--- a/pep-0492.txt
+++ b/pep-0492.txt
@@ -386,9 +386,9 @@ which is semantically equivalent to::
 
     mgr = (EXPR)
     aexit = type(mgr).__aexit__
-    aenter = type(mgr).__aenter__(mgr)
+    aenter = type(mgr).__aenter__
 
-    VAR = await aenter
+    VAR = await aenter(mgr)
     try:
         BLOCK
     except:


### PR DESCRIPTION
This PR changes an example to make it more readable.

Currently the ``__aexit__`` method is assigned to the ``aexit`` variable, but the *return value* of the ``__aenter__`` method is assigned to the ``aenter`` variable.

The fix restores consistency without changing semantics.