### PR TITLE
PEP 585: updates green-lighted by Lukasz

### DIFF
--- a/pep-0585.rst
+++ b/pep-0585.rst
@@ -112,6 +112,9 @@ Python 3.9, the following collections become generic using
 * ``collections.abc.ValuesView``
 * ``contextlib.AbstractContextManager``  # typing.ContextManager
 * ``contextlib.AbstractAsyncContextManager``  # typing.AsyncContextManager
+* ``re.Pattern``  # typing.Pattern, typing.re.Pattern
+* ``re.Match``  # typing.Match, typing.re.Match
+* ``io.IO``  # typing.IO, typing.io.IO
 
 Importing those from ``typing`` is deprecated.  Due to PEP 563 and the
 intention to minimize the runtime impact of typing, this deprecation
@@ -150,10 +153,13 @@ exceptions:
 * the ``__repr__`` shows the parametrized type;
 * the ``__origin__`` attribute points at the non-parametrized
   generic class;
-* the ``__parameters__`` attribute is a tuple (possibly of length
+* the ``__args__`` attribute is a tuple (possibly of length
   1) of generic types passed to the original ``__class_getitem__``;
-* the ``__class_getitem__`` raises an exception to disallow mistakes
-  like ``dict[str][str]``.
+* the ``__parameters__`` attribute is a lazily computed tuple
+  (possibly empty) of unique type variables found in ``__args__``;
+* the ``__getitem__`` raises an exception to disallow mistakes
+  like ``dict[str][str]``.  However it allows e.g. ``dict[str, T][int]``
+  and in that case returns ``dict[str, int]``.
 
 This design means that it is possible to create instances of
 parametrized collections, like::
@@ -165,7 +171,11 @@ parametrized collections, like::
     >>> list is list[str]
     False
     >>> list == list[str]
+    False
+    >>> list[str] == list[str]
     True
+    >>> list[str] == list[int]
+    False
 
 Objects created with bare types and parametrized types are exactly the
 same.  The generic parameters are not preserved in instances created
@@ -181,6 +191,9 @@ a parametrized type.  This provides symmetry between::
 and::
 
     l = list[str]()
+
+For accessing the proxy type from Python code, it will be exported
+from the ``types`` module as ``GenericAlias``.
 
 
 Forward compatibility
@@ -261,7 +274,7 @@ Disallowing instantiation of parametrized types
 -----------------------------------------------
 
 Given that the proxy type which preserves ``__origin__`` and
-``__parameters__`` is mostly useful for runtime introspection purposes,
+``__args__`` is mostly useful for runtime introspection purposes,
 we might have disallowed instantiation of parametrized types.
 
 In fact, forbidding instantiation of parametrized types is what the

--- a/pep-0585.rst
+++ b/pep-0585.rst
@@ -114,7 +114,6 @@ Python 3.9, the following collections become generic using
 * ``contextlib.AbstractAsyncContextManager``  # typing.AsyncContextManager
 * ``re.Pattern``  # typing.Pattern, typing.re.Pattern
 * ``re.Match``  # typing.Match, typing.re.Match
-* ``io.IO``  # typing.IO, typing.io.IO
 
 Importing those from ``typing`` is deprecated.  Due to PEP 563 and the
 intention to minimize the runtime impact of typing, this deprecation

--- a/pep-0585.rst
+++ b/pep-0585.rst
@@ -195,6 +195,9 @@ and::
 For accessing the proxy type from Python code, it will be exported
 from the ``types`` module as ``GenericAlias``.
 
+Pickling or (shallow- or deep-) copying a ``GenericAlias`` instance
+will preserve the type, origin, attributes and parameters.
+
 
 Forward compatibility
 ---------------------

--- a/pep-0585.rst
+++ b/pep-0585.rst
@@ -202,6 +202,13 @@ Forward compatibility
 Future standard collections must implement the same behavior.
 
 
+Reference implementation
+========================
+
+A proof-of-concept or prototype `implementation
+<https://bugs.python.org/issue39481>`__ exists.
+
+
 Rejected alternatives
 =====================
 


### PR DESCRIPTION
- Rename `__parameters__` to `__args__`, for typing.py compatibility
- Genericize, re.{Pattern,Match} ~and io.IO~
- list != list[int], but list[int] == list[int] (and list[str] != list[int])
- Add a lazy `__parameters__` that contains the unique type vars in `__args__` (also for typing.py compatibility)
- make dict[str][str] fail, but dict[T, str][int] return dict[int, str]
- expose proxy type as types.GenericAlias
- pickle and copy should work
- link to implementation