### PR TITLE
PEP 440: update clause range for SemVer 2.0.0

### DIFF
--- a/pep-0440.txt
+++ b/pep-0440.txt
@@ -745,7 +745,7 @@ it covers many of the issues that can arise when depending on other
 distributions, and when publishing a distribution that others rely on.
 
 The "Major.Minor.Patch" (described in this PEP as "major.minor.micro")
-aspects of semantic versioning (clauses 1-9 in the 2.0.0-rc-1 specification)
+aspects of semantic versioning (clauses 1-8 in the 2.0.0 specification)
 are fully compatible with the version scheme defined in this PEP, and abiding
 by these aspects is encouraged.
 


### PR DESCRIPTION
The clauses 1-8 in the Semantic Version 2.0.0 Specification:

  *  https://semver.org/spec/v2.0.0.html

cover what were clauses 1-9 in the first release candidate of
that version of the specification:

  *  https://semver.org/spec/v2.0.0-rc.1.html

The 3rd clause was removed:

  *  https://github.com/semver/semver/issues/7
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
