### PR TITLE
Lint RST inline code on GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U pre-commit
+
+      - name: Lint
+        run: make lint
+        env:
+          PRE_COMMIT_COLOR: always

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.6.0
+    hooks:
+      - id: rst-backticks
+      - id: rst-inline-touching-normal

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,9 @@ repos:
     rev: v1.6.0
     hooks:
       - id: rst-backticks
+        exclude: >
+          (?x)^(
+            pep-0012.rst|
+            pep-0505.rst
+          )$
       - id: rst-inline-touching-normal

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,6 @@ package: all rss
 	cp *.png build/peps/
 	cp *.rss build/peps/
 	tar -C build -czf build/peps.tar.gz peps
+
+lint:
+	pre-commit run --all-files

--- a/pep-0550.rst
+++ b/pep-0550.rst
@@ -537,7 +537,7 @@ generator iteration and popped at the end::
 
     # EC = [outer_LC()]
 
-    g = gen()  # gen_LC is created for the generator object `g`
+    g = gen()  # gen_LC is created for the generator object 'g'
     list(g)
 
     # EC = [outer_LC()]
@@ -760,7 +760,7 @@ Let's see how this pattern can be applied to an example generator::
 
     class CompiledGenSeries:
 
-        # This class is what the `gen_series()` generator can
+        # This class is what the 'gen_series()' generator can
         # be transformed to by a compiler like Cython.
 
         def __init__(self, n):
@@ -769,7 +769,7 @@ Let's see how this pattern can be applied to an example generator::
             self.logical_context = contextvars.LogicalContext()
 
             # Initialize the generator in its LC.
-            # Otherwise `var.set(10)` in the `_init` method
+            # Otherwise 'var.set(10)' in the '_init' method
             # would leak.
             contextvars.run_with_logical_context(
                 self.logical_context, self._init, n)
@@ -854,7 +854,7 @@ Let's review all possible context modification scenarios:
 
     def ContextVar_set(self, val):
         # See a more complete set() definition
-        # in the `Context Variables` section.
+        # in the 'Context Variables' section.
 
         tstate = PyThreadState_Get()
         top_ec_node = tstate.ec

--- a/pep-0567.rst
+++ b/pep-0567.rst
@@ -156,7 +156,7 @@ detect if the default value was provided.)
 ``ContextVar.get(default=_NO_DEFAULT)`` returns a value for
 the context variable for the current ``Context``::
 
-    # Get the value of `var`.
+    # Get the value of 'var'.
     var.get()
 
 If there is no value for the variable in the current context,

--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -1283,22 +1283,22 @@ closures").  Example::
 
     a = 42
     def f():
-        # `a` is local to `f`, but remains unbound
+        # 'a' is local to 'f', but remains unbound
         # until the caller executes this genexp:
         yield ((a := i) for i in range(3))
         yield lambda: a + 100
         print("done")
         try:
-            print(f"`a` is bound to {a}")
+            print(f"'a' is bound to {a}")
             assert False
         except UnboundLocalError:
-            print("`a` is not yet bound")
+            print("'a' is not yet bound")
 
 Then::
 
     >>> results = list(f()) # [genexp, lambda]
     done
-    `a` is not yet bound
+    'a' is not yet bound
     # The execution frame for f no longer exists in CPython,
     # but f's locals live so long as they can still be referenced.
     >>> list(map(type, results))

--- a/pep-0621.rst
+++ b/pep-0621.rst
@@ -104,7 +104,7 @@ then tools MUST raise an error to notify the user about their mistake.
 
 Data specified using this PEP is considered canonical. Tools CANNOT
 remove, add or change data that has been statically specified. Only
-when a field is marked as `dynamic` may a tool provide a "new" value.
+when a field is marked as ``dynamic`` may a tool provide a "new" value.
 
 
 Details

--- a/pep-0631.rst
+++ b/pep-0631.rst
@@ -133,31 +133,31 @@ Parsing
     def parse_dependencies(config):
         dependencies = config.get('dependencies', [])
         if not isinstance(dependencies, list):
-            raise TypeError('Field `project.dependencies` must be an array')
+            raise TypeError("Field 'project.dependencies' must be an array")
 
         for i, entry in enumerate(dependencies, 1):
             if not isinstance(entry, str):
-                raise TypeError(f'Dependency #{i} of field `project.dependencies` must be a string')
+                raise TypeError(f"Dependency #{i} of field 'project.dependencies' must be a string")
 
             try:
                 Requirement(entry)
             except InvalidRequirement as e:
