### PR TITLE
PEP 458: use "OpenPGP" instead of "GPG"

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -112,9 +112,9 @@ Non-goals
 =========
 
 This PEP does not eliminate any existing features from PyPI. In particular, it
-does not replace existing support for GPG signatures. Developers can continue
-to upload detached GPG signatures along with distributions. In the future,
-PEP 480 may allow developers to directly sign TUF metadata using their GPG keys.
+does not replace existing support for OpenPGP signatures. Developers can continue
+to upload detached OpenPGP signatures along with distributions. In the future,
+PEP 480 may allow developers to directly sign TUF metadata using their OpenPGP keys.
 
 
 PEP Status


### PR DESCRIPTION
* PEP 458: use "OpenPGP" instead of "GPG".  The signature format is OpenPGP.  Other
OpenPGP implementations exist aside from gpg, the OpenPGP tool from the GnuPG project.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
