### PR TITLE
PEP 553: Add missing return None in except clause to pseudo-code

### DIFF
--- a/pep-0553.rst
+++ b/pep-0553.rst
@@ -195,6 +195,7 @@ feature looks roughly like the following::
                 'Ignoring unimportable $PYTHONBREAKPOINT: {}'.format(
                     hookname),
                 RuntimeWarning)
+            return None
         return hook(*args, **kws)
 
     __breakpointhook__ = breakpointhook
@@ -238,6 +239,10 @@ which inherits several of the problems this PEP aims to solve.
 
 Version History
 ===============
+
+* 2019-10-13
+
+  * Add missing ``return None`` in ``except`` clause to pseudo-code.
 
 * 2017-09-13
 


### PR DESCRIPTION
Found a missing `return None` in the implementation Python code while implementing the PEP in PyPy.