### PR TITLE
PEP 627:  Remove REQUESTED from the spec 

### DIFF
--- a/pep-0627.rst
+++ b/pep-0627.rst
@@ -204,21 +204,21 @@ any ASCII string in ``INSTALLER``, rather than a lowercase identifier.
 It also suggests using the command-line command, if available.
 
 
-The ``REQUESTED`` File
-----------------------
+The ``REQUESTED`` File: Removed from Spec
+-----------------------------------------
 
-The ``REQUESTED`` file is kept in the specification, with only tool-specific
-notes removed.
+The ``REQUESTED`` file is now considered a tool-specific extension.
 
-It is made clear that while ``REQUESTED`` is optional, tools must handle it:
-it can only be omitted only if it is known that a user did not request
-installation directly.
+Per :pep:`376`, ``REQUESTED`` was to be written when a project was installed
+by direct user request, as opposed to automatically to satisfy dependencies
+of another project. Projects without this marker file could be uninstalled
+when no longer needed.
 
-Note that tools that do not create this file effectively mark all installed
-projects as “removable unless needed by another project”.
-This was was the case with ``pip`` before version 20.2.
-Before ``REQUESTED`` becomes commonplace, automatically uninstalling “orphaned”
-projects should be done with care.
+Despite the standard, many existing installers (including older versions of
+``pip``) never write this file. There is no distinction between projects
+that are “OK to remove when no longer needed” and ones simply installed by
+a tool that ignores ``REQUESTED``. So, the file is currently not usable for its
+intended purpose (unless a tool can use additional, non-standard information).
 
 
 Clarifications
@@ -236,8 +236,9 @@ future PEPs:
 
 * Encoding of the ``RECORD`` file
 * Limiting or namespacing files that can appear in ``.dist-info``
-* Marking the difference between projects installed by a tool that does not
-  support the ``REQUESTED`` file and projects installed as dependencies
+* Marking the difference between projects installed directly by user request
+  versus those installed to satisfy dependencies, so that the latter can be
+  removed when no longer needed.
 
 
 Copyright

--- a/pep-0627.rst
+++ b/pep-0627.rst
@@ -136,7 +136,7 @@ except for ``*.pyc`` and ``RECORD`` itself.
 (Note that PEP 376 is unclear on what was optional; when taken literally,
 its text and examples contradict. Despite that, “both fields are optional“ is a
 reasonable interpretation of PEP 376.
-The alternative would be to mandate—rather rhan recommend—which files can be
+The alternative would be to mandate—rather than recommend—which files can be
 recorded without hash and size, and to update that list over time as new use
 cases come up.)
 


### PR DESCRIPTION
See [discussion on Discourse](https://discuss.python.org/t/pep-627-updating-pep-376-making-record-optional-in-installed-dist-info/4126/30?u=encukou)