### PR TITLE
PEP 627: Mark as Accepted

### DIFF
--- a/pep-0627.rst
+++ b/pep-0627.rst
@@ -3,10 +3,11 @@ Title: Recording installed projects
 Author: Petr Viktorin <encukou@gmail.com>
 BDFL-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-627/4126
-Status: Draft
+Status: Accepted
 Type: Informational
 Content-Type: text/x-rst
 Created: 15-Jul-2020
+Resolution: https://discuss.python.org/t/pep-627/4126/42
 
 
 Abstract


### PR DESCRIPTION
Paul Moore accepted this PEP on [Discourse](https://discuss.python.org/t/pep-627/4126/42).

This should ideally be merged immediately after [the PyPA spec PR](https://github.com/pypa/packaging.python.org/pull/756).