### PR TITLE
PEP 612: Updates from typing-sig discussions

### DIFF
--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -35,12 +35,10 @@ tools to annotate the following common decorator pattern satisfactorily:
 
    from typing import Awaitable, Callable, TypeVar
 
-   TReturn = TypeVar("TReturn")
+   R = TypeVar("R")
 
-   def add_logging(
-       f: Callable[..., TReturn]
-   ) -> Callable[..., Awaitable[TReturn]]:
-       async def inner(*args: object, **kwargs: object) -> TReturn:
+   def add_logging(f: Callable[..., R]) -> Callable[..., Awaitable[R]]:
+       async def inner(*args: object, **kwargs: object) -> R:
            await log_to_database()
            return f(*args, **kwargs)
        return inner
@@ -87,11 +85,11 @@ the decorator and the parameter enforcement of the decorated function.
 
    from typing import Awaitable, Callable, ParamSpec, TypeVar
 
-   Ps = ParamSpec("Ps")
+   P = ParamSpec("P")
    R = TypeVar("R")
 
-   def add_logging(f: Callable[Ps, R]) -> Callable[Ps, Awaitable[R]]:
-       async def inner(*args: Ps.args, **kwargs: Ps.kwargs) -> R:
+   def add_logging(f: Callable[P, R]) -> Callable[P, Awaitable[R]]:
+       async def inner(*args: P.args, **kwargs: P.kwargs) -> R:
            await log_to_database()
            return f(*args, **kwargs)
        return inner
@@ -113,40 +111,24 @@ number of  positional arguments from decorated functions.
 
    from typing.type_variable_operators import Concatenate
 
-   def add_arguments(
-       f: Callable[TParams, str]
-   ) -> Callable[Concatenate[str, bool, TParams], int]:
-       def inner(
-           first: str,
-           second: bool,
-           /,
-           *args: TParams.args,
-           **kwargs: TParams.kwargs,
-       ) -> int:
-           use(first, second)
+   def add(f: Callable[P, str]) -> Callable[Concatenate[str, bool, P], int]:
+       def inner(x: str, y: bool, *args: P.args, **kwargs: P.kwargs) -> int:
+           use(x, y)
            s = f(*args, **kwargs)
            return int(s)
        return inner
 
-   def remove_arguments(
-       f: Callable[Concatenate[int, bool, TParams], str]
-   ) -> Callable[TParams, int]:
-       def inner(*args: TParams.args, **kwargs: TParams.kwargs) -> int:
+   def remove(f: Callable[Concatenate[int, bool, P], str]) -> Callable[P, int]:
+       def inner(*args: P.args, **kwargs: P.kwargs) -> int:
            s = f(75, True, *args, **kwargs)
            return int(s)
        return inner
 
    def change_arguments(
-       f: Callable[Concatenate[int, bool, TParams], str]
-   ) -> Callable[Concatenate[float, string, TParams], int]:
-       def inner(
-           first: float,
-           second: string,
-           /,
-           *args: TParams.args,
-           **kwargs: TParams.kwargs,
-       ) -> int:
-           use(first, second)
+       f: Callable[Concatenate[int, bool, P], str]
+   ) -> Callable[Concatenate[float, str, P], int]:
+       def inner(x: float, y: str, *args: P.args, **kwargs: P.kwargs) -> int:
+           use(x, y)
            s = f(75, True, *args, **kwargs)
            return int(s)
        return inner
@@ -164,8 +146,8 @@ A parameter specification variable is defined in a similar manner to a normal
 .. code-block::
 
    from typing import ParamSpec
-   TParams = ParamSpec("TParams") # Accepted
-   TParams = ParamSpec("WrongName") # Rejected
+   P = ParamSpec("P") # Accepted
+   P = ParamSpec("WrongName") # Rejected
 
 The runtime should accept ``bound``\ s and ``covariant`` and ``contravariant``
 arguments in the declaration just as ``typing.TypeVar`` does, but for now we
@@ -182,7 +164,7 @@ options:
 .. code-block::
 
    parameters_expression ::=
-     | ...
+     | "..."
      | "[" [ type_expression ("," type_expression)\* ] "]"
      | parameter_specification_variable
      | concatenate "["
@@ -203,30 +185,30 @@ a parameters_expression.
 
    T = TypeVar("T")
    S = TypeVar("S")
-   OtherTParams = ParamSpec("OtherTParams")
+   P_2 = ParamSpec("P_2")
 
-   class X(Generic[T, TParams]):
+   class X(Generic[T, P]):
      ...
 
-   def f(x: X[int, OtherTParams]) -> str: ...                   # Accepted
-   def f(x: X[int, Concatenate[int, OtherTParams]]) -> str: ... # Accepted
-   def f(x: X[int, [int, bool]]) -> str: ...                    # Accepted
-   def f(x: X[int, ...]) -> str: ...                            # Accepted
+   def f(x: X[int, P_2]) -> str: ...                    # Accepted
+   def f(x: X[int, Concatenate[int, P_2]]) -> str: ...  # Accepted
+   def f(x: X[int, [int, bool]]) -> str: ...            # Accepted
+   def f(x: X[int, ...]) -> str: ...                    # Accepted
 
-   class Y(Generic[T, Concatenate[S, TParams]]):
+   class Y(Generic[T, Concatenate[S, P]]):
      ...
 
-   def f(x: Y[int, OtherTParams]) -> str: ...                   # Accepted
-   def f(x: Y[int, Concatenate[int, OtherTParams]]) -> str: ... # Accepted
-   def f(x: Y[int, [int, bool]]) -> str: ...                    # Accepted
-   def f(x: Y[int, ...]) -> str: ...                            # Accepted
+   def f(x: Y[int, P_2]) -> str: ...                    # Accepted
+   def f(x: Y[int, Concatenate[int, P_2]]) -> str: ...  # Accepted
+   def f(x: Y[int, [int, bool]]) -> str: ...            # Accepted
+   def f(x: Y[int, ...]) -> str: ...                    # Accepted
 
-We furthermore now accept a special case for when a class is generic with
+We furthermore accept a special case for when a class is generic with
 respect to only a single ParamSpec.
 
 .. code-block::
 
-   class Z(Generic[TParams]):
+   class Z(Generic[P]):
      ...
 
    def f(x: X[[int, str, bool]]) -> str: ...   # Accepted
@@ -237,13 +219,13 @@ places where a type is expected
 
 .. code-block::
 
-   def foo(x: TParams) -> TParams: ...  # Rejected
-   def foo(x: typing.List[TParams]) -> None: ... # Rejected
-   def foo(x: Callable[[int, str], TParams]) -> None: ... # Rejected
+   def foo(x: P) -> P: ...                           # Rejected
+   def foo(x: typing.List[P]) -> None: ...           # Rejected
+   def foo(x: Callable[[int, str], P]) -> None: ...  # Rejected
 
-   def foo(x: Concatenate[int, TParams]) -> int: ...  # Rejected
-   def foo(x: [int, str, bool]) -> int: ...  # Rejected
-   def foo(x: ...) -> int: ...  # Rejected
+   def foo(x: Concatenate[int, P]) -> int: ...       # Rejected
+   def foo(x: [int, str, bool]) -> int: ...          # Rejected
+   def foo(x: ...) -> int: ...                       # Rejected
 
 Semantics
 ^^^^^^^^^
@@ -254,19 +236,19 @@ evaluating ones with ``TypeVar``\ s.
 
 .. code-block::
 
-   def foo(x: Callable[TParams, int]) -> Callable[TParams, str]: ...
+   def foo(x: Callable[P, int]) -> Callable[P, str]: ...
 
    def bar(a: str, b: bool) -> int: ...
 
    f = foo(bar) # f should be inferred to have the same signature as bar,
                 # but returning str
 
-   f("A", True) # Accepted
-   f(a="A", b=True) # Accepted
-   f("A", "A") # Rejected
+   f("A", True)               # Accepted
+   f(a="A", b=True)           # Accepted
+   f("A", "A")                # Rejected
 
-   expects_str(f("A", True)) # Accepted
-   expects_int(f("A", True)) # Rejected
+   expects_str(f("A", True))  # Accepted
+   expects_int(f("A", True))  # Rejected
 
 Just as with traditional ``TypeVars``\ , a user may include the same
 ``ParamSpec`` multiple times in the arguments of the same function,
@@ -283,7 +265,9 @@ but is not obligated to do so.
 
    def x_int_y_str(x: int, y: str) -> int: ...
    def y_int_x_str(y: int, x: str) -> int: ...
+
    foo(x_int_y_str, x_int_y_str) # Should return (x: int, y: str) -> bool
+
    foo(x_int_y_str, y_int_x_str) # Could return (__a: int, __b: str) -> bool
                                  # This works because both callables have types
                                  # that are behavioral subtypes of
@@ -325,21 +309,17 @@ their first position with a ``X`` can satisfy
 
    def expects(x: Callable[Concatenate[int, P], int]) -> None: ...
 
+   @expects # Rejected
    def one(x: str) -> int: ...
 
-   expects(one)  # Rejected
-
+   @expects # Rejected
    def two( *, x: int) -> int: ...
 
-   expects(two)  # Rejected
-
+   @expects # Rejected
    def three( **kwargs: int) -> int: ...
 
-   expects(three) # Rejected
-
+   @expects # Accepted
    def four(*args: int) -> int: ...
-
-   expects(four)  # Accepted
 
 The components of a ``ParamSpec``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -349,34 +329,34 @@ parameters, but there unfortunately is no object in the runtime that captures
 both of these together. Instead, we are forced to separate them into ``*args``
 and ``**kwargs``\ , respectively. This means we need to be able to split apart
 a single ``ParamSpec`` into these two components, and then bring
-them back together into a call.  To do this, we introduce ``TParams.args`` to
+them back together into a call.  To do this, we introduce ``P.args`` to
 represent the tuple of positional arguments in a given call and
-``TParams.kwargs`` to represent the corresponding ``Mapping`` of keywords to
+``P.kwargs`` to represent the corresponding ``Mapping`` of keywords to
 values. These "properties" can only be used together, as the annotated types for
 ``*args`` and ``**kwargs`` , on a ParamSpec already in scope.
 
 .. code-block::
 
-   def d(f: Callable[TParams, int]) -> None:
+   def d(f: Callable[P, int]) -> None:
 
-     def foo(*args: TParams.args, **kwargs: TParams.kwargs) -> None:  # Accepted
+     def foo(*args: P.args, **kwargs: P.kwargs) -> None:  # Accepted
        pass
 
-     def bar(*args: TParams.kwargs, **kwargs: TParams.args) -> None:  # Rejected
+     def bar(*args: P.kwargs, **kwargs: P.args) -> None:  # Rejected
        pass
 
-     def baz(*args: TParams.args) -> None:                            # Rejected
+     def baz(*args: P.args) -> None:                      # Rejected
        pass
 
-     stored_arguments: TParams.args                                   # Rejected
+     stored_arguments: P.args                             # Rejected
 
-     def bap(x: TParams.args) -> None:                                # Rejected
+     def bap(x: P.args) -> None:                          # Rejected
        pass
 
 
 Because the default kind of parameter in Python (\ ``(x: int)``\ ) may be
 addressed both positionally and through its name, two valid invocations of
-a ``(*args: TParams.args, **kwargs: TParams.kwargs)`` function may give
+a ``(*args: P.args, **kwargs: P.kwargs)`` function may give
 different partitions of the same set of parameters. Therefore we need to make
 sure that these special types are only brought into the world together, and are
 used together, so that our usage is valid for all possible partitions.
@@ -385,25 +365,24 @@ With those requirements met, we can now take advantage of the unique properties
 afforded to us by this set up:
 
 
-* Inside the function, ``args`` has the type ``TParams.args``\ , not
-  ``Tuple[TParams.args, ...]`` as would be with a normal annotation
+* Inside the function, ``args`` has the type ``P.args``\ , not
+  ``Tuple[P.args, ...]`` as would be with a normal annotation
   (and likewise with the ``**kwargs``\ )
-* A function of type ``Callable[TParams, TReturn]`` can be called with
-  ``(*args, **kwargs)`` if and only if ``args`` has the type ``TParams.args``
-  and ``kwargs`` has the type ``TParams.kwargs``\ , and that those types both
-  originated from the same function declaration.
-* A function declared as
-  ``def inner(*args: TParams.args, **kwargs: TParams.kwargs) -> X``
-  has type ``Callable[TParams, X]``.
+* A function of type ``Callable[P, R]`` can be called with``(*args, **kwargs)`` 
+  if and only if ``args`` has the type ``P.args`` and ``kwargs`` has the type 
+  ``P.kwargs``\ , and that those types both originated from the same function 
+  declaration.
+* A function declared as ``def inner(*args: P.args, **kwargs: P.kwargs) -> X``
+  has type ``Callable[P, X]``.
 
 With these three properties, we now have the ability to fully type check
 parameter preserving decorators.
 
 .. code-block::
 
-   def decorator(f: Callable[TParams, int]) -> Callable[TParams, None]:
+   def decorator(f: Callable[P, int]) -> Callable[P, None]:
 
-     def foo(*args: TParams.args, **kwargs: TParams.kwargs) -> None:
+     def foo(*args: P.args, **kwargs: P.kwargs) -> None:
 
        f(*args, **kwargs)    # Accepted, should resolve to int
 
@@ -413,40 +392,37 @@ parameter preserving decorators.
 
      return foo              # Accepted
 
-To extend this to include ``Concatenate``, we can declare the following
-properties:
+To extend this to include ``Concatenate``, we declare the following properties:
 
-* A function of type ``Callable[Concatenate[A, B, TParams], TReturn]`` can be
+* A function of type ``Callable[Concatenate[A, B, P], R]`` can be
   called with ``(a, b, *args, **kwargs)`` when ``args`` and ``kwargs`` are the
-  respective components of ``TParams``, ``a`` is of type ``A`` and ``b`` is of
+  respective components of ``P``, ``a`` is of type ``A`` and ``b`` is of
   type ``B``.
 * A function declared as
-  ``def inner(a: A, *args: TParams.args, **kwargs: TParams.kwargs) -> X``
-  has type ``Callable[Concatenate[A, TParams], X]``.
+  ``def inner(a: A, b: B, *args: P.args, **kwargs: P.kwargs) -> R``
+  has type ``Callable[Concatenate[A, B, P], R]``.
 
 .. code-block::
 
    def add(f: Callable[P, int]) -> Callable[Concatenate[str, P], None]:
 
-     # Accepted
-     def foo(s: str, *args: TParams.args, **kwargs: TParams.kwargs) -> None:
+     def foo(s: str, *args: P.args, **kwargs: P.kwargs) -> None:  # Accepted
        pass
 
-     # Rejected
-     def foo(*args: TParams.args, s: str, **kwargs: TParams.kwargs) -> None:
+     def foo(*args: P.args, s: str, **kwargs: P.kwargs) -> None:  # Rejected
        pass
 
