### PR TITLE
PEP 596: 3.9.0b1 was released on 2020-05-19

### DIFF
--- a/pep-0596.rst
+++ b/pep-0596.rst
@@ -51,7 +51,7 @@ Actual:
 - 3.9.0 alpha 4: Wednesday, 2020-02-26
 - 3.9.0 alpha 5: Monday, 2020-03-23
 - 3.9.0 alpha 6: Tuesday, 2020-04-28
-- 3.9.0 beta 1: Monday, 2020-05-18
+- 3.9.0 beta 1: Tuesday, 2020-05-19
   (No new features beyond this point.)
 
 Expected:


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Python 3.9 beta 1 was released today:

* https://pythoninsider.blogspot.com/2020/05/python-390b1-is-now-available-for.html