### PR TITLE
PEP 3108: Fixed small grammar typo, removed "has"

### DIFF
--- a/pep-3108.txt
+++ b/pep-3108.txt
@@ -24,7 +24,7 @@ have lost their need to be included with Python.  There has also been
 an introduction of a naming convention for modules since Python's
 inception that not all modules follow.
 
-Python 3.0 has presents a chance to remove modules that do not have
+Python 3.0 presents a chance to remove modules that do not have
 long term usefulness.  This chance also allows for the renaming of
 modules so that they follow the Python style guide [#pep-0008]_.  This
 PEP lists modules that should not be included in Python 3.0 or which


### PR DESCRIPTION
I noticed the sentence "Python 3.0 has presents a chance to...", so I removed "has" so that the sentence reads "Python 3.0 presents a chance to..."