### PR TITLE
PEP622: Be more explicit about side-effects

### DIFF
--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -796,8 +796,8 @@ Only match-by-name will work by default, and classes should define
 match-by-position.  Additionally, dataclasses and named tuples will
 support match-by-position out of the box. See below for more details.
 
-Exception semantics
--------------------
+Exceptions and side effects
+---------------------------
 
 While matching each case, the ``match`` statement may trigger execution of other
 functions (for example ``__getitem__()``, ``__len__()`` or
@@ -806,6 +806,15 @@ match statement normally. The only case where an exception is not propagated is
 an ``AttributeError`` raised while trying to lookup an attribute while matching
 attributes of a Class Pattern; that case results in just a matching failure,
 and the rest of the statement proceeds normally.
+
+The only side-effect carried on by the matching process is the binding of
+names. However, the process relies on some operations like attribute access,
+instance checks, `len()` and item access on the subject and some of its
+components. While those typically don't create any side-effects, some of
+these objects could. This proposal intentionally leaves out any specification
+of what methods are called or how many times. User code relying on that
+behavior should be considered buggy.
+
 
 The standard library
 --------------------

--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -807,14 +807,14 @@ an ``AttributeError`` raised while trying to lookup an attribute while matching
 attributes of a Class Pattern; that case results in just a matching failure,
 and the rest of the statement proceeds normally.
 
-The only side-effect carried on by the matching process is the binding of
-names. However, the process relies on some operations like attribute access,
-instance checks, `len()` and item access on the subject and some of its
-components. While those typically don't create any side-effects, some of
+The only side-effect carried on explicitly by the matching process is the binding of
+names. However, the process relies on attribute access,
+instance checks, `len()`, equality and item access on the subject and some of
+its components. It also evaluates constant value patterns and the left side of
+class patterns. While none of those typically create any side-effects, some of
 these objects could. This proposal intentionally leaves out any specification
 of what methods are called or how many times. User code relying on that
 behavior should be considered buggy.
-
 
 The standard library
 --------------------

--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -809,7 +809,7 @@ and the rest of the statement proceeds normally.
 
 The only side-effect carried on explicitly by the matching process is the binding of
 names. However, the process relies on attribute access,
-instance checks, `len()`, equality and item access on the subject and some of
+instance checks, ``len()``, equality and item access on the subject and some of
 its components. It also evaluates constant value patterns and the left side of
 class patterns. While none of those typically create any side-effects, some of
 these objects could. This proposal intentionally leaves out any specification


### PR DESCRIPTION
This addresses some concerns about possible methods being called by the `match` statement.