### PR TITLE
PEP 594: Mention uu_codec

### DIFF
--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -227,13 +227,14 @@ Has a designated expert
 Substitute
   **none**
 
-uu
-~~
+uu and the uu encoding
+~~~~~~~~~~~~~~~~~~~~~~
 
 The `uu <https://docs.python.org/3/library/uu.html>`_ module provides
 uuencode format, an old binary encoding format for email from 1980. The uu
 format has been replaced by MIME. The uu codec is provided by the ``binascii``
-module.
+module.  There's also ``encodings/uu_codec.py`` which is a codec for the
+same encoding; it should also be deprecated.
 
 Module type
   pure Python


### PR DESCRIPTION
If we're deprecating and removing `uu` we should do the same to the codec of the same name.