### PR TITLE
PEP 483: Remove reference to implicitly Optional parameters

### DIFF
--- a/pep-0483.txt
+++ b/pep-0483.txt
@@ -738,11 +738,6 @@ are still controversial or not fully specified.)
     class MyComparable:
         def compare(self, other: 'MyComparable') -> int: ...
 
-- If a default of ``None`` is specified, the type is implicitly
-  ``Optional``, e.g.::
-
-    def get(key: KT, default: VT = None) -> VT: ...
-
 - Type variables can be declared in unconstrained, constrained,
   or bounded form. The variance of a generic type can also
   be indicated using a type variable declared with special keyword


### PR DESCRIPTION
This shorthand is no longer recommended - see #689 which changed it in PEP 484.