### PR TITLE
Proposal: Ignore all empty entries within PYTHONPATH

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -1,0 +1,116 @@
+PEP: 9999
+Title: Ignore all empty entries within ``$PYTHONPATH``
+Author: David A. Wheeler <dwheeler@dwheeler.com>
+Status: Draft
+Type: Standards Track
+Content-Type: text/x-rst
+Created: 27-Aug-2020
+Python-Version: 3.7.10
+Post-History: 27-Aug-2020
+
+
+Abstract
+========
+
+Currently, common ways to set ``$PYTHONPATH`` also unexpectedly add the
+current directory as an entry.  As a result, users have an increased
+risk of unintentionally running malicious code.
+
+This PEP proposes that all empty entries within ``$PYTHONPATH`` be ignored,
+instead of being treated as the current directory.
+In the rare cases where the current directory is intended, "." (or
+even better its absolute path) can continue to be used instead.
+This small change eliminates an easily-made and subtle mistake that can
+lead to a security vulnerability.
+
+Motivation
+==========
+
+The essay "Never Run 'python' In Your Downloads Folder" by Glyph
+`Never Run`_
+points out that the way Python currently implements ``$PYTHONPATH``
+easily leads to users unintentionally running malicioous code.
+The problem is that "most places that [recommend using] PYTHONPATH
+recommend adding things to it like so":
+
+    ``export PYTHONPATH="/new/useful/stuff:$PYTHONPATH"``
+
+As the essay notes, "this idiom has a critical flaw:
+the first time it's invoked, if ``$PYTHONPATH`` was previously
+either empty or un-set, this then includes an empty string,
+which resolves to the current directory..."
+As a result, someone who executed this line above will quietly execute
+Python libraries in whatever their current directory happens to be,
+and that could quickly lead to running malicious code.
+
+It could be argued that this is fine, because the shell's ``$PATH``
+does the same thing.
+After all, the current documentation for ``$PYTHONPATH`` says that it
+augments "the default search path for module files.  The format is
+the same as the shell’s PATH: one or more directory pathnames
+separated by os.pathsep (e.g. colons on Unix or semicolons on
+Windows)."
+`Cmdline`_
+
+But this argument ignores a key difference: the shell's ``$PATH`` practically
+*always* has an initial non-empty value, while ``$PYTHONPATH`` typically
+starts with an *empty* value.
+This means that the same patterns that are normally safe with ``$PATH``
+(because ``$PATH`` is non-empty) are *dangerous* with ``$PYTHONPATH``
+`Hacker News`_.
+Once ``$PYTHONPATH`` is set with a dangerous value, it is likely to stay
+dangerous after having other values appended.
+
+A far safer approach is for Python to simply skip all empty entries
+within ``$PYTHONPATH``.
+In this situation, a ``$PYTHONPATH`` with the value "``:spam::eggs:``"
+would be treated the same as "``spam:eggs``".
+Empty entries are almost never intended.
+They are also widely confusing, in part because they are not obvious.
+Users who truly want to include the runtime current directory
+can use "." instead, but in almost all cases they will want the
+absolute path to the current directory anyway.
+
+By ignoring all empty entries, Python users will be quietly protected
+from this mistake, making Python just a little easier to use securely.
+
+Setting ``$PYTHONPATH`` is less common (due to virtualenvs), but it's
+still in use and is a useful mechanism.
+It'd be best to quietly interpret empty entries in ``$PYTHONPATH``
+as unintentional mistakes and ignore them, instead of quietly
+enabling security vulnerabilities.
+
+Implementing this is trivial. I have created this PEP because this
+is a behavioral change in a long-present mechanism, so there is
+a relevant concern about backwards compatibility.
+
+If backwards compatibility of this change is a serious concern, then
+it could be implemented first as a warning about blank entries
+(while *retaining* their meaning), and then later the blank entries could
+trigger a warning (*without* interpreting them as the current directory).
+
+References
+==========
+
+.. _Never Run: https://glyph.twistedmatrix.com/2020/08/never-run-python-in-your-downloads-folder.html
+ by Glyph
+.. _Cmdline: https://docs.python.org/3/using/cmdline.html
+.. _Hacker News: https://news.ycombinator.com/item?id=24250418
+
+
+Copyright
+=========
+
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.
+
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:


### PR DESCRIPTION
Currently, common ways to set ``$PYTHONPATH`` also unexpectedly add the
current directory as an entry.  As a result, users have an increased
risk of unintentionally running malicious code.

This PEP proposes that all empty entries within ``$PYTHONPATH`` be ignored,
instead of being treated as the current directory.

I proposed this to <python-list@python.org>
on Thu, 27 Aug 2020 19:33:13 -0400 (EDT), with subject
"Proposal: Ignore all empty entries within $PYTHONPATH".
I received no comments of any kind. So I thought I'd propose
it here as a PEP.

Implementing this is trivial. I have created this as a PEP because
this is a behavioral change in a long-present mechanism, so there
is a relevant concern about backwards compatibility.
That said, I believe those concerns are easily addressed.
See the proposed PEP for details.

My apologies if this is the wrong process, just let me know
what you'd like me to do instead. Thank you!

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
