### PR TITLE
PEP 638: Fix typo in references

### DIFF
--- a/pep-0638.rst
+++ b/pep-0638.rst
@@ -62,7 +62,7 @@ there will be a constant battle between those wanting to keep the
 language compact and fitting their brains, and those wanting a new feature
 that suits their domain or programming style.
 
-__ https://www.linuxjournal.com/article/4731)
+__ https://www.linuxjournal.com/article/4731
 
 
 Improving the expessiveness of libraries for specific domains


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
There is a typo in the link to https://www.linuxjournal.com/article/4731 at `References` section