### PR TITLE
Change language from BDFL-Delegate to PEP-Delegate

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -94,7 +94,7 @@ the currently active Python core team members described in PEP 13 [5]_.
 Python's BDFL
 -------------
 
-This PEP earlier used the title "BDFL-Delegate" for PEP decision makers. This was
+Previous versions of this PEP used the title "BDFL-Delegate" for PEP decision makers. This was
 a historical reference to Python's previous governance model, where all design
 authority ultimately derived from Guido van Rossum, the original creator of the
 Python programming language. By contrast, the Steering Council's design

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -518,7 +518,7 @@ optional and are described below.  All other headers are required. ::
     Title: <pep title>
     Author: <list of authors' real names and optionally, email addrs>
   * Sponsor: <real name of sponsor>
-  * PEP-Delegate: <PEP czar's real name>
+  * PEP-Delegate: <PEP delegate's real name>
   * Discussions-To: <email address>
     Status: <Draft | Active | Accepted | Provisional | Deferred | Rejected |
              Withdrawn | Final | Superseded>

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -94,11 +94,12 @@ the currently active Python core team members described in PEP 13 [5]_.
 Python's BDFL
 -------------
 
-This PEP still uses the title "BDFL-Delegate" for PEP decision makers. This is
+This PEP earlier used the title "BDFL-Delegate" for PEP decision makers. This was
 a historical reference to Python's previous governance model, where all design
 authority ultimately derived from Guido van Rossum, the original creator of the
 Python programming language. By contrast, the Steering Council's design
 authority derives from their election by the currently active core developers.
+Now, PEP-Delegate is used in place of BDFL-Delegate.
 
 
 PEP Editors
@@ -166,7 +167,7 @@ Ideally, a core developer sponsor is identified, but non-core sponsors may also
 be selected with the approval of the Steering Council.  The sponsor's job is to
 provide guidance to the PEP author to help them through the logistics of the
 PEP process (somewhat acting like a mentor).  Being a sponsor does **not**
-disqualify that person from becoming a co-author or BDFL-Delegate later on (but
+disqualify that person from becoming a co-author or PEP-Delegate later on (but
 not both).  The sponsor of a PEP is recorded in the "Sponsor:" field of the
 header.
 
@@ -275,33 +276,33 @@ notifying the PEP author(s) and giving them a chance to make revisions.
 The final authority for PEP approval is the Steering Council. However, whenever
 a new PEP is put forward, any core developer that believes they are suitably
 experienced to make the final decision on that PEP may offer to serve as
-the BDFL-Delegate for that PEP, and they will then have the authority to approve
+the PEP-Delegate for that PEP, and they will then have the authority to approve
 (or reject) that PEP. Individuals taking on this responsibility are free to seek
 additional guidance from the Steering Council at any time, and are also expected
 to take the advice and perspectives of other core developers into account.
 
-The designated decision maker for each PEP is recorded in the "BDFL-Delegate"
+The designated decision maker for each PEP is recorded in the "PEP-Delegate"
 header in the PEP.
 
 Such self-nominations are accepted by default, but may be explicitly declined by
 the Steering Council. Possible reasons for the Steering Council declining a
-self-nomination as BDFL-Delegate include, but are not limited to, perceptions of
+self-nomination as PEP-Delegate include, but are not limited to, perceptions of
 a potential conflict of interest (e.g. working for the same organisation as the
-PEP submitter), or simply considering another potential BDFL-Delegate to be
+PEP submitter), or simply considering another potential PEP-Delegate to be
 more appropriate. If core developers (or other community members) have concerns
-regarding the suitability of a BDFL-Delegate for any given PEP, they may ask
+regarding the suitability of a PEP-Delegate for any given PEP, they may ask
 the Steering Council to review the delegation.
 
 If no volunteer steps forward, then the Steering Council will approach core
 developers (and potentially other Python community members) with relevant
 expertise, in an attempt to identify a candidate that is willing to serve as
-BDFL-Delegate for that PEP. If no suitable candidate can be found, then the
+PEP-Delegate for that PEP. If no suitable candidate can be found, then the
 PEP will be marked as Deferred until one is available.
 
-Previously appointed BDFL-Delegates may choose to step down, or be asked to step
-down by the Council, in which case a new BDFL-Delegate will be appointed in the
+Previously appointed PEP-Delegates may choose to step down, or be asked to step
+down by the Council, in which case a new PEP-Delegate will be appointed in the
 same manner as for a new PEP (including deferral of the PEP if no suitable
-replacement can be found). In the event that a BDFL-Delegate is asked to step
+replacement can be found). In the event that a PEP-Delegate is asked to step
 down, this will overrule any prior acceptance or rejection of the PEP, and it
 will revert to Draft status.
 
