### PR TITLE
PEP 11: Remove support for AIX systems without dlopen

### DIFF
--- a/pep-0011.txt
+++ b/pep-0011.txt
@@ -275,6 +275,10 @@ No-longer-supported platforms
   | Unsupported in:   Python 3.7
   | Code removed in:  Python 3.7
 
+* | Name:             AIX systems without dlopen support
+  | Unsupported in:   Python 3.10
+  | Code removed in:  Python 3.10
+
 References
 ----------
 


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fixes #1653
