### PR TITLE
PEP 3132: Fix example description

### DIFF
--- a/pep-3132.txt
+++ b/pep-3132.txt
@@ -66,7 +66,7 @@ that are not assigned to any of the mandatory expressions, or an
 empty list if there are no such items.
 
 For example, if ``seq`` is a slicable sequence, all the following
-assignments are equivalent if ``seq`` has at least three elements::
+assignments are equivalent if ``seq`` has at least two elements::
 
     a, b, c = seq[0], list(seq[1:-1]), seq[-1]
     a, *b, c = seq


### PR DESCRIPTION
With two elements, the starred middle expression just is an empty list.
