### PR TITLE
PEP 571: Fix link to manylinux2010 Docker image

### DIFF
--- a/pep-0571.rst
+++ b/pep-0571.rst
@@ -178,12 +178,12 @@ Like ``manylinux1``, the ``auditwheel`` tool adds ``manylinux2010``
 platform tags to ``linux`` wheels built by ``pip wheel`` or
 ``bdist_wheel`` in a ``manylinux2010`` Docker container.
 
-Docker Images
--------------
+Docker Image
+------------
 
-``manylinux2010`` Docker images based on CentOS 6 x86_64 and i686 are
+A ``manylinux2010`` Docker image based on CentOS 6 x86_64 is
 provided for building binary ``linux`` wheels that can reliably be
-converted to ``manylinux2010`` wheels.  [10]_ These images come with a
+converted to ``manylinux2010`` wheels.  [10]_ This image comes with a
 full compiler suite installed (``gcc``, ``g++``, and ``gfortran``
 4.8.2) as well as the latest releases of Python and ``pip``.
 
@@ -336,8 +336,8 @@ References
    https://www.python.org/dev/peps/pep-3149/
 .. [9] SOABI support for Python 2.X and PyPy
    https://github.com/pypa/pip/pull/3075
-.. [10] manylinux2 Docker images
-   (https://hub.docker.com/r/markrwilliams/manylinux2/)
+.. [10] manylinux2010 Docker image
+   (https://quay.io/repository/pypa/manylinux2010_x86_64)
 .. [11] On vsyscalls and the vDSO
    (https://lwn.net/Articles/446528/)
 .. [12] vdso(7)


### PR DESCRIPTION
The PEP was still referencing an old (beta?) Docker image. It was also
written in the plural, but there is only a single image (x86_64, no
i686).

This update was discussed in
https://github.com/pypa/manylinux/issues/179#issuecomment-487852362
but it's taken me until now to get permission to sign the CLA.