### PR TITLE
PEP 617 Edit memoization -> memorization

### DIFF
--- a/pep-0617.rst
+++ b/pep-0617.rst
@@ -142,8 +142,8 @@ the worst case as compared with LL(1) parsers, because PEG parsers have infinite
 for a rule). Usually, PEG parsers avoid this exponential time complexity with a
 technique called "packrat parsing" [1]_ which not only loads the entire
 program in memory before parsing it but also allows the parser to backtrack
-arbitrarily. This is made efficient by memoizing the rules already matched for
-each position. The cost of the memoization cache is that the parser will naturally
+arbitrarily. This is made efficient by memorizing the rules already matched for
+each position. The cost of the memorization cache is that the parser will naturally
 use more memory than a simple LL(1) parser, which normally are table-based. We
 will explain later in this document why we consider this cost acceptable.
 
@@ -282,7 +282,7 @@ Left recursion
 
 PEG parsers normally do not support left recursion but we have implemented a
 technique similar to the one described in Medeiros et al. [2]_ but using the
-memoization cache instead of static variables. This approach is closer to the one
+memorization cache instead of static variables. This approach is closer to the one
 described in Warth et al. [3]_. This allows us to write not only simple left-recursive
 rules but also more complicated rules that involve indirect left-recursion like::
 
@@ -469,7 +469,7 @@ files should be written, each one with a different set of actions, keeping
 everything else apart from said actions identical in both files. As an
 example of a grammar with Python actions, the piece of the parser generator
 that parses grammar files is bootstrapped from a meta-grammar file with
-Python actions that generate the grammar tree as a result of the parsing. 
+Python actions that generate the grammar tree as a result of the parsing.
 
 In the specific case of the new proposed PEG grammar for Python, having
 actions allows to directly describe how the AST is composed in the grammar
@@ -593,21 +593,21 @@ returns a valid C-based Python AST:
 
     start[mod_ty]: a=expr_stmt* $ { Module(a, NULL, p->arena) }
     expr_stmt[stmt_ty]: a=expr NEWLINE { _Py_Expr(a, EXTRA) }
-    expr[expr_ty]: 
+    expr[expr_ty]:
         | l=expr '+' r=term { _Py_BinOp(l, Add, r, EXTRA) }
         | l=expr '-' r=term { _Py_BinOp(l, Sub, r, EXTRA) }
         | t=term { t }
 
-    term[expr_ty]: 
+    term[expr_ty]:
         | l=term '*' r=factor { _Py_BinOp(l, Mult, r, EXTRA) }
         | l=term '/' r=factor { _Py_BinOp(l, Div, r, EXTRA) }
         | f=factor { f }
 
-    factor[expr_ty]: 
+    factor[expr_ty]:
         | '(' e=expr ')' { e }
         | a=atom { a }
 
-    atom[expr_ty]: 
+    atom[expr_ty]:
         | n=NAME { n }
         | n=NUMBER { n }
         | s=STRING { s }
@@ -622,7 +622,7 @@ A similar grammar written to target Python AST objects:
 ::
 
   start: expr NEWLINE? ENDMARKER { ast.Expression(expr) }
-  expr: 
+  expr:
       | expr '+' term { ast.BinOp(expr, ast.Add(), term) }
       | expr '-' term { ast.BinOp(expr, ast.Sub(), term) }
       | term { term }
@@ -636,7 +636,7 @@ A similar grammar written to target Python AST objects:
       | '(' expr ')' { expr }
       | atom { atom }
 
-  atom: 
+  atom:
       | NAME { ast.Name(id=name.string, ctx=ast.Load()) }
       | NUMBER { ast.Constant(value=ast.literal_eval(number.string)) }
 


### PR DESCRIPTION
Edit a typo "memoization" -> "memorization".
