### PR TITLE
PEP 563: Make `from __future__ import annotations` the default in Python 3.10

### DIFF
--- a/pep-0563.rst
+++ b/pep-0563.rst
@@ -85,7 +85,7 @@ aforementioned PEPs should be considered deprecated.
 Implementation
 ==============
 
-In Python 4.0, function and variable annotations will no longer be
+In Python 3.10, function and variable annotations will no longer be
 evaluated at definition time.  Instead, a string form will be preserved
 in the respective ``__annotations__`` dictionary.  Static type checkers
 will see no difference in behavior, whereas tools using annotations at


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Follow on from https://github.com/python/peps/pull/1371.

Ping @ambv.