### PR TITLE
PEP 8: Add one line docstring example

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -747,7 +747,9 @@ Conventions for writing good documentation strings
       """
 
 - For one liner docstrings, please keep the closing ``"""`` on
-  the same line.
+  the same line.::
+
+      """Return an ex-parrot."""
 
 
 Naming Conventions

--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -747,7 +747,7 @@ Conventions for writing good documentation strings
       """
 
 - For one liner docstrings, please keep the closing ``"""`` on
-  the same line.::
+  the same line::
 
       """Return an ex-parrot."""
 


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Based on a conversation w/ @gvanrossum during the 2020 core dev sprint, there was a suggestion to add an example for one line docstrings to draw more attention to it (the issue comes up decently often, especially in CPython PRs).