-     return foo              # Accepted
+     return foo                                                   # Accepted
 
 
    def remove(x: Callable[Concatenate[int, P], int]) -> Callable[P, None]:
 
-     def foo(*args: TParams.args, **kwargs: TParams.kwargs) -> None:
+     def foo(*args: P.args, **kwargs: P.kwargs) -> None:
        f(1, *args, **kwargs) # Accepted
 
        f(*args, 1, **kwargs) # Rejected
 
-       f(*args, **kwargs) # Rejected
+       f(*args, **kwargs)    # Rejected
 
      return foo
 
@@ -480,8 +456,8 @@ these parameters can not be addressed via a named argument:
 
      return bar
 
-This is not an implementation convenience, but a requirement.  If we were to
-allow that second calling style, then the following snippet would be
+This is not an implementation convenience, but a soundness requirement.  If we 
+were to allow that second calling style, then the following snippet would be
 problematic.
 
 .. code-block::
@@ -492,7 +468,7 @@ problematic.
 
    problem(x="uh-oh")
 
-Inside of ``bar``, we would get a
+Inside of ``bar``, we would get
 ``TypeError: foo() got multiple values for argument 'x'``.  Requiring these
 concatenated arguments to be addressed positionally avoids this kind of problem,
 and simplifies the syntax for spelling these types.

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -22,8 +22,8 @@ There currently are two ways to specify the type of a callable, the
 544 <https://www.python.org/dev/peps/pep-0544/#callback-protocols>`_. Neither of
 these support forwarding the parameter types of one callable over to another
 callable, making it difficult to annotate function decorators. This PEP proposes
-``typing.ParamSpec``\ , a new kind of type variable, to support
-expressing these kinds of relationships. 
+``typing.ParamSpec`` and ``typing.type_variable_operators.Concatenate`` to
+support expressing these kinds of relationships. 
 
 Motivation
 ----------
@@ -94,7 +94,6 @@ the decorator and the parameter enforcement of the decorated function.
        async def inner(*args: Ps.args, **kwargs: Ps.kwargs) -> R:
            await log_to_database()
            return f(*args, **kwargs)
-
        return inner
 
    @add_logging
@@ -105,6 +104,51 @@ the decorator and the parameter enforcement of the decorated function.
    await foo("B", 2) # Incompatible parameter type: 
                      # Expected `int` for 1st anonymous parameter to call `foo` 
                      # but got `str`
+
+With the further addition of the ``Concatenate`` operator, we can also express
+the types of more complex decorators which add, remove, or modify a finite 
+number of  positional arguments from decorated functions.
+
+.. code-block::
+   
+   def add_arguments(
+       f: Callable[TParams, str]
+   ) -> Callable[Concatenate[str, bool, TParams], int]:
+       def inner(
+           first: str,
+           second: bool,
+           /,
+           *args: TParams.args,
+           **kwargs: TParams.kwargs,
+       ) -> int:
+           use(first, second)
+           s = f(*args, **kwargs)
+           return int(s)
+       return inner
+
+   def remove_arguments(
+       f: Callable[Concatenate[int, bool, TParams], str]
+   ) -> Callable[TParams, int]:
+       def inner(*args: TParams.args, **kwargs: TParams.kwargs) -> int:
+           s = f(75, True, *args, **kwargs)
+           return int(s)
+       return inner
+
+   def change_arguments(
+       f: Callable[Concatenate[int, bool, TParams], str]
+   ) -> Callable[Concatenate[float, string, TParams], int]:
+       def inner(
+           first: float,
+           second: string,
+           /,
+           *args: TParams.args,
+           **kwargs: TParams.kwargs,
+       ) -> int:
+           use(first, second)
+           s = f(75, True, *args, **kwargs)
+           return int(s)
+       return inner
+
 
 Specification
 -------------
@@ -352,7 +396,7 @@ capture two categories when there are some things that can be in either
 category, we need a higher level primitive (\ ``ParamSpec``\ ) to
 capture all three, and then split them out afterward.
 
-Mutations on ParameterSpecifications
+Mutations on ParamSpecs 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 There are still a class of decorators still not supported with these features:

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -106,13 +106,13 @@ the practice of adding or removing arguments from the decorated function.  For
 example:
 
 .. code-block::
-  
+
    class Request:
     ...
 
    def with_request(f: Callable[..., R]) -> Callable[..., R]:
       def inner(*args: object, **kwargs: object) -> R:
-          return f(Request(), *args, **kwargs)  
+          return f(Request(), *args, **kwargs)
       return inner
 
    @with_request
@@ -122,7 +122,7 @@ example:
 
    takes_int_str(1, "A")
    takes_int_str("B", 2) # fails at runtime
-    
+
 
 With the addition of the ``Concatenate`` operator from this PEP, we can even
 type this more complex decorator.
@@ -133,7 +133,7 @@ type this more complex decorator.
 
    def with_request(f: Callable[Concatenate[Request, P], R]) -> Callable[P, R]:
        def inner(*args: P.args, **kwargs: P.kwargs) -> R:
-           return f(Request(), *args, **kwargs)  
+           return f(Request(), *args, **kwargs)
        return inner
 
    @with_request
@@ -143,7 +143,7 @@ type this more complex decorator.
 
    takes_int_str(1, "A") # Accepted
    takes_int_str("B", 2) # Correctly rejected by the type checker
-    
+
 
 Specification
 -------------
@@ -170,7 +170,7 @@ Valid use locations
 Previously only a list of parameter arguments (``[A, B, C]``) or an ellipsis
 (signifying "undefined parameters") were acceptable as the first "argument" to
 ``typing.Callable`` .  We now augment that with two new options: a parameter
-specification variable (``Callable[P, int]``\ ) or a concatenation on a 
+specification variable (``Callable[P, int]``\ ) or a concatenation on a
 parameter specification variable (``Callable[Concatenate[int, P], int]``\ ).
 
 .. code-block::
@@ -205,8 +205,8 @@ User-Defined Generic Classes
 ````````````````````````````
 
 Just as defining a class as inheriting from ``Generic[T]`` makes a class generic
-for a single parameter (when ``T`` is a ``TypeVar``\ ), defining a class as 
-inheriting from ``Generic[P]`` makes a class generic on 
+for a single parameter (when ``T`` is a ``TypeVar``\ ), defining a class as
+inheriting from ``Generic[P]`` makes a class generic on
 ``parameters_expression``\ s (when ``P`` is a ``ParamSpec``).
 
 .. code-block::
@@ -224,7 +224,7 @@ inheriting from ``Generic[P]`` makes a class generic on
    def f(x: X[int, ...]) -> str: ...                    # Accepted
    def f(x: X[int, int]) -> str: ...                    # Rejected
 
-By the rules defined above, spelling an concrete instance of a class generic   
+By the rules defined above, spelling an concrete instance of a class generic
 with respect to only a single ``ParamSpec`` would require unsightly double
 brackets.  For aesthetic purposes we allow these to be omitted.
 
@@ -333,10 +333,10 @@ their first position with a ``X`` can satisfy
 There are still some classes of decorators still not supported with these
 features:
 
-   - those that add/remove/change a **variable** number of parameters.  For 
-     example, ``functools.partial`` will remain untypable even after this PEP.  
+   - those that add/remove/change a **variable** number of parameters.  For
+     example, ``functools.partial`` will remain untypable even after this PEP.
    - those that add/remove/change keyword-only parameters (See
-     Concatenating Keyword Parameters in Rejected Alternatives for more 
+     Concatenating Keyword Parameters in Rejected Alternatives for more
      details).
 
 The components of a ``ParamSpec``
@@ -350,7 +350,7 @@ a single ``ParamSpec`` into these two components, and then bring
 them back together into a call.  To do this, we introduce ``P.args`` to
 represent the tuple of positional arguments in a given call and
 ``P.kwargs`` to represent the corresponding ``Mapping`` of keywords to
