### PR TITLE
PEP 622: Write up why we reject alternative spellings of OR patterns

### DIFF
--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -434,8 +434,8 @@ arbitrarily nested patterns by chaining all of the instance checks and
 attribute lookups appropriately.
 
 
-Combining multiple patterns
----------------------------
+Combining multiple patterns (OR patterns)
+-----------------------------------------
 
 Multiple alternative patterns can be combined into one using ``|``. This means
 the whole pattern matches if at least one alternative matches.
@@ -1389,6 +1389,80 @@ as a throwaway target in other contexts, and this use is pretty
 similar.  This example is from ``difflib.py`` in the stdlib::
 
   for tag, _, _, j1, j2 in group: ...
+
+Use some other syntax instead of ``|`` for OR patterns
+------------------------------------------------------
+
+A few alternatives to using ``|`` to separate the alternatives in OR
+patterns have been proposed.  Instead of::
+
+  case 401|403|404:
+      print("Some HTTP error")
+
+the following proposals have been fielded:
+
+- Use a comma::
+
+    case 401, 403, 404:
+      print("Some HTTP error")
+
+  This looks too much like a tuple -- we would have to find a
+  different way to spell tuples, and the construct would have to be
+  parenthesized inside the argument list of a class pattern.  In
+  general, commas already have many different meanings in Python, we
+  shouldn't add more.
+
+- Allow stacked cases::
+
+    case 401:
+    case 403:
+    case 404:
+      print("Some HTTP error")
+
+  This is how this would be done in C, using its fall-through
+  semantics for cases.  However, we don't want to mislead people into
+  thinking that ``match``/``case`` uses fall-through semantics (which
+  are a common source of bugs in C).  Also, this would be a novel
+  indentation pattern, which might make it harder to support in IDEs
+  and such (it would break the simple rule "add an indentation level
+  after a line ending in a colon").
+
+- Use ``case in`` followed by a comma-separated list::
+
+    case in 401, 403, 404:
+      print("Some HTTP error")
+
+  This wouldn't work when a list of alternatives is nested inside
+  another pattern, like::
+
+    case Point(0|1, 0|1):
+        print("A corner of the unit square")
+
+- Use the ``or`` keyword::
+
+    case 401 or 403 or 404:
+        print("Some HTTP error")
+
+  This could work, and the readability is not too different from using
+  ``|``.  Some users expressed a preference for ``or`` because they
+  associate ``|`` with bitwise OR.  However:
+
+  1. Many other languages that have pattern matching use ``|`` (the
+     list includes Elixir, Erlang, F#, Haskell, Mathematica, OCaml,
+     Ruby, Rust, and Scala).
+  2. ``|`` is shorter, which may contribute to the readability of
+     nested patterns like ``Point(0|1, 0|1)``.
+  3. Some people mistakenly believe that ``|`` has the wrong priority;
+     but since patterns don't support other operators it has the same
+     priority as in expressions.
+  4. Python users use ``or`` very frequently, and may build an
+     impression that it is strongly associated with Boolean
+     short-circuiting.
+  5. ``|`` is used between alternatives in regular expressions
+     and in EBNF grammars (like Python's own).
+  6. ``|`` not just used for bitwise OR -- it's used for set unions,
+     dict merging (:pep:`584`) and is being considered as an
+     alternative to ``typing.Union`` (:pep:`604`).
 
 
 .. _deferred ideas:

--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -1464,6 +1464,14 @@ the following proposals have been fielded:
   6. ``|`` not just used for bitwise OR -- it's used for set unions,
      dict merging (:pep:`584`) and is being considered as an
      alternative to ``typing.Union`` (:pep:`604`).
+  7. ``|`` works better as a visual separator, especially between
+     strings.  Compare::
+
+       case "spam" or "eggs" or "cheese":
+
+     to::
+
+       case "spam" | "eggs" | "cheese":
 
 
 .. _deferred ideas:

--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -1425,15 +1425,16 @@ the following proposals have been fielded:
   are a common source of bugs in C).  Also, this would be a novel
   indentation pattern, which might make it harder to support in IDEs
   and such (it would break the simple rule "add an indentation level
-  after a line ending in a colon").
+  after a line ending in a colon").  Finally, this wouldn't support
+  OR patterns nested inside other patterns.
 
 - Use ``case in`` followed by a comma-separated list::
 
     case in 401, 403, 404:
       print("Some HTTP error")
 
-  This wouldn't work when a list of alternatives is nested inside
-  another pattern, like::
+  This wouldn't work for OR patterns nested inside other patterns,
+  like::
 
     case Point(0|1, 0|1):
         print("A corner of the unit square")

--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -1449,8 +1449,8 @@ the following proposals have been fielded:
   associate ``|`` with bitwise OR.  However:
 
   1. Many other languages that have pattern matching use ``|`` (the
-     list includes Elixir, Erlang, F#, Haskell, Mathematica, OCaml,
-     Ruby, Rust, and Scala).
+     list includes Elixir, Erlang, F#, Mathematica, OCaml, Ruby, Rust,
+     and Scala).
   2. ``|`` is shorter, which may contribute to the readability of
      nested patterns like ``Point(0|1, 0|1)``.
   3. Some people mistakenly believe that ``|`` has the wrong priority;


### PR DESCRIPTION
Much of this was cribbed from https://github.com/gvanrossum/patma/issues/93
