### PR TITLE
PEP 534: Mark as Deferred

### DIFF
--- a/pep-0534.txt
+++ b/pep-0534.txt
@@ -5,11 +5,10 @@ Last-Modified: $Date$
 Author: Tomáš Orsava <tomas.n@orsava.cz>,
         Petr Viktorin <encukou@gmail.com>,
         Nick Coghlan <ncoghlan@gmail.com>
-Status: Draft
+Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 5-Sep-2016
-Python-Version: 3.9
 Post-History:
 
 
@@ -24,6 +23,14 @@ modules.
 This PEP proposes a mechanism for identifying expected standard library modules
 and providing more informative error messages to users when attempts to import
 standard library modules fail.
+
+
+PEP Deferral
+============
+
+The PEP authors aren't actively working on this PEP, so if this is an idea
+that you're interested in pursuing, please get in touch! (e.g. by posting
+to the python-dev mailing list).
 
 
 Motivation

--- a/pep-0534.txt
+++ b/pep-0534.txt
@@ -28,9 +28,13 @@ standard library modules fail.
 PEP Deferral
 ============
 
-The PEP authors aren't actively working on this PEP, so if this is an idea
-that you're interested in pursuing, please get in touch! (e.g. by posting
-to the python-dev mailing list).
+The PEP authors aren't actively working on this PEP, so if improving these
+error messages is an idea that you're interested in pursuing, please get in
+touch! (e.g. by posting to the python-dev mailing list).
+
+The key piece of open work is determining how to get the autoconf and Visual
+Studio build processes to populate the sysconfig metadata file with the lists
+of expected and optional standard library modules.
 
 
 Motivation


### PR DESCRIPTION
None of us are currently working on this PEP, so remove the Python-Version target, mark it as Deferred, and explain the key work that remains to be done.