### PR TITLE
PEP 318: Fix the url to Python Decorators Wiki

### DIFF
--- a/pep-0318.txt
+++ b/pep-0318.txt
@@ -658,7 +658,7 @@ but added:
     must go on.
 
 .. _Python wiki:
-    http://www.python.org/moin/PythonDecorators
+    http://wiki.python.org/moin/PythonDecorators
 .. _subsequently rejected:
      https://mail.python.org/pipermail/python-dev/2004-September/048518.html
 


### PR DESCRIPTION
It should be wiki.python.org instead of www.python.org

Closes #1426
