### PR TITLE
PEP 13: Change the Council Election to use Approval voting.

### DIFF
--- a/pep-0013.rst
+++ b/pep-0013.rst
@@ -107,7 +107,7 @@ A council election consists of two phases:
   must be nominated by a core team member. Self-nominations are
   allowed.
 
-* Phase 2: Each core team member can vote for zero to five of the
+* Phase 2: Each core team member can vote for zero or more of the
   candidates. Voting is performed anonymously. Candidates are ranked
   by the total number of votes they receive. If a tie occurs, it may
   be resolved by mutual agreement among the candidates, or else the


### PR DESCRIPTION
Change PEP 13 to make the Council Election use regular (multiwinner) approval voting, the same thing used for the PSF board elections, instead of restricting the number of votes to the number of seats in the Council.
