### PR TITLE
PEP 458: Fix figure reference and typo

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -625,7 +625,7 @@ implementation (Nov 7 2019), summarized in Tables 2-3, PyPI SHOULD
 split all targets in the *bins* role by delegating them to 16,384
 *bin-n* roles (see C10 in Table 2). Each *bin-n* role would sign
 for the PyPI targets whose SHA2-512 hashes fall into that bin
-(see and Figure 2 and `Consistent Snapshots`_). It was found
+(see Figure 1 and `Consistent Snapshots`_). It was found
 that this number of bins would result in a 5-9% metadata overhead
 (relative to the average size of downloaded distribution files; see V13 and
 V15 in Table 3) for returning users, and a 69% overhead for new


### PR DESCRIPTION
In secure-systems-lab/peps#73 Figure 2 became Figure 1. This change fixes a missed reference update. It also removes a stray "and".

Note: The live [PEP 458](https://www.python.org/dev/peps/pep-0458/) page still references the [old `pep-0458-1.png`](https://s3.dualstack.us-east-2.amazonaws.com/pythondotorg-assets/media/dev/peps/pep-0458/pep-0458-1.png), although this repo has the  [correct `pep-0458-1.png`](https://github.com/python/peps/blob/master/pep-0458-1.png).  This is due to an issue in the pep generation script, for which I have provided a fix in https://github.com/python/pythondotorg/pull/1556. It would be nice to integrate the fix. Or, until then, just replace the file on the server.
