### PR TITLE
pep-0622.rst: fix typo

### DIFF
--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -176,7 +176,7 @@ Match semantics
 
 The proposed large scale semantics for choosing the match is to choose the first
 matching pattern and execute the corresponding suite. The remaining patterns
-are not tried. If there are no matching pattens, the statement 'falls
+are not tried. If there are no matching patterns, the statement 'falls
 through', and execution continues at the following statement.
 
 Essentially this is equivalent to a chain of ``if ... elif ... else``


### PR DESCRIPTION
PEP 622: Summary of the changes made

Change `patten` to `pattern`
