### PR TITLE
PEP 558: Fix mention of old locals() semantics

### DIFF
--- a/pep-0558.rst
+++ b/pep-0558.rst
@@ -302,7 +302,7 @@ internal attributes not exposed as part of the Python runtime API:
 * *frame*: the underlying frame that the snapshot is for
 
 For backwards compatibility, the stored snapshot will continue to be made
-available through the public ``PyEval_GetLocals()`` C API
+available through the public ``PyEval_GetLocals()`` C API.
 
 ``__getitem__`` operations on the proxy will read directly from the stored
 snapshot.

--- a/pep-0558.rst
+++ b/pep-0558.rst
@@ -289,17 +289,20 @@ defined ``locals()`` builtin, trace functions necessarily use the implementation
 dependent ``frame.f_locals`` interface, as a frame reference is what gets
 passed to hook implementations.
 
-Instead of being a direct reference to the dynamic snapshot returned by
-``locals()``, ``frame.f_locals`` will be updated to instead return a dedicated
-proxy type (implemented as a private subclass of the existing
-``types.MappingProxyType``) that has two internal attributes not exposed as
-part of either the Python or public C API:
+Instead of being a direct reference to the internal dynamic snapshot used to
+populate the independent snapshots returned by ``locals()``, ``frame.f_locals``
+will be updated to instead return a dedicated proxy type (implemented as a
+private subclass of the existing ``types.MappingProxyType``) that has two
+internal attributes not exposed as part of the Python runtime API:
 
 * *mapping*: an implicitly updated snapshot of the function local variables
   and closure references, as well as any arbitrary items that have been set via
   the mapping API, even if they don't have storage allocated for them on the
   underlying frame
 * *frame*: the underlying frame that the snapshot is for
+
+For backwards compatibility, the stored snapshot will continue to be made
+available through the public ``PyEval_GetLocals()`` C API
 
 ``__getitem__`` operations on the proxy will read directly from the stored
 snapshot.


### PR DESCRIPTION
When updating the PEP to specify independent snapshots for locals()
at function scope, I missed this reference to the old semantics
that returned a direct reference to the dynamic internal snapshot.
