### PR TITLE
PEP 624: Add rejected idea.

### DIFF
--- a/pep-0624.rst
+++ b/pep-0624.rst
@@ -6,6 +6,7 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 06-Jul-2020
 Python-Version: 3.11
+Post-History: 08-Jul-2020
 
 
 Abstract
@@ -261,6 +262,44 @@ a dangling reference after ``PyUnicode_EncodeUTF8()`` returned.
 Additionally, since we are not changing behavior but removing C APIs,
 runtime ``DeprecationWarning`` might not helpful for Python
 developers. We should warn to extension developers instead.
+
+
+Deprecate ``PyUnicode_Decode*`` APIs too
+----------------------------------------
+
+Not only remove ``PyUnicode_Encode*()`` APIs, but also deprecate
+following APIs too for symmetry and reducing number of APIs.
+
+* ``PyUnicode_DecodeASCII()``
+* ``PyUnicode_DecodeLatin1()``
+* ``PyUnicode_DecodeUTF7()``
+* ``PyUnicode_DecodeUTF8()``
+* ``PyUnicode_DecodeUTF16()``
+* ``PyUnicode_DecodeUTF32()``
+* ``PyUnicode_DecodeUnicodeEscape()``
+* ``PyUnicode_DecodeRawUnicodeEscape()``
+* ``PyUnicode_DecodeCharmap()``
+* ``PyUnicode_DecodeMBCS()``
+
+This idea is excluded from this PEP because of several reasons:
+
+* We can not remove them anytime soon because they are part of stable
+  ABI.
+
+* ``PyUnicode_DecodeASCII()`` and ``PyUnicode_DecodeUTF8()`` are used
+  very widely. Deprecating them is not worth enough.
+
+* Decoding from ``const char*`` is independent from Unicode
+  representation.
+
+  * ``PyUnicode_Decode*()`` APIs are useful for applications and
+    extensions using UTF-8 or Python Unicode objects to store Unicode
+    string. But ``PyUnicode_Encode*()`` APIs are not useful for them.
+
+  * Python implementations using UTF-8 for Unicode internal
+    representation (e.g. PyPy and micropython) may not have encoder
+    with ``wchar_t*`` or UCS-4 input. But decoding from ``char*``
+    is very natural for them too.
 
 
 Discussions


### PR DESCRIPTION
New section describes why this PEP doesn't deprecate
`PyUnicode_Decode***()` APIs.