### PR TITLE
PEP 458: update dead or outdated references

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -50,7 +50,7 @@ work (none by clients), but it also proposes an easy-to-use key management
 solution for developers, how to interface with a potential future build farm on
 PyPI infrastructure, and discusses the feasibility of end-to-end signing.
 
-__ https://github.com/theupdateframework/tuf/tree/develop/tuf/client#updaterpy
+__ https://github.com/theupdateframework/tuf/tree/v0.11.1/tuf/client#updaterpy
 
 
 PEP Status
@@ -284,7 +284,7 @@ The `Metadata`__ document provides information about each of the required
 metadata and their expected content.  The next section covers the different
 kinds of metadata RECOMMENDED for PyPI.
 
-__ https://github.com/theupdateframework/tuf/blob/develop/METADATA.md
+__ https://github.com/theupdateframework/tuf/blob/v0.11.1/docs/METADATA.md
 
 
 PyPI and TUF Metadata
@@ -349,7 +349,7 @@ Automation will continuously sign for a timestamped, snapshot of all projects.
 A `repository management`__ tool is available that can sign metadata files,
 generate cryptographic keys, and manage a TUF repository.
 
-__ https://github.com/theupdateframework/tuf/tree/develop/tuf#repository-management
+__ https://github.com/theupdateframework/tuf/blob/v0.11.1/docs/TUTORIAL.md#how-to-create-and-modify-a-tuf-repository
 
 
 How to Establish Initial Trust in the PyPI Root Keys
@@ -434,7 +434,7 @@ project signed for by the *bins* role.  For example, applying this scheme to
 the previous repository resulted in pip downloading between 1.3KB and 111KB to
 install or upgrade a PyPI project via TUF.
 
-__ https://github.com/theupdateframework/tuf/issues/39
+__ https://github.com/theupdateframework/tuf/blob/v0.11.1/docs/TUTORIAL.md#delegate-to-hashed-bins
 
 Based on our findings as of the time of writing, PyPI SHOULD split all targets
 in the *bins* role by delegating them to 1024 delegated roles, each of which
@@ -942,7 +942,7 @@ in this section:
    distributions and manage keys is expected to render key signing an unused
    feature.
 
-    __ https://minilock.io/
+    __ https://github.com/kaepora/miniLock
 
 3. A two-phase approach, where the minimum security model is implemented first
    followed by the maximum security model, can simplify matters and give PyPI
@@ -1044,7 +1044,7 @@ References
 ==========
 
 .. [1] https://pypi.python.org
-.. [2] https://isis.poly.edu/~jcappos/papers/samuel_tuf_ccs_2010.pdf
+.. [2] https://theupdateframework.github.io/papers/survivable-key-compromise-ccs2010.pdf
 .. [3] http://www.pip-installer.org
 .. [4] https://wiki.python.org/moin/WikiAttack2013
 .. [5] https://github.com/theupdateframework/pip/wiki/Attacks-on-software-repositories
@@ -1057,19 +1057,19 @@ References
 .. [11] https://mail.python.org/pipermail/distutils-sig/2013-May/020848.html
 .. [12] PEP 449, Removal of the PyPI Mirror Auto Discovery and Naming Scheme, Stufft
         http://www.python.org/dev/peps/pep-0449/
-.. [13] https://isis.poly.edu/~jcappos/papers/cappos_mirror_ccs_08.pdf
+.. [13] https://theupdateframework.github.io/papers/attacks-on-package-managers-ccs2008.pdf
 .. [14] https://mail.python.org/pipermail/distutils-sig/2013-September/022755.html
 .. [15] https://pypi.python.org/security
-.. [16] https://github.com/theupdateframework/tuf/blob/develop/docs/tuf-spec.txt
+.. [16] https://github.com/theupdateframework/specification/blob/master/tuf-spec.md
 .. [17] PEP 426, Metadata for Python Software Packages 2.0, Coghlan, Holth, Stufft
         http://www.python.org/dev/peps/pep-0426/
 .. [18] https://en.wikipedia.org/wiki/Continuous_delivery
 .. [19] https://mail.python.org/pipermail/distutils-sig/2013-August/022154.html
 .. [20] https://en.wikipedia.org/wiki/RSA_%28algorithm%29
 .. [21] https://en.wikipedia.org/wiki/Key-recovery_attack
-.. [22] http://csrc.nist.gov/publications/nistpubs/800-57/SP800-57-Part1.pdf
+.. [22] https://doi.org/10.6028/NIST.SP.800-57pt1r4
 .. [23] https://www.openssl.org/
-.. [24] https://pypi.python.org/pypi/pycrypto
+.. [24] https://github.com/pyca/cryptography
 .. [25] http://ed25519.cr.yp.to/
 .. [26] https://www.python.org/dev/peps/pep-0480/
 .. [27] https://pyfound.blogspot.com/2019/09/pypi-security-q4-2019-request-for.html


### PR DESCRIPTION
Uses static last stable version tag (v0.11.1), instead of dynamic branch name (develop), when pointing to documents in the TUF repository. This makes them more prone to become outdated but less prone to 404.

Note, that the two referenced tuf publications are also available under more permanent, albeit paywalled DOIs:
[2] https://doi.org/10.1145/1866307.1866315
[13] https://doi.org/10.1145/1455770.1455841

