### PR TITLE
Build and deploy HTML on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
             github.repository == 'python/peps' &&
             github.ref == 'refs/heads/master'
           )
-
         run: |
           bash deploy.bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U docutils
+
+      - name: Build
+        run: make -j$(nproc)
+
+      - name: Deploy
+        if: >
+          (
+            github.repository == 'python/peps' &&
+            github.ref == 'refs/heads/master'
+          )
+
+        run: |
+          bash deploy.bash


### PR DESCRIPTION
(Split from https://github.com/python/peps/pull/1570.)

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Adds a GitHub Actions workflow to build and deploy, like Travis CI.

Notes:

* Travis CI builds against 3.7 and 3.7-dev. I only added 3.8 to GHA. Should it build against a range? For example, we can do 3.6-3.9.

* It will only deploy for `python/peps` and `master` (like Travis)

* I've left Travis CI in place for now. I'd suggest confirming the deploy works first from GHA, then removing from Travis in a followup PR.

* (I also noticed that on Travis, it's deploying for both 3.7 and 3.7-dev. It probably only needs doing from a single job.)

* Nice bonus: `make -j$(nproc)` is quicker on GHA (~80s) than Travis (~110s)

## TODO

* [ ] The deploy will need credentials. I guess there are some at 
https://travis-ci.com/github/python/peps? They will need to be added at https://github.com/python/peps/settings/secrets

