### PR TITLE
PEP 621: Clarify expectations for sdists

### DIFF
--- a/pep-0621.rst
+++ b/pep-0621.rst
@@ -443,7 +443,7 @@ thus becomes a corresponding ``Requires-Dist`` entry for the matching
 Specifies which fields listed by this PEP were intentionally
 unspecified so another tool can/will provide such metadata
 dynamically. This clearly delineates which metadata is purposefully
-unspecified and expected to stay unspecified compared versus being
+unspecified and expected to stay unspecified compared to being
 provided via tooling later on.
 
 - A build back-end MUST honour statically-specified metadata (which

--- a/pep-0621.rst
+++ b/pep-0621.rst
@@ -91,10 +91,12 @@ version), but it cannot become less specific.
 
 Build back-ends creating a source distribution -- aka an "sdist" --
 SHOULD provide as much data as possible using this PEP within a source
-distribution. Some fields specified below MUST be provided statically
-in a source distribution *if* the metadata is to be provided at any
-point for the project. Other metadata must *always* be provided
-statically in a source distribution.
+distribution. The ``name`` and ``version`` fields MUST NOT be omitted
+and must be statically specified. Other fields which pertain to data
+surfaced on PyPI, and thus are not expected to be determined at wheel
+creation time, MUST NOT be listed as ``dynamic`` in a source
+distribution. All other fields have no specific requirements placed
+upon them in a source distribution.
 
 
 Details
@@ -116,7 +118,7 @@ fields.
 - Format: string
 - `Core metadata`_: ``Name``
   (`link <https://packaging.python.org/specifications/core-metadata/#name>`__)
-- Source distributions: always provided
+- Source distributions: required
 - Synonyms
 
   - Flit_: ``module``/``dist-name``
@@ -138,7 +140,7 @@ as it is read for internal consistency.
 - Format: string
 - `Core metadata`_: ``Version``
   (`link <https://packaging.python.org/specifications/core-metadata/#version>`__)
-- Source distributions: always provided
+- Source distributions: required
 - Synonyms
 
   - Flit_: N/A (read from a ``__version__`` attribute)
@@ -157,7 +159,7 @@ Users SHOULD prefer to specify already-normalized versions.
 - Format: string
 - `Core metadata`_: ``Summary``
   (`link <https://packaging.python.org/specifications/core-metadata/#summary>`__)
-- Source distributions: statically specified if provided
+- Source distributions: cannot by dynamic
 - Synonyms
 
   - Flit_: N/A
@@ -173,7 +175,7 @@ The summary description of the project.
 - Format: String or table
 - `Core metadata`_: ``Description``
   (`link <https://packaging.python.org/specifications/core-metadata/#description>`__)
-- Source distributions: statically specified if provided
+- Source distributions: cannot by dynamic
 - Synonyms
 
   - Flit_: ``description-file``
@@ -217,7 +219,7 @@ error for unsupported content-types.
 - Format: string
 - `Core metadata`_: ``Requires-Python``
   (`link <https://packaging.python.org/specifications/core-metadata/#summary>`__)
-- Source distributions: statically specified if provided
+- Source distributions: cannot by dynamic
 - Synonyms
 
   - Flit_: ``requires-python``
@@ -239,7 +241,7 @@ the user specified for this field.
 - Format: Table
 - `Core metadata`_: ``License``
   (`link <https://packaging.python.org/specifications/core-metadata/#license>`__)
-- Source distributions: statically specified if provided
+- Source distributions: cannot by dynamic
 - Synonyms
 
   - Flit_: ``license``
@@ -269,7 +271,7 @@ classifiers.
 - Format: Array of inline tables with string keys and values
 - `Core metadata`_: ``Author``/``Author-email``/``Maintainer``/``Maintainer-email``
   (`link <https://packaging.python.org/specifications/core-metadata/#author>`__)
-- Source distributions: statically specified if provided
+- Source distributions: cannot by dynamic
 - Synonyms
 
   - Flit_: ``author``/``author-email``/``maintainer``/``maintainer-email``
@@ -309,7 +311,7 @@ Using the data to fill in `core metadata`_ is as follows:
 - Format: array of strings
 - `Core metadata`_: ``Keywords``
   (`link <https://packaging.python.org/specifications/core-metadata/#keywords>`__)
-- Source distributions: statically specified if provided
+- Source distributions: cannot by dynamic
 - Synonyms
 
   - Flit_: ``keywords``
@@ -326,7 +328,7 @@ The keywords for the project.
 - Format: array of strings
 - `Core metadata`_: ``Classifier``
   (`link <https://packaging.python.org/specifications/core-metadata/#classifier-multiple-use>`__)
