### PR TITLE
Make `from __future__ import annotations` the default in Python 3.10

### DIFF
--- a/pep-0563.rst
+++ b/pep-0563.rst
@@ -280,13 +280,7 @@ Deprecation policy
 Starting with Python 3.7, a ``__future__`` import is required to use the
 described functionality.  No warnings are raised.
 
-In Python 3.8 a ``PendingDeprecationWarning`` is raised by the
-compiler in the presence of type annotations in modules without the
-``__future__`` import.
-
-Starting with Python 3.9 the warning becomes a ``DeprecationWarning``.
-
-In Python 4.0 this will become the default behavior.  Use of annotations
+In Python 3.10 this will become the default behavior.  Use of annotations
 incompatible with this PEP is no longer supported.
 
 


### PR DESCRIPTION
The Language Summit discussion suggests this should be flipped either in Python 3.9 or in Python 3.10. An informal poll ran at the event with 33 votes has shown that 65% would like to see the change in 3.9, 29% in 3.10, 3% in 4.0, and 3% "never" :-)

This PR is open to gather feedback from those concerned.

Side note: The previously documented policy of raising deprecation warnings if there's any annotation was unrealistic. It would raise huge numbers of warnings, a lot of them in third-party code that the receiver of the warning can do nothing about. That part we need to remove from the document anyway.