### PR TITLE
PEP 612: Fixed bad TypeVar definition

### DIFF
--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -87,7 +87,7 @@ the decorator and the parameter enforcement of the decorated function.
    from typing import Awaitable, Callable, ParameterSpecification, TypeVar
 
    Ps = ParameterSpecification("Ps")
-   R = TypeVar("TReturn")
+   R = TypeVar("R")
 
    def add_logging(f: Callable[Ps, R]) -> Callable[Ps, Awaitable[R]]:
        async def inner(*args: Ps.args, **kwargs: Ps.kwargs) -> R:


### PR DESCRIPTION
Identifier must match TypeVar name


