### PR TITLE
PEP 0571: compiler version matching x86_64 docker image

### DIFF
--- a/pep-0571.rst
+++ b/pep-0571.rst
@@ -181,11 +181,12 @@ platform tags to ``linux`` wheels built by ``pip wheel`` or
 Docker Image
 ------------
 
-A ``manylinux2010`` Docker image based on CentOS 6 x86_64 is
+Two ``manylinux2010`` Docker images based on CentOS 6 is
 provided for building binary ``linux`` wheels that can reliably be
-converted to ``manylinux2010`` wheels.  [10]_ This image comes with a
-fully new compiler suite installed (``gcc``, ``g++``, and ``gfortran``
+converted to ``manylinux2010`` wheels.  [10]_ The x86_64 image comes with a
+new compiler suite installed (``gcc``, ``g++``, and ``gfortran``
 from ``devtoolset-8``) as well as the latest releases of Python and ``pip``.
+For the i686 image, the compiler suite installed is from ``devtoolset-7``.
 
 Compatibility with kernels that lack ``vsyscall``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pep-0571.rst
+++ b/pep-0571.rst
@@ -184,8 +184,8 @@ Docker Image
 A ``manylinux2010`` Docker image based on CentOS 6 x86_64 is
 provided for building binary ``linux`` wheels that can reliably be
 converted to ``manylinux2010`` wheels.  [10]_ This image comes with a
-full compiler suite installed (``gcc``, ``g++``, and ``gfortran``
-4.8.2) as well as the latest releases of Python and ``pip``.
+fully new compiler suite installed (``gcc``, ``g++``, and ``gfortran``
+from ``devtoolset-8``) as well as the latest releases of Python and ``pip``.
 
 Compatibility with kernels that lack ``vsyscall``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pep-0571.rst
+++ b/pep-0571.rst
@@ -181,7 +181,7 @@ platform tags to ``linux`` wheels built by ``pip wheel`` or
 Docker Image
 ------------
 
-Two ``manylinux2010`` Docker images based on CentOS 6 is
+Two ``manylinux2010`` Docker images based on CentOS 6 are
 provided for building binary ``linux`` wheels that can reliably be
 converted to ``manylinux2010`` wheels.  [10]_ The x86_64 image comes with a
 new compiler suite installed (``gcc``, ``g++``, and ``gfortran``


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
Fix #1204
