### PR TITLE
PEP 584: Fix order in specification examples

### DIFF
--- a/pep-0584.rst
+++ b/pep-0584.rst
@@ -152,7 +152,7 @@ the last-seen value (i.e. that from the right-hand operand) wins::
     >>> d | e
     {'spam': 1, 'eggs': 2, 'cheese': 'cheddar', 'aardvark': 'Ethel'}
     >>> e | d
-    {'aardvark': 'Ethel', 'spam': 1, 'eggs': 2, 'cheese': 3}
+    {'cheese': 3, 'aardvark': 'Ethel', 'spam': 1, 'eggs': 2}
 
 The augmented assignment version operates in-place::
 
@@ -174,7 +174,7 @@ accept any iterable, not just lists.  Continued from above::
 
     >>> d |= [('spam', 999)]
     >>> d
-    {'eggs': 2, 'cheese': 'cheddar', 'aardvark': 'Ethel', 'spam': 999}
+    {'spam': 999, 'eggs': 2, 'cheese': 'cheddar', 'aardvark': 'Ethel'}
 
 When new keys are added, their order matches their order within the
 right-hand mapping, if any exists for its type.
@@ -580,7 +580,7 @@ Advantages
 * Accepts sequences of ``(key, value)`` pairs like the ``update``
   method.
 
-* Being a method, it is easily to override in a subclass if you need
+* Being a method, it is easy to override in a subclass if you need
   alternative behaviors such as "first wins", "unique keys", etc.
 
 


### PR DESCRIPTION
Updating an existing key's value doesn't move it to the back.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
