### PR TITLE
PEP-551: Complete missing end of sentence

### DIFF
--- a/pep-0551.rst
+++ b/pep-0551.rst
@@ -297,7 +297,10 @@ single buffer and the file is closed.
 Compilation will later trigger a ``compile`` event, so there is no need
 to validate the contents now using mechanisms that also apply to
 dynamically generated code. However, if a whitelist of source files or
-file hashes is available, then this is the point
+file hashes is available, then other validation mechanisms such as
+DeviceGuard [4]_ should be performed here.
+
+
 
 **Restrict globals in pickles**
 


### PR DESCRIPTION
Complete broken sentence, based on content in https://github.com/python/peps/commit/cd795ec53c939e5b40808bb9d7a80c428c85dd52#diff-a370cb418156597b81cb01e582c6f518R438

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
