### PR TITLE
PEP 458: Add non-goals section

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -108,6 +108,13 @@ of end-to-end signing.
 __ https://github.com/theupdateframework/tuf/tree/v0.11.1/tuf/client#updaterpy
 
 
+Non-goals
+=========
+
+This PEP does not eliminate any existing features from PyPI. In particular, it
+does not replace existing support for GPG signatures.
+
+
 PEP Status
 ==========
 

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -112,7 +112,9 @@ Non-goals
 =========
 
 This PEP does not eliminate any existing features from PyPI. In particular, it
-does not replace existing support for GPG signatures.
+does not replace existing support for GPG signatures. Developers can continue
+to upload detached GPG signatures along with distributions. In the future,
+PEP 480 may allow developers to directly sign TUF metadata using their GPG keys.
 
 
 PEP Status


### PR DESCRIPTION
Clarify that this PEP does not affect GPG support per the discussion on [discourse](https://discuss.python.org/t/pep-458-secure-pypi-downloads-with-package-signing/2648/66).