### PR TITLE
PEP 604: Remove a misleading sentence in PROS

### DIFF
--- a/pep-0604.rst
+++ b/pep-0604.rst
@@ -163,7 +163,6 @@ if we accept to not be compatible with the dynamic evaluation of annotations (``
 PROS:
 
 - If they were permitted, then instance checking could use an extremely clean-looking notation
-- The implementation can use the tuple present in ``Union`` parameter, without create a new instance
 
 CONS:
 


### PR DESCRIPTION
`The implementation can use the tuple present in ``Union`` parameter, without create a new instance` doesn't seem real PROS, because `int | float | str` can not be faster than `(int, float, str)`.
It just only mitigate CONS (worse performance).