### PR TITLE
PEP-636: Fix mistake on class patterns

### DIFF
--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -316,10 +316,10 @@ different kinds of objects, and also apply patterns to its attributes::
         case other_event:
             raise ValueError(f"Unrecognized event: {other_event}")
 
-A pattern like ``Click(position=(x, y))`` only matches if the actual event is a subclass of
-the ``Click`` class. It will also requires that the event has a ``position`` attribute
-that matches the ``(x, y)`` pattern. If there's a match, the locals ``x`` and ``y`` will
-get the expected values.
+A pattern like ``Click(position=(x, y))`` only matches if the the type of the event is
+a subclass of the ``Click`` class. It will also requires that the event has a ``position``
+attribute that matches the ``(x, y)`` pattern. If there's a match, the locals ``x`` and
+``y`` will get the expected values.
 
 A pattern like ``KeyPress()``, with no arguments will match any object which is an
 instance of the ``KeyPress`` class. Only the attributes you specify in the pattern are


### PR DESCRIPTION
caught by @merwok in https://github.com/python/peps/commit/5f9a50d3d43f3b2b921ade84c3d6ca4dbf248480#r43496834