### PR TITLE
Lint RST inline code on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U docutils
+
+      - name: Build
+        run: make -j$(nproc)
+
+      - name: Deploy
+        if: >
+          (
+            github.repository == 'python/peps' &&
+            github.ref == 'refs/heads/master'
+          )
+
+        run: |
+          bash deploy.bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U pre-commit
+
+      - name: Lint
+        run: make lint
+        env:
+          PRE_COMMIT_COLOR: always

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.6.0
+    hooks:
+      - id: rst-backticks
+      - id: rst-inline-touching-normal

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,12 @@ repos:
     rev: v1.6.0
     hooks:
       - id: rst-backticks
+        exclude: >
+          (?x)^(
+            pep-0012.rst|
+            pep-0505.rst|
+            pep-0550.rst|
+            pep-0567.rst|
+            pep-0572.rst
+          )$
       - id: rst-inline-touching-normal

--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,6 @@ package: all rss
 	cp *.png build/peps/
 	cp *.rss build/peps/
 	tar -C build -czf build/peps.tar.gz peps
+
+lint:
+	pre-commit run --all-files


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->


This PR adds two reStructuredText lint rules and runs them on the CI using GitHub Actions. [Example run.](https://github.com/hugovk/peps/runs/988763650?check_suite_focus=true)

1. Detect single backticks, which should be double in RST for inline code, e.g. stuff fixed in https://github.com/python/peps/pull/1554.

2. Detect inline code touching normal text, e.g. stuff fixed in https://github.com/python/peps/pull/1560.

---

This uses the [pre-commit](https://pre-commit.com/) tool for linting. It's possible, but completely optional, to use it locally and it'll check your changes when you're committing, and fail before commit if something is found.

Optional local set up (run once):

```sh
pip install -U pre-commit && pre-commit install
```

Then make changes and commit as normal:

```sh
git commit -m "PEP XXX: etc"
```

Lint all files:

```sh
pre-commit run --all-files

# Or this does the same thing
make lint
```

The very first run takes a little while to set things up, after that it's quick.

But again, local use of pre-commit is completely optional for those who aren't keen, and the CI will run the checks anyway.

---

The first lint rule finds some false positives:

```
pep-0012.rst:602:    `single-quoted' or ``double-quoted''
pep-0505.rst:245:    Total None-coalescing `if` blocks: 449
pep-0505.rst:246:    Total [possible] None-coalescing `or`: 120
pep-0505.rst:248:    Total Safe navigation `and`: 13
pep-0505.rst:249:    Total Safe navigation `if` blocks: 61
pep-0550.rst:540:    g = gen()  # gen_LC is created for the generator object `g`
pep-0550.rst:763:        # This class is what the `gen_series()` generator can
pep-0550.rst:772:            # Otherwise `var.set(10)` in the `_init` method
pep-0550.rst:857:        # in the `Context Variables` section.
pep-0567.rst:159:    # Get the value of `var`.
pep-0572.rst:1286:        # `a` is local to `f`, but remains unbound
pep-0572.rst:1301:    `a` is not yet bound
```

* pep-0012.rst is an example of what _not_ to do! So that needs to stay.

* pep-0505.rst is example output from a command, so (most likely) needs to stay.

* The other three are from comments in code.  Because it's (indented) code, no _extra_ formatting is added in the rendered monospace output. so these _could_ be changed to either double backticks or no backticks from a formatting point of view.

Now, there's no way to exclude single lines from the linter, so the whole file needs to be excluded.

# Question

Should the single backticks be changed in the latter three code comments?
