### PR TITLE
PEP 554: Fix minor typo in marshal example code (#1229)

### DIFF
--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -320,7 +320,7 @@ Passing objects via marshal
 ::
 
    interp = interpreters.create()
-   r, s = interpreters.create_fifo()
+   r, s = interpreters.create_channel()
    interp.run(tw.dedent("""
        import marshal
        """),


### PR DESCRIPTION
Fixes #1229; CLA signed.

In PEP 554, "Passing objects via marshal" section example code, `create_fifo` should be `create_channel`.

@ericsnowcurrently 