### PR TITLE
PEP 609: Move PyPA to PSF Code of Conduct

### DIFF
--- a/pep-0609.rst
+++ b/pep-0609.rst
@@ -134,6 +134,12 @@ As long as the project is adhering to the Code of Conduct and
 following specifications supported by the PyPA, the PyPA should only
 concerned with large, ecosystem-wide changes.
 
+Develop and maintain standalone Code of Conduct
+'''''''''''''''''''''''''''''''''''''''''''''''
+
+PyPA projects follow `the PSF Code of Conduct`_.
+
+
 Goals of the PyPA's Governance Model
 ------------------------------------
 
@@ -232,6 +238,23 @@ If the request is not opposed by another committer of the same project
 over a 7 day period, the project would leave the PyPA and be
 transferred out of the PyPA organization as per the request.
 
+Code of Conduct enforcement
+'''''''''''''''''''''''''''
+
+Each project that is a part of the PyPA organization follows `the PSF
+Code of Conduct`_, including its incident reporting guidelines and
+enforcement procedures.
+
+PyPA members are responsible for leading by example. PyPA members
+occasionally may need to more explicitly moderate behavior in their
+projects, and each project that is a part of the PyPA organization
+must designate at least one PyPA member as available to contact in
+case of a Code of Conduct incident. If told of any Code of Conduct
+incidents involving their projects, PyPA members are expected to
+report those incidents up to `the PSF Conduct WG`_, for recording
+purposes and for potential assistance.
+
+
 References
 ==========
 
@@ -241,7 +264,8 @@ References
 .. _PyPA-Committers: https://mail.python.org/mm3/mailman3/lists/pypa-committers.python.org/
 .. _Packaging-WG Wiki page: https://wiki.python.org/psf/PackagingWG
 .. _standing delegations: https://github.com/python/steering-council/blob/master/process/standing-delegations.md#pypa-delegations
-
+.. _the PSF Code of Conduct: https://www.python.org/psf/conduct/
+.. _the PSF Conduct WG: https://wiki.python.org/psf/ConductWG/Charter
 
 Copyright
 =========


### PR DESCRIPTION
Change PyPA governance procedures to reflect moving under the PSF CoC.

Per conversation in https://discuss.python.org/t/move-to-the-psf-code-of-conduct/3876/ and https://discuss.python.org/t/pep-609-pypa-governance/2619/23 .

cc @di 

Signed-off-by: Sumana Harihareswara <sh@changeset.nyc>