-- Source distributions: statically specified if provided
+- Source distributions: cannot by dynamic
 - Synonyms
 
   - Flit_: ``classifiers``
@@ -346,7 +348,7 @@ if the back-end can deduce the classifiers from the provided metadata.
 - Format: Table, with keys and values of strings
 - `Core metadata`_: ``Project-URL``
   (`link <https://packaging.python.org/specifications/core-metadata/#project-url-multiple-use>`__)
-- Source distributions: statically specified if provided
+- Source distributions: cannot by dynamic
 - Synonyms
 
   - Flit_: ``[tool.flit.metadata.urls]`` table

--- a/pep-0621.rst
+++ b/pep-0621.rst
@@ -28,12 +28,14 @@ Motivation
 The key motivators of this PEP are:
 
 - Encourage users to specify core metadata statically for speed,
-  ease of specification, deterministic consumption by build back-ends,
-  and ease analysis of source checkouts
+  ease of specification, and deterministic consumption by build
+  back-ends
 - Provide a tool-agnostic way of specifying the metadata for ease of
   learning and transitioning between build back-ends
 - Allow for more code sharing between build back-ends for the
   "boring parts" of a project's metadata
+- Provide a way to specify canonical data both by users and in
+  source distributions
 
 This PEP does **not** attempt to standardize all possible metadata
 required by a build back-end, only the metadata covered by the
@@ -75,10 +77,11 @@ The design guidelines the authors of this PEP followed were:
   have used TOML for their metadata
 - Don't try to standardize things which lack a pre-existing standard
   at a lower-level
-- *When* metadata is specified using this PEP then it is considered
-  canonical, but that any and all metadata can be considered
-  *optional* (`core metadata`_ has its own requirements of what
-  data must be provided *somehow*)
+- *When* metadata is specified using this PEP, it is considered
+  canonical
+- Make the specified data useful in a source distribution to
+  statically define what metadata is known at the time of source
+  distribution creation
 
 
 Specification
@@ -87,6 +90,20 @@ Specification
 When specifying project metadata, tools MUST adhere and honour the
 metadata as specified in this PEP. If metadata is improperly specified
 then tools MUST raise an error to notify the user about their mistake.
+
+Data specified using this PEP is considered canonical. Tools CANNOT
+remove or change data, but they MAY add to it. This allows for tools
+to make data more accurate/static when possible by updating the data
+specified in the ``pyproject.toml`` file. For example, a version
+can become more specific when building a wheel (e.g. adding a local
+version), but it cannot become less specific.
+
+Build back-ends creating a source distribution -- aka an "sdist" --
+SHOULD provide as much data as possible using this PEP within a source
+distribution. Some fields specified below MUST be provided statically
+in a source distribution *if* the metadata is to be provided at any
+point for the project. Other metadata must *always* be provided
+statically in a source distribution.
 
 Details
 -------
@@ -106,6 +123,7 @@ build back-end will dynamically provide all fields.
 - Format: string
 - `Core metadata`_: ``Name``
   (`link <https://packaging.python.org/specifications/core-metadata/#name>`__)
+- Source distributions: always provided
 - Synonyms
 
   - Flit_: ``module``/``dist-name``
@@ -127,6 +145,7 @@ as it is read for internal consistency.
 - Format: string
 - `Core metadata`_: ``Version``
   (`link <https://packaging.python.org/specifications/core-metadata/#version>`__)
+- Source distributions: always provided
 - Synonyms
 
   - Flit_: N/A (read from a ``__version__`` attribute)
@@ -145,6 +164,7 @@ Users SHOULD prefer to specify already-normalized versions.
 - Format: string
 - `Core metadata`_: ``Summary``
   (`link <https://packaging.python.org/specifications/core-metadata/#summary>`__)
+- Source distributions: statically specified if provided
 - Synonyms
 
   - Flit_: N/A
@@ -160,6 +180,7 @@ The summary description of the project.
 - Format: String or table
 - `Core metadata`_: ``Description``
   (`link <https://packaging.python.org/specifications/core-metadata/#description>`__)
+- Source distributions: statically specified if provided
 - Synonyms
 
   - Flit_: ``description-file``
@@ -202,6 +223,7 @@ Otherwise tools MUST raise an error for unsupported content-types.
 - Format: string
 - `Core metadata`_: ``Requires-Python``
   (`link <https://packaging.python.org/specifications/core-metadata/#summary>`__)
+- Source distributions: statically specified if provided
 - Synonyms
 
   - Flit_: ``requires-python``
