### PR TITLE
PEP 627: Record Paul Moore as PEP delegate; update based on his feedback

### DIFF
--- a/pep-0627.rst
+++ b/pep-0627.rst
@@ -1,6 +1,7 @@
 PEP: 627
 Title: Recording installed projects
 Author: Petr Viktorin <encukou@gmail.com>
+BDFL-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-627/4126
 Status: Draft
 Type: Informational
@@ -130,9 +131,14 @@ The “base” of relative paths in ``RECORD`` is specified relative to the
 ``--prefix`` options.
 
 Both *hash* and *size* fields are now optional (for any file, not just
-``.pyc``, ``.pyo`` and ``RECORD``).
-This simplifies the spec, and makes it possible for tools to modify files
-(for example, rewrite shebangs) after ``RECORD`` is generated.
+``.pyc``, ``.pyo`` and ``RECORD``). Leavng them out is discouraged,
+except for ``*.pyc`` and ``RECORD`` itself.
+(Note that PEP 376 is unclear on what was optional; when taken literally,
+its text and examples contradict. Despite that, “both fields are optional“ is a
+reasonable interpretation of PEP 376.
+The alternative would be to mandate—rather rhan recommend—which files can be
+recorded without hash and size, and to update that list over time as new use
+cases come up.)
 
 The new spec explicitly says that the ``RECORD`` file must now include *all*
 files of the installed project (the exception for ``.pyc`` files remains).
@@ -143,6 +149,10 @@ any files if the full list of files is unknown.
 
 A sketch of an uninstallation algorithm is included to clarify the file's
 primary purpose and contents.
+
+Tools must not uninstall/remove projects that lack a ``RECORD`` file
+(unless they have external information, such as in system package
+managers of Linux distros).
 
 On Windows, files in ``RECORD`` may be separated by either ``/`` or ``\``.
 PEP 376 was unclear on this: it mandates forward slashes in one place, but
@@ -172,9 +182,11 @@ Optional ``INSTALLER`` File
 
 The ``INSTALLER`` file is also made optional, and specified to be used for
 informational purposes only.
+It is still a single-line text file containing the name of the installer.
 
-This file was added to distinguish projects installed by the Python installer
-(``pip``) from ones installed by other package managers (e.g. ``dnf``).
+This file was originally added to distinguish projects installed by the Python
+installer (``pip``) from ones installed by other package managers
+(e.g. ``dnf``).
 There were attempts to use this file to prevent ``pip`` from updating or
 uninstalling packages it didn't install.
 
@@ -197,6 +209,10 @@ The ``REQUESTED`` File
 
 The ``REQUESTED`` file is kept in the specification, with only tool-specific
 notes removed.
+
+It is made clear that while ``REQUESTED`` is optional, tools must handle it:
+it can only be omitted only if it is known that a user did not request
+installation directly.
 
 Note that tools that do not create this file effectively mark all installed
 projects as “removable unless needed by another project”.


### PR DESCRIPTION
Paul is the standing delegate for Package Distribution Metadata PEPs.

His feedback is here: https://discuss.python.org/t/pep-627-updating-pep-376-making-record-optional-in-installed-dist-info/4126/22?u=encukou

The accompanying spec PR was [updated](https://github.com/pypa/packaging.python.org/pull/756/commits/336610cfb94966a341d377eb08d50e60e1603475).