### PR TITLE
PEP 622: Drop ImpossibleMatchError

### DIFF
--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -576,12 +576,12 @@ The procedure is as following:
   where ``Point2D.__match_args__ == ["x", "y"]``, is translated
   (approximately) into ``obj.x == 5 and obj.y == 8``.
 
-* If there are more positional items than the length of ``__match_args__``, an
-  ``ImpossibleMatchError`` is raised.
+* If there are more positional items than the length of
+  ``__match_args__``, a ``TypeError`` is raised.
 
 * If the ``__match_args__`` attribute is absent on the matched class,
   and one or more positional item appears in a match,
-  ``ImpossibleMatchError`` is also raised. We don't fall back on
+  ``TypeError`` is also raised. We don't fall back on
   using ``__slots__`` or ``__annotations__`` -- "In the face of ambiguity,
   refuse the temptation to guess."
 
@@ -637,13 +637,15 @@ available names and their types should resemble the arguments to ``__init__()``.
 Ambiguous matches
 -----------------
 
-Impossible and ambiguous matches are detected at runtime and a special
-exception ``ImpossibleMatchError`` (proposed to be a subclass of ``TypeError``)
-will be raised. In addition to basic checks described in the previous
-subsection:
+Certain classes of impossible and ambiguous matches are detected at
+runtime and will raise exceptions. In addition to basic checks
+described in the previous subsection:
 
 * The interpreter will check that two match items are not targeting the same
   attribute, for example ``Point2D(1, 2, y=3)`` is an error.
+
+* It will also check that a mapping pattern does not attempt to match
+  the same key more than once.
 
 
 Special attribute ``__match_args__``


### PR DESCRIPTION
Also, document the remaining error-checking behavior.