-                raise ValueError(f'Dependency #{i} of field `project.dependencies` is invalid: {e}')
+                raise ValueError(f"Dependency #{i} of field 'project.dependencies' is invalid: {e}")
 
         return dependencies
 
     def parse_optional_dependencies(config):
         optional_dependencies = config.get('optional-dependencies', {})
         if not isinstance(optional_dependencies, dict):
-            raise TypeError('Field `project.optional-dependencies` must be a table')
+            raise TypeError("Field 'project.optional-dependencies' must be a table")
 
         optional_dependency_entries = {}
 
         for option, dependencies in optional_dependencies.items():
             if not isinstance(dependencies, list):
                 raise TypeError(
-                    f'Dependencies for option `{option}` of field '
-                    '`project.optional-dependencies` must be an array'
+                    f"Dependencies for option '{option}' of field "
+                    "'project.optional-dependencies' must be an array"
                 )
 
             entries = []
@@ -165,16 +165,16 @@ Parsing
             for i, entry in enumerate(dependencies, 1):
                 if not isinstance(entry, str):
                     raise TypeError(
-                        f'Dependency #{i} of option `{option}` of field '
-                        '`project.optional-dependencies` must be a string'
+                        f"Dependency #{i} of option '{option}' of field "
+                        "'project.optional-dependencies' must be a string"
                     )
 
                 try:
                     Requirement(entry)
                 except InvalidRequirement as e:
                     raise ValueError(
-                        f'Dependency #{i} of option `{option}` of field '
-                        f'`project.optional-dependencies` is invalid: {e}'
+                        f"Dependency #{i} of option '{option}' of field "
+                        f"'project.optional-dependencies' is invalid: {e}"
                     )
                 else:
                     entries.append(entry)

--- a/pep-0635.rst
+++ b/pep-0635.rst
@@ -939,7 +939,7 @@ overall pattern fails, which is not feasible.
 
 To identify sequences we cannot rely on ``len()`` and subscripting and
 slicing alone, because sequences share these protocols with mappings
-(e.g. `dict`) in this regard.  It would be surprising if a sequence
+(e.g. ``dict``) in this regard.  It would be surprising if a sequence
 pattern also matched a dictionaries or other objects implementing
 the mapping protocol (i.e. ``__getitem__``).  The interpreter therefore
 performs an instance check to ensure that the subject in question really
@@ -1141,7 +1141,7 @@ organised structured data in 'tagged tuples' rather than ``struct`` as in
 instance, be a tuple with two elements for the left and right branches,
 respectively, and a ``Node`` tag, written as ``Node(left, right)``.  In
 Python we would probably put the tag inside the tuple as
-``('Node', left, right)`` or define a data class `Node` to achieve the
+``('Node', left, right)`` or define a data class ``Node`` to achieve the
 same effect.
 
 Using modern syntax, a depth-first tree traversal would then be written as
@@ -1216,7 +1216,7 @@ indicator if it is not possible.
 
 In Python, we simply use ``isinstance()`` together with the ``__match_args__``
 field of a class to check whether an object has the correct structure and
-then transform some of its attributes into a tuple.  For the `Node` example
+then transform some of its attributes into a tuple.  For the ``Node`` example
 above, for instance, we would have ``__match_args__ = ('left', 'right')`` to
 indicate that these two attributes should be extracted to form the tuple.
 That is, ``case Node(x, y)`` would first check whether a given object is an
@@ -1229,7 +1229,7 @@ specific attributes.  Instead of ``Node(x, y)`` you could also write
 ``object(left=x, right=y)``, effectively eliminating the ``isinstance()``
 check and thus supporting any object with ``left`` and ``right`` attributes.
 Or you would combine these ideas to write ``Node(right=y)`` so as to require
-an instance of ``Node`` but only extract the value of the `right` attribute.
+an instance of ``Node`` but only extract the value of the ``right`` attribute.
 
 
 Backwards Compatibility

--- a/pep-0637.rst
+++ b/pep-0637.rst
@@ -133,10 +133,10 @@ specification would improve notation and provide additional value:
    ::
 
      >>> # Let's start this example with basic syntax without keywords.
-     >>> # the positional values are arguments to `func` while
-     >>> # `name=` is processed by `trio.run`.
+     >>> # the positional values are arguments to 'func' while
+     >>> # 'name=' is processed by 'trio.run'.
      >>> trio.run(func, value1, value2, name="func")
