### PR TITLE
PEP 596 and PEP 619: Correct bugfix release cadence

### DIFF
--- a/pep-0596.rst
+++ b/pep-0596.rst
@@ -64,7 +64,7 @@ Expected:
 - 3.9.0 candidate 2: Monday, 2020-09-14
 - 3.9.0 final: Monday, 2020-10-05
 
-Subsequent bugfix releases at a monthly cadence.
+Subsequent bugfix releases every two months.
 
 
 3.9 Lifespan

--- a/pep-0619.rst
+++ b/pep-0619.rst
@@ -64,7 +64,8 @@ Expected:
 - 3.10.0 candidate 2: Monday, 2021-09-06 (if necessary)
 - 3.10.0 final: Monday, 2021-10-04
 
-Subsequent bugfix releases at a monthly cadence.
+Subsequent bugfix releases every two months.
+
 
 3.10 Lifespan
 -------------


### PR DESCRIPTION
Resolves #1551 

In response to @hugovk's [comment](https://github.com/python/peps/issues/1551#issuecomment-668985256) I have gone for the following wording:

> Subsequent bugfix releases every two months.

which avoids the ambiguity of "bi-monthly".
