### PR TITLE
PEP 622: Fix example

### DIFF
--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -188,7 +188,7 @@ sequence. With the proposal in this PEP, we could rewrite that code
 into this::
 
     match value:
-        case [*v, label := (Promise() | str())]:
+        case [*v, label := (Promise() | str())] if v:
             value = tuple(v)
         case _:
             label = key.replace('_', ' ').title()


### PR DESCRIPTION
The original requires `len(value) > 1`, not `len(value) >= 1`.