### PR TITLE
PEP 596, 619: Update based on released versions

### DIFF
--- a/pep-0596.rst
+++ b/pep-0596.rst
@@ -59,9 +59,6 @@ Actual:
 - 3.9.0 beta 5: Monday, 2020-07-20
 - 3.9.0 candidate 1: Tuesday, 2020-08-11
 - 3.9.0 candidate 2: Thursday, 2020-09-17
-
-Expected:
-
 - 3.9.0 final: Monday, 2020-10-05
 
 Subsequent bugfix releases every two months, starting with:

--- a/pep-0619.rst
+++ b/pep-0619.rst
@@ -43,10 +43,10 @@ PEP 602.
 Actual:
 
 - 3.10 development begins: Monday, 2020-05-18
+- 3.10.0 alpha 1: Monday, 2020-10-05
 
 Expected:
 
-- 3.10.0 alpha 1: Monday, 2020-10-05
 - 3.10.0 alpha 2: Monday, 2020-11-02
 - 3.10.0 alpha 3: Monday, 2020-12-07
 - 3.10.0 alpha 4: Monday, 2021-01-04


### PR DESCRIPTION
https://www.python.org/downloads/release/python-390/
https://www.python.org/downloads/release/python-3100a1/