### PR TITLE
PEP 611: Spellchecking, minor copyedit

### DIFF
--- a/pep-0611.rst
+++ b/pep-0611.rst
@@ -35,11 +35,11 @@ It is unsafe as malicious or poorly generated code could cause values to exceed 
 
 For example, line numbers are represented by 32 bit values internally. 
 This is inefficient, given that modules almost never exceed a few thousand lines.
-Despite being inefficent, is is still vulnerable to overflow as
+Despite being inefficient, is is still vulnerable to overflow as
 it is easy for an attacker to created a module with billions of newline characters.
 
 Memory access is usually a limiting factor in the performance of modern CPUs.
-Better packing of data structures enhances locality and reduces memory bandwith,
+Better packing of data structures enhances locality and reduces memory bandwidth,
 at a modest increase in ALU usage (for shifting and masking).
 Being able to safely store important values in 20 bits would allow memory savings
 in several data structures including, but not limited to:
@@ -71,7 +71,7 @@ has significant advantages for ease of implementation and efficiency of virtual 
 If the limit is sufficiently large, there is no adverse effect on users of the language.
 
 By selecting a fixed but large limit for these values, 
-it is possible to have both safety and efficiency whilst causing no inconvience to human programmers
+it is possible to have both safety and efficiency whilst causing no inconvenience to human programmers
 and only very rare problems for code generators.
 
 One million
@@ -185,10 +185,10 @@ However, if a limit can be enforced without hurting performance, then it should 
 
 It is anticipated that CPython will enforce the limits as follows:
 
-* The number of source code lines in a module: 3.9 onwards.
-* The number of bytecode instructions in a code object: 3.9 onwards.
-* The sum of local variables and stack usage for a code object: 3.9 onwards.
-* The number of classes in a running interpreter: probably 3.10 onwards, maybe warning in 3.9.
+* The number of source code lines in a module: 3.9 onward.
+* The number of bytecode instructions in a code object: 3.9 onward.
+* The sum of local variables and stack usage for a code object: 3.9 onward.
+* The number of classes in a running interpreter: probably 3.10 onward, maybe warning in 3.9.
 
 Backwards Compatibility
 =======================
@@ -198,7 +198,7 @@ The author believes that to be highly unlikely and easily fixed by modifying the
 
 We would like to gain the benefit from the above limits for performance as soon as possible.
 To that end, CPython will start applying limits from 3.9 onward.
-To ease the transition and mimimize breakage, the initial limits would be much larger than one million
+To ease the transition and minimize breakage, the initial limits would be much larger than one million
 and will be gradually reduced to one million over several versions.
 
 The actual limits enforced by CPython will be:
@@ -212,7 +212,7 @@ The actual limits enforced by CPython will be:
  3.12 onward   1 million
 =============  ===============
 
-Given the rarity of code genenerators that would exceed the one million limits,
+Given the rarity of code generators that would exceed the one million limits,
 and the environments in which they are typically used, it seems reasonable
 to start issuing warnings in 3.9 if any limited quantity exceeds one million.
 
@@ -232,7 +232,7 @@ Special purpose implementations
 -------------------------------
 
 Special purpose implementations may use lower limits, as long as they are clearly documented.
-For example, Jython might need to use a lower class limit of fifty or sixty thousand becuase of JVM limits.
+For example, Jython might need to use a lower class limit of fifty or sixty thousand because of JVM limits.
 An implementation designed for embedded systems, for example MicroPython, might impose limits as low as a few thousand.
 
 Security Implications

--- a/pep-0611.rst
+++ b/pep-0611.rst
@@ -185,7 +185,7 @@ However, if a limit can be enforced without hurting performance, then it should 
 
 It is anticipated that CPython will enforce the limits as follows:
 
-* The number of source code lines in a module: 3.9 onward.
+* The number of source code lines in a module: version 3.9 onward.
 * The number of bytecode instructions in a code object: 3.9 onward.
 * The sum of local variables and stack usage for a code object: 3.9 onward.
 * The number of classes in a running interpreter: probably 3.10 onward, maybe warning in 3.9.
@@ -197,7 +197,7 @@ It is hypothetically possible that some machine generated code exceeds one or mo
 The author believes that to be highly unlikely and easily fixed by modifying the output stage of the code generator.
 
 We would like to gain the benefit from the above limits for performance as soon as possible.
-To that end, CPython will start applying limits from 3.9 onward.
+To that end, CPython will start applying limits from version 3.9 onward.
 To ease the transition and minimize breakage, the initial limits would be much larger than one million
 and will be gradually reduced to one million over several versions.
 


### PR DESCRIPTION
Ran the rest of PEP 611 through mechanical spellchecking (set to UK English), results applied.

In addition (in a separate commit), inserted "version" in two sections before a CPython version number, the first time it's mentioned without being identified as such. But I can drop (or separate out) that change if requested.