### PR TITLE
PEP 343: Clean up some __context__ context

### DIFF
--- a/pep-0343.txt
+++ b/pep-0343.txt
@@ -853,9 +853,8 @@ refers to an action which is to be done in the ``__exit__`` method.
             try:
                 try:
                     for context in contexts:
-                        mgr = context.__context__()
-                        exit = mgr.__exit__
-                        enter = mgr.__enter__
+                        exit = context.__exit__
+                        enter = context.__enter__
                         vars.append(enter())
                         exits.append(exit)
                     yield vars
@@ -900,7 +899,7 @@ This PEP was first accepted by Guido at his EuroPython
 keynote, 27 June 2005.
 It was accepted again later, with ``the __context__`` method added.
 The PEP was implemented in Subversion for Python 2.5a1
-The ``__context__()`` method will be removed in Python 2.5a3
+The ``__context__()`` method was removed in Python 2.5b1
 
 
 Acknowledgements


### PR DESCRIPTION
Clarify when the `__context__()` function was removed from the API; the projected 2.5a3 tag never happened.

Also remove `__context__()` from example code.