### PR TITLE
PEP 573 updates

### DIFF
--- a/pep-0573.rst
+++ b/pep-0573.rst
@@ -375,11 +375,6 @@ New types:
 
 * ``PyCMethodObject``
 
-Modified functions:
-
-* ``_PyMethodDef_RawFastCallDict`` now receives ``PyTypeObject *cls``.
-* ``_PyMethodDef_RawFastCallKeywords`` now receives ``PyTypeObject *cls``.
-
 Modified structures:
 
 * _heaptypeobject - added ``ht_module``

--- a/pep-0573.rst
+++ b/pep-0573.rst
@@ -405,7 +405,7 @@ Modified functions:
 
 Modified structures:
 
-* _heaptypeobject - added ``ht_module`` and ``ht_moduleptr``
+* _heaptypeobject - added ``ht_module``
 
 Other changes:
 

--- a/pep-0573.rst
+++ b/pep-0573.rst
@@ -332,25 +332,6 @@ must be heap-allocated.
 On failure, exception is set and NULL is returned.
 
 
-PyType_offsets
---------------
-
-Some extension types are using instances with ``__dict__`` or ``__weakref__``
-allocated. Currently, there is no way of passing offsets of these through
-``PyType_Spec``. To allow this, a new structure and a spec slot are proposed.
-
-A new structure, ``PyType_offsets``, will have two members containing the
-offsets of ``__dict__`` and ``__weakref__``::
-
-    typedef struct {
-        Py_ssize_t dict;
-        Py_ssize_t weaklist;
-    } PyType_offsets;
-
-The new slot, ``Py_offsets``, will be used to pass a ``PyType_offsets *``
-structure containing the mentioned data.
-
-
 Helpers
 -------
 
@@ -394,10 +375,6 @@ New types:
 
 * ``PyCMethodObject``
 
-New structures:
-
-* ``PyType_offsets``
-
 Modified functions:
 
 * ``_PyMethodDef_RawFastCallDict`` now receives ``PyTypeObject *cls``.
@@ -412,7 +389,6 @@ Other changes:
 * ``METH_METHOD`` call flag
 * ``defining_class`` converter in clinic
 * ``Py_TPFLAGS_HEAP_IMMUTABLE`` flag
-* ``Py_offsets`` type spec slot
 
 
 Backwards Compatibility

--- a/pep-0573.rst
+++ b/pep-0573.rst
@@ -475,8 +475,8 @@ References
 Copyright
 =========
 
-This document has been placed in the public domain.
-
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.
 
 
 ..

--- a/pep-0573.rst
+++ b/pep-0573.rst
@@ -383,14 +383,13 @@ Other changes:
 
 * ``METH_METHOD`` call flag
 * ``defining_class`` converter in clinic
-* ``Py_TPFLAGS_HEAP_IMMUTABLE`` flag
 
 
 Backwards Compatibility
 =======================
 
 Two new pointers are added to all heap types.
-All other changes are adding new functions, structures and a type flag,
+All other changes are adding new functions and structures,
 or changes to private implementation details.
 
 Implementation


### PR DESCRIPTION
The substantial change here is removing `PyType_offsets`. Dino is working on a better way to specify these, which will hopefully be straightforward enough to not need a PEP.

The public domain dedication is changed. I figure I don't need explicit permission from all co-authors, since y'all placed this in public domain :)

cc @Dormouse759 