### PR TITLE
PEP 345: Disallow environment markers in Requires-Python

### DIFF
--- a/pep-0345.txt
+++ b/pep-0345.txt
@@ -496,7 +496,6 @@ to use other sequences like tuples or lists on the right side.
 
 The fields that benefit from this marker are:
 
-- Requires-Python
 - Requires-External
 - Requires-Dist
 - Provides-Dist


### PR DESCRIPTION
Neither pip nor setuptools or warehouse are expecting them and since
Requires-Python disallows multiple use, environment markers would be
useless.

Cf https://github.com/pypa/packaging.python.org/pull/771 for more context.
