### PR TITLE
Convert Python 2 example in PEP 8 to Python 3

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -854,7 +854,7 @@ case convention):
 - ``single_trailing_underscore_``: used by convention to avoid
   conflicts with Python keyword, e.g. ::
 
-      Tkinter.Toplevel(master, class_='ClassName')
+      tkinter.Toplevel(master, class_='ClassName')
 
 - ``__double_leading_underscore``: when naming a class attribute,
   invokes name mangling (inside class FooBar, ``__boo`` becomes


### PR DESCRIPTION
Turn ``Tkinter`` to ``tkinter``. See issue #1520 .