### PR TITLE
PEP 633: Fix reference implementation

### DIFF
--- a/pep-0633.rst
+++ b/pep-0633.rst
@@ -185,7 +185,7 @@ performed):
             if vcs in requirement:
                 pep508 += " @ " + vcs + "+" requirement[vcs]
                 if "revision" in requirement:
-                    pep508 += "@" + revision
+                    pep508 += "@" + requirement["revision"]
         extra = None
         if "for-extra" in requirement:
             extra = requirement["for-extra"]


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

From putting the reference implementation in a file and running Flake8 on it:

```console
$ flake8 1.py
1.py:15:33: F821 undefined name 'revision' 
```

See also PR https://github.com/python/peps/pull/1605 and cc @pganssle and @EpicWink.

(And Flake8 found the first but not the second thing fixed in #1605, so there may be more.)