### PR TITLE
PEP 8: Change requirement to adhere to Standard English

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -728,7 +728,8 @@ complete sentences, with each sentence ending in a period.
 You should use two spaces after a sentence-ending period in multi-
 sentence comments, except after the final sentence.
 
-When writing English, follow Strunk and White.
+Ensure that your comments are clear and easily understandable to other 
+speakers of the language you are writing in.
 
 Python coders from non-English speaking countries: please write your
 comments in English, unless you are 120% sure that the code will never


### PR DESCRIPTION
Instead of requiring that comments be written in Strunk & White Standard English, require instead that English-language comments be clear and easily understandable by other English speakers. This accomplishes the same goal without alienating or putting up barriers for people (especially people of color) whose native dialect of English is not Standard English. This change is a simple way to correct that while maintaining the original intent of the requirement. This change also makes the requirement more clear to people who are not familiar with Strunk & White, since for programmers, the main relevant aspect of that standard is "be clear and concise;" simply saying that instead of referencing Strunk & White communicates this more effectively. 
