### PR TITLE
PEP 571: Update GCC_4.5.0

### DIFF
--- a/pep-0571.rst
+++ b/pep-0571.rst
@@ -342,7 +342,7 @@ References
 .. [7] ncurses 5 -> 6 transition means we probably need to drop some
    libraries from the manylinux whitelist
    (https://github.com/pypa/manylinux/issues/94)
-.. [8] PEP 3149libgcc_s
+.. [8] PEP 3149
    https://www.python.org/dev/peps/pep-3149/
 .. [9] SOABI support for Python 2.X and PyPy
    https://github.com/pypa/pip/pull/3075

--- a/pep-0571.rst
+++ b/pep-0571.rst
@@ -155,7 +155,7 @@ the ``manylinux2010`` tag:
        GLIBC_2.12
        CXXABI_1.3.3
        GLIBCXX_3.4.13
-       GCC_4.4.0
+       GCC_4.5.0
 
    As an example, ``manylinux2010`` wheels may include binary artifacts
    that require ``glibc`` symbols at version ``GLIBC_2.4``, because
@@ -313,6 +313,16 @@ to be uploaded in the same way that it permits ``manylinux1``.  It
 should not attempt to verify the compatibility of ``manylinux2010``
 wheels.
 
+Summary of changes to \PEP 571
+==============================
+
+The following changes were made to this PEP based on feedback received after
+it was approved:
+
+* The maximum version symbol of ``libgcc_s`` was updated from ``GCC_4.3.0``
+  to ``GCC_4.5.0`` to address 32-bit Cent OS 6. This doesn't affect x86_64
+  because ``libgcc_s`` for x86_64 has no additional symbol from
+  ``GCC_4.3.0`` to ``GCC_4.5.0``.
 
 References
 ==========
@@ -332,7 +342,7 @@ References
 .. [7] ncurses 5 -> 6 transition means we probably need to drop some
    libraries from the manylinux whitelist
    (https://github.com/pypa/manylinux/issues/94)
-.. [8] PEP 3149
+.. [8] PEP 3149libgcc_s
    https://www.python.org/dev/peps/pep-3149/
 .. [9] SOABI support for Python 2.X and PyPy
    https://github.com/pypa/pip/pull/3075

--- a/pep-0571.rst
+++ b/pep-0571.rst
@@ -155,7 +155,7 @@ the ``manylinux2010`` tag:
        GLIBC_2.12
        CXXABI_1.3.3
        GLIBCXX_3.4.13
-       GCC_4.3.0
+       GCC_4.4.0
 
    As an example, ``manylinux2010`` wheels may include binary artifacts
    that require ``glibc`` symbols at version ``GLIBC_2.4``, because


### PR DESCRIPTION
`manylinux2010` is based on CentOS 6 which is bundled with `GCC 4.4` and corresponding `libgcc_s.so`. Current PEP says that its maximum version is `GCC_4.3.0` but this should be updated to `GCC_4.4.0` because 32-bit CentOS 6 has many symbols with `GCC_4.4.0` but 64-bit CentOS 6 doesn't. It seems that this constraints was made only with 64-bit CentOS 6.

From [libgcc-glibc.ver](https://github.com/gcc-mirror/gcc/blame/master/libgcc/config/i386/libgcc-glibc.ver), they put new symbols introduced with `GCC 4.3` in `GCC_4.4.0` only for 32 bits. As a result, those symbols are placed in different version tag depending on architecture.

Comment in the source says:
```
# 128 bit long double support was introduced with GCC 4.3.0 to 64bit
# and with GCC 4.4.0 to 32bit.  These lines make the symbols to get
# a @@GCC_4.3.0 or @@GCC_4.4.0 attached.
```

Without this change, application built on 32-bit CentOS 6 and linked with following functions cannot be manylinux2010-compliant even though they are.

```
GCC_4.4.0 {
  __addtf3
  __copysigntf3
  __divtc3
  __divtf3
  __eqtf2
  __extenddftf2
  __extendsftf2
  __fabstf2
  __fixtfdi
  __fixtfsi
  __fixunstfdi
  __fixunstfsi
  __floatditf
  __floatsitf
  __floatunditf
  __floatunsitf
  __getf2
  __gttf2
  __letf2
  __lttf2
  __multc3
  __multf3
  __negtf2
  __netf2
  __powitf2
  __subtf3
  __trunctfdf2
  __trunctfsf2
  __trunctfxf2
  __unordtf2
}
```

Context: https://github.com/pypa/auditwheel/pull/141#issuecomment-535998315