### PR TITLE
PEP 616: Python-implementation clarity

### DIFF
--- a/pep-0616.rst
+++ b/pep-0616.rst
@@ -46,64 +46,58 @@ Specification
 The builtin ``str`` class will gain two new methods with roughly the
 following behavior::
 
-    def cutprefix(self, prefix, /):
-        if not isinstance(self, str):
-            raise TypeError()
-        self_str = str(self)
+    def cutprefix(self, prefix):
+        if isinstance(prefix, str):
+            if self.startswith(prefix):
+                return self[len(prefix):]
+            else:
+                return self
 
         if isinstance(prefix, tuple):
-            for option in tuple(prefix):
+            for option in prefix:
                 if not isinstance(option, str):
-                    raise TypeError()
-                option_str = str(option)
+                    raise TypeError(
+                        f"tuple for cutprefix must only contain str,"
+                        f" not {type(option).__name__}"
+                    )
 
-                if self_str.startswith(option_str):
-                    return self_str[len(option_str):]
+                if self.startswith(option):
+                    return self[len(option):]
 
-            return self_str[:]
+            return self
 
-        if not isinstance(prefix, str):
-            raise TypeError()
-
-        prefix_str = str(prefix)
-
-        if self_str.startswith(prefix_str):
-            return self_str[len(prefix_str):]
-        else:
-            return self_str[:]
+        raise TypeError(
+            f"cutprefix first arg must be str or a tuple of str,"
+            f" not {type(prefix).__name__}"
+        )
 
 
-    def cutsuffix(self, suffix, /):
-        if not isinstance(self, str):
-            raise TypeError()
-        self_str = str(self)
+    def cutsuffix(self, suffix):
+        if isinstance(suffix, str):
+            if self.endswith(suffix):
+                # Here, len(self)-len(suffix) is used for the stop instead of
+                # simply len(suffix) to account for an empty string suffix.
+                return self[:len(self)-len(suffix)]
+            else:
+                return self
 
         if isinstance(suffix, tuple):
-            for option in tuple(suffix):
+            for option in suffix:
                 if not isinstance(option, str):
-                    raise TypeError()
-                option_str = str(option)
+                    raise TypeError(
+                        f"tuple for cutsuffix must only contain str,"
+                        f" not {type(option).__name__}"
+                    )
 
-                if not option_str:
-                    return self_str[:]
-                if self_str.endswith(option_str):
-                    return self_str[:-len(option_str)]
+                if self.endswith(option):
+                    return self[:len(self)-len(option)]
 
-            return self_str[:]
+            return self
 
-        if not isinstance(suffix, str):
-            raise TypeError()
-        suffix_str = str(suffix)
-
-        if suffix_str and self_str.startswith(suffix_str):
-            return self_str[:-len(suffix_str)]
-        else:
-            return self_str[:]
-
-
-Note that without the check for the truthyness of suffixes,
-``s.cutsuffix('')`` would be mishandled and always return the empty
-string due to the unintended evaluation of ``self[:-0]``.
+        raise TypeError(
+            f"cutsuffix first arg must be str or a tuple of str,"
+            f" not {type(suffix).__name__}"
+        )
 
 Methods with the corresponding semantics will be added to the builtin
 ``bytes`` and ``bytearray`` objects.  If ``b`` is either a ``bytes``
@@ -111,23 +105,6 @@ or ``bytearray`` object, then ``b.cutsuffix()`` and ``b.cutprefix()``
 will accept any bytes-like object or tuple of bytes-like objects as an
 argument.  The one-at-a-time checking of types matches the implementation
 of ``startswith()`` and ``endswith()`` methods.
-
-The ``self_str[:]`` copying behavior in the code ensures that the
-``bytearray`` methods do not return ``self``, but it does not preclude
-the ``str`` and ``bytes`` methods from returning ``self``.  Because
-``str`` and ``bytes`` instances are immutable, the  ``cutprefix()``
-and ``cutsuffix()`` methods on these objects may (but are not
-required to) make the optimization of returning ``self`` if
-``type(self) is str`` (``type(self) is bytes`` respectively)
-and the given affixes are not found, or are empty.  As such, the
-following behavior is considered a CPython implementation detail, and
-is not guaranteed by this specification::
-
-    >>> x = 'foobar' * 10**6
-    >>> x.cutprefix('baz') is x is x.cutsuffix('baz')
-    True
-    >>> x.cutprefix('') is x is x.cutsuffix('')
-    True
 
 To test whether any affixes were removed during the call, users
 should use the constant-time behavior of comparing the lengths of


### PR DESCRIPTION
In attempt to get out ahead of the `str.__getitem__(self, slice(str.__len__(option), None))` version that was posted ~4 hours ago, this:

- Removes all of the unnecessary copying, casting.  This does two things, (1) it allows for non-builtin string subclasses to work provided they support `__getitem__`, (2) it obviates the need to talk about potentially returning `self` later in the doc.
- Tweaks handling of empty string (without affecting the overall result).  And also removes the (now) unnecessary discussion about it.
- Adds TypeError messages (based on those of `.startswith`, but they may just be unnecessary clutter)

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
