### PR TITLE
PEP 8: Discourage use of return/break/continue in finally

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -1335,6 +1335,20 @@ Programming Recommendations
       No:    if greeting == True:
       Worse: if greeting is True:
 
+- Use of the flow control statements ``return``/``break``/``continue``
+  within the finally suite of a ``try...finally``, where the flow control
+  statement would jump outside the finally suite, is discouraged.  This
+  is because such statements will implicitly cancel any active exception
+  that is propagating through the finally suite.
+
+  No::
+
+      def foo():
+          try:
+              1 / 0
+          finally:
+              return 42
+
 Function Annotations
 --------------------
 


### PR DESCRIPTION
As per discussion on PEP 601: https://discuss.python.org/t/pep-601-forbid-return-break-continue-breaking-out-of-finally/2239/32