### PR TITLE
PEP 571: Toolchain change in the manylinux2010 i686 image

### DIFF
--- a/pep-0571.rst
+++ b/pep-0571.rst
@@ -183,10 +183,9 @@ Docker Image
 
 Two ``manylinux2010`` Docker images based on CentOS 6 are
 provided for building binary ``linux`` wheels that can reliably be
-converted to ``manylinux2010`` wheels.  [10]_ The x86_64 image comes with a
+converted to ``manylinux2010`` wheels.  [10]_ The x86_64 and i686 images comes with a
 new compiler suite installed (``gcc``, ``g++``, and ``gfortran``
 from ``devtoolset-8``) as well as the latest releases of Python and ``pip``.
-For the i686 image, the compiler suite installed is from ``devtoolset-7``.
 
 Compatibility with kernels that lack ``vsyscall``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Following popular demands over at manylinux, the `i686` image was updated to use the same `devtoolset-8` as the `x86_64` image.
`devtoolset-8` was not included in the first place because was not available anywhere for `i686`. We're now rebuilding it on COPR to address concerns expressed in the manylinux repo about this software stack inconsistency.
