### PR TITLE
PEP 617: Move metagrammar after explanation of operators

### DIFF
--- a/pep-0617.rst
+++ b/pep-0617.rst
@@ -311,98 +311,6 @@ the rule: ::
 If the return type is omitted, then a ``void *`` is returned in C and an
 ``Any`` in Python.
 
-The full meta-grammar for the grammars supported by the PEG generator is:
-
-::
-
-    start[Grammar]: grammar ENDMARKER { grammar }
-
-    grammar[Grammar]:
-        | metas rules { Grammar(rules, metas) }
-        | rules { Grammar(rules, []) }
-
-    metas[MetaList]:
-        | meta metas { [meta] + metas }
-        | meta { [meta] }
-
-    meta[MetaTuple]:
-        | "@" NAME NEWLINE { (name.string, None) }
-        | "@" a=NAME b=NAME NEWLINE { (a.string, b.string) }
-        | "@" NAME STRING NEWLINE { (name.string, literal_eval(string.string)) }
-
-    rules[RuleList]:
-        | rule rules { [rule] + rules }
-        | rule { [rule] }
-
-    rule[Rule]:
-        | rulename ":" alts NEWLINE INDENT more_alts DEDENT {
-              Rule(rulename[0], rulename[1], Rhs(alts.alts + more_alts.alts)) }
-        | rulename ":" NEWLINE INDENT more_alts DEDENT { Rule(rulename[0], rulename[1], more_alts) }
-        | rulename ":" alts NEWLINE { Rule(rulename[0], rulename[1], alts) }
-
-    rulename[RuleName]:
-        | NAME '[' type=NAME '*' ']' {(name.string, type.string+"*")}
-        | NAME '[' type=NAME ']' {(name.string, type.string)}
-        | NAME {(name.string, None)}
-
-    alts[Rhs]:
-        | alt "|" alts { Rhs([alt] + alts.alts)}
-        | alt { Rhs([alt]) }
-
-    more_alts[Rhs]:
-        | "|" alts NEWLINE more_alts { Rhs(alts.alts + more_alts.alts) }
-        | "|" alts NEWLINE { Rhs(alts.alts) }
-
-    alt[Alt]:
-        | items '$' action { Alt(items + [NamedItem(None, NameLeaf('ENDMARKER'))], action=action) }
-        | items '$' { Alt(items + [NamedItem(None, NameLeaf('ENDMARKER'))], action=None) }
-        | items action { Alt(items, action=action) }
-        | items { Alt(items, action=None) }
-
-    items[NamedItemList]:
-        | named_item items { [named_item] + items }
-        | named_item { [named_item] }
-
-    named_item[NamedItem]:
-        | NAME '=' ~ item {NamedItem(name.string, item)}
-        | item {NamedItem(None, item)}
-        | it=lookahead {NamedItem(None, it)}
-
-    lookahead[LookaheadOrCut]:
-        | '&' ~ atom {PositiveLookahead(atom)}
-        | '!' ~ atom {NegativeLookahead(atom)}
-        | '~' {Cut()}
-
-    item[Item]:
-        | '[' ~ alts ']' {Opt(alts)}
-        |  atom '?' {Opt(atom)}
-        |  atom '*' {Repeat0(atom)}
-        |  atom '+' {Repeat1(atom)}
-        |  sep=atom '.' node=atom '+' {Gather(sep, node)}
-        |  atom {atom}
-
-    atom[Plain]:
-        | '(' ~ alts ')' {Group(alts)}
-        | NAME {NameLeaf(name.string) }
-        | STRING {StringLeaf(string.string)}
-
-    # Mini-grammar for the actions
-
-    action[str]: "{" ~ target_atoms "}" { target_atoms }
-
-    target_atoms[str]:
-        | target_atom target_atoms { target_atom + " " + target_atoms }
-        | target_atom { target_atom }
-
-    target_atom[str]:
-        | "{" ~ target_atoms "}" { "{" + target_atoms + "}" }
-        | NAME { name.string }
-        | NUMBER { number.string }
-        | STRING { string.string }
-        | "?" { "?" }
-        | ":" { ":" }
-
-
 Grammar Expressions
 ~~~~~~~~~~~~~~~~~~~
 
