### PR TITLE
PEP 345: Improve example for the Project-URL field and clarify purpose

### DIFF
--- a/pep-0345.txt
+++ b/pep-0345.txt
@@ -385,14 +385,19 @@ Examples::
 Project-URL (multiple-use)
 ::::::::::::::::::::::::::
 
-A string containing a browsable URL for the project and a label for it,
-separated by a comma.
+A string containing an extra URL for the project and a label for it,
+separated by a comma.  For use when there are other URLs to list
+in the metadata in addition to the "Home-page" field.
 
-Example::
+Examples::
 
-    Bug Tracker, http://bitbucket.org/tarek/distribute/issues/
+    Project-URL: Bug Tracker, https://github.com/pypa/setuptools/issues
+    Project-URL: Documentation, https://setuptools.readthedocs.io/
+    Project-URL: Funding, https://donate.pypi.org
 
-The label is a free text limited to 32 signs.
+The label is free text limited to length 32.  Notice that distributions
+uploaded to PyPI will have these extra entries displayed under the
+"Project links" section of their landing page.
 
 
 Version Specifiers

--- a/pep-0345.txt
+++ b/pep-0345.txt
@@ -386,8 +386,8 @@ Project-URL (multiple-use)
 ::::::::::::::::::::::::::
 
 A string containing an extra URL for the project and a label for it,
-separated by a comma.  For use when there are other URLs to list
-in the metadata in addition to the "Home-page" field.
+separated by a comma.  This should be used when there are other URLs
+to list in the metadata in addition to the "Home-page" field.
 
 Examples::
 
@@ -395,9 +395,9 @@ Examples::
     Project-URL: Documentation, https://setuptools.readthedocs.io/
     Project-URL: Funding, https://donate.pypi.org
 
-The label is free text limited to length 32.  Notice that distributions
-uploaded to PyPI will have these extra entries displayed under the
-"Project links" section of their landing page.
+The label is free text, with a maximum length of 32 characters.  Notice 
+that distributions uploaded to PyPI will have these extra entries 
+displayed under the "Project links" section of their landing page.
 
 
 Version Specifiers


### PR DESCRIPTION
The [existing Project-URL section](https://www.python.org/dev/peps/pep-0345/#project-url-multiple-use) is a bit weak:

- Every other field in this PEP lists the field name in the example, this one was missing it
- I don't know what "_The label is a free text limited to 32 signs_" means.
- It's confusing, why you would use this field instead of using "Home-page"?

Description was improved in [PEP-0459](https://www.python.org/dev/peps/pep-0459/#project-urls) but that was withdrawn.

Likely the strange wording in this section was due to historical reasons: in https://github.com/python/peps/commit/0ed1ae32e9f4152f40294bfc6ba79998f29e1275 three separate fields (`Repository-URL`, `Repository-Browser-URL`, `Bug-Tracker-URL`) were consolidated into `Project-URL` (multiple use).

I've tried to update the description/example and make it more useful.