### PR TITLE
PEP 637: Removed currently normal Ellipsis on keyword argument

### DIFF
--- a/pep-0637.rst
+++ b/pep-0637.rst
@@ -413,12 +413,7 @@ The following old semantics are preserved:
     This may open up the possibility to accept the same syntax for general function
     calls, but this is not part of this recommendation.
 
-11. Keyword arguments must allow Ellipsis::
-
-        obj[..., spam=..., eggs=2]
-        # calls type(obj).__getitem__(obj, Ellipsis, spam=Ellipsis, eggs=2)
-
-12. Keyword arguments allow for default values::
+11. Keyword arguments allow for default values::
 
         # Given type(obj).__getitem__(obj, index, spam=True, eggs=2)
         obj[3]               # Valid. index = 3, spam = True, eggs = 2
@@ -426,7 +421,7 @@ The following old semantics are preserved:
         obj[spam=False]      # Valid. index = (), spam = False, eggs = 2
         obj[]                # Invalid.
 
-13. The same semantics given above must be extended to ``__class__getitem__``:
+12. The same semantics given above must be extended to ``__class__getitem__``:
     Since PEP 560, type hints are dispatched so that for ``x[y]``, if no
     ``__getitem__`` method is found, and ``x`` is a type (class) object,
     and ``x`` has a class method ``__class_getitem__``, that method is


### PR DESCRIPTION
Removes the Ellipsis on keyword arguments, as it's normally accepted in python 3