@@ -585,6 +493,97 @@ different possibilities:
 
 If the action is omitted and Python code is being generated, then a list
 with all the parsed expressions get returned (this is meant for debugging).
+
+The full meta-grammar for the grammars supported by the PEG generator is:
+
+::
+
+    start[Grammar]: grammar ENDMARKER { grammar }
+
+    grammar[Grammar]:
+        | metas rules { Grammar(rules, metas) }
+        | rules { Grammar(rules, []) }
+
+    metas[MetaList]:
+        | meta metas { [meta] + metas }
+        | meta { [meta] }
+
+    meta[MetaTuple]:
+        | "@" NAME NEWLINE { (name.string, None) }
+        | "@" a=NAME b=NAME NEWLINE { (a.string, b.string) }
+        | "@" NAME STRING NEWLINE { (name.string, literal_eval(string.string)) }
+
+    rules[RuleList]:
+        | rule rules { [rule] + rules }
+        | rule { [rule] }
+
+    rule[Rule]:
+        | rulename ":" alts NEWLINE INDENT more_alts DEDENT {
+              Rule(rulename[0], rulename[1], Rhs(alts.alts + more_alts.alts)) }
+        | rulename ":" NEWLINE INDENT more_alts DEDENT { Rule(rulename[0], rulename[1], more_alts) }
+        | rulename ":" alts NEWLINE { Rule(rulename[0], rulename[1], alts) }
+
+    rulename[RuleName]:
+        | NAME '[' type=NAME '*' ']' {(name.string, type.string+"*")}
+        | NAME '[' type=NAME ']' {(name.string, type.string)}
+        | NAME {(name.string, None)}
+
+    alts[Rhs]:
+        | alt "|" alts { Rhs([alt] + alts.alts)}
+        | alt { Rhs([alt]) }
+
+    more_alts[Rhs]:
+        | "|" alts NEWLINE more_alts { Rhs(alts.alts + more_alts.alts) }
+        | "|" alts NEWLINE { Rhs(alts.alts) }
+
+    alt[Alt]:
+        | items '$' action { Alt(items + [NamedItem(None, NameLeaf('ENDMARKER'))], action=action) }
+        | items '$' { Alt(items + [NamedItem(None, NameLeaf('ENDMARKER'))], action=None) }
+        | items action { Alt(items, action=action) }
+        | items { Alt(items, action=None) }
+
+    items[NamedItemList]:
+        | named_item items { [named_item] + items }
+        | named_item { [named_item] }
+
+    named_item[NamedItem]:
+        | NAME '=' ~ item {NamedItem(name.string, item)}
+        | item {NamedItem(None, item)}
+        | it=lookahead {NamedItem(None, it)}
+
+    lookahead[LookaheadOrCut]:
+        | '&' ~ atom {PositiveLookahead(atom)}
+        | '!' ~ atom {NegativeLookahead(atom)}
+        | '~' {Cut()}
+
+    item[Item]:
+        | '[' ~ alts ']' {Opt(alts)}
+        |  atom '?' {Opt(atom)}
+        |  atom '*' {Repeat0(atom)}
+        |  atom '+' {Repeat1(atom)}
+        |  sep=atom '.' node=atom '+' {Gather(sep, node)}
+        |  atom {atom}
+
+    atom[Plain]:
+        | '(' ~ alts ')' {Group(alts)}
+        | NAME {NameLeaf(name.string) }
+        | STRING {StringLeaf(string.string)}
+
+    # Mini-grammar for the actions
+
+    action[str]: "{" ~ target_atoms "}" { target_atoms }
+
+    target_atoms[str]:
+        | target_atom target_atoms { target_atom + " " + target_atoms }
+        | target_atom { target_atom }
+
+    target_atom[str]:
+        | "{" ~ target_atoms "}" { "{" + target_atoms + "}" }
+        | NAME { name.string }
+        | NUMBER { number.string }
+        | STRING { string.string }
+        | "?" { "?" }
+        | ":" { ":" }
 
 As an illustrative example this simple grammar file allows to directly
 generate a full parser that can parse simple arithmetic expressions and that


### PR DESCRIPTION
Following @brettcannon's suggestion on python/steering-council#24, I moved the meta grammar after all the different operators are explained.

CC: @gvanrossum @pablogsal 
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
