### PR TITLE
PEP 458: Move to Draft status and update Delegate

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -5,9 +5,9 @@ Last-Modified: $Date$
 Author: Trishank Karthik Kuppusamy <trishank@nyu.edu>,
         Vladimir Diaz <vladimir.diaz@nyu.edu>,
         Donald Stufft <donald@stufft.io>, Justin Cappos <jcappos@nyu.edu>
-BDFL-Delegate: Richard Jones <r1chardj0n3s@gmail.com>
+BDFL-Delegate: Donald Stufft <donald@stufft.io>
 Discussions-To: DistUtils mailing list <distutils-sig@python.org>
-Status: Deferred
+Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 27-Sep-2013
@@ -56,8 +56,10 @@ __ https://github.com/theupdateframework/tuf/tree/develop/tuf/client#updaterpy
 PEP Status
 ==========
 
-Due to the amount of work required to implement this PEP, it is deferred until
-appropriate funding can be secured to implement the PEP.
+Due to the amount of work required to implement this PEP, in early
+2019 it was deferred until appropriate funding could be secured to
+implement the PEP. The Python Software Foundation secured this funding
+[27]_.
 
 
 Motivation
@@ -1070,7 +1072,7 @@ References
 .. [24] https://pypi.python.org/pypi/pycrypto
 .. [25] http://ed25519.cr.yp.to/
 .. [26] https://www.python.org/dev/peps/pep-0480/
-
+.. [27] https://pyfound.blogspot.com/2019/09/pypi-security-q4-2019-request-for.html
 
 Acknowledgements
 ================


### PR DESCRIPTION
Facebook Research has now funded implementation of cryptographic signing of packages on PyPI. Per https://github.com/pypa/warehouse/issues/5247#issuecomment-535278176 this means that PEP 458 now moves out of Deferred status and into Draft status.

Since the PEP was created, the BDFL-Delegate for PyPI-related PEPs has shifted, and Donald Stufft is now the Delegate.