-     >>> # `trio.run` ends up calling `func(value1, value2)`.
+     >>> # 'trio.run' ends up calling 'func(value1, value2)'.
 
      >>> # If we want/need to pass value2 by keyword (keyword-only argument,
      >>> # additional arguments that won't break backwards compatibility ...),
@@ -144,13 +144,13 @@ specification would improve notation and provide additional value:
      >>> trio.run(functools.partial(func, param2=value2), value1, name="func")
      >>> trio.run(functools.partial(func, value1, param2=value2), name="func")
 
-     >>> # One possible workaround is to convert `trio.run` to an object
-     >>> # with a `__call__` method, and use an "option" helper,
+     >>> # One possible workaround is to convert 'trio.run' to an object
+     >>> # with a '__call__' method, and use an "option" helper,
      >>> trio.run.option(name="func")(func, value1, param2=value2)
      >>> # However, foo(bar)(baz) is uncommon and thus disruptive to the reader.
-     >>> # Also, you need to remember the name of the `option` method.
+     >>> # Also, you need to remember the name of the 'option' method.
 
-     >>> # This PEP allows us to replace `option` with `__getitem__`.
+     >>> # This PEP allows us to replace 'option' with '__getitem__'.
      >>> # The call is now shorter, more mnemonic, and looks+works like typing
      >>> trio.run[name="func"](func, value1, param2=value2)
 
@@ -835,7 +835,7 @@ Allowing for empty index notation obj[]
 The current proposal prevents ``obj[]`` from being valid notation. However
 a commenter stated
 
-    We have ``Tuple[int, int]`` as a tuple of two integers. And we have `Tuple[int]`
+    We have ``Tuple[int, int]`` as a tuple of two integers. And we have ``Tuple[int]``
     as a tuple of one integer. And occasionally we need to spell a tuple of *no*
     values, since that's the type of ``()``. But we currently are forced to write
     that as ``Tuple[()]``. If we allowed ``Tuple[]`` that odd edge case would be

--- a/pep-0639.rst
+++ b/pep-0639.rst
@@ -389,7 +389,7 @@ gently teach users on how to provide correct license expressions over time.
 Tools may also help with the conversion and suggest a license expression in some
 cases:
 
-1. The section `Mapping Legacy Classifiers to New License expressions` provides
+1. The section `Mapping Legacy Classifiers to New License expressions`_ provides
    tools authors with guidelines on how to suggest a license expression from
    legacy classifiers.
 
@@ -442,8 +442,8 @@ A mapping would be needed as you cannot guarantee that all expressions (e.g. a
 GPL with an exception may be in a single file) or all the license keys have a
 single license file and that any expression does not have more than one. (e.g.
 an Apache license ``LICENSE`` and its ``NOTICE`` file for instance are two
-distinct file). Yet in most cases, there is a simpler `one license`, `one or
-more license files`. In the rarer and more complex cases where there are many
+distinct file). Yet in most cases, there is a simpler "one license", "one or
+more license files". In the rarer and more complex cases where there are many
 licenses involved you can still use the proposed conventions at the cost of a
 slight loss of clarity by not specifying which text file is for which license
 identifier, but you are not forcing the more complex data model (e.g. a mapping)
@@ -599,7 +599,7 @@ In Python code files
 (Note: Documenting licenses in source code is not in the scope of this PEP)
 
 Beside using comments and/or ``SPDX-License-Identifier`` conventions, the license
