### PR TITLE
PEP 606: Fix incorrect backticks

### DIFF
--- a/pep-0606.rst
+++ b/pep-0606.rst
@@ -133,7 +133,7 @@ One of the `Zen of Python (PEP 20)
     There should be one-- and preferably only one --obvious way to do
     it.
 
-When Python evolves, new ways inevitably emerge. ``DeprecationWarning``s
+When Python evolves, new ways inevitably emerge. ``DeprecationWarning``\ s
 are emitted to suggest using the new way, but many developers ignore
 these warnings, which are silent by default (except in the ``__main__``
 module: see the `PEP 565 <https://www.python.org/dev/peps/pep-0565/>`_).


### PR DESCRIPTION
Fix \`\` in section "Cleaning up Python and DeprecationWarning" (L136).