### PR TITLE
PEP 007: Add C99 Flexible Array Member to the required feature list.

### DIFF
--- a/pep-0007.txt
+++ b/pep-0007.txt
@@ -46,6 +46,8 @@ C dialect
   - intermingled declarations
   - booleans
   - C++-style line comments
+  - Flexible array member ``char spam[];`` syntax for the last member
+    in variable length structs (Python 3.9 or later).
 
   Future C99 features may be added to this list in the future
   depending on compiler support (mostly significantly MSVC).


### PR DESCRIPTION
PEP 007: Add C99 Flexible Array Member to the required feature list.

 https://en.wikipedia.org/wiki/Flexible_array_member

Required to fix undefined C behavior.
 https://bugs.python.org/issue40120

See also https://github.com/python/cpython/pull/19232 which will use this.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
