### PR TITLE
Suggested changes for PEP 387

### DIFF
--- a/pep-0387.txt
+++ b/pep-0387.txt
@@ -78,6 +78,9 @@ be removed at any time in any way.  These include:
 - Test suites.  (Anything in the ``Lib/test`` directory or test
   subdirectories of packages.)
 
+Backward compatibility rules do not apply to any module or API that is
+explicitly documented as **Provisional**.
+
 
 Basic policy for backwards compatibility
 ----------------------------------------
@@ -122,7 +125,7 @@ several releases:
    raise the warning.  If an API is being removed, simply warn
    whenever it is entered.  ``DeprecationWarning`` is the usual
    warning category to use, but ``PendingDeprecationWarning`` may be
-   used in special cases were the old and new versions of the API will
+   used in special cases where the old and new versions of the API will
    coexist for many releases [#warnings]_. Compiler warnings are also
    acceptable. The warning message should include the release the
    incompatibility is expected to become the default and a link to an

--- a/pep-0387.txt
+++ b/pep-0387.txt
@@ -78,8 +78,8 @@ be removed at any time in any way.  These include:
 - Test suites.  (Anything in the ``Lib/test`` directory or test
   subdirectories of packages.)
 
-Backward compatibility rules do not apply to any module or API that is
-explicitly documented as **Provisional**.
+- Backward compatibility rules do not apply to any module or API that is
+  explicitly documented as **Provisional** per PEP 411.
 
 
 Basic policy for backwards compatibility


### PR DESCRIPTION
Reviewing PEP 387 for SC pronouncement, I found one typo.  I also suggest including text for APIs explicitly documented as **provisional**.