### PR TITLE
PEP 508: Add missing comma to grammar test code

### DIFF
--- a/pep-0508.txt
+++ b/pep-0508.txt
@@ -476,7 +476,7 @@ A test program - if the grammar is in a string ``grammar``::
         "A.B-C_D",
         "aa",
         "name",
-        "name<=1"
+        "name<=1",
         "name>=3",
         "name>=3,<2",
         "name@http://foo.com",


### PR DESCRIPTION
Without this, running the test code and grammar result in an error like:

```
A -> ('A', [], [], None)
A.B-C_D -> ('A.B-C_D', [], [], None)
aa -> ('aa', [], [], None)
name -> ('name', [], [], None)
Traceback (most recent call last):
  File "test.py", line 164, in <module>
    parsed = compiled(test).specification()
  File "/tmp/user/1000/tmp.NdEyR4kt1E/env/lib/python3.8/site-packages/parsley.py", line 98, in invokeRule
    raise err
ometa.runtime.ParseError:
name<=1name>=3
            ^
Parse error at line 1, column 12: expected EOF. trail: [quoted_marker]
```