@@ -517,7 +518,7 @@ optional and are described below.  All other headers are required. ::
     Title: <pep title>
     Author: <list of authors' real names and optionally, email addrs>
   * Sponsor: <real name of sponsor>
-  * BDFL-Delegate: <PEP czar's real name>
+  * PEP-Delegate: <PEP czar's real name>
   * Discussions-To: <email address>
     Status: <Draft | Active | Accepted | Provisional | Deferred | Rejected |
              Withdrawn | Final | Superseded>
@@ -556,7 +557,7 @@ Steering Council) is sponsoring the PEP.  If one of the authors of the PEP is a
 core developer then no sponsor is necessary and thus this field should be left
 out.
 
-The BDFL-Delegate field is used to record the individual appointed by the
+The PEP-Delegate field is used to record the individual appointed by the
 Steering Council to make the final decision on whether or not to approve or
 reject a PEP. (The delegate's email address is currently omitted due to a
 limitation in the email address masking for reStructuredText PEPs)

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -162,7 +162,7 @@ your PEP)::
   Title: [...]
   Author: [Full Name <email at example.com>]
   Sponsor: *[Full Name <email at example.com>]
-  BDFL-Delegate:
+  PEP-Delegate:
   Discussions-To: *[...]
   Status: Draft
   Type: [Standards Track | Informational | Process]

--- a/pep0/pep.py
+++ b/pep0/pep.py
@@ -162,6 +162,7 @@ class PEP(object):
     headers = (('PEP', True), ('Title', True), ('Version', False),
                ('Last-Modified', False), ('Author', True),
                ('Sponsor', False), ('BDFL-Delegate', False),
+               ('PEP-Delegate', False),
                ('Discussions-To', False), ('Status', True), ('Type', True),
                ('Content-Type', False), ('Requires', False),
                ('Created', True), ('Python-Version', False),

--- a/pep2html.py
+++ b/pep2html.py
@@ -219,7 +219,8 @@ def fixfile(inpath, input_lines, outfile):
     print('</td></tr></table>', file=outfile)
     print('<div class="header">\n<table border="0">', file=outfile)
     for k, v in header:
-        if k.lower() in ('author', 'bdfl-delegate', 'discussions-to', 'sponsor'):
+        if k.lower() in ('author', 'pep-delegate', 'bdfl-delegate', 'discussions-to',
+                         'sponsor'):
             mailtos = []
             for part in re.split(r',\s*', v):
                 if '@' in part:
@@ -401,7 +402,7 @@ class PEPHeaders(Transform):
                 # empty
                 continue
             para = body[0]
-            if name in ('author', 'bdfl-delegate', 'sponsor'):
+            if name in ('author', 'bdfl-delegate', 'pep-delegate', 'sponsor'):
                 for node in para:
                     if isinstance(node, nodes.reference):
                         node.replace_self(peps.mask_email(node))

--- a/pep2pyramid.py
+++ b/pep2pyramid.py
@@ -208,7 +208,7 @@ def fixfile(inpath, input_lines, outfile):
     print >> outfile, COMMENT
     print >> outfile, '<div class="header">\n<table border="0" class="rfc2822">'
     for k, v in header:
-        if k.lower() in ('author', 'bdfl-delegate', 'discussions-to'):
+        if k.lower() in ('author', 'bdfl-delegate', 'pep-delegate', 'discussions-to'):
             mailtos = []
             for part in re.split(',\s*', v):
                 if '@' in part:


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fixes #1431.

The first commit updates the header fields from BDFL-Delegate to PEP-Delegate.

The second updates other uses in PEPs. I left a couple in I thought should stay (one in a post history, another being contrasted with PEP Delegate).

And also added a bit to the PEP 1 paragraph that gives the BDFL background:

```diff
-This PEP still uses the title "BDFL-Delegate" for PEP decision makers. This was
+This PEP earlier used the title "BDFL-Delegate" for PEP decision makers. This was
a historical reference to Python's previous governance model, where all design
authority ultimately derived from Guido van Rossum, the original creator of the
Python programming language. By contrast, the Steering Council's design
authority derives from their election by the currently active core developers.
+Now, PEP-Delegate is used in place of BDFL-Delegate.
```

And the last commit updates generation scripts.
