### PR TITLE
PEP 599: Updates

### DIFF
--- a/pep-0599.rst
+++ b/pep-0599.rst
@@ -166,7 +166,7 @@ the ``manylinux2014`` tag:
        GLIBC_2.17
        CXXABI_1.3.7
        GLIBCXX_3.4.19
-       GCC_4.8.5
+       GCC_4.8.0
 
    As an example, ``manylinux2014`` wheels may include binary
    artifacts that require ``glibc`` symbols at version ``GLIBC_2.12``,

--- a/pep-0599.rst
+++ b/pep-0599.rst
@@ -83,12 +83,12 @@ the ``manylinux2014`` tag:
        x86_64
        i686
        aarch64
-       armhfp
+       armv7l
        ppc64
        ppc64le
        s390x
 
-   This list adds support for ARM (aarch64, armhfp) and PowerPC
+   This list adds support for ARMv7 (armv7l), ARMv8 (aarch64) and PowerPC
    (ppc64, ppc64le) architectures supported by the CentOS Alternative
    Architecture Special Interest Group, as well as the IBM Z (s390x)
    architecture. [5]_
@@ -229,7 +229,7 @@ Specifically, the algorithm we propose is::
             "linux-x86_64",
             "linux-i686",
             "linux-aarch64",
-            "linux-armhfp",
+            "linux-armv7l",
             "linux-ppc64",
             "linux-ppc64le",
             "linux-s390x",

--- a/pep-0599.rst
+++ b/pep-0599.rst
@@ -280,19 +280,18 @@ References
 
 .. [1] CentOS Product Specifications
    (https://wiki.centos.org/About/Product)
-.. [2] PEP 425 -- Compatibility Tags for Built Distributions
+.. [2] PEP 425: Compatibility Tags for Built Distributions
    (https://www.python.org/dev/peps/pep-0425/)
 .. [3] Tracking issue for manylinux2010 rollout
    (https://github.com/pypa/manylinux/issues/179)
 .. [4] Red Hat Universal Base Image 7
    (https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/ubi7)
-   (https://wiki.centos.org/SpecialInterestGroup/AltArch)
 .. [5] The CentOS Alternative Architecture Special Interest Group
    (https://wiki.centos.org/SpecialInterestGroup/AltArch)
-.. [6] PEP 3149
-   https://www.python.org/dev/peps/pep-3149/
+.. [6] PEP 3149: ABI version tagged .so files
+   (https://www.python.org/dev/peps/pep-3149/)
 .. [7] SOABI support for Python 2.X and PyPy
-   https://github.com/pypa/pip/pull/3075
+   (https://github.com/pypa/pip/pull/3075)
 .. [8] auditwheel
    (https://github.com/pypa/auditwheel/)
 


### PR DESCRIPTION
* Per https://github.com/pypa/warehouse/pull/6684#issuecomment-534266929, correctly specifies the reported ARMv7 architecture string as `armv7l`, not `armhfp`.
* Also fixes some poor formatting in the footer.

(cc @brettcannon @ncoghlan)