-values. 
+values.
 
 Valid use locations
 ```````````````````
@@ -375,9 +375,9 @@ These "properties" can only be used as the annotated types for
       pass
 
 
-A function cannot use just one of ``*args: P.args`` or ``**kwargs: P.kwargs``, 
-they must both be used together. Because the default kind of parameter in Python 
-(\ ``(x: int)``\ ) may be addressed both positionally and through its name, two 
+A function cannot use just one of ``*args: P.args`` or ``**kwargs: P.kwargs``,
+they must both be used together. Because the default kind of parameter in Python
+(\ ``(x: int)``\ ) may be addressed both positionally and through its name, two
 valid invocations of a ``(*args: P.args, **kwargs: P.kwargs)`` function may give
 different partitions of the same set of parameters. Therefore we need to make
 sure that these special types are only brought into the world together, and are
@@ -498,12 +498,12 @@ problematic.
 Inside of ``bar``, we would get
 ``TypeError: foo() got multiple values for argument 'x'``.  Requiring these
 concatenated arguments to be addressed positionally avoids this kind of problem,
-and simplifies the syntax for spelling these types. Note that this also why we 
-have to reject signatures of the form 
+and simplifies the syntax for spelling these types. Note that this also why we
+have to reject signatures of the form
 ``(*args: P.args, s: str, **kwargs: P.kwargs)`` (See Concatenating Keyword
 Parameters in Rejected Alternatives for more details).
 
-If one of these prepended positional parameters contains a free ``ParamSpec``\ , 
+If one of these prepended positional parameters contains a free ``ParamSpec``\ ,
 we consider that variable in scope for the purposes of extracting the components
 of that ``ParamSpec``.  That allows us to spell things like this:
 
@@ -518,10 +518,10 @@ outer ``Callable``.  This has the following semantics:
 
 .. code-block::
 
-   def a_int_b_str(a: int, b: str) -> int: 
+   def a_int_b_str(a: int, b: str) -> int:
      pass
 
-   twice(a_int_b_str, 1, "A")       # Accepted 
+   twice(a_int_b_str, 1, "A")       # Accepted
 
    twice(a_int_b_str, b="A", a=1)   # Accepted
 
@@ -699,13 +699,13 @@ when ``P`` itself does not already have a parameter named ``n``\ .
    def problem(n: int) -> None:
      pass
 
-Calling ``problem(2)`` works fine, but callin ``problem(n=2)`` leads to a 
+Calling ``problem(2)`` works fine, but callin ``problem(n=2)`` leads to a
 ``TypeError: problem() got multiple values for argument 'n'`` from the call to
 ``added`` inside of ``innocent_wrapper``\ .
 
 This kind of situation could be avoided, and this kind of decorator could be
 typed if we could reify the constraint that a set of parameters **not** contain
-a certain name, with something like: 
+a certain name, with something like:
 
 .. code-block::
 

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -287,7 +287,7 @@ but is not obligated to do so.
 
    def keyword_only_x( *, x: int) -> int: ...
    def keyword_only_y( *, y: int) -> int: ...
-   foo(keyword_only_x, keyword_only_y) # Should be rejected
+   foo(keyword_only_x, keyword_only_y) # Rejected
    
 The semantics of ``Concatenate[X, Y, P]`` are that it represents the parameters
 represented by ``P`` with two positional-only parameters prepended.  This means
@@ -323,27 +323,19 @@ their first position with a ``X`` can satisfy
 
    def one(x: str) -> int: ...
 
-   expects(one)  # Should be rejected
+   expects(one)  # Rejected
 
    def two( *, x: int) -> int: ...
 
-   expects(two)  # Should be rejected
+   expects(two)  # Rejected
 
    def three( **kwargs: int) -> int: ...
 
-   expects(three) # Should be rejected
+   expects(three) # Rejected
 
    def four(*args: int) -> int: ...
 
-   expects(four)  # Should be accepted
-
-Use in ``Generic`` Classes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Just as with normal ``TypeVar``\ s, ``ParamSpec``\ s can be used to
-make generic classes as well as generic functions. These are able to be
-mixed with normal ``TypeVar``\ s. This also work with
-protocols in the same manner.
+   expects(four)  # Accepted
 
 The components of a ``ParamSpec``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -356,30 +348,27 @@ a single ``ParamSpec`` into these two components, and then bring
 them back together into a call.  To do this, we introduce ``TParams.args`` to
 represent the tuple of positional arguments in a given call and
 ``TParams.kwargs`` to represent the corresponding ``Mapping`` of keywords to
-values. These operators can only be used together, as the annotated types for
-``*args`` and ``**kwargs`` .
+values. These "properties" can only be used together, as the annotated types for
+``*args`` and ``**kwargs`` , on a ParamSpec already in scope.
 
 .. code-block::
 
-   class G(Generic[TParams]):
-       def foo(*args: TParams.args, **kwargs: TParams.kwargs) -> int: # Accepted
-           ...
+   def d(f: Callable[TParams, int]) -> None:
 
-       def bar(*args: TParams.kwargs, **kwargs: TParams.args) -> int: # Rejected
-           ...
+     def foo(*args: TParams.args, **kwargs: TParams.kwargs) -> None:  # Accepted 
+       pass
 
-       def baz(*args: TParams.args) -> int:                           # Rejected
-           ...
+     def bar(*args: TParams.kwargs, **kwargs: TParams.args) -> None:  # Rejected
+       pass
+       
+     def baz(*args: TParams.args) -> None:                            # Rejected
+       pass
 
-       stored_arguments: TParams.args                                 # Rejected
+     stored_arguments: TParams.args                                   # Rejected
 
-       def bap(x: TParams.args) -> int: ...                           # Rejected
+     def bap(x: TParams.args) -> None:                                # Rejected
+       pass
 
-       def bop(
-           *args: List[TParams.args], 
-           **kwargs: TParams.kwargs,
-       ) -> int:                                                     # Rejected
-           ...
 
 Because the default kind of parameter in Python (\ ``(x: int)``\ ) may be
 addressed both positionally and through its name, two valid invocations of
@@ -405,6 +394,64 @@ afforded to us by this set up:
 
 With these three properties, we now have the ability to fully type check
 parameter preserving decorators.
+
+.. code-block::
+
+   def decorator(f: Callable[TParams, int]) -> Callable[TParams, None]:
+
+     def foo(*args: TParams.args, **kwargs: TParams.kwargs) -> None:
+
+       f(*args, **kwargs)    # Accepted, should resolve to int
+
+       f(*kwargs, **args)    # Rejected
+
+       f(1, *args, **kwargs) # Rejected
+     
+     return foo              # Accepted
+
+To extend this to include ``Concatenate``, we can declare the following
+properties:
+
+* A function of type ``Callable[Concatenate[A, B, TParams], TReturn]`` can be 
+  called with ``(a, b, *args, **kwargs)`` when ``args`` and ``kwargs`` are the
+  respective components of ``TParams``, ``a`` is of type ``A`` and ``b`` is of 
+  type ``B``.
+* A function declared as 
+  ``def inner(__a: A, *args: TParams.args, **kwargs: TParams.kwargs) -> X``
+  or as 
+  ``def inner(a: A, /, *args: TParams.args, **kwargs: TParams.kwargs) -> X``
+  has type ``Callable[Concatenate[A, TParams], X]``.
+
+.. code-block::
+
+   def add(f: Callable[P, int]) -> Callable[Concatenate[str, P], None]:
+
+     # Accepted
+     def foo(s: str, /, *args: TParams.args, **kwargs: TParams.kwargs) -> None:
+
+       f(*args, **kwargs)    # Accepted, should resolve to int
+
+     # Accepted
+     def bar(__s: str, *args: TParams.args, **kwargs: TParams.kwargs) -> None:
+       pass
+
+     # Rejected
+     def baz(s: str,  *args: TParams.args, **kwargs: TParams.kwargs) -> None:
+       pass
+     
+     return foo              # Accepted
+
+
+   def remove(x: Callable[Concatenate[int, P], int]) -> Callable[P, None]:
+     
+     def foo(*args: TParams.args, **kwargs: TParams.kwargs) -> None:
+       f(1, *args, **kwargs) # Accepted
+
+       f(*args, 1, **kwargs) # Rejected
+
+       f(*args, **kwargs) # Rejected
+
+     return foo
 
 One additional form that we want to support is functions that pass only a subset
 of their arguments on to another function. To avoid shadowing a named or keyword

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -303,7 +303,7 @@ transform a finite number of parameters of a callable.
 This also means that while any function that returns an ``R`` can satisfy
 ``typing.Callable[P, R]``, only functions that can be called positionally in
 their first position with a ``X`` can satisfy
-``typing.Callable[Concatenate[X, P]``.
+``typing.Callable[Concatenate[X, P]]``.
 
 .. code-block::
 
@@ -320,6 +320,10 @@ their first position with a ``X`` can satisfy
 
    @expects # Accepted
    def four(*args: int) -> int: ...
+
+There are still a class of decorators still not supported with these features:
+those that add/remove/change a **variable** number of parameters.  For example,
+functools.partial will remain untypable even after this PEP. 
 
 The components of a ``ParamSpec``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -409,7 +413,7 @@ To extend this to include ``Concatenate``, we declare the following properties:
      def foo(s: str, *args: P.args, **kwargs: P.kwargs) -> None:  # Accepted
        pass
 
-     def foo(*args: P.args, s: str, **kwargs: P.kwargs) -> None:  # Rejected
+     def bar(*args: P.args, s: str, **kwargs: P.kwargs) -> None:  # Rejected
        pass
 
      return foo                                                   # Accepted
@@ -473,6 +477,8 @@ Inside of ``bar``, we would get
 concatenated arguments to be addressed positionally avoids this kind of problem,
 and simplifies the syntax for spelling these types.
 
+Note that this also why we have to reject signatures of the form
+``(*args: P.args, s: str, **kwargs: P.kwargs)``.
 
 Backwards Compatibility
 -----------------------
@@ -611,17 +617,6 @@ We decided to go with ``ParamSpec``\ s over this approach for several reasons:
 
 In summary, between these two equivalently powerful syntaxes, ``ParamSpec`` fits
 much more naturally into the status quo.
-
-Mutations on ParamSpecs
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-There are still a class of decorators still not supported with these features:
-those that add/remove/change a variable number of parameters.  For example,
-functools.partial will remain untypable even after this PEP.  Defining operators
-that do these mutations becomes very complicated very quickly, as you have to
-deal with name collision issues much more prominently.
-We will defer that work until there is significant demand, and then we would be
-open to revisiting it.
 
 Naming this a ``ParameterSpecification``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -417,9 +417,7 @@ properties:
   respective components of ``TParams``, ``a`` is of type ``A`` and ``b`` is of 
   type ``B``.
 * A function declared as 
-  ``def inner(__a: A, *args: TParams.args, **kwargs: TParams.kwargs) -> X``
-  or as 
-  ``def inner(a: A, /, *args: TParams.args, **kwargs: TParams.kwargs) -> X``
+  ``def inner(a: A, *args: TParams.args, **kwargs: TParams.kwargs) -> X``
   has type ``Callable[Concatenate[A, TParams], X]``.
 
 .. code-block::
@@ -427,16 +425,11 @@ properties:
    def add(f: Callable[P, int]) -> Callable[Concatenate[str, P], None]:
 
      # Accepted
-     def foo(s: str, /, *args: TParams.args, **kwargs: TParams.kwargs) -> None:
-
-       f(*args, **kwargs)    # Accepted, should resolve to int
-
-     # Accepted
-     def bar(__s: str, *args: TParams.args, **kwargs: TParams.kwargs) -> None:
+     def foo(s: str, *args: TParams.args, **kwargs: TParams.kwargs) -> None:
        pass
 
      # Rejected
-     def baz(s: str,  *args: TParams.args, **kwargs: TParams.kwargs) -> None:
+     def foo(*args: TParams.args, s: str, **kwargs: TParams.kwargs) -> None:
        pass
      
      return foo              # Accepted
@@ -460,31 +453,63 @@ like this:
 
 .. code-block::
 
-   def twice(f: Callable[P, int], /, *args: P.args, **kwargs: P.kwargs) -> int:
+   def twice(f: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int:
        return f(*args, **kwargs) + f(*args, **kwargs)
 
 The type of ``twice`` in the above example is 
 ``Callable[Concatenate[Callable[P, int], P], int]``, where ``P`` is bound by the
 outer ``Callable``.
 
+Also note that the names of the parameters preceding the ``ParamSpec`` 
+components are not mentioned in the resulting ``Concatenate``.  This means that
+these parameters can not be addressed via a named argument:
+
+.. code-block::
+
+   def outer(f: Callable[P, None]) -> Callable[P, None]:
+     def foo(x: int, *args: P.args, **kwargs: P.kwargs) -> None:
+       f(*args, **kwargs)
+
+     def bar(*args: P.args, **kwargs: P.kwargs) -> None:
+       foo(1, *args, **kwargs)   # Accepted
+       foo(x=1, *args, **kwargs) # Rejected
+
+     return bar
+
+This is not an implementation convenience, but a requirement.  If we were to
+allow that second calling style, then the following snippet would be
+problematic.
+
+.. code-block::
+
+   @outer
+   def problem( *, x: object) -> None:
+     pass
+
+   problem(x="uh-oh")
+
+Inside of ``bar``, we would get a 
+``TypeError: foo() got multiple values for argument 'x'``.  Requiring these
+concatenated arguments to be addressed positionally avoids this kind of problem,
+and simplifies the syntax for spelling these types.       
+
+
 Backwards Compatibility
 -----------------------
 
 The only changes necessary to existing features in ``typing`` is allowing these
-``ParamSpec`` objects to be the first parameter to ``Callable`` and
-to be a parameter to ``Generic``. Currently ``Callable`` expects a list of types
-there and ``Generic`` expects single types, so they are currently mutually
-exclusive. Otherwise, existing code that doesn't reference the new interfaces
-will be unaffected.
+``ParamSpec`` and ``Concatenate`` objects to be the first parameter to 
+``Callable`` and to be a parameter to ``Generic``. Currently ``Callable`` 
+expects a list of types there and ``Generic`` expects single types, so they are 
+currently mutually exclusive. Otherwise, existing code that doesn't reference 
+the new interfaces will be unaffected.
 
 Reference Implementation
 ------------------------
 
-The `Pyre <https://pyre-check.org/>`_ type checker supports
-``ParamSpec``\ s, ``.args`` and ``.kwargs`` in the context of
-functions. Support for use with ``Generic`` is not yet implemented. A reference
-implementation of the runtime components needed for those uses is provided in
-the ``pyre_extensions`` module.
+The `Pyre <https://pyre-check.org/>`_ type checker supports all of the behavior
+described above.  A reference implementation of the runtime components needed 
+for those uses is provided in the ``pyre_extensions`` module.
 
 Rejected Alternatives
 ---------------------
@@ -550,19 +575,20 @@ Mutations on ParamSpecs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 There are still a class of decorators still not supported with these features:
-those that mutate (add/remove/change) the parameters of the given function.
-Defining operators that do these mutations becomes very complicated very
-quickly, as you have to deal with name collision issues much more prominently.
+those that add/remove/change a variable number of parameters.  For example,
+functools.partial will remain untypable even after this PEP.  Defining operators 
+that do these mutations becomes very complicated very quickly, as you have to 
+deal with name collision issues much more prominently.
 We will defer that work until there is significant demand, and then we would be
 open to revisiting it.
 
 Naming this a ``ParameterSpecification``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 We decided that ParameterSpecification was a little too long-winded for use 
 here, and that this style of abbreviated name made it look more like TypeVar.
 
 Naming this an ``ArgSpec``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We think that calling this a ParamSpec is more correct than
 referring to it as an ArgSpec, since callables have parameters,

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -218,25 +218,28 @@ a parameters_expression.
    def f(x: Y[int, [int, bool]]) -> str: ...                    # Accepted
    def f(x: Y[int, ...]) -> str: ...                            # Accepted
 
+We furthermore now accept a special case for when a class is generic with
+respect to only a single ParamSpec.
 
-A declared ``ParamSpec`` can only be used in the place of the list
-of types in the declaration of a ``Callable`` type, or a user defined class
-which is generic in a ``ParamSpec`` variable (i.e., ``MyClass`` in
-the following example).
+.. code-block::
+   class Z(Generic[TParams]):
+     ...
+
+   def f(x: X[[int, str, bool]]) -> str: ...   # Accepted
+   def f(x: X[int, str, bool]) -> str: ...     # Also accepted
+
+As before, ``parameters_expression``s by themselves are not acceptable in places
+where a type is expected
 
 .. code-block::
 
-   def foo(
-       x: typing.Callable[TParams, int]
-   ) -> typing.Callable[TParams, str]:  # Accepted
-       ...
-   def foo(
-       x: MyClass[TParams, int]
-   ) -> typing.Callable[TParams, str]:  # Accepted
-       ...
    def foo(x: TParams) -> TParams: ...  # Rejected
    def foo(x: typing.List[TParams]) -> None: ... # Rejected
    def foo(x: typing.Callable[[int, str], TParams]) -> None: ... # Rejected
+
+   def foo(x: Concatenate[int, TParams]) -> int: ...  # Rejected
+   def foo(x: [int, str, bool]) -> int: ...  # Rejected
+   def foo(x: ...) -> int: ...  # Rejected
 
 Semantics
 ^^^^^^^^^

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -113,7 +113,7 @@ number of  positional arguments from decorated functions.
 
    def add(f: Callable[P, str]) -> Callable[Concatenate[str, bool, P], int]:
        def inner(x: str, y: bool, *args: P.args, **kwargs: P.kwargs) -> int:
-           use(x, y)
+           # use x & y
            s = f(*args, **kwargs)
            return int(s)
        return inner
@@ -128,7 +128,7 @@ number of  positional arguments from decorated functions.
        f: Callable[Concatenate[int, bool, P], str]
    ) -> Callable[Concatenate[float, str, P], int]:
        def inner(x: float, y: str, *args: P.args, **kwargs: P.kwargs) -> int:
-           use(x, y)
+           # use x & y
            s = f(75, True, *args, **kwargs)
            return int(s)
        return inner
@@ -211,8 +211,8 @@ respect to only a single ParamSpec.
    class Z(Generic[P]):
      ...
 
-   def f(x: X[[int, str, bool]]) -> str: ...   # Accepted
-   def f(x: X[int, str, bool]) -> str: ...     # Also accepted
+   def f(x: Z[[int, str, bool]]) -> str: ...   # Accepted
+   def f(x: Z[int, str, bool]) -> str: ...     # Also accepted
 
 As before, ``parameters_expression``\ s by themselves are not acceptable in
 places where a type is expected
@@ -220,12 +220,10 @@ places where a type is expected
 .. code-block::
 
    def foo(x: P) -> P: ...                           # Rejected
+   def foo(x: Concatenate[int, P]) -> int: ...       # Rejected
+
    def foo(x: typing.List[P]) -> None: ...           # Rejected
    def foo(x: Callable[[int, str], P]) -> None: ...  # Rejected
-
-   def foo(x: Concatenate[int, P]) -> int: ...       # Rejected
-   def foo(x: [int, str, bool]) -> int: ...          # Rejected
-   def foo(x: ...) -> int: ...                       # Rejected
 
 Semantics
 ^^^^^^^^^
@@ -323,7 +321,7 @@ their first position with a ``X`` can satisfy
 
 There are still a class of decorators still not supported with these features:
 those that add/remove/change a **variable** number of parameters.  For example,
-functools.partial will remain untypable even after this PEP. 
+``functools.partial`` will remain untypable even after this PEP.
 
 The components of a ``ParamSpec``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -608,11 +606,11 @@ We decided to go with ``ParamSpec``\ s over this approach for several reasons:
 * The lack of user-defined operators makes common patterns hard to spell.
   ``unwrapping`` is odd to read because ``F`` is not actually referring to any
   callable. It’s just being used as a container for the parameters we wish to
-  propagate.  It would read better if you could define an operator
+  propagate.  It would read better if we could define an operator
   ``RemoveList[List[X]] = X`` and then ``unwrapping`` could take ``F`` and
   return ``Callable[ParametersOf[F], RemoveList[ReturnType[F]]]``.  Without
-  that, you unfortunately get into a situation where you have to use a
-  ``Function``-variable as an improvised ``ParamSpec``, in that you never
+  that, we unfortunately get into a situation where we have to use a
+  ``Function``-variable as an improvised ``ParamSpec``, in that we never
   actually bind the return type.
 
 In summary, between these two equivalently powerful syntaxes, ``ParamSpec`` fits

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -368,9 +368,9 @@ afforded to us by this set up:
 * Inside the function, ``args`` has the type ``P.args``\ , not
   ``Tuple[P.args, ...]`` as would be with a normal annotation
   (and likewise with the ``**kwargs``\ )
-* A function of type ``Callable[P, R]`` can be called with``(*args, **kwargs)`` 
-  if and only if ``args`` has the type ``P.args`` and ``kwargs`` has the type 
-  ``P.kwargs``\ , and that those types both originated from the same function 
+* A function of type ``Callable[P, R]`` can be called with``(*args, **kwargs)``
+  if and only if ``args`` has the type ``P.args`` and ``kwargs`` has the type
+  ``P.kwargs``\ , and that those types both originated from the same function
   declaration.
 * A function declared as ``def inner(*args: P.args, **kwargs: P.kwargs) -> X``
   has type ``Callable[P, X]``.
@@ -456,7 +456,7 @@ these parameters can not be addressed via a named argument:
 
      return bar
 
-This is not an implementation convenience, but a soundness requirement.  If we 
+This is not an implementation convenience, but a soundness requirement.  If we
 were to allow that second calling style, then the following snippet would be
 problematic.
 

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -668,10 +668,10 @@ We decided to go with ``ParamSpec``\ s over this approach for several reasons:
 In summary, between these two equivalently powerful syntaxes, ``ParamSpec`` fits
 much more naturally into the status quo.
 
