### PR TITLE
PEP 587: PyConfig_InitPythonConfig() cannot fail anymore

### DIFF
--- a/pep-0587.rst
+++ b/pep-0587.rst
@@ -354,12 +354,9 @@ Example setting the program name::
     void init_python(void)
     {
         PyStatus status;
-        PyConfig config;
 
-        status = PyConfig_InitPythonConfig(&config);
-        if (PyStatus_Exception(status)) {
-            goto fail;
-        }
+        PyConfig config;
+        PyConfig_InitPythonConfig(&config);
 
         /* Set the program name. Implicitly preinitialize Python. */
         status = PyConfig_SetString(&config, &config.program_name,
@@ -382,9 +379,9 @@ Example setting the program name::
 
 ``PyConfig`` methods:
 
-* ``PyStatus PyConfig_InitPythonConfig(PyConfig *config)``
+* ``void PyConfig_InitPythonConfig(PyConfig *config)``
   Initialize configuration with `Python Configuration`_.
-* ``PyStatus PyConfig_InitIsolatedConfig(PyConfig *config)``:
+* ``void PyConfig_InitIsolatedConfig(PyConfig *config)``:
   Initialize configuration with `Isolated Configuration`_.
 * ``PyStatus PyConfig_SetString(PyConfig *config, wchar_t * const *config_str, const wchar_t *str)``:
   Copy the wide character string *str* into ``*config_str``.
@@ -596,12 +593,9 @@ configuration, and then override some parameters::
     PyStatus init_python(const char *program_name)
     {
         PyStatus status;
-        PyConfig config;
 
-        status = PyConfig_InitPythonConfig(&config);
-        if (PyStatus_Exception(status)) {
-            goto done;
-        }
+        PyConfig config;
+        PyConfig_InitPythonConfig(&config);
 
         /* Set the program name before reading the configuration
            (decode byte string from the locale encoding).
@@ -684,12 +678,9 @@ Example of customized Python always running in isolated mode::
     int main(int argc, char **argv)
     {
         PyStatus status;
-        PyConfig config;
 
-        status = PyConfig_InitPythonConfig(&config);
-        if (PyStatus_Exception(status)) {
-            goto fail;
-        }
+        PyConfig config;
+        PyConfig_InitPythonConfig(&config);
 
         config.isolated = 1;
 
@@ -859,13 +850,9 @@ phases::
     void init_python(void)
     {
         PyStatus status;
-        PyConfig config;
 
-        status = PyConfig_InitPythonConfig(&config);
-        if (PyStatus_Exception(status)) {
-            PyConfig_Clear(&config);
-            Py_ExitStatusException(status);
-        }
+        PyConfig config;
+        PyConfig_InitPythonConfig(&config);
 
         config._init_main = 0;
 


### PR DESCRIPTION
PyConfig_InitPythonConfig() and PyConfig_InitIsolatedConfig() no
longer return PyStatus: they cannot fail anymore.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
