### PR TITLE
PEP 622: Add exception semantics

### DIFF
--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -686,6 +686,16 @@ Finally, all attributes are exposed for matching, if a class wants to hide
 some attributes from matching against them, a custom ``__match__()`` method is
 required.
 
+Exception semantics
+-------------------
+
+While matching each case, the ``match`` statement may trigger execution of other
+functions (for example ``__getitem__()``, ``__len__()`` or ``__get__()`` of some
+descriptor). Almost every exception caused by those propagates outside of the
+match statement normally. The only case where an exception is not propagated is
+an ``AttributeError`` raised while trying to lookup an attribute while matching
+attributes of a Class Pattern; that case results in just a matching failure,
+and the rest of the statement proceeds normally.
 
 The standard library
 --------------------

--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -690,8 +690,8 @@ Exception semantics
 -------------------
 
 While matching each case, the ``match`` statement may trigger execution of other
-functions (for example ``__getitem__()``, ``__len__()`` or ``__get__()`` of some
-descriptor). Almost every exception caused by those propagates outside of the
+functions (for example ``__getitem__()``, ``__len__()`` or
+a property). Almost every exception caused by those propagates outside of the
 match statement normally. The only case where an exception is not propagated is
 an ``AttributeError`` raised while trying to lookup an attribute while matching
 attributes of a Class Pattern; that case results in just a matching failure,


### PR DESCRIPTION
This describes more explicitly how exceptions are handled during pattern matching, addressing gvanrossum/patma#111
