### PR TITLE
PEP 13: Clarify how the inactive voters will be notified

### DIFF
--- a/pep-0013.rst
+++ b/pep-0013.rst
@@ -286,11 +286,11 @@ will. While someone is in inactive status, though, they lose their
 active privileges like voting or nominating for the steering council,
 and commit access.
 
-One month before each election, and automated script will be
+One month before each election, an automated script will be
 run to produce a list of potentially inactive core team members.
-An email will be sent to python-committers mailing list with this list,
-to notify that they've been deemed inactive due to lack of activity
-in the past two months. If they did not respond after two weeks,
+An email will be sent to the python-committers mailing list with this list,
+as notification that they've been deemed inactive due to lack of activity
+in the previous two months. If they do not respond after two weeks,
 they will be removed from the voter's list.
 
 The initial active core team members will consist of everyone

--- a/pep-0013.rst
+++ b/pep-0013.rst
@@ -278,9 +278,7 @@ provide the general public with a reasonable idea of how many people
 maintain Python, core team members who have stopped contributing are
 encouraged to declare themselves as "inactive". Those who haven't made
 any non-trivial contribution in two years may be asked to move
-themselves to this category, and moved there if they don't respond.
-
-To
+themselves to this category, and moved there if they don't respond.  To
 record and honor their contributions, inactive team members will
 continue to be listed alongside active core team members; and, if they
 later resume contributing, they can switch back to active status at

--- a/pep-0013.rst
+++ b/pep-0013.rst
@@ -278,7 +278,7 @@ provide the general public with a reasonable idea of how many people
 maintain Python, core team members who have stopped contributing are
 encouraged to declare themselves as "inactive". Those who haven't made
 any non-trivial contribution in two years may be asked to move
-themselves to this category, and moved there if they don't respond.  To
+themselves to this category, and moved there if they don't respond. To
 record and honor their contributions, inactive team members will
 continue to be listed alongside active core team members; and, if they
 later resume contributing, they can switch back to active status at

--- a/pep-0013.rst
+++ b/pep-0013.rst
@@ -278,13 +278,22 @@ provide the general public with a reasonable idea of how many people
 maintain Python, core team members who have stopped contributing are
 encouraged to declare themselves as "inactive". Those who haven't made
 any non-trivial contribution in two years may be asked to move
-themselves to this category, and moved there if they don't respond. To
+themselves to this category, and moved there if they don't respond.
+
+To
 record and honor their contributions, inactive team members will
 continue to be listed alongside active core team members; and, if they
 later resume contributing, they can switch back to active status at
 will. While someone is in inactive status, though, they lose their
 active privileges like voting or nominating for the steering council,
 and commit access.
+
+One month before each election, and automated script will be
+run to produce a list of potentially inactive core team members.
+An email will be sent to python-committers mailing list with this list,
+to notify that they've been deemed inactive due to lack of activity
+in the past two months. If they did not respond after two weeks,
+they will be removed from the voter's list.
 
 The initial active core team members will consist of everyone
 currently listed in the `"Python core" team on Github

--- a/pep-0013.rst
+++ b/pep-0013.rst
@@ -291,7 +291,7 @@ run to produce a list of potentially inactive core team members.
 An email will be sent to the python-committers mailing list with this list,
 as notification that they've been deemed inactive due to lack of activity
 in the previous two years. If they do not respond after two weeks,
-they will be removed from the voter's list.
+they will be removed from the voters list.
 
 The initial active core team members will consist of everyone
 currently listed in the `"Python core" team on Github

--- a/pep-0013.rst
+++ b/pep-0013.rst
@@ -290,7 +290,7 @@ One month before each election, an automated script will be
 run to produce a list of potentially inactive core team members.
 An email will be sent to the python-committers mailing list with this list,
 as notification that they've been deemed inactive due to lack of activity
-in the previous two months. If they do not respond after two weeks,
+in the previous two years. If they do not respond after two weeks,
 they will be removed from the voter's list.
 
 The initial active core team members will consist of everyone


### PR DESCRIPTION
I've added a paragraph to clarify how we will notify the folks that are inactive for the purpose of voting.
It does not change the original meaning of this PEP, rather make it clearer of how this will be done.
Hopefully it will be less ambiguous going forward.
