### PR TITLE
PEP 573: Mark as final

### DIFF
--- a/pep-0573.rst
+++ b/pep-0573.rst
@@ -8,7 +8,7 @@ Author: Petr Viktorin <encukou@gmail.com>,
         Marcel Plch <gmarcel.plch@gmail.com>
 BDFL-Delegate: Stefan Behnel
 Discussions-To: import-sig@python.org
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 02-Jun-2016


### PR DESCRIPTION
API for module state access from C extension methods has been implemented in Python 3.9.
