### PR TITLE
PEP 345: correct the Changed fields in "Summary of Differences From PEP 314"

### DIFF
--- a/pep-0345.txt
+++ b/pep-0345.txt
@@ -512,8 +512,8 @@ Summary of Differences From PEP 314
 
 * Changed fields:
 
-  - Platform
-  - Author
+  - Platform (syntax change)
+  - Author-email (change to optional field)
 
 * Added fields:
 


### PR DESCRIPTION
2 improvements:

1. According to document in both [PEP 314](https://www.python.org/dev/peps/pep-0314/#author-optional) and [PEP 345](https://www.python.org/dev/peps/pep-0345/#author-optional), there's no difference in **Author**, but a change in **Author-email** to make it optional. This change also follows the [11 years old logic in Distutils](https://github.com/python/cpython/blame/9f9dac0a4e58d5c72aa3b644701cb155c009cb2c/Lib/distutils/command/check.py#L100-L103).

2. To make the changed fields clear as **Deprecated fields**, I append the change description in bracket.