### PR TITLE
PEP 627: Bring back the REQUESTED file

### DIFF
--- a/pep-0627.rst
+++ b/pep-0627.rst
@@ -20,7 +20,6 @@ for changing it.
 Two files in installed ``.dist-info`` directories are made optional:
 ``RECORD`` (which PEP 376 lists as mandatory, but suggests it can be left out
 for "system packages"), and ``INSTALLER``.
-The ``REQUESTED`` file is removed from the specification.
 
 
 Motivation
@@ -193,23 +192,17 @@ any ASCII string in ``INSTALLER``, rather than a lowercase identifier.
 It also suggests using the command-line command, if available.
 
 
-Removed ``REQUESTED`` File
---------------------------
+The ``REQUESTED`` File
+----------------------
 
-The ``REQUESTED`` file, which was never implemented in ``pip``, is removed
-from the specification.
+The ``REQUESTED`` file is kept in the specification, with only tool-specific
+notes removed.
 
-The semantics of this file depend on all tools creating it when they should.
-Since today's most popular tool, ``pip``, does not create it, the file is
-not useful.
-(It might be useful in environments managed by a single tool; in that case,
-the tool is free to use ``REQUESTED`` as a private extension.)
-
-(The author of this PEP considers ``REQUESTED`` an unnecessary attempt to emulate
-system package managers. Recent tools tend to support creating easily
-reproducible environments, rather than manage long-lived ones;
-deleting the environment and starting a new one is a surprissingly good
-solution to “dangling dependencies”.)
+Note that tools that do not create this file effectively mark all installed
+projects as “removable unless needed by another project”.
+This was was the case with ``pip`` before version 20.2.
+Before ``REQUESTED`` becomes commonplace, automatically uninstalling “orphaned”
+projects should be done wit care.
 
 
 Clarifications
@@ -227,6 +220,8 @@ future PEPs:
 
 * Encoding of the ``RECORD`` file
 * Limiting or namespacing files that can appear in ``.dist-info``
+* Marking the difference between projects installed by a tool that does not
+  support the ``REQUESTED`` file and projects installed as dependencies
 
 
 Copyright


### PR DESCRIPTION
As pip now implements REQUESTED, the main reason to remove the file is gone,
so I'm adding it back as it is in PEP 376.
Possibly fixing the semantics is left to another PEP.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
