### PR TITLE
PEP-634: Describe how keys are compared in mapping patterns

### DIFF
--- a/pep-0634.rst
+++ b/pep-0634.rst
@@ -418,7 +418,9 @@ A mapping pattern fails if the subject value is not an instance of
 ``collections.abc.Mapping``.
 
 A mapping pattern succeeds if every key given in the mapping pattern
-matches the corresponding item of the subject mapping.  If a ``'**'
+is present in the subject mapping, and the pattern for 
+each key matches the corresponding item of the subject mapping. Keys
+are always compared with the ``==`` operator.  If a ``'**'
 NAME`` form is present, that name is bound to a ``dict`` containing
 remaining key-value pairs from the subject mapping.
 


### PR DESCRIPTION
Clarifies slightly better how mapping patterns work, in particular it covers better if a ``True`` key in a pattern matches a ``1`` value in the subject.