### PR TITLE
PEP 584: Add post-history and remove draft note

### DIFF
--- a/pep-0584.rst
+++ b/pep-0584.rst
@@ -8,9 +8,7 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 01-Mar-2019
-Post-History:
-
-**DRAFT** -- This is a draft document for discussion.
+Post-History: 01-Mar-2019, 16-Oct-2019
 
 Abstract
 --------


### PR DESCRIPTION
There's no need to put "DRAFT" at the top of the PEP, that's already in the headers.

There are more formatting issues with this PEP that as a PEP editor
bother me, but IMO the authors should be made to do those, after
studying PEP 12.

I'll just merge this once the tests pass; I'll post a message with a content critique to python-ideas shortly.