### PR TITLE
PEP 622: make the binding semantics explicit

### DIFF
--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -198,6 +198,19 @@ statement. For example::
           ...
   print(x, y)  # This works
 
+During failed pattern matches, some subpatterns may succeed. For example,
+while matching the value ``[0, 1, 2]`` with the pattern ``(0, x, 1)``, the
+subpattern `x` may succeed if the list elements are matched from left to right.
+The implementation may choose to either make persistent bindings for those
+partial matches or not. User code including a `match` statement should not rely
+on the bindings being made for a failed match, but also shouldn't assume that
+variables being unchanged by a negative match. This part of the behavior is
+left intentionally unspecified so different implementations can add
+optimizations, and to prevent introducing semantic restrictions that could
+limit the extendability of this feature.
+
+Note that some of the pattern kinds below define more specific rules about when
+the binding is made.
 
 .. _patterns:
 

--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -204,7 +204,7 @@ subpattern `x` may succeed if the list elements are matched from left to right.
 The implementation may choose to either make persistent bindings for those
 partial matches or not. User code including a `match` statement should not rely
 on the bindings being made for a failed match, but also shouldn't assume that
-variables being unchanged by a negative match. This part of the behavior is
+variables being unchanged by a failed match. This part of the behavior is
 left intentionally unspecified so different implementations can add
 optimizations, and to prevent introducing semantic restrictions that could
 limit the extendability of this feature.

--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -198,18 +198,18 @@ statement. For example::
           ...
   print(x, y)  # This works
 
-During failed pattern matches, some subpatterns may succeed. For example,
+During failed pattern matches, some sub-patterns may succeed. For example,
 while matching the value ``[0, 1, 2]`` with the pattern ``(0, x, 1)``, the
-subpattern `x` may succeed if the list elements are matched from left to right.
+sub-pattern `x` may succeed if the list elements are matched from left to right.
 The implementation may choose to either make persistent bindings for those
 partial matches or not. User code including a `match` statement should not rely
 on the bindings being made for a failed match, but also shouldn't assume that
-variables being unchanged by a failed match. This part of the behavior is
+variables are unchanged by a failed match. This part of the behavior is
 left intentionally unspecified so different implementations can add
 optimizations, and to prevent introducing semantic restrictions that could
-limit the extendability of this feature.
+limit the extensibility of this feature.
 
-Note that some of the pattern kinds below define more specific rules about when
+Note that some pattern types below define more specific rules about when
 the binding is made.
 
 .. _patterns:


### PR DESCRIPTION
This addresses issues discussed in gvanrossum/patma#110 about clarity of names bound when a failed pattern has succesful partial matches 