### PR TITLE
PEP 499: Mark as deferred until 3.10

### DIFF
--- a/pep-0499.txt
+++ b/pep-0499.txt
@@ -4,11 +4,20 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Cameron Simpson <cs@cskk.id.au>, Chris Angelico <rosuav@gmail.com>, Joseph Jevnik <joejev@gmail.com>
 BDFL-Delegate: Nick Coghlan
-Status: Draft
+Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 07-Aug-2015
-Python-Version: 3.8
+Python-Version: 3.10
+
+
+PEP Deferral
+============
+
+The implementation of this PEP isn't currently expected to be ready for the
+Python 3.9 feature freeze in April 2020, so it has been deferred 12 months to
+Python 3.10.
+
 
 Abstract
 ========


### PR DESCRIPTION
This is pretty close to acceptance, but requires some additional work as described in https://bugs.python.org/issue36375#msg356499.

If that work is expected to be done in the next few weeks, we can reject this PR, and update the PEP instead. Otherwise, let's defer until 3.10.