### PR TITLE
PEP637 setter notation getitem -> setitem

### DIFF
--- a/pep-0637.rst
+++ b/pep-0637.rst
@@ -462,7 +462,7 @@ With the introduction of the new notation, a few corner cases need to be analyse
 
 2. a similar case occurs with setter notation::
 
-       # Given type(obj).__getitem__(self, index, value):
+       # Given type(obj).__setitem__(self, index, value):
        obj[1, value=3] = 5
 
    This poses no issue because the value is passed automatically, and the python interpreter will raise


### PR DESCRIPTION
In PEP-0637, in the example discussing setter notation, change the example from `__getitem__` to `__setitem__`, as the former appears to be a mistake in this context.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