+.. _Concatenating Keyword Parameters:
+
 Concatenating Keyword Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. _Concatenating Keyword Parameters:
 
 In principle the idea of concatenation as a means to modify a finite number of
 positional parameters could be expanded to include keyword parameters.

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -453,21 +453,19 @@ properties:
 
      return foo
 
-One additional form that we want to support is functions that pass only a subset
-of their arguments on to another function. To avoid shadowing a named or keyword
-only argument in the ``ParamSpec`` we require that the additional
-arguments be anonymous arguments that precede the ``*args`` and ``*kwargs``
+We also consider functions with a ``ParamSpec`` included in one of the preceding
+anonymous parameters to have the variable "already in scope" for the purposes of
+extracting the components of that ``ParamSpec``.  That allows us to spell things
+like this:
 
 .. code-block::
 
-   def call_n_times(
-       __f: Callable[TParams, None], 
-       __n: int, 
-       *args: TParams.args, 
-       **kwargs: TParams.kwargs,
-   ) -> None:
-       for x in range(__n):
-           __f(*args, **kwargs)
+   def twice(f: Callable[P, int], /, *args: P.args, **kwargs: P.kwargs) -> int:
+       return f(*args, **kwargs) + f(*args, **kwargs)
+
+The type of ``twice`` in the above example is 
+``Callable[Concatenate[Callable[P, int], P], int]``, where ``P`` is bound by the
+outer ``Callable``.
 
 Backwards Compatibility
 -----------------------

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -144,8 +144,8 @@ normal type variable is defined with ``typing.TypeVar``.
 .. code-block::
 
    from typing import ParamSpec
-   P = ParamSpec("P") # Accepted
-   P = ParamSpec("WrongName") # Rejected
+   P = ParamSpec("P")         # Accepted
+   P = ParamSpec("WrongName") # Rejected because P =/= WrongName
 
 The runtime should accept ``bound``\ s and ``covariant`` and ``contravariant``
 arguments in the declaration just as ``typing.TypeVar`` does, but for now we

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -63,7 +63,7 @@ parameters of the returned function. `PEP 484
 <https://www.python.org/dev/peps/pep-0484>`_ supports dependencies between
 single types, as in ``def append(l: typing.List[T], e: T) -> typing.List[T]:
 ...``\ , but there is no existing way to do so with a complicated entity like
-the parameters one could pass to a function.
+the parameters of a function.
 
 Due to the limitations of the status quo, the ``add_logging`` example will type
 check but will fail at runtime. ``inner`` will pass the string “B” into
@@ -312,7 +312,7 @@ transform a finite number of parameters of a callable.
 This also means that while any function that returns an ``R`` can satisfy
 ``typing.Callable[P, R]``, only functions that can be called positionally in
 their first position with a ``X`` can satisfy
-``typing.Callable[Concatenate[X, P]]``.
+``typing.Callable[Concatenate[X, P], R]``.
 
 .. code-block::
 
@@ -331,13 +331,10 @@ their first position with a ``X`` can satisfy
    def four(*args: int) -> int: ...
 
 There are still some classes of decorators still not supported with these
-features:
-
-   - those that add/remove/change a **variable** number of parameters.  For
-     example, ``functools.partial`` will remain untypable even after this PEP.
-   - those that add/remove/change keyword-only parameters (See
-     Concatenating Keyword Parameters in Rejected Alternatives for more
-     details).
+features: those that add/remove/change a **variable** number of parameters (for
+example, ``functools.partial`` will remain untypable even after this PEP), and
+those that add/remove/change keyword-only parameters (See
+`Concatenating Keyword Parameters`_ for more details).
 
 The components of a ``ParamSpec``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -376,12 +373,13 @@ These "properties" can only be used as the annotated types for
 
 
 A function cannot use just one of ``*args: P.args`` or ``**kwargs: P.kwargs``,
-they must both be used together. Because the default kind of parameter in Python
-(\ ``(x: int)``\ ) may be addressed both positionally and through its name, two
-valid invocations of a ``(*args: P.args, **kwargs: P.kwargs)`` function may give
-different partitions of the same set of parameters. Therefore we need to make
-sure that these special types are only brought into the world together, and are
-used together, so that our usage is valid for all possible partitions.
+they must both be used together. Furthermore, because the default kind of
+parameter in Python (\ ``(x: int)``\ ) may be addressed both positionally and
+through its name, two valid invocations of a
+``(*args: P.args, **kwargs: P.kwargs)`` function may give different partitions
+of the same set of parameters. Therefore we need to make sure that these special
+types are only brought into the world together, and are used together, so that
+our usage is valid for all possible partitions.
 
 .. code-block::
 
@@ -500,8 +498,8 @@ Inside of ``bar``, we would get
 concatenated arguments to be addressed positionally avoids this kind of problem,
 and simplifies the syntax for spelling these types. Note that this also why we
 have to reject signatures of the form
-``(*args: P.args, s: str, **kwargs: P.kwargs)`` (See Concatenating Keyword
-Parameters in Rejected Alternatives for more details).
+``(*args: P.args, s: str, **kwargs: P.kwargs)`` (See
+`Concatenating Keyword Parameters`_ for more details).
 
 If one of these prepended positional parameters contains a free ``ParamSpec``\ ,
 we consider that variable in scope for the purposes of extracting the components
@@ -668,6 +666,8 @@ much more naturally into the status quo.
 
 Concatenating Keyword Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. _Concatenating Keyword Parameters:
 
 In principle the idea of concatenation as a means to modify a finite number of
 positional parameters could be expanded to include keyword parameters.

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -132,14 +132,14 @@ type this more complex decorator.
    from typing.type_variable_operators import Concatenate
 
    def with_request(f: Callable[Concatenate[Request, P], R]) -> Callable[P, R]:
-      def inner(*args: P.args, **kwargs: P.kwargs) -> R:
-          return f(Request(), *args, **kwargs)  
-      return inner
+       def inner(*args: P.args, **kwargs: P.kwargs) -> R:
+           return f(Request(), *args, **kwargs)  
+       return inner
 
    @with_request
    def takes_int_str(request: Request, x: int, y: str) -> int:
-    # use request
-    return x + 7
+       # use request
+       return x + 7
 
    takes_int_str(1, "A") # Accepted
    takes_int_str("B", 2) # Correctly rejected by the type checker
@@ -687,15 +687,15 @@ when ``P`` itself does not already have a parameter named ``n``\ .
 
 .. code-block::
 
-  def innocent_wrapper(f: Callable[P, R]) -> Callable[P, R]:
-    def inner(*args: P.args, **kwargs: P.kwargs) -> R:
-      added = add_n(f)
-      return added(*args, n=1, **kwargs)
-    return inner
-  
-  @innocent_wrapper
-  def problem(n: int) -> None:
-    pass
+   def innocent_wrapper(f: Callable[P, R]) -> Callable[P, R]:
+     def inner(*args: P.args, **kwargs: P.kwargs) -> R:
+       added = add_n(f)
+       return added(*args, n=1, **kwargs)
+     return inner
+
+   @innocent_wrapper
+   def problem(n: int) -> None:
+     pass
 
 Calling ``problem(2)`` works fine, but callin ``problem(n=2)`` leads to a 
 ``TypeError: problem() got multiple values for argument 'n'`` from the call to

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -551,6 +551,67 @@ capture two categories when there are some things that can be in either
 category, we need a higher level primitive (\ ``ParamSpec``\ ) to
 capture all three, and then split them out afterward.
 
+Defining ParametersOf
+^^^^^^^^^^^^^^^^^^^^^^
+
+Another proposal we considered was defining `ParametersOf`` and ``ReturnType``
+operators which would operate on a domain of a newly defined ``Function`` type.
+``Function`` would be callable with, and only with ``ParametersOf[F]``.
+``ParametersOf`` and ``ReturnType`` would only operate on type variables with
+precisely this bound.  The combination of these three features could express
+everything that we can express with ``ParamSpecs``.
+
+
+.. code-block::
+
+   F = TypeVar("F", bound=Function)
+
+   def no_change(f: F) -> F:
+       def inner(
+         *args: ParametersOf[F].args,
+         **kwargs: ParametersOf[F].kwargs
+       ) -> ReturnType[F]:
+          return f(*args, **kwargs)
+       return inner
+
+   def wrapping(f: F) -> Callable[ParametersOf[F], List[ReturnType[F]]]:
+       def inner(
+           *args: ParametersOf[F].args,
+           **kwargs: ParametersOf[F].kwargs
+        ) -> List[ReturnType[F]]:
+          return [f(*args, **kwargs)]
+       return inner
+
+   def unwrapping(
+       f: Callable[ParametersOf[F], List[TReturn]]
+   ) -> Callable[ParametersOf[F], TReturn]:
+       def inner(
+          *args: ParametersOf[F].args,
+          **kwargs: ParametersOf[F].kwargs
+       ) -> TReturn:
+          return f(*args, **kwargs)[0]
+       return inner
+
+We decided to go with ``ParamSpec``\ s over this approach for several reasons:
+
+* The footprint of this change would be larger, as we would need two new
+  operators, and a new type, while ``ParamSpec`` just introduces a new variable.
+* Python typing has so far has avoided supporting operators, whether
+  user-defined or built-in, in favor of destructuring.  Accordingly,
+  ``ParamSpec`` based signatures look much more like existing Python.
+* The lack of user-defined operators makes common patterns hard to spell.
+  ``unwrapping`` is odd to read because ``F`` is not actually referring to any
+  callable. It’s just being used as a container for the parameters we wish to
+  propagate.  It would read better if you could define an operator
+  ``RemoveList[List[X]] = X`` and then ``unwrapping`` could take ``F`` and
+  return ``Callable[ParametersOf[F], RemoveList[ReturnType[F]]]``.  Without
+  that, you unfortunately get into a situation where you have to use a
+  ``Function``-variable as an improvised ``ParamSpec``, in that you never
+  actually bind the return type.
+
+In summary, between these two equivalently powerful syntaxes, ``ParamSpec`` fits
+much more naturally into the status quo.
+
 Mutations on ParamSpecs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -110,6 +110,7 @@ the types of more complex decorators which add, remove, or modify a finite
 number of  positional arguments from decorated functions.
 
 .. code-block::
+
    from typing.type_variable_operators import Concatenate
 
    def add_arguments(
@@ -179,6 +180,7 @@ ellipsis (signifying "undefined parameters").  We now augment that with two new
 options:
 
 .. code-block::
+
    parameters_expression ::=
      | ...
      | "[" [ type_expression ("," type_expression)\* ] "]"
@@ -198,6 +200,7 @@ generic types, as long as they are declared as being generic in
 a parameters_expression.
 
 .. code-block::
+
    T = TypeVar("T")
    S = TypeVar("S")
    OtherTParams = ParamSpec("OtherTParams")
@@ -222,14 +225,15 @@ We furthermore now accept a special case for when a class is generic with
 respect to only a single ParamSpec.
 
 .. code-block::
+
    class Z(Generic[TParams]):
      ...
 
    def f(x: X[[int, str, bool]]) -> str: ...   # Accepted
    def f(x: X[int, str, bool]) -> str: ...     # Also accepted
 
-As before, ``parameters_expression``s by themselves are not acceptable in places
-where a type is expected
+As before, ``parameters_expression``\ s by themselves are not acceptable in
+places where a type is expected
 
 .. code-block::
 

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -169,7 +169,9 @@ Valid use locations
 
 Previously only a list of parameter arguments (``[A, B, C]``) or an ellipsis
 (signifying "undefined parameters") were acceptable as the first "argument" to
-``typing.Callable`` .  We now augment that with two new options:
+``typing.Callable`` .  We now augment that with two new options: a parameter
+specification variable (``Callable[P, int]``\ ) or a concatenation on a 
+parameter specification variable (``Callable[Concatenate[int, P], int]``\ ).
 
 .. code-block::
 
@@ -184,8 +186,8 @@ Previously only a list of parameter arguments (``[A, B, C]``) or an ellipsis
                       parameter_specification_variable
                    "]"
 
-Where ``parameter_specification_variable`` resolves to a ``typing.ParamSpec``
-declaration as defined above, and ``concatenate`` resolves to
+where ``parameter_specification_variable`` is a ``typing.ParamSpec`` variable,
+declared in the manner as defined above, and ``concatenate`` is
 ``typing.type_variable_operators.Concatenate``.
 
 As before, ``parameters_expression``\ s by themselves are not acceptable in

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -560,7 +560,7 @@ capture all three, and then split them out afterward.
 Defining ParametersOf
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Another proposal we considered was defining `ParametersOf`` and ``ReturnType``
+Another proposal we considered was defining ``ParametersOf`` and ``ReturnType``
 operators which would operate on a domain of a newly defined ``Function`` type.
 ``Function`` would be callable with, and only with ``ParametersOf[F]``.
 ``ParametersOf`` and ``ReturnType`` would only operate on type variables with

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -652,7 +652,7 @@ In summary, between these two equivalently powerful syntaxes, ``ParamSpec`` fits
 much more naturally into the status quo.
 
 Concatenating Keyword Parameters
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In principle the idea of concatenation as a means to modify a finite number of
 positional parameters could be expanded to include keyword parameters.
@@ -665,12 +665,12 @@ positional parameters could be expanded to include keyword parameters.
            return f(*args, **kwargs)
        return inner
 
-However, the key distinction is that while prepending positional only parameters
+However, the key distinction is that while prepending positional-only parameters
 to a valid callable type always yields another valid callable type, the same
-cannot be said to adding keyword-only parameters. As alluded to in the
+cannot be said for adding keyword-only parameters. As alluded to in the
 Semantics section of "The components of a ``ParamSpec``, the issue is name
 collisions.  The parameters ``Concatenate[("n", int), P]`` are only valid
-when ``P`` itself does not have a parameter named ``n``\ .
+when ``P`` itself does not already have a parameter named ``n``\ .
 
 .. code-block::
 

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -315,9 +315,14 @@ their first position with a ``X`` can satisfy
    @expects_int_first # Accepted
    def four(*args: int) -> int: ...
 
-There are still a class of decorators still not supported with these features:
-those that add/remove/change a **variable** number of parameters.  For example,
-``functools.partial`` will remain untypable even after this PEP.
+There are still some classes of decorators still not supported with these
+features:
+
+   - those that add/remove/change a **variable** number of parameters.  For 
+     example, ``functools.partial`` will remain untypable even after this PEP.  
+   - those that add/remove/change keyword-only parameters (See
+     Concatenating Keyword Parameters in Rejected Alternatives for more 
+     details).
 
 The components of a ``ParamSpec``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -480,7 +485,8 @@ Inside of ``bar``, we would get
 concatenated arguments to be addressed positionally avoids this kind of problem,
 and simplifies the syntax for spelling these types. Note that this also why we 
 have to reject signatures of the form 
-``(*args: P.args, s: str, **kwargs: P.kwargs)``.
+``(*args: P.args, s: str, **kwargs: P.kwargs)`` (See Concatenating Keyword
+Parameters in Rejected Alternatives for more details).
 
 If one of these prepended positional parameters contains a free ``ParamSpec``\ , 
 we consider that variable in scope for the purposes of extracting the components
