### PR TITLE
Restore reference to a style guide.

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -728,8 +728,10 @@ complete sentences, with each sentence ending in a period.
 You should use two spaces after a sentence-ending period in multi-
 sentence comments, except after the final sentence.
 
-Ensure that your comments are clear and easily understandable to other 
-speakers of the language you are writing in.
+Ensure that your comments are clear and easily understandable to other
+speakers of the language you are writing in.  If you would like some
+guidance, consult a style guide such as Strunk and White's "The
+Elements of Style".
 
 Python coders from non-English speaking countries: please write your
 comments in English, unless you are 120% sure that the code will never


### PR DESCRIPTION
The argument in commit 0c6427dcec1e98ca0bd46a876a7219ee4a9347f4 is
contextually narrow, conflates classism with racism, and ignores the
benefit to mutual comprehension of a strong degree of
standardization.  More importantly, it disadvantages a lot of
neuro-atypical people who find a lack of structure intimidating.
Adding a recommendation for a specific style guide helps them; Strunk
& White gets the nod for being brief and consistent with the general
approach of PEP-8.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
