### PR TITLE
Fix likely-accidental blockquotes around code

### DIFF
--- a/pep-0637.txt
+++ b/pep-0637.txt
@@ -20,16 +20,12 @@ At present keyword arguments are allowed in function calls, but not in
 item access. This PEP proposes that Python be extended to allow keyword
 arguments in item access.
 
-The following example shows keyword arguments for ordinary function calls:
-
-::
+The following example shows keyword arguments for ordinary function calls::
 
   >>> val = f(1, 2, a=3, b=4)
 
 The proposal would extend the syntax to allow a similar construct
-to indexing operations:
-
-::
+to indexing operations::
 
   >>> val = x[1, 2, a=3, b=4]  # getitem
   >>> x[1, 2, a=3, b=4] = val  # setitem
@@ -63,7 +59,7 @@ annotations, e.g. to specify a list of integers as Sequence[int]. Additionally,
 there has been an expanded growth of packages for data analysis such as pandas
 and xarray, which use names to describe columns in a table (pandas) or axis in
 an nd-array (xarray). These packages allow users to access specific data by
-names, but cannot currently use index notation ([]) for this functionality.
+names, but cannot currently use index notation (``[]``) for this functionality.
 
 As a result, a renewed interest in a more flexible syntax that would allow for
 named information has been expressed occasionally in many different threads on
@@ -159,9 +155,7 @@ Subscripting ``obj[x]`` is, effectively, an alternate and specialised form of
 function call syntax with a number of differences and restrictions compared to
 ``obj(x)``. The current python syntax focuses exclusively on position to express
 the index, and also contains syntactic sugar to refer to non-punctiform
-selection (slices). Some common examples:
-
-   ::
+selection (slices). Some common examples::
 
      >>> a[3]       # returns the fourth element of 'a'
      >>> a[1:10:2]  # slice notation (extract a non-trivial data subset)
@@ -185,16 +179,12 @@ violate this intrinsic meaning.
 The second difference of the indexing notation compared to a function
 is that indexing can be used for both getting and setting operations.
 In python, a function cannot be on the left hand side of an assignment. In
-other words, both of these are valid
-
-   ::
+other words, both of these are valid::
 
      >>> x = a[1, 2]
      >>> a[1, 2] = 5
 
-but only the first one of these is valid
-
-   ::
+but only the first one of these is valid::
 
      >>> x = f(1, 2)
      >>> f(1, 2) = 5  # invalid
@@ -208,19 +198,14 @@ arguments, unless the passed parameters are captured with \*args, in which case
 they end up as entries in the args tuple. In other words, functions already
 have anonymous argument semantic, exactly like the indexing operation. However,
 __(get|set|del)item__ is not always receiving a tuple as the ``index`` argument
-(to be uniform in behavior with \*args).  In fact, given a trivial class:
-
-
-   ::
+(to be uniform in behavior with \*args).  In fact, given a trivial class::
 
      class X:
          def __getitem__(self, index):
              print(index)
 
 The index operation basically forwards the content of the square brackets "as is"
-in the ``index`` argument:
-
-   ::
+in the ``index`` argument::
 
      >>> x=X()
      >>> x[0]
@@ -240,27 +225,19 @@ in the ``index`` argument:
      ('hello', 'hi')
 
 The fourth difference is that the indexing operation knows how to convert
-colon notations to slices, thanks to support from the parser. This is valid
-
-   ::
+colon notations to slices, thanks to support from the parser. This is valid::
 
      a[1:3]
 
-this one isn't
-
-   ::
+this one isn't::
 
      f(1:3)
 
-The fifth difference is that there's no zero-argument form. This is valid
-
-   ::
+The fifth difference is that there's no zero-argument form. This is valid::
 
      f()
 
-this one isn't
-
-   ::
+this one isn't::
 
      a[]
 
@@ -296,9 +273,7 @@ operation, may be used to take indexing decisions to obtain the final index, and
 will have to accept values that are unconventional for functions. See for
 example use case 1, where a slice is accepted.
 
-The new notation will make all of the following valid notation:
-
-  ::
+The new notation will make all of the following valid notation::
 
     >>> a[1]               # Current case, single index
     >>> a[1, 2]            # Current case, multiple indexes
@@ -308,9 +283,7 @@ The new notation will make all of the following valid notation:
     >>> a[3, R=3:10, K=4]  # New case. Slice in keyword argument
     >>> a[3, R=..., K=4]   # New case. Ellipsis in keyword argument
 
-The new notation will NOT make the following valid notation:
-
-  ::
+The new notation will NOT make the following valid notation::
 
     >>> a[]                # INVALID. No index and no keyword arguments.
 
@@ -376,9 +349,7 @@ The following old semantics are preserved:
    arguments give a SyntaxError.
 
 5. Keyword subscripts, if any, will be handled like they are in
-   function calls. Examples:
-
-   ::
+   function calls. Examples::
 
      # Single index with keywords:
 
@@ -431,9 +402,7 @@ The following old semantics are preserved:
    - but if no ``**kwargs`` parameter is defined, it is an error.
 
 
-7. Sequence unpacking remains a syntax error inside subscripts:
-
-   ::
+7. Sequence unpacking remains a syntax error inside subscripts::
 
      obj[*items]
 
@@ -445,18 +414,14 @@ The following old semantics are preserved:
    This restriction has however been considered arbitrary by some, and it might
    be lifted at a later stage for symmetry with kwargs unpacking, see next.
 
-8. Dict unpacking is permitted:
-
-   ::
+8. Dict unpacking is permitted::
 
      items = {'spam': 1, 'eggs': 2}
      obj[index, **items]
      # equivalent to obj[index, spam=1, eggs=2]
 
 