@@ -223,6 +245,7 @@ the user specified for this field.
 - Format: Table
 - `Core metadata`_: ``License``
   (`link <https://packaging.python.org/specifications/core-metadata/#license>`__)
+- Source distributions: statically specified if provided
 - Synonyms
 
   - Flit_: ``license``
@@ -252,6 +275,7 @@ classifiers.
 - Format: Array of inline tables with string keys and values
 - `Core metadata`_: ``Author``/``Author-email``/``Maintainer``/``Maintainer-email``
   (`link <https://packaging.python.org/specifications/core-metadata/#author>`__)
+- Source distributions: statically specified if provided
 - Synonyms
 
   - Flit_: ``author``/``author-email``/``maintainer``/``maintainer-email``
@@ -291,6 +315,7 @@ Using the data to fill in `core metadata`_ is as follows:
 - Format: array of strings
 - `Core metadata`_: ``Keywords``
   (`link <https://packaging.python.org/specifications/core-metadata/#keywords>`__)
+- Source distributions: statically specified if provided
 - Synonyms
 
   - Flit_: ``keywords``
@@ -307,6 +332,7 @@ The keywords for the project.
 - Format: array of strings
 - `Core metadata`_: ``Classifier``
   (`link <https://packaging.python.org/specifications/core-metadata/#classifier-multiple-use>`__)
+- Source distributions: statically specified if provided
 - Synonyms
 
   - Flit_: ``classifiers``
@@ -326,6 +352,7 @@ if the back-end can deduce the classifiers from the provided metadata.
 - Format: Table, with keys and values of strings
 - `Core metadata`_: ``Project-URL``
   (`link <https://packaging.python.org/specifications/core-metadata/#project-url-multiple-use>`__)
+- Source distributions: statically specified if provided
 - Synonyms
 
   - Flit_: ``[tool.flit.metadata.urls]`` table
@@ -344,6 +371,7 @@ Entry points
   ``[project.entry-points]``)
 - `Core metadata`_: N/A;
   `Entry point specification <https://packaging.python.org/specifications/entry-points/>`_
+- Source distributions: optional
 - Synonyms
 
   - Flit_: ``[tool.flit.scripts]`` table for console scripts,
@@ -382,6 +410,7 @@ be ambiguous in the face of ``[project.scripts]`` and
 - `Core metadata`_: ``Requires-Dist`` and ``Provides-Extra``
   (`link <https://packaging.python.org/specifications/core-metadata/#requires-dist-multiple-use>`__,
   `link <https://packaging.python.org/specifications/core-metadata/#provides-extra-multiple-use>`__)
+- Source distributions: optional
 - Synonyms
 
   - Flit_: ``requires`` for required dependencies, ``requires-extra``
