### PR TITLE
PEP 596: 3.9.0b4 was published last Friday

### DIFF
--- a/pep-0596.rst
+++ b/pep-0596.rst
@@ -55,10 +55,10 @@ Actual:
   (No new features beyond this point.)
 - 3.9.0 beta 3: Tuesday, 2020-06-09
   (beta 2 was recalled.)
+- 3.9.0 beta 4: Friday, 2020-07-03
 
 Expected:
 
-- 3.9.0 beta 4: Monday, 2020-06-29
 - 3.9.0 beta 5: Monday, 2020-07-20
 - 3.9.0 candidate 1: Monday, 2020-08-10
 - 3.9.0 candidate 2: Monday, 2020-09-14


### PR DESCRIPTION
@ambv, is 3.9.0b5 still expected July 20, or is that pushed back now? How about the rest of the releases?