-9. Keyword-only subscripts are permitted. The positional index will be the empty tuple:
-
-   ::
+9. Keyword-only subscripts are permitted. The positional index will be the empty tuple::
 
      obj[spam=1, eggs=2]
      # calls type(obj).__getitem__(obj, (), spam=1, eggs=2)
@@ -517,15 +482,11 @@ Corner case and Gotchas
 
 With the introduction of the new notation, a few corner cases need to be analysed:
 
-1. Technically, if a class defines their getter like this:
-
-   ::
+1. Technically, if a class defines their getter like this::
 
      def __getitem__(self, index):
 
-   then the caller could call that using keyword syntax, like these two cases:
-
-   ::
+   then the caller could call that using keyword syntax, like these two cases::
 
      obj[3, index=4]
      obj[index=1]
@@ -540,9 +501,7 @@ With the introduction of the new notation, a few corner cases need to be analyse
    backward compatibility issues on this respect.
 
    Classes that wish to stress this behavior explicitly can define their
-   parameters as positional-only:
-
-   ::
+   parameters as positional-only::
 
       def __getitem__(self, index, /):
 
@@ -560,21 +519,15 @@ With the introduction of the new notation, a few corner cases need to be analyse
 
 3. If the subscript dunders are declared to use positional-or-keyword
    parameters, there may be some surprising cases when arguments are passed
-   to the method. Given the signature:
-
-   ::
+   to the method. Given the signature::
 
      def __getitem__(self, index, direction='north')
 
-   if the caller uses this:
-
-   ::
+   if the caller uses this::
 
      obj[0, 'south']
 
-   they will probably be surprised by the method call:
-
-   ::
+   they will probably be surprised by the method call::
 
      # expected type(obj).__getitem__(0, direction='south')
      # but actually get:
@@ -582,9 +535,7 @@ With the introduction of the new notation, a few corner cases need to be analyse
 
 
    Solution: best practice suggests that keyword subscripts should be
-   flagged as keyword-only when possible:
-
-   ::
+   flagged as keyword-only when possible::
 
      def __getitem__(self, index, *, direction='north')
 
@@ -597,9 +548,7 @@ With the introduction of the new notation, a few corner cases need to be analyse
    ``d[1, a=3]`` is treated as ``__getitem__(1, a=3)``, NOT ``__getitem__((1,), a=3)``. It would be
    extremely confusing if adding keyword arguments were to change the type of the passed index.
    In other words, adding a keyword to a single-valued subscript will not change it into a tuple.
-   For those cases where an actual tuple needs to be passed, a proper syntax will have to be used:
-
-   ::
+   For those cases where an actual tuple needs to be passed, a proper syntax will have to be used::
 
      obj[(1,), a=3]  # calls __getitem__((1,), a=3)
 
@@ -618,18 +567,14 @@ With the introduction of the new notation, a few corner cases need to be analyse
      obj[1,]         # calls __getitem__((1,))
      obj[(1,), a=3]  # calls __getitem__((1,), a=3)
 
-   This is particularly relevant in the case where two entries are passed:
-
-   ::
+   This is particularly relevant in the case where two entries are passed::
 
      obj[1, 2]         # calls __getitem__((1, 2))
      obj[(1, 2)]       # same as above
      obj[1, 2, a=3]    # calls __getitem__((1, 2), a=3)
      obj[(1, 2), a=3]  # calls __getitem__((1, 2), a=3)
 
-   And particularly when the tuple is extracted as a variable:
-
-   ::
+   And particularly when the tuple is extracted as a variable::
 
      t = (1, 2)
      obj[t]       # calls __getitem__((1, 2))
@@ -682,14 +627,14 @@ helpers.
 1. User defined classes can be given ``getitem`` and ``delitem`` methods,
    that respectively get and delete values stored in a container.
 
-    ::
+   ::
 
       >>> val = x.getitem(1, 2, a=3, b=4)
       >>> x.delitem(1, 2, a=3, b=4)
 
    The same can't be done for ``setitem``. It's not valid syntax.
 
-    ::
+   ::
 
       >>> x.setitem(1, 2, a=3, b=4) = val
       SyntaxError: can't assign to function call
@@ -771,15 +716,11 @@ that are invoked over the ``__(get|set|del)item__`` triad, if they are present.
 
 The rationale around this choice is to make the intuition around how to add kwd
 arg support to square brackets more obvious and in line with the function
-behavior. Given:
-
-::
+behavior. Given::
 
   def __getitem_ex__(self, x, y): ...
 
-These all just work and produce the same result effortlessly:
-
-::
+These all just work and produce the same result effortlessly::
 
   obj[1, 2]
   obj[1, y=2]
@@ -813,7 +754,7 @@ The problems with this approach were found to be:
 - it would potentially lead to mixed situations where the extended version is
   defined for the getter, but not for the setter.
 
-- In the __setitem_ex__ signature, value would have to be made the first
+- In the ``__setitem_ex__`` signature, value would have to be made the first
   element, because the index is of arbitrary length depending on the specified
   indexes. This would look awkward because the visual notation does not match
   the signature:
@@ -971,16 +912,12 @@ Common objections
    One problem is type hint creation has been extended to built-ins in python 3.9,
    so that you do not have to import Dict, List, et al anymore.
 
-   Without kwdargs inside ``[]``, you would not be able to do this:
-
-   ::
+   Without kwdargs inside ``[]``, you would not be able to do this::
 
      Vector = dict[i=float, j=float]
 
    but for obvious reasons, call syntax using builtins to create custom type hints
-   isn't an option:
-
-   ::
+   isn't an option::
 
      dict(i=float, j=float)  # would create a dictionary, not a type
 


### PR DESCRIPTION
Additionally, `::` can be used at the end of a sentence to both add a colon and start a code block at the same time

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
