### PR TITLE
PEP-456: fix typo

### DIFF
--- a/pep-0456.txt
+++ b/pep-0456.txt
@@ -210,7 +210,7 @@ pure C89 platforms. The 32-bit variant is fully C89-compatible.
 Aumasson, Bernstein and Boßlet have shown [sip]_ [ocert-2012-001]_ that
 Murmur3 is not resilient against hash collision attacks. Therefore, Murmur3
 can no longer be considered as secure algorithm. It still may be an
-alternative is hash collision attacks are of no concern.
+alternative if hash collision attacks are of no concern.
 
 
 CityHash


### PR DESCRIPTION
The conditional statement likely meant "if", not "is"