### PR TITLE
PEP 1: Remove mentions of peps@python.org, update the process

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -658,7 +658,7 @@ If you are interested in assuming ownership of a PEP, you can also do this via
 pull request.  Fork the `PEP repository`_, make your ownership modification,
 and submit a pull request.  You should mention both the original author and
 ``@python/pep-editors`` in a comment on the pull request.  (If the original
-author's GitHub username is unknown, use e-mail.)  If the original author
+author's GitHub username is unknown, use email.)  If the original author
 doesn't respond in a timely manner, the PEP editors will make a
 unilateral decision (it's not like such decisions can't be reversed :).
 

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -110,9 +110,9 @@ changing their status).  See `PEP Editor Responsibilities & Workflow`_ for
 details.
 
 PEP editorship is by invitation of the current editors, and they can be
-contacted via the address <peps@python.org>, but you may only need to use this
-to contact the editors semi-privately.  All of the PEP workflow can be
-conducted via the GitHub `PEP repository`_ issues and pull requests.
+contacted by mentioning ``@python/pep-editors`` on GitHub.  All of the PEP
+workflow can be conducted via the GitHub `PEP repository`_ issues and pull
+requests.
 
 
 Start with an idea for Python
@@ -228,9 +228,10 @@ numbers directly by creating and committing a new PEP. When doing so, the
 developer must handle the tasks that would normally be taken care of by the
 PEP editors (see `PEP Editor Responsibilities & Workflow`_). This includes
 ensuring the initial version meets the expected standards for submitting a
-PEP. Alternately, even developers may choose to submit PEPs via pull request.
-When doing so, let the PEP editors know you have git push privileges and they
-can guide you through the process of updating the PEP repository directly.
+PEP.  Alternately, even developers should submit PEPs via pull request.
+When doing so, you are generally expected to handle the process yourself;
+if you need assistance from PEP editors, mention ``@python/pep-editors``
+on GitHub.
 
 As updates are necessary, the PEP author can check in new versions if they
 (or a collaborating developer) have git push privileges.
@@ -655,20 +656,23 @@ submit a competing PEP.
 
 If you are interested in assuming ownership of a PEP, you can also do this via
 pull request.  Fork the `PEP repository`_, make your ownership modification,
-and submit a pull request.  You should also send a message asking to take
-over, addressed to both the original author and the PEP editors
-<peps@python.org>.  If the original author doesn't respond to email in a
-timely manner, the PEP editors will make a unilateral decision (it's not like
-such decisions can't be reversed :).
+and submit a pull request.  You should mention both the original author and
+``@python/pep-editors`` in a comment on the pull request.  (If the original
+author's GitHub username is unknown, use e-mail.)  If the original author
+doesn't respond in a timely manner, the PEP editors will make a
+unilateral decision (it's not like such decisions can't be reversed :).
 
 
 PEP Editor Responsibilities & Workflow
 ======================================
 
-A PEP editor must subscribe to the <peps@python.org> list and must watch the
-`PEP repository`_.  Most correspondence regarding PEP administration can be
-handled through GitHub issues and pull requests, but you may also use
-<peps@python.org> for semi-private discussions.  Please do not cross-post!
+A PEP editor must be added to the ``@python/pep-editors`` group on GitHub and
+must watch the `PEP repository`_.
+
+Note that developers with git push privileges for the `PEP repository`_ may
+handle the tasks that would normally be taken care of by the PEP editors.
+Alternately, even developers may request assistance from PEP editors by
+mentioning ``@python/pep-editors`` on GitHub.
 
 For each new PEP that comes in an editor does the following:
 
@@ -728,11 +732,10 @@ Once the PEP is ready for the repository, a PEP editor will:
   python-list & -dev).
 
 Updates to existing PEPs should be submitted as a `GitHub pull request`_.
-Questions may of course still be sent to <peps@python.org>.
 
 Many PEPs are written and maintained by developers with write access
-to the Python codebase.  The PEP editors monitor the python-checkins
-list for PEP changes, and correct any structure, grammar, spelling, or
+to the Python codebase.  The PEP editors monitor the PEP repository
+for changes, and correct any structure, grammar, spelling, or
 markup mistakes they see.
 
 PEP editors don't pass judgment on PEPs.  They merely do the


### PR DESCRIPTION
See [discussion on Discourse](https://discuss.python.org/t/pep-editors-are-you-still-around/4727/4?u=encukou).

This PR does a bit more than just replace the mailing list with the GitHub group: I meant to be closer to the current practice. Please amend and update this however you see fit.

- `peps@python.org` is replaced by mentioning @python/pep-editors
- Developers with write access are expected to handle their PRs
  themselves, and may mention @python/pep-editors if needed.
  This corresponds to the current situation (and means less
  work/responsibility for PEP editors, without a real downside).
- Taking ownership of a PEP is done through GitHub rather than e-mail
- A note about core devs managing their own PRs is repeated in
  "PEP Editor Responsibilities & Workflow": people might look there
  instead of reading all of "Submitting a PEP".

