### PR TITLE
PEP 458: Change title to clarify intent

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -1,5 +1,5 @@
 PEP: 458
-Title: Securing the Link from PyPI to the End User
+Title: Secure PyPI downloads with package signing
 Version: $Revision$
 Last-Modified: $Date$
 Author: Trishank Karthik Kuppusamy <trishank@nyu.edu>,

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -1,5 +1,5 @@
 PEP: 458
-Title: Surviving a Compromise of PyPI
+Title: Securing the Link from PyPI to the End User
 Version: $Revision$
 Last-Modified: $Date$
 Author: Trishank Karthik Kuppusamy <trishank@nyu.edu>,


### PR DESCRIPTION
Per conversation in
https://discuss.python.org/t/pep-458-surviving-a-compromise-of-pypi/2648/21

about problems with current title, and and per former PEP coauthor
Vladimir Diaz in
https://mail.python.org/archives/list/distutils-sig@python.org/thread/TXM2O34TMSHH5U6WA2IF7XKO5J3G5NQQ/#3QLN4KECII6KULKYXS7U4CVBEPGK4B6S

Signed-off-by: Sumana Harihareswara <sh@changeset.nyc>