### PR TITLE
PEP 569: Python 3.8.6 was released on 2020-09-24

### DIFF
--- a/pep-0569.rst
+++ b/pep-0569.rst
@@ -74,12 +74,12 @@ Actual:
 - 3.8.4: Monday, 2020-07-13
 - 3.8.5: Monday, 2020-07-20 (security hotfix)
 - 3.8.6rc1: Tuesday, 2020-09-08
+- 3.8.6: Monday, 2020-09-24
 
 Subsequent bugfix releases at a bi-monthly cadence.
 
 Expected:
 
-- 3.8.6: Monday, 2020-09-21
 - 3.8.7rc1: Monday, 2020-11-02
 - 3.8.7: Monday, 2020-11-16
 


### PR DESCRIPTION
* https://www.python.org/downloads/release/python-386/
* https://discuss.python.org/t/python-3-8-6-is-now-available/5299

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
