### PR TITLE
PEP 594: Don't remove the legacy email modules

### DIFF
--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -176,9 +176,6 @@ audio processing.
     cgitb,3.8 (2.0\*\*),3.10,1995,no,\-
     chunk,3.8,3.10,1999,no,\-
     crypt,3.8,3.10,1994,**yes (inactive)**,"legacycrypt, bcrypt, argon2cffi, hashlib, passlib"
-    email.message.Message,3.3,3.10,2001,yes,email.message.EmailMessage
-    email.mime,3.3,3.10,2001,yes,email.contentmanager
-    email.policy.Compat32,3.3,3.10,2011,yes,email.policy.EmailPolicy
     formatter,**3.4**,3.10,1995,no,\-
     fpectl,**3.7**,**3.7**,1997,n/a,\-
     imghdr,3.8,3.10,1992,no,"filetype, puremagic, python-magic"
@@ -529,39 +526,6 @@ Has a designated expert
    no
 Substitute
   **none**
-
-email (legacy API)
-~~~~~~~~~~~~~~~~~~
-
-The `email <https://docs.python.org/3/library/email.html>`_ package is a
-library for managing email messages. The email package contains several
-legacy modules, legacy functions, and legacy classes, that provide backwards
-compatibility to Python 3.2 and 2.7:
-
- * ``email.message.Message`` (replaced by ``email.message.EmailMessage``)
- * ``email.mime`` (replaced by ``email.contentmanager``)
- * ``email.header`` (replaced by dict-like API of ``EmailMessage`` class)
- * ``email.charset``
- * ``email.encoders`` (replaced by ``EmailMessage.set_content``)
- * ``email.utils`` (new API performs parsing and formatting automatically)
- * ``email.iterators``
- * ``email.policy.Compat32``
-
-The classes ``email.mime.audio.MIMEAudio`` and ``email.mime.image.MIMEImage``
-depend on the ``sndhdr`` and ``imghdr`` modules. In case the ``email.mime``
-package is not removed, the auto-detection of file formats must be deprecated
-and ``_subtype`` argument a required argument.
-
-Module type
-  pure Python
-Deprecated in
-  3.8 (documented as legacy APIs since 3.3 or 3.4)
-To be removed in
-  3.10
-Has a designated expert
-   yes
-Substitute
-  email (non-legacy APIs)
 
 smtpd
 ~~~~~
@@ -1090,6 +1054,11 @@ Update 2
 * Add creation year to overview table
 * Mention :pep:`206` and :pep:`3108`
 * Update sections for ``aifc``, ``audioop``, ``cgi``, and ``wave``.
+
+Update 3
+--------
+* Keep the legacy email API modules.  Internal deprecations will be
+  handled separately.
 
 
 References


### PR DESCRIPTION
I propose to keep the legacy email modules.  They are still being maintained (at least as well as the new APIs) and they are probably in widespread use.  The dependencies on other stdlib modules that are being proposed to be removed should be handled separately.