### PR TITLE
PEP 508: Add missing parentheses

### DIFF
--- a/pep-0508.txt
+++ b/pep-0508.txt
@@ -277,7 +277,7 @@ error like all other unknown variables.
        ``Java HotSpot(TM) 64-Bit Server VM, 25.51-b03, Oracle Corporation``
        ``Darwin Kernel Version 14.5.0: Wed Jul 29 02:18:53 PDT 2015; root:xnu-2782.40.9~2/RELEASE_X86_64``
    * - ``python_version``
-     - ``'.'.join(platform.python_version_tuple()[:2]``
+     - ``'.'.join(platform.python_version_tuple()[:2])``
      - ``3.4``, ``2.7``
    * - ``python_full_version``
      - ``platform.python_version()``
@@ -534,7 +534,7 @@ implementation:
 
 - The definition of ``python_version`` was changed from
   ``platform.python_version()[:3]`` to
-  ``'.'.join(platform.python_version_tuple()[:2]``, to accommodate potential
+  ``'.'.join(platform.python_version_tuple()[:2])``, to accommodate potential
   future versions of Python with 2-digit major and minor versions
   (e.g. 3.10). [#future_versions]_
 


### PR DESCRIPTION
The definition of python_version was updated in #1123.
However, two closing parentheses are missing:
https://github.com/python/peps/blob/47fa1fb501121f6c8956493b28b30f4300fbd1df/pep-0508.txt#L280
https://github.com/python/peps/blob/47fa1fb501121f6c8956493b28b30f4300fbd1df/pep-0508.txt#L537
Note: It is not necessary to change the line 519 because a closing parenthesis exists.