### PR TITLE
PEP 615: Resolve "using datetime" and add rationale to updates section

### DIFF
--- a/pep-0615.rst
+++ b/pep-0615.rst
@@ -170,10 +170,19 @@ added to the cache.
 Behavior during data updates
 ############################
 
-If a source of time zone data is updated during a run of the interpreter, it
-will not invalidate any caches or modify any existing ``ZoneInfo`` objects, but
-newly constructed ``ZoneInfo`` objects should come from the updated data
-source.
+It is important that a given ``ZoneInfo`` object's behavior not change during
+its lifetime, because a ``datetime``'s ``utcoffset()`` method is used in both
+its equality and hash calculations, and if the result were to change during the
+``datetime``'s lifetime, it could break the invariant for all hashable objects
+[#hashable_def]_ [#hashes_equality]_  that if ``x == y``, it must also be true
+that ``hash(x) == hash(y)`` [c]_ .
+
+Considering both the preservation of ``datetime``'s invariants and the
+primary constructor's contract to always return the same object when called
+with identical arguments, if a source of time zone data is updated during a run
+of the interpreter, it must not invalidate any caches or modify any
+existing ``ZoneInfo`` objects. Newly constructed ``ZoneInfo`` objects, however,
+should come from the updated data source.
 
 This means that the point at which a ``ZoneInfo`` file is updated depends
 primarily on the semantics of the caching behavior. The only guaranteed way to
@@ -778,6 +787,11 @@ Footnotes
     identical objects may be violated if the user deliberately clears the time
     zone cache.
 
+.. [c]
+    The hash value for a given ``datetime`` is cached on first calculation, so
+    we do not need to worry about the possibly more serious issue that a given
+    ``datetime`` object's hash would change during its lifetime.
+
 References
 ==========
 
@@ -801,6 +815,14 @@ References
 .. [#fastest-footgun]
     Paul Ganssle: "pytz: The Fastest Footgun in the West" (Published 19 March
     2018) https://blog.ganssle.io/articles/2018/03/pytz-fastest-footgun.html
+
+.. [#hashable_def]
+    Python documentation: "Glossary" (Version 3.8.2)
+    https://docs.python.org/3/glossary.html#term-hashable
+
+.. [#hashes_equality]
+    Hynek Schlawack: "Python Hashes and Equality" (Published 20 November 2017)
+    https://hynek.me/articles/hashes-and-equality/
 
 .. [#cldr]
     CLDR: Unicode Common Locale Data Repository

--- a/pep-0615.rst
+++ b/pep-0615.rst
@@ -678,17 +678,13 @@ There are several other schemes that were considered and rejected:
    these special values as necessary in a backwards-compatible way in future
    versions of the library.
 
-Open Issues
-===========
-
 Using the ``datetime`` module
 -----------------------------
 
 One possible idea would be to add ``ZoneInfo`` to the ``datetime`` module,
-rather than giving it its own separate module. In the current version of the
-PEP, this has been resolved in favor of using a separate module, for the
-reasons detailed below, but the use of a nested submodule ``datetime.zoneinfo``
-is also under consideration.
+rather than giving it its own separate module. This PEP favors the use of
+a separate ``zoneinfo`` module,though a nested ``datetime.zoneinfo`` module
+was also under consideration.
 
 Arguments against putting ``ZoneInfo`` directly into ``datetime``
 #################################################################
@@ -764,10 +760,9 @@ Arguments against this:
    standpoint, and it would preclude the version of nesting where end users are
    required to explicitly import ``datetime.zoneinfo``.
 
-This PEP currently takes the position that on balance it would be best to use a
-separate top-level ``zoneinfo`` module because the benefits of nesting are not
-so great that it overwhelms the practical implementation concerns, but this
-still requires some discussion.
+This PEP takes the position that on balance it would be best to use a separate
+top-level ``zoneinfo`` module because the benefits of nesting are not so great
+that it overwhelms the practical implementation concerns.
 
 Footnotes
 =========

--- a/pep-0615.rst
+++ b/pep-0615.rst
@@ -7,7 +7,7 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 2020-02-22
 Python-Version: 3.9
-Post-History: 2020-02-25
+Post-History: 2020-02-25, 2020-03-29
 Replaces: 431
 
 


### PR DESCRIPTION
No one has really commented on the section about using the datetime module, so I think we can go ahead and move that to "Rejected ideas".

I've also clarified the rationale for not allowing the `ZoneInfo` object's behavior to change.