### PR TITLE
Support code highlighting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U docutils
+          python -m pip install -U docutils pygments
 
       - name: Build
         run: make -j$(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U docutils pygments
+          python -m pip install -r requirements.txt
 
       - name: Build
         run: make -j$(nproc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Requirements for building PEPs with Sphinx
-sphinx >= 3.5
-docutils >= 0.16
-Pygments >= 2.9.0
+Pygments ~= 2.9.0
+Sphinx ~= 4.0.2
+docutils ~= 0.17.1
 
 # For RSS
-feedgen >= 0.9.0  # For RSS feed
+feedgen ~= 0.9.0  # For RSS feed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+docutils==0.17.1
+Pygments==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Requirements for building PEPs with Sphinx
-Pygments ~= 2.9.0
-Sphinx ~= 4.0.2
-docutils ~= 0.17.1
+Pygments >= 2.9.0
+Sphinx >= 4.0.2
+docutils >= 0.17.1
 
 # For RSS
-feedgen ~= 0.9.0  # For RSS feed
+feedgen >= 0.9.0  # For RSS feed


### PR DESCRIPTION
See: https://github.com/python/peps/pull/1571#discussion_r478701944

> Fine to try it in another PR, but looks like all that really is needed is to install pygments:
> 
> 1. The `script` step calls `make` to turn plaintext PEPs into HTML, and I assume pygments is only needed here to add colour to the generated HTML files (I'm afk this week so cannot verify this assumption.now).
> 2. Then the `deploy` step calls `deploy.bash` which does `make package` to `tar.gz` the plaintext and generated files and images, and then calls `aws` to actually deploy the `tar.gz` to AWS.