### PR TITLE
PEP 599: Allow CXXABI_TM_1 symbol version

### DIFF
--- a/pep-0599.rst
+++ b/pep-0599.rst
@@ -164,7 +164,7 @@ the ``manylinux2014`` tag:
    they may only depend on the following maximum versions::
 
        GLIBC_2.17
-       CXXABI_1.3.7
+       CXXABI_1.3.7, CXXABI_TM_1 is also allowed
        GLIBCXX_3.4.19
        GCC_4.8.0
 


### PR DESCRIPTION
More information in [auditwheel discussion](https://github.com/pypa/auditwheel/pull/192/files#r332459037) of [manylinux2014 Pull Request](https://github.com/pypa/auditwheel/pull/192)