### PR TITLE
PEP 571: Change status to Final

### DIFF
--- a/pep-0571.rst
+++ b/pep-0571.rst
@@ -7,7 +7,7 @@ Author: Mark  Williams <mrw@enotuniq.org>,
         Thomas Kluyver <thomas@kluyver.me.uk>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
 Discussions-To: Distutils SIG <distutils-sig@python.org>
-Status: Active
+Status: Final
 Type: Informational
 Content-Type: text/x-rst
 Created:


### PR DESCRIPTION
Per https://github.com/pypa/manylinux/issues/179 , manylinux2010 is
now implemented in its entirety. Per PEP 1, "When the reference
implementation is complete and incorporated into the main source code
repository, the status will be changed to 'Final'."

Signed-off-by: Sumana Harihareswara <sh@changeset.nyc>