### PR TITLE
PEP 3154: fix typo

### DIFF
--- a/pep-3154.txt
+++ b/pep-3154.txt
@@ -98,7 +98,7 @@ for newlines in the pickle stream.  It also complicates the implementation
 of binary framing.
 
 Protocol 4 forbids use of the GLOBAL opcode and replaces it with
-GLOBAL_STACK, a new opcode which takes its operand from the stack.
+STACK_GLOBAL, a new opcode which takes its operand from the stack.
 
 Serializing more "lookupable" objects
 -------------------------------------
@@ -109,7 +109,7 @@ is a common request. Actually, third-party support for some of them, such
 as bound methods, is implemented in the multiprocessing module [5]_.
 
 The ``__qualname__`` attribute from :pep:`3155` makes it possible to
-lookup many more objects by name.  Making the GLOBAL_STACK opcode accept
+lookup many more objects by name.  Making the STACK_GLOBAL opcode accept
 dot-separated names would allow the standard pickle implementation to
 support all those kinds of objects.
 


### PR DESCRIPTION
Hi

possible typo in pep 3154. GLOBAL_STACK -> STACK_GLOBAL ?