@@ -413,6 +442,7 @@ thus becomes a corresponding ``Requires-Dist`` entry for the matching
 '''''''''''
 - Format: Array of strings
 - `Core metadata`_: N/A
+- Source distributions: optional
 - No synonyms
 
 Specifies which fields listed by this PEP were intentionally

--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -34,6 +34,9 @@ This is considered supporting material for PEP 634 (the technical specification
 for pattern matching) and PEP 635 (the motivation and rationale for having pattern
 matching and design considerations).
 
+For readers who are looking more for a quick review than for a tutorial,
+see `Appendix A`_.
+
 Meta
 ====
 
@@ -367,6 +370,178 @@ can be taken from https://www.pygame.org/docs/ref/event.html
 example of getting constants from module (like key names for keyboard events)
 
 customizing match_args?
+
+
+.. _Appendix A:
+
+Appendix A -- Quick Intro
+=========================
+
+A ``match`` statement takes an expression and compares it to successive
+patterns given as one or more ``case`` blocks.  This is superficially
+similar to a ``switch`` statement in C, Java or JavaScript (an many
+other languages), but much more powerful.
+
+The simplest form compares a subject value against one or more literals::
+
+    def http_error(status):
+        match status:
+            case 400:
+                return "Bad request"
+            case 401:
+                return "Unauthorized"
+            case 403:
+                return "Forbidden"
+            case 404:
+                return "Not found"
+            case 418:
+                return "I'm a teapot"
+            case _:
+                return "Something's wrong with the Internet"
+
+Note the last block: the "variable name" ``_`` acts as a *wildcard* and
+never fails to match.
+
+You can combine several literals in a single pattern using ``|`` ("or")::
+
+            case 401 | 403 | 404:
+                return "Not allowed"
+
+Patterns can look like unpacking assignments, and can be used to bind
+variables::
+
+    # The subject is an (x, y) tuple
+    match point:
+        case (0, 0):
+            print("Origin")
+        case (0, y):
+            print(f"Y={y}")
+        case (x, 0):
+            print(f"X={x}")
+        case (x, y):
+            print(f"X={x}, Y={y}")
+        case _:
+            raise ValueError("Not a point")
+
+Study that one carefully!  The first pattern has two literals, and can
+be thought of as an extension of the literal pattern shown above.  But
+the next two patterns combine a literal and a variable, and the
+variable *captures* a value from the subject (``point``).  The fourth
+pattern captures two values, which makes it conceptually similar to
+the unpacking assignment ``(x, y) = point``.
+
+If you are using classes to structure your data (e.g. data classes)
+you can use the class name followed by an argument list resembling a
+constructor, but with the ability to capture variables::
+
+    from dataclasses import dataclass
+
+    @dataclass
+    class Point:
+        x: int
+        y: int
+
+    def whereis(point):
+        match point:
+            case Point(0, 0):
+                print("Origin")
+            case Point(0, y):
+                print(f"Y={y}")
+            case Point(x, 0):
+                print(f"X={x}")
+            case Point():
+                print("Somewhere else")
+            case _:
+                print("Not a point")
+
+We can use keyword parameters too.  The following patterns are all
+equivalent (and all bind the ``y`` attribute to the ``var`` variable)::
+
+    Point(1, var)
+    Point(1, y=var)
+    Point(x=1, y=var)
+    Point(y=var, x=1)
+
+Patterns can be arbitrarily nested.  For example, if we have a short
+list of points, we could match it like this::
+
+    match points:
+        case []:
+            print("No points")
+        case [Point(0, 0)]:
+            print("The origin")
+        case [Point(x, y)]:
+            print(f"Single point {x}, {y}")
+        case [Point(0, y1), Point(0, y2)]:
+            print(f"Two on the Y axis at {y1}, {y2}")
+        case _:
+            print("Something else")
+
+We can add an ``if`` clause to a pattern, known as a "guard".  If the
+guard is false, ``match`` goes on to try the next ``case`` block.  Note
+that value capture happens before the guard is evaluated::
+
+    match point:
+        case Point(x, y) if x == y:
+            print(f"Y=X at {x}")
+        case Point(x, y):
+            print(f"Not on the diagonal")
+
+Several other key features:
+
+- Like unpacking assignments, tuple and list patterns have exactly the
+  same meaning and actually match arbitrary sequences.  An important
+  exception is that they don't match iterators or strings.
+  (Technically, the subject  must be an instance of
+  ``collections.abc.Sequence``.)
+
+- Sequence patterns support wildcards: ``[x, y, *rest]`` and ``(x, y,
+  *rest)`` work similar to wildcards in unpacking assignments.  The
+  name after ``*`` may also be ``_``, so ``(x, y, *_)`` matches a sequence
+  of at least two items without binding the remaining items.
+
+- Mapping patterns: ``{"bandwidth": b, "latency": l}`` captures the
+  ``"bandwidth"`` and ``"latency"`` values from a dict.  Unlike sequence
+  patterns, extra keys are ignored.  A wildcard ``**rest`` is also
+  supported.  (But ``**_`` would be redundant, so it not allowed.)
+
+- Subpatterns may be captured using the walrus (``:=``) operator::
+
+      case (Point(x1, y1), p2 := Point(x2, y2)): ...
+
+- Patterns may use named constants.  These must be dotted names
+  to prevent them from being interpreted as capture variable::
+
+      from enum import Enum
+      class Color(Enum):
+          RED = 0
+          GREEN = 1
+          BLUE = 2
+
+      match color:
+          case Color.RED:
+              print("I see red!")
+          case Color.GREEN:
+              print("Grass is green")
+          case Color.BLUE:
+              print("I'm feeling the blues :(")
+
+- The literals ``None``, ``False`` and ``True`` are treated specially:
+  comparisons to the subject are done using ``is``.  This::
+
+      match b:
+          case True:
+              print("Yes!")
+
+  is exactly quivalent to this::
+
+      if b is True:
+          print("Yes!")
+
+- Classes may override the mapping from positional arguments to
+  attributes by setting a class variable ``__match_args__``.
+  Read about it in PEP 634.
+
 
 Copyright
 =========


### PR DESCRIPTION
I'm starting with "SHOULD", but open to making it "MUST" for sdists to include this. The only reason for the latter is I wasn't sure if pip had worked through all the isolation build issues around simply having `pyproject.toml` defined.