### PR TITLE
Fix typos and other minor edits in PEP 617.

### DIFF
--- a/pep-0617.rst
+++ b/pep-0617.rst
@@ -563,11 +563,13 @@ inside curly-braces, which specifies the return value of the alternative:::
        | second_alt1 second_alt2 { second_alt1 }
 
 If the action is omitted and C code is being generated, then there are two
-different possibilities: 1. If there’s a single name in the alternative, this gets
-returned. 2. If not, a dummy name object gets returned (this case should be avoided).
+different possibilities:
 
-If Python code is being generated, then a list with all the parsed
-expressions get returned if no action is specified (this is meant for debugging).
+1. If there’s a single name in the alternative, this gets returned.
+2. If not, a dummy name object gets returned (this case should be avoided).
+
+If the action is omitted and Python code is being generated, then a list
+with all the parsed expressions get returned (this is meant for debugging).
 
 As an illustrative example this simple grammar file allows to directly generate a full
 parser that can parse simple aritmetic expressions and that returns a valid Python AST:
@@ -593,10 +595,10 @@ parser that can parse simple aritmetic expressions and that returns a valid Pyth
                   | s=STRING { s }
                   )
 
-here ``EXTRA`` is a macro that expands to ``start_lineno, start_col_offset,
-end_lineno, end_col_offset, p->arena``, being the values for this variables
-automatically injected by the parser; ``p`` points to an object
-that holds on to all state for the parser.
+Here ``EXTRA`` is a macro that expands to ``start_lineno, start_col_offset,
+end_lineno, end_col_offset, p->arena``, those being variables automatically
+injected by the parser; ``p`` points to an object that holds on to all state
+for the parser.
 
 ==============
 Migration plan

--- a/pep-0617.rst
+++ b/pep-0617.rst
@@ -555,7 +555,7 @@ maintainable. This AST generation process is supported by the use of some helper
 functions that factor out common AST object manipulations and some other required
 operations that are not directly related to the grammar.
 
-To indicate these actions each alternative can be followed by a the action code
+To indicate these actions each alternative can be followed by the action code
 inside curly-braces, which specifies the return value of the alternative:::
 
    rule_name[return_type]:


### PR DESCRIPTION
Fix minor typo.

Fix what appears to be meant as a numbered list that was reflowed incorrectly.

Clarify a slightly awkward sentence about the EXTRA C macro.
