### PR TITLE
PEP 487: Remove extra underscore.

### DIFF
--- a/pep-0487.txt
+++ b/pep-0487.txt
@@ -268,7 +268,7 @@ As a second change, the new ``type.__init__`` just ignores keyword
 arguments. Currently, it insists that no keyword arguments are given. This
 leads to a (wanted) error if one gives keyword arguments to a class declaration
 if the metaclass does not process them. Metaclass authors that do want to
-accept keyword arguments must filter them out by overriding ``__init___``.
+accept keyword arguments must filter them out by overriding ``__init__``.
 
 In the new code, it is not ``__init__`` that complains about keyword arguments,
 but ``__init_subclass__``, whose default implementation takes no arguments. In


### PR DESCRIPTION
Just something small I noticed while reading up on `__init_subclass__`.