### PR TITLE
PEP 429: Python 3.4 is EOL, mark PEP status as final

### DIFF
--- a/pep-0429.txt
+++ b/pep-0429.txt
@@ -3,7 +3,7 @@ Title: Python 3.4 Release Schedule
 Version: $Revision$
 Last-Modified: $Date$
 Author: Larry Hastings <larry@hastings.org>
-Status: Active
+Status: Final
 Type: Informational
 Content-Type: text/x-rst
 Created: 17-Oct-2012


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Mark Python 3.4's PEP as Final, like all the other EOL Pythons' PEPs.

~Also fix a small typo in Python 2.7's PEP 373. (Please me know if this shouldn't be in this same PR.)~
--> Removed, was fixed in https://github.com/python/peps/pull/1375.