### PR TITLE
PEP 567: typo in pseudocode of ContextVar.reset

### DIFF
--- a/pep-0567.rst
+++ b/pep-0567.rst
@@ -496,10 +496,10 @@ directly::
                     "Token was created in a different Context")
 
             if token._old_value is Token.MISSING:
-                ts.context._data = data.delete(token._var)
+                ts.context._data = ts.context._data.delete(token._var)
             else:
-                ts.context._data = data.set(token._var,
-                                            token._old_value)
+                ts.context._data = ts.context._data.set(token._var,
+                                                        token._old_value)
 
             token._used = True
 


### PR DESCRIPTION
I use the sketched Python code in the PyPy's 3.7 implementation of contextvars and noticed a typo in ContextVar.reset: the local name data does not exist. I think this is the correct way to express it (at least it passes tests for us). /cc @1st1