### PR TITLE
PEP 478: Add release date of 3.5.8 final

### DIFF
--- a/pep-0478.txt
+++ b/pep-0478.txt
@@ -65,6 +65,7 @@ The releases so far:
 - 3.5.7 final: March 18, 2019
 - 3.5.8 candidate 1: September 9, 2019
 - 3.5.8 candidate 2: October 12, 2019
+- 3.5.8 final: October 29, 2019
 - 3.5.9 final: November 1, 2019
 - 3.5.10 rc1: August 21, 2020
 - 3.5.10 final: September 5, 2020


### PR DESCRIPTION
Re: 
* https://www.python.org/downloads/release/python-358/
* https://github.com/python/cpython/releases/tag/v3.5.8

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
