### PR TITLE
PEP 622: Fix wrong statements of Haskell

### DIFF
--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -1551,7 +1551,7 @@ rarely.
 Algebraic matching of repeated names
 ------------------------------------
 
-A technique occasionally seen in functional languages like Erlang and Prolog is
+A technique occasionally seen in functional languages like Erlang is
 to use a match variable multiple times in the same pattern::
 
   match value:

--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -1551,7 +1551,7 @@ rarely.
 Algebraic matching of repeated names
 ------------------------------------
 
-A technique occasionally seen in functional languages like Erlang is
+A technique occasionally seen in functional languages like Erlang and Elixir is
 to use a match variable multiple times in the same pattern::
 
   match value:

--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -1551,7 +1551,7 @@ rarely.
 Algebraic matching of repeated names
 ------------------------------------
 
-A technique occasionally seen in functional languages like Haskell is
+A technique occasionally seen in functional languages like Erlang and Prolog is
 to use a match variable multiple times in the same pattern::
 
   match value:


### PR DESCRIPTION
The well-known languages with bound-once matching are Erlang and Prolog.

[Prolog is matching patterns with unifications](http://www.deransart.fr/prolog/unification.html), hence this technique is natural to achieve.

[Erlang is using scope to classify if variable is to be bound or loaded](https://erlang.org/doc/reference_manual/expressions.html#variables), this is closer to PEP 622.  