### PR TITLE
PEP 257: Remove unneeded code block terminator

### DIFF
--- a/pep-0257.txt
+++ b/pep-0257.txt
@@ -91,7 +91,6 @@ one line.  For example::
         """Return the pathname of the KOS root directory."""
         global _kos_root
         if _kos_root: return _kos_root
-        ...
 
 Notes:
 


### PR DESCRIPTION
Line 94 should not need the tripple back tick to be processed as a code block, because it is already indented.
