### PR TITLE
PEP 637: Updated Post-History with the mail date to python-ideas

### DIFF
--- a/pep-0637.txt
+++ b/pep-0637.txt
@@ -10,7 +10,7 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 24-Aug-2020
 Python-Version: 3.10
-Post-History: 
+Post-History: 23-Sep-2020
 Resolution: 
 
 Abstract


### PR DESCRIPTION
Adds the Post-History metadata with the date of the announcement email sent to python-ideas