### PR TITLE
Updates to PEP 613 Explicit Type Aliases

### DIFF
--- a/pep-0613.rst
+++ b/pep-0613.rst
@@ -51,9 +51,10 @@ Forward References:
   def foo() -> MyType: ...
 
 This code snippet should not error so long as :code:`ClassName` is defined
-later on. However, a type checker is forced to throw spurious errors that
-(1) :code:`MyType` is an unannotated global string, and (2) :code:`MyType`
-is not a valid type.
+later on. However, a type checker is forced to assume that MyType is a value
+assignment rather than a type alias, and therefore may throw spurious errors
+that (1) :code:`MyType` is an unannotated global string, and (2) :code:`MyType`
+cannot be used as a return annotation because it is not a valid type.
 
 ::
 
@@ -101,10 +102,11 @@ Scope Restrictions:
     x = ClassName
 
 The outer :code:`x` is a valid type alias, but type checkers must error if the
-inner :code:`x` is ever used as a type. This is confusing because the alias
-declaration rule is not explicit, and the error is not thrown on the location
-of the inner type alias declaration but rather on every one of its subsequent
-use cases.
+inner :code:`x` is ever used as a type because type aliases cannot be defined
+inside a nested scope.
+This is confusing because the alias declaration rule is not explicit, and because
+a type error will not be thrown on the location of the inner type alias declaration
+but rather on every one of its subsequent use cases.
 
 ::
 

--- a/pep-0613.rst
+++ b/pep-0613.rst
@@ -198,14 +198,6 @@ appealing because it still sticks with the :code:`MyType = int` assignment
 syntax, and adds some information for the type checker purely as an annotation.
 
 
-Open Issues
-===========
-
-
-The current implementation utilizes the :code:`TypeAlias` already defined in :code:`typing.pyi`,
-but for conciseness there are suggestions to standardize this to a new class, :code:`typing.Alias`.
-
-
 Copyright
 =========
 


### PR DESCRIPTION
Incorporating some feedback: https://github.com/python/peps/pull/1278

as well as closing the open issue listed previously.
