### PR TITLE
CI: Only deploy for upstream to prevent forks failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ deploy:
     skip_cleanup: true
     on:
         branch: master
+        repo: python/peps


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fork CI builds fail on the deploy step, because they (correctly) don't have the deploy credentials.

For example, failing fork build:

* https://travis-ci.org/github/hugovk/peps/jobs/711542881

Instead, only do the deploy for this upstream `python/peps` repo.

For example, passing fork build:

* https://travis-ci.org/github/hugovk/peps/builds/711552315

This will encourage people to make sure tests pass on branches, and less likely to submit a failing PR.

# Travis CI docs

* https://docs.travis-ci.com/user/deployment#conditional-releases-with-on
