### PR TITLE
Withdraw PEP 543 and PEP 595

### DIFF
--- a/pep-0543.rst
+++ b/pep-0543.rst
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Cory Benfield <cory@lukasa.co.uk>,
         Christian Heimes <christian@python.org>
-Status: Draft
+Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 17-Oct-2016
@@ -21,6 +21,14 @@ third-party libraries to provide bindings to TLS libraries other than OpenSSL
 that can be used by tools that expect the interface provided by the Python
 standard library, with the goal of reducing the dependence of the Python
 ecosystem on OpenSSL.
+
+
+Resolution
+==========
+
+2020-06-25: With contemporary agreement with one author, and past
+agreement with another, this PEP is withdrawn due to changes in the
+APIs of the underlying operating systems.
 
 
 Rationale

--- a/pep-0595.rst
+++ b/pep-0595.rst
@@ -2,8 +2,8 @@ PEP: 595
 Title: Improving bugs.python.org
 Author: Ezio Melotti <ezio.melotti@gmail.com>, Berker Peksag <berker.peksag@gmail.com>
 BDFL-Delegate: Barry Warsaw <barry@python.org>
-Status: Draft
-Type: Process
+Status: Withdrawn
+Type: Informational
 Content-Type: text/x-rst
 Created: 12-May-2019
 
@@ -15,6 +15,14 @@ This PEP proposes a list of improvements to make bugs.python.org
 more usable for contributors and core developers.  This PEP also
 discusses why remaining on Roundup should be preferred over
 switching to GitHub Issues, as proposed by :pep:`581`.
+
+
+Resolution
+==========
+
+2020-06-25: With the acceptance of PEP 581, the move to GitHub for
+issues is proceeding, this PEP is being marked as a withdrawn
+informational PEP.
 
 
 Motivation


### PR DESCRIPTION
Updates based on the Steering Council's PEP Parade and replies with the PEP authors.