### PR TITLE
PEP 585: Explain the choice of GenericAlias over GenericType

### DIFF
--- a/pep-0585.rst
+++ b/pep-0585.rst
@@ -339,6 +339,14 @@ been useful, however implementing the type checker within Python that
 would deal with complex types, nested type checking, type variables,
 string forward references, and so on is out of scope for this PEP.
 
+Naming the type ``GenericType`` instead of ``GenericAlias``
+-----------------------------------------------------------
+
+We considered a different name for this type, but decided
+``GenericAlias`` is better -- these aren't real types, they are
+aliases for the corresponding container type with some extra metadata
+attached.
+
 
 Note on the initial draft
 =========================


### PR DESCRIPTION
A brief summary of @ncoghlan's explanation on python-dev.