### PR TITLE
Travis CI: Only deploy once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ deploy:
     on:
         branch: master
         repo: python/peps
+        python: "3.7"


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Right now, the deploy to S3 is made for both the `3.7` and `3.7-dev` jobs, for example:

* https://travis-ci.com/github/python/peps/jobs/388374276#L737
* https://travis-ci.com/github/python/peps/jobs/388374277#L741

Instead, only deploy for a single CI job.