@@ -644,6 +650,66 @@ We decided to go with ``ParamSpec``\ s over this approach for several reasons:
 
 In summary, between these two equivalently powerful syntaxes, ``ParamSpec`` fits
 much more naturally into the status quo.
+
+Concatenating Keyword Parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In principle the idea of concatenation as a means to modify a finite number of
+positional parameters could be expanded to include keyword parameters.
+
+.. code-block::
+
+   def add_n(f: Callable[P, R]) -> Callable[Concatenate[("n", int), P], R]:
+       def inner(*args: P.args, n: int, **kwargs: P.kwargs) -> R:
+           # use n
+           return f(*args, **kwargs)
+       return inner
+
+However, the key distinction is that while prepending positional only parameters
+to a valid callable type always yields another valid callable type, the same
+cannot be said to adding keyword-only parameters. As alluded to in the
+Semantics section of "The components of a ``ParamSpec``, the issue is name
+collisions.  The parameters ``Concatenate[("n", int), P]`` are only valid
+when ``P`` itself does not have a parameter named ``n``\ .
+
+.. code-block::
+
+  def innocent_wrapper(f: Callable[P, R]) -> Callable[P, R]:
+    def inner(*args: P.args, **kwargs: P.kwargs) -> R:
+      added = add_n(f)
+      return added(*args, n=1, **kwargs)
+    return inner
+  
+  @innocent_wrapper
+  def problem(n: int) -> None:
+    pass
+
+Calling ``problem(2)`` works fine, but callin ``problem(n=2)`` leads to a 
+``TypeError: problem() got multiple values for argument 'n'`` from the call to
+``added`` inside of ``innocent_wrapper``\ .
+
+This kind of situation could be avoided, and this kind of decorator could be
+typed if we could reify the constraint that a set of parameters **not** contain
+a certain name, with something like: 
+
+.. code-block::
+
+   P_without_n = ParamSpec("P_without_n", banned_names=["n"])
+
+   def add_n(
+     f: Callable[P_without_n, R]
+   ) -> Callable[Concatenate[("n", int), P_without_n], R]: ...
+
+The call to ``add_n`` inside of ``innocent_wrapper`` could then be rejected
+since the callable was not guaranteed not to already have a parameter named
+``n``\ .
+
+
+However, enforcing these constraints would require enough additional
+implementation work that we judged this extension to be out of scope of this
+PEP.  Fortunately the design of ``ParamSpec``\ s are such that we can return to
+this idea later if there is sufficient demand.
+
 
 Naming this a ``ParameterSpecification``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -160,6 +160,8 @@ Previously only a list of parameter arguments (``[A, B, C]``) or an ellipsis
 
 .. code-block::
 
+   callable ::= Callable "[" parameters_expression, type_expression "]"
+
    parameters_expression ::=
      | "..."
      | "[" [ type_expression ("," type_expression)\* ] "]"
@@ -173,10 +175,24 @@ Where ``parameter_specification_variable`` resolves to a ``typing.ParamSpec``
 declaration as defined above, and ``concatenate`` resolves to
 ``typing.type_variable_operators.Concatenate``.
 
-As before, ``parameters_expression`` is the only valid thing for the first
-parameter of ``typing.Callable``, but it is now acceptable in other user-defined
-generic types, as long as they are declared as being generic in
-a parameters_expression.
+As before, ``parameters_expression``\ s by themselves are not acceptable in
+places where a type is expected
+
+.. code-block::
+
+   def foo(x: P) -> P: ...                           # Rejected
+   def foo(x: Concatenate[int, P]) -> int: ...       # Rejected
+   def foo(x: typing.List[P]) -> None: ...           # Rejected
+   def foo(x: Callable[[int, str], P]) -> None: ...  # Rejected
+
+
+User-Defined Generic Classes
+````````````````````````````
+
+Just as defining a class as inheriting from ``Generic[T]`` makes a class generic
+for a single parameter (when ``T`` is a ``TypeVar``\ ), defining a class as 
+inheriting from ``Generic[P]`` makes a class generic on 
+``parameters_expression``\ s (when ``P`` is a ``ParamSpec``).
 
 .. code-block::
 
@@ -191,17 +207,11 @@ a parameters_expression.
    def f(x: X[int, Concatenate[int, P_2]]) -> str: ...  # Accepted
    def f(x: X[int, [int, bool]]) -> str: ...            # Accepted
    def f(x: X[int, ...]) -> str: ...                    # Accepted
+   def f(x: X[int, int]) -> str: ...                    # Rejected
 
-   class Y(Generic[T, Concatenate[S, P]]):
-     ...
-
-   def f(x: Y[int, P_2]) -> str: ...                    # Accepted
-   def f(x: Y[int, Concatenate[int, P_2]]) -> str: ...  # Accepted
-   def f(x: Y[int, [int, bool]]) -> str: ...            # Accepted
-   def f(x: Y[int, ...]) -> str: ...                    # Accepted
-
-We furthermore accept a special case for when a class is generic with
-respect to only a single ParamSpec.
+By the rules defined above, spelling an concrete instance of a class generic   
+with respect to only a single ``ParamSpec`` would require unsightly double
+brackets.  For aesthetic purposes we allow these to be omitted.
 
 .. code-block::
 
@@ -209,18 +219,7 @@ respect to only a single ParamSpec.
      ...
 
    def f(x: Z[[int, str, bool]]) -> str: ...   # Accepted
-   def f(x: Z[int, str, bool]) -> str: ...     # Also accepted
-
-As before, ``parameters_expression``\ s by themselves are not acceptable in
-places where a type is expected
-
-.. code-block::
-
-   def foo(x: P) -> P: ...                           # Rejected
-   def foo(x: Concatenate[int, P]) -> int: ...       # Rejected
-
-   def foo(x: typing.List[P]) -> None: ...           # Rejected
-   def foo(x: Callable[[int, str], P]) -> None: ...  # Rejected
+   def f(x: Z[int, str, bool]) -> str: ...     # Equivalent
 
 Semantics
 ^^^^^^^^^

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -230,12 +230,12 @@ evaluating ones with ``TypeVar``\ s.
 
 .. code-block::
 
-   def foo(x: Callable[P, int]) -> Callable[P, str]: ...
+   def changes_return_type_to_str(x: Callable[P, int]) -> Callable[P, str]: ...
 
-   def bar(a: str, b: bool) -> int: ...
+   def returns_int(a: str, b: bool) -> int: ...
 
-   f = foo(bar) # f should be inferred to have the same signature as bar,
-                # but returning str
+   f = changes_return_type_to_str(returns_int) # f should have the type:
+                                               # (a: str, b: bool) -> str
 
    f("A", True)               # Accepted
    f(a="A", b=True)           # Accepted
@@ -267,8 +267,8 @@ but is not obligated to do so.
                                  # that are behavioral subtypes of
                                  # Callable[[int, str], object]
 
-   def keyword_only_x( *, x: int) -> int: ...
-   def keyword_only_y( *, y: int) -> int: ...
+   def keyword_only_x(*, x: int) -> int: ...
+   def keyword_only_y(*, y: int) -> int: ...
    foo(keyword_only_x, keyword_only_y) # Rejected
 
 The semantics of ``Concatenate[X, Y, P]`` are that it represents the parameters
@@ -278,19 +278,19 @@ transform a finite number of parameters of a callable.
 
 .. code-block::
 
+   def bar(x: int, *args: bool) -> int: ...
+
    def add(x: Callable[P, int]) -> Callable[Concatenate[str, P], bool]: ...
 
+   add(bar)       # Should return (__a: str, x: int, *args: bool) -> bool
+
    def remove(x: Callable[Concatenate[int, P], int]) -> Callable[P, bool]: ...
+
+   remove(bar)    # Should return (*args: bool) -> bool
 
    def transform(
      x: Callable[Concatenate[int, P], int]
    ) -> Callable[Concatenate[str, P], bool]: ...
-
-   def bar(x: int, *args: bool) -> int: ...
-
-   add(bar)       # Should return (__a: str, x: int, *args: bool) -> bool
-
-   remove(bar)    # Should return (*args: bool) -> bool
 
    transform(bar) # Should return (__a: str, *args: bool) -> bool
 
@@ -301,18 +301,18 @@ their first position with a ``X`` can satisfy
 
 .. code-block::
 
-   def expects(x: Callable[Concatenate[int, P], int]) -> None: ...
+   def expects_int_first(x: Callable[Concatenate[int, P], int]) -> None: ...
 
-   @expects # Rejected
+   @expects_int_first # Rejected
    def one(x: str) -> int: ...
 
-   @expects # Rejected
-   def two( *, x: int) -> int: ...
+   @expects_int_first # Rejected
+   def two(*, x: int) -> int: ...
 
-   @expects # Rejected
-   def three( **kwargs: int) -> int: ...
+   @expects_int_first # Rejected
+   def three(**kwargs: int) -> int: ...
 
-   @expects # Accepted
+   @expects_int_first # Accepted
    def four(*args: int) -> int: ...
 
 There are still a class of decorators still not supported with these features:
@@ -330,34 +330,56 @@ a single ``ParamSpec`` into these two components, and then bring
 them back together into a call.  To do this, we introduce ``P.args`` to
 represent the tuple of positional arguments in a given call and
 ``P.kwargs`` to represent the corresponding ``Mapping`` of keywords to
-values. These "properties" can only be used together, as the annotated types for
-``*args`` and ``**kwargs`` , on a ParamSpec already in scope.
+values. 
+
+Valid use locations
+```````````````````
+
+These "properties" can only be used as the annotated types for
+``*args`` and ``**kwargs``\ , accessed from a ParamSpec already in scope.
 
 .. code-block::
 
-   def d(f: Callable[P, int]) -> None:
+   def puts_p_into_scope(f: Callable[P, int]) -> None:
 
-     def foo(*args: P.args, **kwargs: P.kwargs) -> None:  # Accepted
+     def inner(*args: P.args, **kwargs: P.kwargs) -> None:      # Accepted
        pass
 
-     def bar(*args: P.kwargs, **kwargs: P.args) -> None:  # Rejected
+     def mixed_up(*args: P.kwargs, **kwargs: P.args) -> None:   # Rejected
        pass
 
-     def baz(*args: P.args) -> None:                      # Rejected
+     def misplaced(x: P.args) -> None:                          # Rejected
        pass
 
-     stored_arguments: P.args                             # Rejected
-
-     def bap(x: P.args) -> None:                          # Rejected
-       pass
+   def out_of_scope(*args: P.args, **kwargs: P.kwargs) -> None: # Rejected
+      pass
 
 
-Because the default kind of parameter in Python (\ ``(x: int)``\ ) may be
-addressed both positionally and through its name, two valid invocations of
-a ``(*args: P.args, **kwargs: P.kwargs)`` function may give
+A function cannot use just one of ``*args: P.args`` or ``**kwargs: P.kwargs``, 
+they must both be used together. Because the default kind of parameter in Python 
+(\ ``(x: int)``\ ) may be addressed both positionally and through its name, two 
+valid invocations of a ``(*args: P.args, **kwargs: P.kwargs)`` function may give
 different partitions of the same set of parameters. Therefore we need to make
 sure that these special types are only brought into the world together, and are
 used together, so that our usage is valid for all possible partitions.
+
+.. code-block::
+
+   def puts_p_into_scope(f: Callable[P, int]) -> None:
+
+     stored_args: P.args                      # Rejected
+
+     stored_kwargs: P.args                    # Rejected
+
+     def just_args(*args: P.args) -> None:    # Rejected
+       pass
+
+     def just_kwargs(*args: P.args) -> None:  # Rejected
+       pass
+
+
+Semantics
+`````````
 
 With those requirements met, we can now take advantage of the unique properties
 afforded to us by this set up:
@@ -462,7 +484,7 @@ problematic.
 .. code-block::
 
    @outer
-   def problem( *, x: object) -> None:
+   def problem(*, x: object) -> None:
      pass
 
    problem(x="uh-oh")

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -17,7 +17,7 @@ Abstract
 --------
 
 There currently are two ways to specify the type of a callable, the
-``Callable[[T1, T2], TReturn]`` syntax defined in  `PEP 484
+``Callable[[T1, T2], R]`` syntax defined in  `PEP 484
 <https://www.python.org/dev/peps/pep-0484>`_\ , and callback protocols from `PEP
 544 <https://www.python.org/dev/peps/pep-0544/#callback-protocols>`_. Neither of
 these support forwarding the parameter types of one callable over to another
@@ -507,11 +507,11 @@ so:
 
 .. code-block::
 
-   Treturn = typing.TypeVar(“Treturn”)
+   R = typing.TypeVar(“R”)
    Tpositionals = ....
    Tkeywords = ...
-   class BetterCallable(typing.Protocol[Tpositionals, Tkeywords, Treturn]):
-     def __call__(*args: Tpositionals, **kwargs: Tkeywords) -> Treturn: ...
+   class BetterCallable(typing.Protocol[Tpositionals, Tkeywords, R]):
+     def __call__(*args: Tpositionals, **kwargs: Tkeywords) -> R: ...
 
 However there are some problems with trying to come up with a consistent
 solution for those type variables for a given callable. This problem comes up
@@ -587,12 +587,12 @@ everything that we can express with ``ParamSpecs``.
        return inner
 
    def unwrapping(
-       f: Callable[ParametersOf[F], List[TReturn]]
-   ) -> Callable[ParametersOf[F], TReturn]:
+       f: Callable[ParametersOf[F], List[R]]
+   ) -> Callable[ParametersOf[F], R]:
        def inner(
           *args: ParametersOf[F].args,
           **kwargs: ParametersOf[F].kwargs
-       ) -> TReturn:
+       ) -> R:
           return f(*args, **kwargs)[0]
        return inner
 

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -395,13 +395,14 @@ parameter preserving decorators.
 
 To extend this to include ``Concatenate``, we declare the following properties:
 
-* A function of type ``Callable[Concatenate[A, B, P], R]`` can be
+* A function of type ``Callable[Concatenate[A, B, P], R]`` can only be
   called with ``(a, b, *args, **kwargs)`` when ``args`` and ``kwargs`` are the
   respective components of ``P``, ``a`` is of type ``A`` and ``b`` is of
   type ``B``.
 * A function declared as
   ``def inner(a: A, b: B, *args: P.args, **kwargs: P.kwargs) -> R``
-  has type ``Callable[Concatenate[A, B, P], R]``.
+  has type ``Callable[Concatenate[A, B, P], R]``. Placing keyword-only
+  parameters beterrn the ``*args`` and ``**kwargs`` is forbidden.
 
 .. code-block::
 

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -69,8 +69,8 @@ Due to the limitations of the status quo, the ``add_logging`` example will type
 check but will fail at runtime. ``inner`` will pass the string “B” into
 ``takes_int_str``\, which will try to add 7 to it, triggering a type error.
 This was not caught by the type checker because the decorated ``takes_int_str``
