### PR TITLE
PEP 458: Update Discussions-To header

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -12,7 +12,7 @@ Author: Trishank Karthik Kuppusamy <trishank@nyu.edu>,
         Justin Cappos <jcappos@nyu.edu>
 Sponsor: Nick Coghlan <ncoghlan@gmail.com>
 BDFL-Delegate: Donald Stufft <donald@stufft.io>
-Discussions-To: DistUtils mailing list <distutils-sig@python.org>
+Discussions-To: https://discuss.python.org/t/pep-458-secure-pypi-downloads-with-package-signing/2648
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst


### PR DESCRIPTION
Updated the Discussions-To header to reflect the current conversation happening at: https://discuss.python.org/t/pep-458-secure-pypi-downloads-with-package-signing/2648