### PR TITLE
PEP 622: sync explanation with example; case 0 is now first.

### DIFF
--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -242,8 +242,8 @@ a Boolean literal (``True`` or ``False``), or ``None``::
           print("Good luck with that...")
 
 Literal pattern uses equality with literal on the right hand side, so that
-in the above example ``number == 1`` and then possibly ``number == 2`` will
-be evaluated. Note that although technically negative numbers
+in the above example ``number == 0`` and then possibly ``number == 1``, etc
+will be evaluated. Note that although technically negative numbers
 are represented using unary minus, they are considered
 literals for the purpose of pattern matching. Unary plus is not allowed.
 Binary plus and minus are allowed only to join a real number and an imaginary


### PR DESCRIPTION
It claimed to start with 1, and maybe proceed with 2.  The example currently starts with 0, and maybe proceeds with 1, maybe followed by other possibilities.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
