### PR TITLE
PEP 631: Refactor reference implementation

### DIFF
--- a/pep-0631.rst
+++ b/pep-0631.rst
@@ -141,27 +141,27 @@ Parsing
 
         for i, entry in enumerate(dependencies, 1):
             if not isinstance(entry, str):
-                raise TypeError('Dependency #{} of field `project.dependencies` must be a string'.format(i))
+                raise TypeError(f'Dependency #{i} of field `project.dependencies` must be a string')
 
             try:
                 Requirement(entry)
             except InvalidRequirement as e:
-                raise ValueError('Dependency #{} of field `project.dependencies` is invalid: {}'.format(i, e))
+                raise ValueError(f'Dependency #{i} of field `project.dependencies` is invalid: {e}')
 
-        return sorted(dependencies, key=lambda d: d.lower())
+        return dependencies
 
     def parse_optional_dependencies(config):
         optional_dependencies = config.get('optional-dependencies', {})
         if not isinstance(optional_dependencies, dict):
             raise TypeError('Field `project.optional-dependencies` must be a table')
 
-        optional_dependency_entries = OrderedDict()
+        optional_dependency_entries = {}
 
-        for option, dependencies in sorted(optional_dependencies.items()):
+        for option, dependencies in optional_dependencies.items():
             if not isinstance(dependencies, list):
                 raise TypeError(
-                    'Dependencies for option `{}` of field `project.optional-dependencies` '
-                    'must be an array'.format(option)
+                    f'Dependencies for option `{option}` of field '
+                    '`project.optional-dependencies` must be an array'
                 )
 
             entries = []
@@ -169,21 +169,21 @@ Parsing
             for i, entry in enumerate(dependencies, 1):
                 if not isinstance(entry, str):
                     raise TypeError(
-                        'Dependency #{} of option `{}` of field `project.optional-dependencies` '
-                        'must be a string'.format(i, option)
+                        f'Dependency #{i} of option `{option}` of field '
+                        '`project.optional-dependencies` must be a string'
                     )
 
                 try:
                     Requirement(entry)
                 except InvalidRequirement as e:
                     raise ValueError(
-                        'Dependency #{} of option `{}` of field `project.optional-dependencies` '
-                        'is invalid: {}'.format(i, option, e)
+                        f'Dependency #{i} of option `{option}` of field '
+                        f'`project.optional-dependencies` is invalid: {e}'
                     )
                 else:
                     entries.append(entry)
 
-            optional_dependency_entries[option] = sorted(entries, key=lambda d: d.lower())
+            optional_dependency_entries[option] = entries
 
         return optional_dependency_entries
 
@@ -201,17 +201,19 @@ Metadata
         ...
 
         if metadata_object.dependencies:
-            for dependency in metadata_object.dependencies:
-                metadata_file += 'Requires-Dist: {}\n'.format(dependency)
+            # Sort dependencies to ensure reproducible builds
+            for dependency in sorted(metadata_object.dependencies):
+                metadata_file += f'Requires-Dist: {dependency}\n'
 
         if metadata_object.optional_dependencies:
-            for option, dependencies in metadata_object.optional_dependencies.items():
-                metadata_file += 'Provides-Extra: {}\n'.format(option)
-                for dependency in dependencies:
+            # Sort extras and dependencies to ensure reproducible builds
+            for option, dependencies in sorted(metadata_object.optional_dependencies.items()):
+                metadata_file += f'Provides-Extra: {option}\n'
+                for dependency in sorted(dependencies):
                     if ';' in dependency:
-                        metadata_file += 'Requires-Dist: {} and extra == "{}"\n'.format(dependency, option)
+                        metadata_file += f'Requires-Dist: {dependency} and extra == "{option}"\n'
                     else:
-                        metadata_file += 'Requires-Dist: {}; extra == "{}"\n'.format(dependency, option)
+                        metadata_file += f'Requires-Dist: {dependency}; extra == "{option}"\n'
 
         ...
 


### PR DESCRIPTION
There are two separate commits that make two changes:

1. Replace `sorted(..., key=lambda d: d.lower())` with `sorted(..., key=str.casefold)`: I'm not sure why these things need to be sorted in a case-insensitive way (we can always just drop the `sorted` entirely if it's not necessary), but I think `str.casefold` is the right logical operation to perform even if they aren't allowed to contain non-ASCII characters at the moment.
2. Used f-strings and take advantage of the fact that in Python 3.6+, dictionaries are already ordered (though again I'm not sure why we need it to be ordered in the first place).

I think the f-strings in particular make this much easier to read at the cost of wide compatibility. Implementations that want wider compatibility can always backport and use the more cumbersome constructs.

CC: @ofek 