### PR TITLE
PEP 458: Allow compression of json metadata

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -729,7 +729,7 @@ this PEP.  However, due to the large number of delegations, compressed
 versions of all metadata SHOULD also be made available to clients via the
 existing Warehouse mechanisms for HTTP compression. In addition, the JSON
 metadata could be compressed before being sent to clients. The TUF reference
-implementation does not currently support verifying compressed JSON metadata,
+implementation does not currently support downloading compressed JSON metadata,
 but this could be added to reduce the metadata size.
 
 

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -727,7 +727,10 @@ open and well-known standard for data interchange, which is already supported by
 the TUF reference implementation, and therefore the recommended data format by
 this PEP.  However, due to the large number of delegations, compressed
 versions of all metadata SHOULD also be made available to clients via the
-existing Warehouse mechanisms for HTTP compression.
+existing Warehouse mechanisms for HTTP compression. In addition, the JSON
+metadata could be compressed before being sent to clients. The TUF reference
+implementation does not currently support verifying compressed JSON metadata,
+but this could be added to reduce the metadata size.
 
 
 PyPI and Key Requirements


### PR DESCRIPTION
Clarify that json metadata can be optionally compressed on the wire to reduce the metadata size.

cc @ncoghlan @trishankatdatadog 