### PR TITLE
PEP 629: Fix and clarify wording, add BDFL-Delegate header

### DIFF
--- a/pep-0629.rst
+++ b/pep-0629.rst
@@ -1,6 +1,7 @@
 PEP: 629
 Title: Versioning PyPI's Simple API
 Author: Donald Stufft <donald@stufft.io>
+BDFL-Delegate: Donald Stufft <donald@stufft.io>
 Discussions-To: https://discuss.python.org/t/pep-629-versioning-pypis-simple-api/4720
 Status: Draft
 Type: Standards Track

--- a/pep-0629.rst
+++ b/pep-0629.rst
@@ -53,12 +53,20 @@ This would end up looking like::
 
   <meta name="pypi:repository-version" content="1.0">
 
-Interpretation of this version is that incrementing the major version
-is considereed a backwards incompatible change such that existing
-clients would no longer be expected to be able to meaningfully use the
-new API, and incrementing the minor version is a backwards compatible
-change that existing clients would no longer be able to meaningfully
-use the API.
+When intepreting the repository version:
+
+* Incrementing the major version is used to signal a backwards
+  incompatible change such that existing clients would no longer be
+  expected to be able to meaningfully use the API.
+* Incrementing the minor version is used to signal a backwards
+  compatible change such that existing clients would still be
+  expected to be able to meaningfully use the API.
+
+  It is left up to the discretion of any future PEPs as to what
+specifically constitutes a backwards incompatible vs compatible change
+beyond the broad suggestion that existing clients will be able to
+"meaningfully" continue to use the API, and can include adding,
+modifying, or removing existing features.
 
 It is expectation of this PEP that the major version will never be
 incremented, and any future major API evolutions would utilize a

--- a/pep-0629.rst
+++ b/pep-0629.rst
@@ -54,7 +54,7 @@ This would end up looking like::
 
   <meta name="pypi:repository-version" content="1.0">
 
-When intepreting the repository version:
+When interpreting the repository version:
 
 * Incrementing the major version is used to signal a backwards
   incompatible change such that existing clients would no longer be
@@ -63,7 +63,7 @@ When intepreting the repository version:
   compatible change such that existing clients would still be
   expected to be able to meaningfully use the API.
 
-  It is left up to the discretion of any future PEPs as to what
+It is left up to the discretion of any future PEPs as to what
 specifically constitutes a backwards incompatible vs compatible change
 beyond the broad suggestion that existing clients will be able to
 "meaningfully" continue to use the API, and can include adding,


### PR DESCRIPTION
* Fixes the wording to actually say what was meant with regards to compatibility on minor versions.
* Restructure compatibility section to be easier to read.
* Add myself as BDFL-Delegate
  * I'm the default delegate for PyPI PEPs, and this PEP should be uncontroversial, so I believe this should be fine. If anyone has concerns Paul Moore has volunteered to act as delegate in my place.