-is sometimes documented in Python code file using `dunder` variables typically
+is sometimes documented in Python code file using "dunder" variables typically
 named after one of the lower cased Core metadata field such as ``__license__``
 [#pycode]_.
 
@@ -611,7 +611,7 @@ the ``help()`` DATA section for a module.
 In some other Python packaging tools
 ------------------------------------
 
-- `Conda package manifest` [#conda]_ has support for ``license`` and ``license_file``
+- Conda package manifest [#conda]_ has support for ``license`` and ``license_file``
   fields as well as a ``license_family`` license grouping field.
 
 - ``flit`` [#flit]_ recommends to use classifiers instead of License (as per the

--- a/pep-0642.rst
+++ b/pep-0642.rst
@@ -191,7 +191,7 @@ then we don't have any real way to revisit those decisions in a future release.
 Specification
 =============
 
-This PEP retains the overall `match`/`case` statement structure and semantics
+This PEP retains the overall ``match``/``case`` statement structure and semantics
 from PEP 634, but proposes multiple changes that mean that user intent is
 explicitly specified in the concrete syntax rather than needing to be inferred
 from the pattern matching context.
@@ -2007,7 +2007,7 @@ The following new nodes are added to the AST by this PEP::
 Appendix C: Summary of changes relative to PEP 634
 ==================================================
 
-The overall `match`/`case` statement syntax and the guard expression syntax
+The overall ``match``/``case`` statement syntax and the guard expression syntax
 remain the same as they are in PEP 634.
 
 Relative to PEP 634 this PEP makes the following key changes:

--- a/pep-0644.rst
+++ b/pep-0644.rst
@@ -22,12 +22,12 @@ incompatible forks, and other TLS libraries are dropped.
 Motivation
 ==========
 
-Python makes use of OpenSSL in `hashlib`, `hmac`, and `ssl` modules. OpenSSL
+Python makes use of OpenSSL in ``hashlib``, ``hmac``, and ``ssl`` modules. OpenSSL
 provides fast implementations of cryptographic primitives and a full TLS
-stack including handling of X.509 certificates. The `ssl` module is used by
-standard library modules like `urllib` and 3rd party modules like `urllib3`
-to implement secure variants of internet protocols. `pip` uses the `ssl`
-module to securely download packages from PyPI. Any bug in the ssl module's
+stack including handling of X.509 certificates. The ``ssl`` module is used by
+standard library modules like ``urllib`` and 3rd party modules like ``urllib3``
+to implement secure variants of internet protocols. ``pip`` uses the ``ssl``
+module to securely download packages from PyPI. Any bug in the ``ssl`` module's
 bindings to OpenSSL can lead to a severe security issue.
 
 Over time OpenSSL's public API has evolved and changed. Version 1.0.2
@@ -164,7 +164,7 @@ created: 2014-04 (forked from OpenSSL 1.0.1g)
 Some distributions like FreeBSD, Gentoo, and OPNsense also feature LibreSSL
 instead of OpenSSL as non-standard TLS libraries.
 
-OpenBSD ports has a port `security/openssl/1.1` which is documented as
+OpenBSD ports has a port ``security/openssl/1.1`` which is documented as
 "[...] is present to provide support for applications which cannot be made
 compatible with LibReSSL" [7]_. The package could be used by OpenBSD to
 provide a working ssl module.
@@ -203,9 +203,9 @@ SHA-3
 
 Since 1.1.0, OpenSSL ships with SHA-3 and SHAKE implementations.
 Python's builtin SHA-3 support is based on the reference implementation. The
-internal `_sha3` code is fairly large and the resulting shared library close
+internal ``_sha3`` code is fairly large and the resulting shared library close
 to 0.5 MB. Python could drop the builtin implementation and rely on OpenSSL's
-`libcrypto` instead.
+``libcrypto`` instead.
 
 So far LibreSSL upstream development has refused to add SHA-3 support. [2]_
 
@@ -217,7 +217,7 @@ OpenSSL downstream patches and options
 --------------------------------------
 
 OpenSSL features more than 70 configure and build time options in the form
-of  `OPENSSL_NO_*` macros. Around 60 options affect the presence of features
+of  ``OPENSSL_NO_*`` macros. Around 60 options affect the presence of features
 like cryptographic algorithms and TLS versions. Some distributions apply
 patches to alter settings. Furthermore default values for settings like
 security level, ciphers, TLS version range, and signature algorithms can
@@ -227,8 +227,8 @@ The Python core team lacks resources to test all possible combinations.
 This PEP proposes that Python only supports OpenSSL builds that have
 standard features enabled. Vendors shall disable deprecated or insecure
 algorithms and TLS versions with build time options like
-`OPENSSL_NO_TLS1_1_METHOD` or OpenSSL config options like
-`MinProtocol = TLSv1.2`.
+``OPENSSL_NO_TLS1_1_METHOD`` or OpenSSL config options like
+``MinProtocol = TLSv1.2``.
 
 Python assumes that OpenSSL is built with
 
@@ -260,7 +260,7 @@ latest release LibreSSL 3.3.2 is missing features and behaves differently
 in some cases. Mentionable missing or incompatible features include
 
 - SHA-3, SHAKE, BLAKE2
-- `SSL_CERT_*` environment variables
+- ``SSL_CERT_*`` environment variables
 - security level APIs
 - session handling APIs
 - key logging API

--- a/pep-0645.rst
+++ b/pep-0645.rst
@@ -59,8 +59,8 @@ The widespread adoption and popularity of these languages means that Python deve
     // Optional in C#
     string? example;
 
-Adding this syntax would also follow the often used pattern of using builtin types as annotations. For example, `list`, `dict` and `None`. This would allow more annotations to be
-added to Python code without importing from `typing`.
+Adding this syntax would also follow the often used pattern of using builtin types as annotations. For example, ``list``, ``dict`` and ``None``. This would allow more annotations to be
+added to Python code without importing from ``typing``.
 
 
 Specification
@@ -107,7 +107,7 @@ Since the new Union syntax specified in PEP 604 is supported in ``isinstance`` a
     isinstance(1, int?) # true
     issubclass(Child, Super?) # true
 
-A new dunder method will need to be implemented to allow the `?` operator to be overloaded for other functionality.
+A new dunder method will need to be implemented to allow the ``?`` operator to be overloaded for other functionality.
 
 
 Backwards Compatibility

--- a/pep-0647.rst
+++ b/pep-0647.rst
@@ -205,8 +205,8 @@ narrowed within the conditional code block.
 
 Some built-in type guards provide narrowing for both positive and negative
 tests (in both the ``if`` and ``else`` clauses). For example, consider the
-type guard for an expression of the form `x is None`. If `x` has a type that
-is a union of None and some other type, it will be narrowed to `None` in the
+type guard for an expression of the form ``x is None``. If ``x`` has a type that
+is a union of None and some other type, it will be narrowed to ``None`` in the
 positive case and the other type in the negative case. User-defined type
 guards apply narrowing only in the positive case (the ``if`` clause). The type
 is not narrowed in the negative case.

--- a/pep-0650.rst
+++ b/pep-0650.rst
@@ -592,8 +592,8 @@ though, it was considered an orthogonal idea.
 Open Issues
 ===========
 
-Should the `dependency_group` argument take an iterable?
---------------------------------------------------------
+Should the ``dependency_group`` argument take an iterable?
+----------------------------------------------------------
 
 This would allow for specifying non-overlapping dependency groups in
 a single call, e.g. "docs" and "test" groups which have independent


### PR DESCRIPTION
(Split from https://github.com/python/peps/pull/1570.)

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->


This PR adds two reStructuredText lint rules and runs them on the CI using GitHub Actions. [Example run.](https://github.com/hugovk/peps/runs/988763650?check_suite_focus=true)

1. Detect single backticks, which should be double in RST for inline code, e.g. stuff fixed in https://github.com/python/peps/pull/1554.

2. Detect inline code touching normal text, e.g. stuff fixed in https://github.com/python/peps/pull/1560.

---

This uses the [pre-commit](https://pre-commit.com/) tool for linting. It's possible, but completely optional, to use it locally and it'll check your changes when you're committing, and fail before commit if something is found.

Optional local set up (run once):

```sh
pip install -U pre-commit && pre-commit install
```

Then make changes and commit as normal:

```sh
git commit -m "PEP XXX: etc"
```

Lint all files:

```sh
pre-commit run --all-files

# Or this does the same thing
make lint
```

The very first run takes a little while to set things up, after that it's quick.

But again, local use of pre-commit is completely optional for those who aren't keen, and the CI will run the checks anyway.

---

The first lint rule finds some false positives:

```
pep-0012.rst:602:    `single-quoted' or ``double-quoted''
pep-0505.rst:245:    Total None-coalescing `if` blocks: 449
pep-0505.rst:246:    Total [possible] None-coalescing `or`: 120
pep-0505.rst:248:    Total Safe navigation `and`: 13
pep-0505.rst:249:    Total Safe navigation `if` blocks: 61
pep-0550.rst:540:    g = gen()  # gen_LC is created for the generator object `g`
pep-0550.rst:763:        # This class is what the `gen_series()` generator can
pep-0550.rst:772:            # Otherwise `var.set(10)` in the `_init` method
pep-0550.rst:857:        # in the `Context Variables` section.
```

* pep-0012.rst is an example of what _not_ to do! So that needs to stay.

* pep-0505.rst is example output from a command, so (most likely) needs to stay.

There's no way to exclude single lines from the linter, so both these files have been excluded.

* Backticks already in code: I've changed them to single quotes. Because it's already formatted with code, no _extra_ formatting was added in the rendered monospace output, so single quotes can also be used for the emphasis.

* After rebasing on `master`, this found a few other single backticks which should have been double backticks or links. I've fixed them.