-was given the type ``Callable[..., Awaitable[int]]`` which is specified to do no
-validation on its arguments.
+was given the type ``Callable[..., Awaitable[int]]`` (an ellipsis in place of
+parameter types is specified to mean that we do no validation on arguments).
 
 Without the ability to define dependencies between the parameters of different
 callable types, there is no way, at present, to make ``add_logging`` compatible

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -17,7 +17,7 @@ Abstract
 --------
 
 There currently are two ways to specify the type of a callable, the
-``Callable[[T1, T2], R]`` syntax defined in  `PEP 484
+``Callable[[int, str], bool]`` syntax defined in  `PEP 484
 <https://www.python.org/dev/peps/pep-0484>`_\ , and callback protocols from `PEP
 544 <https://www.python.org/dev/peps/pep-0544/#callback-protocols>`_. Neither of
 these support forwarding the parameter types of one callable over to another
@@ -44,11 +44,11 @@ tools to annotate the following common decorator pattern satisfactorily:
        return inner
 
    @add_logging
-   def foo(x: int, y: str) -> int:
+   def takes_int_str(x: int, y: str) -> int:
        return x + 7
 
-   await foo(1, "A")
-   await foo("B", 2) # fails at runtime
+   await takes_int_str(1, "A")
+   await takes_int_str("B", 2) # fails at runtime
 
 ``add_logging``\ , a decorator which logs before each entry into the decorated
 function, is an instance of the Python idiom of one function passing all
@@ -66,11 +66,11 @@ single types, as in ``def append(l: typing.List[T], e: T) -> typing.List[T]:
 the parameters one could pass to a function.
 
 Due to the limitations of the status quo, the ``add_logging`` example will type
-check but will fail at runtime. ``inner`` will pass the string “B” into ``foo``\
-, which will try to add 7 to it, triggering a type error.  This was not caught
-by the type checker because the decorated ``foo`` was given the type
-``Callable[..., Awaitable[int]]`` which is specified to do no validation on its
-arguments.
+check but will fail at runtime. ``inner`` will pass the string “B” into
+``takes_int_str``\, which will try to add 7 to it, triggering a type error.
+This was not caught by the type checker because the decorated ``takes_int_str``
+was given the type ``Callable[..., Awaitable[int]]`` which is specified to do no
+validation on its arguments.
 
 Without the ability to define dependencies between the parameters of different
 callable types, there is no way, at present, to make ``add_logging`` compatible
@@ -95,13 +95,11 @@ the decorator and the parameter enforcement of the decorated function.
        return inner
 
    @add_logging
-   def foo(x: int, y: str) -> int:
+   def takes_int_str(x: int, y: str) -> int:
        return x + 7
 
-   await foo(1, "A")
-   await foo("B", 2) # Incompatible parameter type:
-                     # Expected `int` for 1st anonymous parameter to call `foo`
-                     # but got `str`
+   await takes_int_str(1, "A")
+   await takes_int_str("B", 2) # Correctly rejected by the type checker
 
 With the further addition of the ``Concatenate`` operator, we can also express
 the types of more complex decorators which add, remove, or modify a finite

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -138,8 +138,8 @@ Specification
 ParamSpec Declarations
 ^^^^^^^^^^^^^^^^^^^^^^
 
-A parameter specification variable is defined in a similar manner to a normal
-``typing.TypeVar``.
+A parameter specification variable is defined in a similar manner to how a
+normal type variable is defined with ``typing.TypeVar``.
 
 .. code-block::
 

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -54,18 +54,18 @@ tools to annotate the following common decorator pattern satisfactorily:
 
 ``add_logging``\ , a decorator which logs before each entry into the decorated
 function, is an instance of the Python idiom of one function passing all
-arguments given to it over to another function through the combination of the
-``*args`` and ``**kwargs`` features in both parameters and in arguments. When
-one defines a function (like ``inner``\ ) that takes ``(*args, **kwargs)`` and
-goes on to call another function with ``(*args, **kwargs)``\ , the wrapping
-function can only be safely called in all of the ways that the wrapped function
-could be safely called. To type this decorator, we’d like to be able to place
-a dependency between the parameters of the callable ``f`` and the parameters of
-the returned function. `PEP 484 <https://www.python.org/dev/peps/pep-0484>`_
-supports dependencies between single types, as in ``def append(l:
-typing.List[T], e: T) -> typing.List[T]: ...``\ , but there is no existing way
-to do so with a complicated entity like the parameters one could pass to
-a function.
+arguments given to it over to another function.  This is done through the
+combination of the ``*args`` and ``**kwargs`` features in both parameters and in
+arguments. When one defines a function (like ``inner``\ ) that takes ``(*args,
+**kwargs)`` and goes on to call another function with ``(*args, **kwargs)``\
+, the wrapping function can only be safely called in all of the ways that the
+wrapped function could be safely called. To type this decorator, we’d like to be
+able to place a dependency between the parameters of the callable ``f`` and the
+parameters of the returned function. `PEP 484
+<https://www.python.org/dev/peps/pep-0484>`_ supports dependencies between
+single types, as in ``def append(l: typing.List[T], e: T) -> typing.List[T]:
+...``\ , but there is no existing way to do so with a complicated entity like
+the parameters one could pass to a function.
 
 Due to the limitations of the status quo, the ``add_logging`` example will type
 check but will fail at runtime. ``inner`` will pass the string “B” into ``foo``\
@@ -110,6 +110,7 @@ the types of more complex decorators which add, remove, or modify a finite
 number of  positional arguments from decorated functions.
 
 .. code-block::
