### PR TITLE
PEP 625: Delegate sdist format specification to PEP 517

### DIFF
--- a/pep-0625.rst
+++ b/pep-0625.rst
@@ -81,8 +81,8 @@ The name of an sdist should be ``{distribution}-{version}.sdist``.
 
 Each component is escaped according to the same rules as :pep:`427`.
 
-An sdist must be a gzipped tar archive that is able to be extracted by the
-standard library ``tarfile`` module with the open flag ``'r:gz'``.
+An sdist must be an archive with a specific content layout, as defined in
+:pep:`517`.
 
 
 Backwards Compatibility


### PR DESCRIPTION
Following [the discussion on possible sdist formats](https://discuss.python.org/t/pep-625-file-name-of-a-source-distribution/4686/6), avoid adding any specifics on sdist formats at all in the PEP.