### PR TITLE
PEP 384: Update PyType_Spec struct per bpo-15140

### DIFF
--- a/pep-0384.txt
+++ b/pep-0384.txt
@@ -142,10 +142,9 @@ are available::
 
   typedef struct{
     const char* name;
-    const char* doc;
     int basicsize;
     int itemsize;
-    int flags;
+    unsigned int flags;
     PyType_Slot *slots; /* terminated by slot==0. */
   } PyType_Spec;
 


### PR DESCRIPTION
https://bugs.python.org/issue15140

In PEP 384, the PyType_Spec struct has  "const char *doc" and "unsigned int flags" these is not present in the implementation (Include/object.h).
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