+   from typing.type_variable_operators import Concatenate
    
    def add_arguments(
        f: Callable[TParams, str]
@@ -153,8 +154,8 @@ number of  positional arguments from decorated functions.
 Specification
 -------------
 
-Declarations
-^^^^^^^^^^^^
+ParamSpec Declarations
+^^^^^^^^^^^^^^^^^^^^^^
 
 A parameter specification variable is defined in a similar manner to a normal
 ``typing.TypeVar``.
@@ -171,6 +172,52 @@ will defer the standardization of the semantics of those options to a later PEP.
 
 Valid use locations
 ^^^^^^^^^^^^^^^^^^^
+
+Previously, the only things acceptable in the first "argument" to the
+``typing.Callable`` type are a list of parameter arguments (``[A, B, C]``) or an
+ellipsis (signifying "undefined parameters").  We now augment that with two new
+options: 
+
+.. code-block::
+   parameters_expression ::= 
+     | ...
+     | "[" [ type_expression ("," type_expression)\* ] "]"
+     | parameter_specification_variable
+     | concatenate "[" 
+                      type_expression ("," type_expression)\* ","
+                      parameter_specification_variable 
+                   "]"
+
+Where ``parameter_specification_variable`` resolves to a ``typing.ParamSpec``
+declaration as defined above, and ``concatenate`` resolves to
+``typing.type_variable_operators.Concatenate``.
+
+As before, ``parameters_expression`` is the only valid thing for the first
+parameter of ``typing.Callable``, but it is now acceptable in other user-defined
+generic types, as long as they are declared as being generic in
+a parameters_expression.
+
+.. code-block::
+   T = TypeVar("T") 
+   S = TypeVar("S")
+   OtherTParams = ParamSpec("OtherTParams")
+
+   class X(Generic[T, TParams]):
+     ...
+
+   def f(x: X[int, OtherTParams]) -> str: ...                   # Accepted
+   def f(x: X[int, Concatenate[int, OtherTParams]]) -> str: ... # Accepted
+   def f(x: X[int, [int, bool]]) -> str: ...                    # Accepted
+   def f(x: X[int, ...]) -> str: ...                            # Accepted
+
+   class Y(Generic[T, Concatenate[S, TParams]]):
+     ...
+
+   def f(x: Y[int, OtherTParams]) -> str: ...                   # Accepted
+   def f(x: Y[int, Concatenate[int, OtherTParams]]) -> str: ... # Accepted
+   def f(x: Y[int, [int, bool]]) -> str: ...                    # Accepted
+   def f(x: Y[int, ...]) -> str: ...                            # Accepted
+
 
 A declared ``ParamSpec`` can only be used in the place of the list
 of types in the declaration of a ``Callable`` type, or a user defined class

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -22,7 +22,7 @@ There currently are two ways to specify the type of a callable, the
 544 <https://www.python.org/dev/peps/pep-0544/#callback-protocols>`_. Neither of
 these support forwarding the parameter types of one callable over to another
 callable, making it difficult to annotate function decorators. This PEP proposes
-``typing.ParameterSpecification``\ , a new kind of type variable, to support
+``typing.ParamSpec``\ , a new kind of type variable, to support
 expressing these kinds of relationships. 
 
 Motivation
@@ -79,15 +79,15 @@ callable types, there is no way, at present, to make ``add_logging`` compatible
 with all functions, while still preserving the enforcement of the parameters of
 the decorated function. 
 
-With the addition of the ``ParameterSpecification`` variables proposed by this
+With the addition of the ``ParamSpec`` variables proposed by this
 PEP, we can rewrite the previous example in a way that keeps the flexibility of
 the decorator and the parameter enforcement of the decorated function.
 
 .. code-block::
 
-   from typing import Awaitable, Callable, ParameterSpecification, TypeVar
+   from typing import Awaitable, Callable, ParamSpec, TypeVar
 
-   Ps = ParameterSpecification("Ps")
+   Ps = ParamSpec("Ps")
    R = TypeVar("R")
 
    def add_logging(f: Callable[Ps, R]) -> Callable[Ps, Awaitable[R]]:
@@ -117,9 +117,9 @@ A parameter specification variable is defined in a similar manner to a normal
 
 .. code-block::
 
-   from typing import ParameterSpecification
-   TParams = ParameterSpecification("TParams") # Accepted
-   TParams = ParameterSpecification("WrongName") # Rejected
+   from typing import ParamSpec
+   TParams = ParamSpec("TParams") # Accepted
+   TParams = ParamSpec("WrongName") # Rejected
 
 The runtime should accept ``bound``\ s and ``covariant`` and ``contravariant``
 arguments in the declaration just as ``typing.TypeVar`` does, but for now we
@@ -128,9 +128,9 @@ will defer the standardization of the semantics of those options to a later PEP.
 Valid use locations
 ^^^^^^^^^^^^^^^^^^^
 
-A declared ``ParameterSpecification`` can only be used in the place of the list
+A declared ``ParamSpec`` can only be used in the place of the list
 of types in the declaration of a ``Callable`` type, or a user defined class
-which is generic in a ``ParameterSpecification`` variable (i.e., ``MyClass`` in
+which is generic in a ``ParamSpec`` variable (i.e., ``MyClass`` in
 the following example).
 
 .. code-block::
@@ -151,7 +151,7 @@ Semantics
 ^^^^^^^^^
 
 The inference rules for the return type of a function invocation whose signature
-contains a ``ParameterSpecification`` variable are analogous to those around
+contains a ``ParamSpec`` variable are analogous to those around
 evaluating ones with ``TypeVar``\ s. 
 
 .. code-block::
@@ -167,7 +167,7 @@ evaluating ones with ``TypeVar``\ s.
    f("A", "A") # Rejected
 
 Just as with traditional ``TypeVars``\ , a user may include the same
-``ParameterSpecification`` multiple times in the arguments of the same function,
+``ParamSpec`` multiple times in the arguments of the same function,
 to indicate a dependency between multiple arguments.  In these cases a type
 checker may choose to solve to a common behavioral supertype (i.e. a set of
 parameters for which all of the valid calls are valid in both of the subtypes),
@@ -194,19 +194,19 @@ but is not obligated to do so.
 Use in ``Generic`` Classes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Just as with normal ``TypeVar``\ s, ``ParameterSpecification``\ s can be used to
+Just as with normal ``TypeVar``\ s, ``ParamSpec``\ s can be used to
 make generic classes as well as generic functions. These are able to be
 mixed with normal ``TypeVar``\ s. This also work with
 protocols in the same manner.
 
-The components of a ``ParameterSpecification``
+The components of a ``ParamSpec``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A ``ParameterSpecification`` captures both positional and keyword accessible
+A ``ParamSpec`` captures both positional and keyword accessible
 parameters, but there unfortunately is no object in the runtime that captures
 both of these together. Instead, we are forced to separate them into ``*args``
 and ``**kwargs``\ , respectively. This means we need to be able to split apart
-a single ``ParameterSpecification`` into these two components, and then bring
+a single ``ParamSpec`` into these two components, and then bring
 them back together into a call.  To do this, we introduce ``TParams.args`` to
 represent the tuple of positional arguments in a given call and
 ``TParams.kwargs`` to represent the corresponding ``Mapping`` of keywords to
@@ -259,7 +259,7 @@ parameter preserving decorators.
 
 One additional form that we want to support is functions that pass only a subset
 of their arguments on to another function. To avoid shadowing a named or keyword
-only argument in the ``ParameterSpecification`` we require that the additional
+only argument in the ``ParamSpec`` we require that the additional
 arguments be anonymous arguments that precede the ``*args`` and ``*kwargs``
 
 .. code-block::
@@ -277,7 +277,7 @@ Backwards Compatibility
 -----------------------
 
 The only changes necessary to existing features in ``typing`` is allowing these
-``ParameterSpecification`` objects to be the first parameter to ``Callable`` and
+``ParamSpec`` objects to be the first parameter to ``Callable`` and
 to be a parameter to ``Generic``. Currently ``Callable`` expects a list of types
 there and ``Generic`` expects single types, so they are currently mutually
 exclusive. Otherwise, existing code that doesn't reference the new interfaces
@@ -287,7 +287,7 @@ Reference Implementation
 ------------------------
 
 The `Pyre <https://pyre-check.org/>`_ type checker supports
-``ParameterSpecification``\ s, ``.args`` and ``.kwargs`` in the context of
+``ParamSpec``\ s, ``.args`` and ``.kwargs`` in the context of
 functions. Support for use with ``Generic`` is not yet implemented. A reference
 implementation of the runtime components needed for those uses is provided in
 the ``pyre_extensions`` module.
@@ -349,7 +349,7 @@ three categories (positional-only, positional-or-keyword, keyword-only) we’re
 trying to jam into two categories. This is the same problem that we briefly
 mentioned when discussing ``.args`` and ``.kwargs``. Fundamentally, in order to
 capture two categories when there are some things that can be in either
-category, we need a higher level primitive (\ ``ParameterSpecification``\ ) to
+category, we need a higher level primitive (\ ``ParamSpec``\ ) to
 capture all three, and then split them out afterward.
 
 Mutations on ParameterSpecifications
@@ -362,13 +362,18 @@ quickly, as you have to deal with name collision issues much more prominently.
 We will defer that work until there is significant demand, and then we would be
 open to revisiting it.
 
+Naming this a ``ParameterSpecification``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+We decided that ParameterSpecification was a little too long-winded for use 
+here, and that this style of abbreviated name made it look more like TypeVar.
+
 Naming this an ``ArgSpec``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We think that calling this a ParameterSpecification is more correct than
-referring to it as an Argument Specification, since callables have parameters,
+We think that calling this a ParamSpec is more correct than
+referring to it as an ArgSpec, since callables have parameters,
 which are distinct from the arguments which are passed to them in a given call
-site.  A given binding for a ParameterSpecification is a set of function
+site.  A given binding for a ParamSpec is a set of function
 parameters, not a call-site’s arguments.
 
 Acknowledgements

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -447,21 +447,7 @@ To extend this to include ``Concatenate``, we declare the following properties:
 
      return foo
 
-We also consider functions with a ``ParamSpec`` included in one of the preceding
-anonymous parameters to have the variable "already in scope" for the purposes of
-extracting the components of that ``ParamSpec``.  That allows us to spell things
-like this:
-
-.. code-block::
-
-   def twice(f: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int:
-       return f(*args, **kwargs) + f(*args, **kwargs)
-
-The type of ``twice`` in the above example is
-``Callable[Concatenate[Callable[P, int], P], int]``, where ``P`` is bound by the
-outer ``Callable``.
-
-Also note that the names of the parameters preceding the ``ParamSpec``
+Note that the names of the parameters preceding the ``ParamSpec``
 components are not mentioned in the resulting ``Concatenate``.  This means that
 these parameters can not be addressed via a named argument:
 
@@ -492,10 +478,34 @@ problematic.
 Inside of ``bar``, we would get
 ``TypeError: foo() got multiple values for argument 'x'``.  Requiring these
 concatenated arguments to be addressed positionally avoids this kind of problem,
-and simplifies the syntax for spelling these types.
-
-Note that this also why we have to reject signatures of the form
+and simplifies the syntax for spelling these types. Note that this also why we 
+have to reject signatures of the form 
 ``(*args: P.args, s: str, **kwargs: P.kwargs)``.
+
+If one of these prepended positional parameters contains a free ``ParamSpec``\ , 
+we consider that variable in scope for the purposes of extracting the components
+of that ``ParamSpec``.  That allows us to spell things like this:
+
+.. code-block::
+
+   def twice(f: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int:
+       return f(*args, **kwargs) + f(*args, **kwargs)
+
+The type of ``twice`` in the above example is
+``Callable[Concatenate[Callable[P, int], P], int]``, where ``P`` is bound by the
+outer ``Callable``.  This has the following semantics:
+
+.. code-block::
+
+   def a_int_b_str(a: int, b: str) -> int: 
+     pass
+
+   twice(a_int_b_str, 1, "A")       # Accepted 
+
+   twice(a_int_b_str, b="A", a=1)   # Accepted
+
+   twice(a_int_b_str, "A", 1)       # Rejected
+
 
 Backwards Compatibility
 -----------------------

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -368,7 +368,7 @@ afforded to us by this set up:
 * Inside the function, ``args`` has the type ``P.args``\ , not
   ``Tuple[P.args, ...]`` as would be with a normal annotation
   (and likewise with the ``**kwargs``\ )
-* A function of type ``Callable[P, R]`` can be called with``(*args, **kwargs)``
+* A function of type ``Callable[P, R]`` can be called with ``(*args, **kwargs)``
   if and only if ``args`` has the type ``P.args`` and ``kwargs`` has the type
   ``P.kwargs``\ , and that those types both originated from the same function
   declaration.

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -98,39 +98,52 @@ the decorator and the parameter enforcement of the decorated function.
    def takes_int_str(x: int, y: str) -> int:
        return x + 7
 
-   await takes_int_str(1, "A")
+   await takes_int_str(1, "A") # Accepted
    await takes_int_str("B", 2) # Correctly rejected by the type checker
 
-With the further addition of the ``Concatenate`` operator, we can also express
-the types of more complex decorators which add, remove, or modify a finite
-number of  positional arguments from decorated functions.
+Another common decorator pattern that has previously been impossible to type is
+the practice of adding or removing arguments from the decorated function.  For
+example:
+
+.. code-block::
+  
+   class Request:
+    ...
+
+   def with_request(f: Callable[..., R]) -> Callable[..., R]:
+      def inner(*args: object, **kwargs: object) -> R:
+          return f(Request(), *args, **kwargs)  
+      return inner
+
+   @with_request
+   def takes_int_str(request: Request, x: int, y: str) -> int:
+    # use request
+    return x + 7
+
+   takes_int_str(1, "A")
+   takes_int_str("B", 2) # fails at runtime
+    
+
+With the addition of the ``Concatenate`` operator from this PEP, we can even
+type this more complex decorator.
 
 .. code-block::
 
    from typing.type_variable_operators import Concatenate
 
-   def add(f: Callable[P, str]) -> Callable[Concatenate[str, bool, P], int]:
-       def inner(x: str, y: bool, *args: P.args, **kwargs: P.kwargs) -> int:
-           # use x & y
-           s = f(*args, **kwargs)
-           return int(s)
-       return inner
+   def with_request(f: Callable[Concatenate[Request, P], R]) -> Callable[P, R]:
+      def inner(*args: P.args, **kwargs: P.kwargs) -> R:
+          return f(Request(), *args, **kwargs)  
+      return inner
 
-   def remove(f: Callable[Concatenate[int, bool, P], str]) -> Callable[P, int]:
-       def inner(*args: P.args, **kwargs: P.kwargs) -> int:
-           s = f(75, True, *args, **kwargs)
-           return int(s)
-       return inner
+   @with_request
+   def takes_int_str(request: Request, x: int, y: str) -> int:
+    # use request
+    return x + 7
 
-   def change_arguments(
-       f: Callable[Concatenate[int, bool, P], str]
-   ) -> Callable[Concatenate[float, str, P], int]:
-       def inner(x: float, y: str, *args: P.args, **kwargs: P.kwargs) -> int:
-           # use x & y
-           s = f(75, True, *args, **kwargs)
-           return int(s)
-       return inner
-
+   takes_int_str(1, "A") # Accepted
+   takes_int_str("B", 2) # Correctly rejected by the type checker
+    
 
 Specification
 -------------

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -156,10 +156,9 @@ will defer the standardization of the semantics of those options to a later PEP.
 Valid use locations
 ^^^^^^^^^^^^^^^^^^^
 
-Previously, the only things acceptable in the first "argument" to the
-``typing.Callable`` type are a list of parameter arguments (``[A, B, C]``) or an
-ellipsis (signifying "undefined parameters").  We now augment that with two new
-options:
+Previously only a list of parameter arguments (``[A, B, C]``) or an ellipsis
+(signifying "undefined parameters") were acceptable as the first "argument" to
+``typing.Callable`` .  We now augment that with two new options:
 
 .. code-block::
 

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -270,7 +270,7 @@ arguments be anonymous arguments that precede the ``*args`` and ``*kwargs``
        *args: TParams.args, 
        **kwargs: TParams.kwargs,
    ) -> None:
-       for x in range(__n);
+       for x in range(__n):
            __f(*args, **kwargs)
 
 Backwards Compatibility

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -235,7 +235,7 @@ where a type is expected
 
    def foo(x: TParams) -> TParams: ...  # Rejected
    def foo(x: typing.List[TParams]) -> None: ... # Rejected
-   def foo(x: typing.Callable[[int, str], TParams]) -> None: ... # Rejected
+   def foo(x: Callable[[int, str], TParams]) -> None: ... # Rejected
 
    def foo(x: Concatenate[int, TParams]) -> int: ...  # Rejected
    def foo(x: [int, str, bool]) -> int: ...  # Rejected
@@ -250,15 +250,19 @@ evaluating ones with ``TypeVar``\ s.
 
 .. code-block::
 
-   def foo(
-       x: typing.Callable[TParams, int]
-   ) -> typing.Callable[TParams, str]: ...
+   def foo(x: Callable[TParams, int]) -> Callable[TParams, str]: ...
+
    def bar(a: str, b: bool) -> int: ...
+
    f = foo(bar) # f should be inferred to have the same signature as bar, 
                 # but returning str
+
    f("A", True) # Accepted
    f(a="A", b=True) # Accepted
    f("A", "A") # Rejected
+
+   expects_str(f("A", True)) # Accepted
+   expects_int(f("A", True)) # Rejected
 
 Just as with traditional ``TypeVars``\ , a user may include the same
 ``ParamSpec`` multiple times in the arguments of the same function,
@@ -269,21 +273,69 @@ but is not obligated to do so.
 
 .. code-block::
 
-   def foo(
-       x: typing.Callable[TParams, int], y: typing.Callable[TParams, int]
-   ) -> typing.Callable[TParams, bool]: ...
+   P = ParamSpec("P")
+
+   def foo(x: Callable[P, int], y: Callable[P, int]) -> Callable[P, bool]: ...
 
    def x_int_y_str(x: int, y: str) -> int: ...
    def y_int_x_str(y: int, x: str) -> int: ...
-   foo(x_int_y_str, x_int_y_str) # Must return (x: int, y: str) -> int
-   foo(x_int_y_str, y_int_x_str) # Could return (__a: int, __b: str) -> int 
+   foo(x_int_y_str, x_int_y_str) # Should return (x: int, y: str) -> bool 
+   foo(x_int_y_str, y_int_x_str) # Could return (__a: int, __b: str) -> bool 
                                  # This works because both callables have types 
                                  # that are behavioral subtypes of 
-                                 # Callable[[int, str], int]
+                                 # Callable[[int, str], object]
 
-   def keyword_only_x(*, x: int) -> int: ...
-   def keyword_only_y(*, y: int) -> int: ...
-   foo(keyword_only_x, keyword_only_y) # Must be rejected
+   def keyword_only_x( *, x: int) -> int: ...
+   def keyword_only_y( *, y: int) -> int: ...
+   foo(keyword_only_x, keyword_only_y) # Should be rejected
+   
+The semantics of ``Concatenate[X, Y, P]`` are that it represents the parameters
+represented by ``P`` with two positional-only parameters prepended.  This means
+that we can use it to represent higher order functions that add, remove or
+transform a finite number of parameters of a callable.
+
+.. code-block::
+   
+   def add(x: Callable[P, int]) -> Callable[Concatenate[str, P], bool]: ...
+
+   def remove(x: Callable[Concatenate[int, P], int]) -> Callable[P, bool]: ...
+
+   def transform(
+     x: Callable[Concatenate[int, P], int]
+   ) -> Callable[Concatenate[str, P], bool]: ...
+
+   def bar(x: int, *args: bool) -> int: ...
+
+   add(bar)       # Should return (__a: str, x: int, *args: bool) -> bool
+
+   remove(bar)    # Should return (*args: bool) -> bool
+
+   transform(bar) # Should return (__a: str, *args: bool) -> bool
+
+This also means that while any function that returns an ``R`` can satisfy
+``typing.Callable[P, R]``, only functions that can be called positionally in
+their first position with a ``X`` can satisfy
+``typing.Callable[Concatenate[X, P]``.
+
+.. code-block::
+   
+   def expects(x: Callable[Concatenate[int, P], int]) -> None: ...
+
+   def one(x: str) -> int: ...
+
+   expects(one)  # Should be rejected
+
+   def two( *, x: int) -> int: ...
+
+   expects(two)  # Should be rejected
+
+   def three( **kwargs: int) -> int: ...
+
+   expects(three) # Should be rejected
+
+   def four(*args: int) -> int: ...
+
+   expects(four)  # Should be accepted
 
 Use in ``Generic`` Classes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -310,20 +362,23 @@ values. These operators can only be used together, as the annotated types for
 .. code-block::
 
    class G(Generic[TParams]):
-       def foo(
-           *args: TParams.args, **kwargs: TParams.kwargs
-       ) -> int:                                # Accepted
+       def foo(*args: TParams.args, **kwargs: TParams.kwargs) -> int: # Accepted
            ...
-       def bar(
-           *args: TParams.kwargs, **kwargs: TParams.args
-       ) -> int:                                # Rejected
+
+       def bar(*args: TParams.kwargs, **kwargs: TParams.args) -> int: # Rejected
            ...
-       def baz(*args: TParams.args) -> int: ... # Rejected
-       stored_arguments: TParams.args           # Rejected
-       def bap(x: TParams.args) -> int: ...     # Rejected
+
+       def baz(*args: TParams.args) -> int:                           # Rejected
+           ...
+
+       stored_arguments: TParams.args                                 # Rejected
+
+       def bap(x: TParams.args) -> int: ...                           # Rejected
+
        def bop(
-           *args: List[TParams.args], **kwargs: TParams.kwargs
-       ) -> int:                                # Rejected
+           *args: List[TParams.args], 
+           **kwargs: TParams.kwargs,
+       ) -> int:                                                     # Rejected
            ...
 
 Because the default kind of parameter in Python (\ ``(x: int)``\ ) may be

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -331,10 +331,12 @@ their first position with a ``X`` can satisfy
    def four(*args: int) -> int: ...
 
 There are still some classes of decorators still not supported with these
-features: those that add/remove/change a **variable** number of parameters (for
-example, ``functools.partial`` will remain untypable even after this PEP), and
-those that add/remove/change keyword-only parameters (See
-`Concatenating Keyword Parameters`_ for more details).
+features:
+
+* those that add/remove/change a **variable** number of parameters (for
+  example, ``functools.partial`` will remain untypable even after this PEP)
+* those that add/remove/change keyword-only parameters (See
+  `Concatenating Keyword Parameters`_ for more details).
 
 The components of a ``ParamSpec``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -372,14 +374,12 @@ These "properties" can only be used as the annotated types for
       pass
 
 
-A function cannot use just one of ``*args: P.args`` or ``**kwargs: P.kwargs``,
-they must both be used together. Furthermore, because the default kind of
-parameter in Python (\ ``(x: int)``\ ) may be addressed both positionally and
-through its name, two valid invocations of a
-``(*args: P.args, **kwargs: P.kwargs)`` function may give different partitions
-of the same set of parameters. Therefore we need to make sure that these special
-types are only brought into the world together, and are used together, so that
-our usage is valid for all possible partitions.
+Furthermore, because the default kind of parameter in Python (\ ``(x: int)``\ )
+may be addressed both positionally and through its name, two valid invocations
+of a ``(*args: P.args, **kwargs: P.kwargs)`` function may give different
+partitions of the same set of parameters. Therefore we need to make sure that
+these special types are only brought into the world together, and are used
+together, so that our usage is valid for all possible partitions.
 
 .. code-block::
 
@@ -481,6 +481,8 @@ these parameters can not be addressed via a named argument:
 
      return bar
 
+.. _above:
+
 This is not an implementation convenience, but a soundness requirement.  If we
 were to allow that second calling style, then the following snippet would be
 problematic.
@@ -572,9 +574,9 @@ with even the simplest of callables:
    simple <: BetterCallable[[], {“x”: int}, None]
    BetterCallable[[int], [], None] </: BetterCallable[[], {“x”: int}, None]
 
-Any time where a type can implement a protocol in more than one way that aren’t
+Any time where a type can implement a protocol in more than one way that aren't
 mutually compatible, we can run into situations where we lose information. If we
-were to make a decorator using this protocol, we have to pick one calling
+were to make a decorator using this protocol, we would have to pick one calling
 convention to prefer.
 
 .. code-block::
@@ -586,16 +588,18 @@ convention to prefer.
           x = f(*args, **kwargs)
           return int_to_str(x)
        return decorated
+
    @decorator
    def foo(x: int) -> int:
        return x
+
    reveal_type(foo) # Option A: BetterCallable[[int], {}, str]
                     # Option B: BetterCallable[[], {x: int}, str]
    foo(7)   # fails under option B
    foo(x=7) # fails under option A
 
 The core problem here is that, by default, parameters in Python can either be
-passed in positionally or as a keyword parameter. This means we really have
+called positionally or as a keyword argument. This means we really have
 three categories (positional-only, positional-or-keyword, keyword-only) we’re
 trying to jam into two categories. This is the same problem that we briefly
 mentioned when discussing ``.args`` and ``.kwargs``. Fundamentally, in order to
@@ -682,10 +686,9 @@ positional parameters could be expanded to include keyword parameters.
 
 However, the key distinction is that while prepending positional-only parameters
 to a valid callable type always yields another valid callable type, the same
-cannot be said for adding keyword-only parameters. As alluded to in the
-Semantics section of "The components of a ``ParamSpec``, the issue is name
-collisions.  The parameters ``Concatenate[("n", int), P]`` are only valid
-when ``P`` itself does not already have a parameter named ``n``\ .
+cannot be said for adding keyword-only parameters. As alluded to above_ , the
+issue is name collisions.  The parameters ``Concatenate[("n", int), P]`` are
+only valid when ``P`` itself does not already have a parameter named ``n``\ .
 
 .. code-block::
 
@@ -699,7 +702,7 @@ when ``P`` itself does not already have a parameter named ``n``\ .
    def problem(n: int) -> None:
      pass
 
-Calling ``problem(2)`` works fine, but callin ``problem(n=2)`` leads to a
+Calling ``problem(2)`` works fine, but calling ``problem(n=2)`` leads to a
 ``TypeError: problem() got multiple values for argument 'n'`` from the call to
 ``added`` inside of ``innocent_wrapper``\ .
 

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -23,7 +23,7 @@ There currently are two ways to specify the type of a callable, the
 these support forwarding the parameter types of one callable over to another
 callable, making it difficult to annotate function decorators. This PEP proposes
 ``typing.ParamSpec`` and ``typing.type_variable_operators.Concatenate`` to
-support expressing these kinds of relationships. 
+support expressing these kinds of relationships.
 
 Motivation
 ----------
@@ -77,7 +77,7 @@ arguments.
 Without the ability to define dependencies between the parameters of different
 callable types, there is no way, at present, to make ``add_logging`` compatible
 with all functions, while still preserving the enforcement of the parameters of
-the decorated function. 
+the decorated function.
 
 With the addition of the ``ParamSpec`` variables proposed by this
 PEP, we can rewrite the previous example in a way that keeps the flexibility of
@@ -101,17 +101,17 @@ the decorator and the parameter enforcement of the decorated function.
        return x + 7
 
    await foo(1, "A")
-   await foo("B", 2) # Incompatible parameter type: 
-                     # Expected `int` for 1st anonymous parameter to call `foo` 
+   await foo("B", 2) # Incompatible parameter type:
+                     # Expected `int` for 1st anonymous parameter to call `foo`
                      # but got `str`
 
 With the further addition of the ``Concatenate`` operator, we can also express
-the types of more complex decorators which add, remove, or modify a finite 
+the types of more complex decorators which add, remove, or modify a finite
 number of  positional arguments from decorated functions.
 
 .. code-block::
    from typing.type_variable_operators import Concatenate
-   
+
    def add_arguments(
        f: Callable[TParams, str]
    ) -> Callable[Concatenate[str, bool, TParams], int]:
@@ -176,16 +176,16 @@ Valid use locations
 Previously, the only things acceptable in the first "argument" to the
 ``typing.Callable`` type are a list of parameter arguments (``[A, B, C]``) or an
 ellipsis (signifying "undefined parameters").  We now augment that with two new
-options: 
+options:
 
 .. code-block::
-   parameters_expression ::= 
+   parameters_expression ::=
      | ...
      | "[" [ type_expression ("," type_expression)\* ] "]"
      | parameter_specification_variable
-     | concatenate "[" 
+     | concatenate "["
                       type_expression ("," type_expression)\* ","
-                      parameter_specification_variable 
+                      parameter_specification_variable
                    "]"
 
 Where ``parameter_specification_variable`` resolves to a ``typing.ParamSpec``
@@ -198,7 +198,7 @@ generic types, as long as they are declared as being generic in
 a parameters_expression.
 
 .. code-block::
-   T = TypeVar("T") 
+   T = TypeVar("T")
    S = TypeVar("S")
    OtherTParams = ParamSpec("OtherTParams")
 
@@ -246,7 +246,7 @@ Semantics
 
 The inference rules for the return type of a function invocation whose signature
 contains a ``ParamSpec`` variable are analogous to those around
-evaluating ones with ``TypeVar``\ s. 
+evaluating ones with ``TypeVar``\ s.
 
 .. code-block::
 
@@ -254,7 +254,7 @@ evaluating ones with ``TypeVar``\ s.
 
    def bar(a: str, b: bool) -> int: ...
 
-   f = foo(bar) # f should be inferred to have the same signature as bar, 
+   f = foo(bar) # f should be inferred to have the same signature as bar,
                 # but returning str
 
    f("A", True) # Accepted
@@ -279,23 +279,23 @@ but is not obligated to do so.
 
    def x_int_y_str(x: int, y: str) -> int: ...
    def y_int_x_str(y: int, x: str) -> int: ...
-   foo(x_int_y_str, x_int_y_str) # Should return (x: int, y: str) -> bool 
-   foo(x_int_y_str, y_int_x_str) # Could return (__a: int, __b: str) -> bool 
-                                 # This works because both callables have types 
-                                 # that are behavioral subtypes of 
+   foo(x_int_y_str, x_int_y_str) # Should return (x: int, y: str) -> bool
+   foo(x_int_y_str, y_int_x_str) # Could return (__a: int, __b: str) -> bool
+                                 # This works because both callables have types
+                                 # that are behavioral subtypes of
                                  # Callable[[int, str], object]
 
    def keyword_only_x( *, x: int) -> int: ...
    def keyword_only_y( *, y: int) -> int: ...
    foo(keyword_only_x, keyword_only_y) # Rejected
-   
+
 The semantics of ``Concatenate[X, Y, P]`` are that it represents the parameters
 represented by ``P`` with two positional-only parameters prepended.  This means
 that we can use it to represent higher order functions that add, remove or
 transform a finite number of parameters of a callable.
 
 .. code-block::
-   
+
    def add(x: Callable[P, int]) -> Callable[Concatenate[str, P], bool]: ...
 
    def remove(x: Callable[Concatenate[int, P], int]) -> Callable[P, bool]: ...
@@ -318,7 +318,7 @@ their first position with a ``X`` can satisfy
 ``typing.Callable[Concatenate[X, P]``.
 
 .. code-block::
-   
+
    def expects(x: Callable[Concatenate[int, P], int]) -> None: ...
 
    def one(x: str) -> int: ...
@@ -355,12 +355,12 @@ values. These "properties" can only be used together, as the annotated types for
 
    def d(f: Callable[TParams, int]) -> None:
 
-     def foo(*args: TParams.args, **kwargs: TParams.kwargs) -> None:  # Accepted 
+     def foo(*args: TParams.args, **kwargs: TParams.kwargs) -> None:  # Accepted
        pass
 
      def bar(*args: TParams.kwargs, **kwargs: TParams.args) -> None:  # Rejected
        pass
-       
+
      def baz(*args: TParams.args) -> None:                            # Rejected
        pass
 
@@ -378,17 +378,17 @@ sure that these special types are only brought into the world together, and are
 used together, so that our usage is valid for all possible partitions.
 
 With those requirements met, we can now take advantage of the unique properties
-afforded to us by this set up: 
+afforded to us by this set up:
 
 
-* Inside the function, ``args`` has the type ``TParams.args``\ , not 
-  ``Tuple[TParams.args, ...]`` as would be with a normal annotation 
+* Inside the function, ``args`` has the type ``TParams.args``\ , not
+  ``Tuple[TParams.args, ...]`` as would be with a normal annotation
   (and likewise with the ``**kwargs``\ )
-* A function of type ``Callable[TParams, TReturn]`` can be called with 
-  ``(*args, **kwargs)`` if and only if ``args`` has the type ``TParams.args`` 
-  and ``kwargs`` has the type ``TParams.kwargs``\ , and that those types both 
+* A function of type ``Callable[TParams, TReturn]`` can be called with
+  ``(*args, **kwargs)`` if and only if ``args`` has the type ``TParams.args``
+  and ``kwargs`` has the type ``TParams.kwargs``\ , and that those types both
   originated from the same function declaration.
-* A function declared as 
+* A function declared as
   ``def inner(*args: TParams.args, **kwargs: TParams.kwargs) -> X``
   has type ``Callable[TParams, X]``.
 
@@ -406,17 +406,17 @@ parameter preserving decorators.
        f(*kwargs, **args)    # Rejected
 
        f(1, *args, **kwargs) # Rejected
-     
+
      return foo              # Accepted
 
 To extend this to include ``Concatenate``, we can declare the following
 properties:
 
-* A function of type ``Callable[Concatenate[A, B, TParams], TReturn]`` can be 
+* A function of type ``Callable[Concatenate[A, B, TParams], TReturn]`` can be
   called with ``(a, b, *args, **kwargs)`` when ``args`` and ``kwargs`` are the
-  respective components of ``TParams``, ``a`` is of type ``A`` and ``b`` is of 
+  respective components of ``TParams``, ``a`` is of type ``A`` and ``b`` is of
   type ``B``.
-* A function declared as 
+* A function declared as
   ``def inner(a: A, *args: TParams.args, **kwargs: TParams.kwargs) -> X``
   has type ``Callable[Concatenate[A, TParams], X]``.
 
@@ -431,12 +431,12 @@ properties:
      # Rejected
      def foo(*args: TParams.args, s: str, **kwargs: TParams.kwargs) -> None:
        pass
-     
+
      return foo              # Accepted
 
 
    def remove(x: Callable[Concatenate[int, P], int]) -> Callable[P, None]:
-     
+
      def foo(*args: TParams.args, **kwargs: TParams.kwargs) -> None:
        f(1, *args, **kwargs) # Accepted
 
@@ -456,11 +456,11 @@ like this:
    def twice(f: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int:
        return f(*args, **kwargs) + f(*args, **kwargs)
 
-The type of ``twice`` in the above example is 
+The type of ``twice`` in the above example is
 ``Callable[Concatenate[Callable[P, int], P], int]``, where ``P`` is bound by the
 outer ``Callable``.
 
-Also note that the names of the parameters preceding the ``ParamSpec`` 
+Also note that the names of the parameters preceding the ``ParamSpec``
 components are not mentioned in the resulting ``Concatenate``.  This means that
 these parameters can not be addressed via a named argument:
 
@@ -488,27 +488,27 @@ problematic.
 
    problem(x="uh-oh")
 
-Inside of ``bar``, we would get a 
+Inside of ``bar``, we would get a
 ``TypeError: foo() got multiple values for argument 'x'``.  Requiring these
 concatenated arguments to be addressed positionally avoids this kind of problem,
-and simplifies the syntax for spelling these types.       
+and simplifies the syntax for spelling these types.
 
 
 Backwards Compatibility
 -----------------------
 
 The only changes necessary to existing features in ``typing`` is allowing these
-``ParamSpec`` and ``Concatenate`` objects to be the first parameter to 
-``Callable`` and to be a parameter to ``Generic``. Currently ``Callable`` 
-expects a list of types there and ``Generic`` expects single types, so they are 
-currently mutually exclusive. Otherwise, existing code that doesn't reference 
+``ParamSpec`` and ``Concatenate`` objects to be the first parameter to
+``Callable`` and to be a parameter to ``Generic``. Currently ``Callable``
+expects a list of types there and ``Generic`` expects single types, so they are
+currently mutually exclusive. Otherwise, existing code that doesn't reference
 the new interfaces will be unaffected.
 
 Reference Implementation
 ------------------------
 
 The `Pyre <https://pyre-check.org/>`_ type checker supports all of the behavior
-described above.  A reference implementation of the runtime components needed 
+described above.  A reference implementation of the runtime components needed
 for those uses is provided in the ``pyre_extensions`` module.
 
 Rejected Alternatives
@@ -551,7 +551,7 @@ convention to prefer.
      f: BetterCallable[[Ts], [Tmap], int],
    ) -> BetterCallable[[Ts], [Tmap], str]:
        def decorated(*args: Ts, **kwargs: Tmap) -> str:
-          x = f(*args, **kwargs) 
+          x = f(*args, **kwargs)
           return int_to_str(x)
        return decorated
    @decorator
@@ -571,20 +571,20 @@ capture two categories when there are some things that can be in either
 category, we need a higher level primitive (\ ``ParamSpec``\ ) to
 capture all three, and then split them out afterward.
 
-Mutations on ParamSpecs 
+Mutations on ParamSpecs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 There are still a class of decorators still not supported with these features:
 those that add/remove/change a variable number of parameters.  For example,
-functools.partial will remain untypable even after this PEP.  Defining operators 
-that do these mutations becomes very complicated very quickly, as you have to 
+functools.partial will remain untypable even after this PEP.  Defining operators
+that do these mutations becomes very complicated very quickly, as you have to
 deal with name collision issues much more prominently.
 We will defer that work until there is significant demand, and then we would be
 open to revisiting it.
 
 Naming this a ``ParameterSpecification``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-We decided that ParameterSpecification was a little too long-winded for use 
+We decided that ParameterSpecification was a little too long-winded for use
 here, and that this style of abbreviated name made it look more like TypeVar.
 
 Naming this an ``ArgSpec``
@@ -609,5 +609,5 @@ more compact ``.args``\ /\ ``.kwargs`` syntax.
 Copyright
 ---------
 
-This document is placed in the public domain or under the CC0-1.0-Universal 
+This document is placed in the public domain or under the CC0-1.0-Universal
 license, whichever is more permissive.


### PR DESCRIPTION
This PR updates PEP 612  following discussions on [typing-sig](https://mail.python.org/archives/list/typing-sig@python.org/thread/UDHSH4EVVIDKNLRX2YGCIUCBGZ5ALRKC)

These updates include:
* `ParameterSpecification` is abbreviated to `ParamSpec`
* finite-length parameter modification via `typing.type_variable_operators.Concatenate` is integrated throughout the PEP
* the `ParametersOf` counterproposal is discussed
* a proposed but deferred solution for modifying named parameters is discussed
* the prose has been edited for clarity
* variable names have been shortened to make the code examples more compact