### PR TITLE
PEP 581: Fix switched reference links

### DIFF
--- a/pep-0581.rst
+++ b/pep-0581.rst
@@ -274,11 +274,11 @@ References
 .. [#] An error has occurred
    (https://github.com/python/bugs.python.org/issues/26)
 
-.. [#] s/n ratio -- Python -- Zulip
-   (https://python.zulipchat.com/#narrow/stream/130206-pep581/topic/s.2Fn.20ratio)
-
 .. [#] Backup GitHub information
    (https://github.com/python/core-workflow/issues/20#issuecomment-396709762)
+
+.. [#] s/n ratio -- Python -- Zulip
+   (https://python.zulipchat.com/#narrow/stream/130206-pep581/topic/s.2Fn.20ratio)
 
 .. [#] PEP 581 discussion at Python Core Sprint 2018
    (https://mariatta.ca/core-sprint-2018-part-2.html)


### PR DESCRIPTION
In the "Downsides of GitHub" section, the references for "backing up GitHub" and "increasing triage effort" were switched. Now they are correct.

On the PEPs website [here](https://www.python.org/dev/peps/pep-0581/) these are 15 and 16.