### PR TITLE
PEP 622: Update definition of __match__

### DIFF
--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -580,7 +580,7 @@ The procedure is as following:
   ``ImpossibleMatchError`` is raised.
 
 * If the ``__match_args__`` attribute is absent on the matched class,
-  but more than one positional item appears in a match,
+  and one or more positional item appears in a match,
   ``ImpossibleMatchError`` is also raised. We don't fall back on
   using ``__slots__`` or ``__annotations__`` -- "In the face of ambiguity,
   refuse the temptation to guess."
@@ -588,17 +588,7 @@ The procedure is as following:
 * If there are any match-by-keyword items the keywords are looked up
   as attributes on the proxy.  If the lookup succeeds the value is
   matched against the corresponding sub-pattern.  If the lookup fails,
-  two cases are distinguished:
-
-* If an attribute is missing on the proxy and the class being matched
-  has no ``__match_args__`` attribute, the match
-  fails.  This allows one to write ``case object(name=_)`` to
-  implement a check for the presence of a given attribute, or ``case
-  object(name=var)`` to check for its presence and extract its value.
-
-* If an attribute is missing and the class has a ``__match_args__``,
-  the match fails if the attribute name is in
-  ``__match_args__``, else the match raises ``ImpossibleMatchError``.
+  the match fails.
 
 Such a protocol favors simplicity of implementation over flexibility and
 performance. For other considered alternatives, see `rejected ideas`_.


### PR DESCRIPTION
It should never raise if an attribute is missing.

Also remove one last mention of the exception for a single positional argument (since we no longer have this exception).

See https://github.com/gvanrossum/patma/issues/111#issuecomment-650874268
