### PR TITLE
PEP 621: Fix typos

### DIFF
--- a/pep-0621.rst
+++ b/pep-0621.rst
@@ -160,7 +160,7 @@ Users SHOULD prefer to specify already-normalized versions.
 - Format: string
 - `Core metadata`_: ``Summary``
   (`link <https://packaging.python.org/specifications/core-metadata/#summary>`__)
-- Source distributions: cannot by dynamic
+- Source distributions: cannot be dynamic
 - Synonyms
 
   - Flit_: N/A
@@ -176,7 +176,7 @@ The summary description of the project.
 - Format: String or table
 - `Core metadata`_: ``Description``
   (`link <https://packaging.python.org/specifications/core-metadata/#description>`__)
-- Source distributions: cannot by dynamic
+- Source distributions: cannot be dynamic
 - Synonyms
 
   - Flit_: ``description-file``
@@ -220,7 +220,7 @@ error for unsupported content-types.
 - Format: string
 - `Core metadata`_: ``Requires-Python``
   (`link <https://packaging.python.org/specifications/core-metadata/#summary>`__)
-- Source distributions: cannot by dynamic
+- Source distributions: cannot be dynamic
 - Synonyms
 
   - Flit_: ``requires-python``
@@ -242,7 +242,7 @@ the user specified for this field.
 - Format: Table
 - `Core metadata`_: ``License``
   (`link <https://packaging.python.org/specifications/core-metadata/#license>`__)
-- Source distributions: cannot by dynamic
+- Source distributions: cannot be dynamic
 - Synonyms
 
   - Flit_: ``license``
@@ -272,7 +272,7 @@ classifiers.
 - Format: Array of inline tables with string keys and values
 - `Core metadata`_: ``Author``/``Author-email``/``Maintainer``/``Maintainer-email``
   (`link <https://packaging.python.org/specifications/core-metadata/#author>`__)
-- Source distributions: cannot by dynamic
+- Source distributions: cannot be dynamic
 - Synonyms
 
   - Flit_: ``author``/``author-email``/``maintainer``/``maintainer-email``
@@ -312,7 +312,7 @@ Using the data to fill in `core metadata`_ is as follows:
 - Format: array of strings
 - `Core metadata`_: ``Keywords``
   (`link <https://packaging.python.org/specifications/core-metadata/#keywords>`__)
-- Source distributions: cannot by dynamic
+- Source distributions: cannot be dynamic
 - Synonyms
 
   - Flit_: ``keywords``
@@ -329,7 +329,7 @@ The keywords for the project.
 - Format: array of strings
 - `Core metadata`_: ``Classifier``
   (`link <https://packaging.python.org/specifications/core-metadata/#classifier-multiple-use>`__)
-- Source distributions: cannot by dynamic
+- Source distributions: cannot be dynamic
 - Synonyms
 
   - Flit_: ``classifiers``
@@ -349,7 +349,7 @@ if the back-end can deduce the classifiers from the provided metadata.
 - Format: Table, with keys and values of strings
 - `Core metadata`_: ``Project-URL``
   (`link <https://packaging.python.org/specifications/core-metadata/#project-url-multiple-use>`__)
-- Source distributions: cannot by dynamic
+- Source distributions: cannot be dynamic
 - Synonyms
 
   - Flit_: ``[tool.flit.metadata.urls]`` table


### PR DESCRIPTION
In PEP 621 rather than saying that values "cannot be dynamic" in source distributions it actually says "cannot **by** dynamic". I'm sure that's a typo.
