### PR TITLE
PEP 619: fix year for 3.10.0 final

### DIFF
--- a/pep-0619.rst
+++ b/pep-0619.rst
@@ -62,7 +62,7 @@ Expected:
 - 3.10.0 beta 4: Saturday, 2021-07-10
 - 3.10.0 candidate 1: Monday, 2021-08-02
 - 3.10.0 candidate 2: Monday, 2021-09-06 (if necessary)
-- 3.10.0 final: Monday, 2020-10-04
+- 3.10.0 final: Monday, 2021-10-04
 
 Subsequent bugfix releases at a monthly cadence.
 


### PR DESCRIPTION
For PEP 619, correct the year for 3.10.0 final, so that the date reads 2021-10-04 (was 2020-10-04).
