### PR TITLE
PEP 626: Clarify lifetimes of helper functions and struct.

### DIFF
--- a/pep-0626.rst
+++ b/pep-0626.rst
@@ -219,6 +219,7 @@ Note that these functions are not part of the C-API, so will be need to be linke
   For reliable operation, ``linetable`` should be copied into a local buffer before calling ``PyLineTable_InitAddressRange``.
 
   Although these functions are not part of C-API, they will provided by all future versions of CPython.
+  The ``PyLineTable_`` functions do not call into the C-API, so can be safely copied into any tool that needs to use them.
   The ``PyCodeAddressRange`` struct may acquire additional ``opaque`` fields in future versions, but the ``ar_`` fields will remain unchanged.
 
 For example, the following code prints out all the address ranges:

--- a/pep-0626.rst
+++ b/pep-0626.rst
@@ -2,7 +2,7 @@ PEP: 626
 Title: Precise line numbers for debugging and other tools.
 Author: Mark Shannon <mark@hotpy.org>
 BDFL-Delegate: Pablo Galindo <pablogsal@python.org>
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 15-Jul-2020

--- a/pep-0626.rst
+++ b/pep-0626.rst
@@ -214,6 +214,13 @@ Note that these functions are not part of the C-API, so will be need to be linke
 
 ``PyLineTable_PreviousAddressRange`` retreats the range to the previous entry, returning non-zero if valid.
 
+.. note::
+  The data in ``linetable`` is immutable, but its lifetime depends on its code object.
+  For reliable operation, ``linetable`` should be copied into a local buffer before calling ``PyLineTable_InitAddressRange``.
+
+  Although these functions are not part of C-API, they will provided by all future versions of CPython.
+  The ``PyCodeAddressRange`` struct may acquire additional ``opaque`` fields in future versions, but the ``ar_`` fields will remain unchanged.
+
 For example, the following code prints out all the address ranges:
 
 ::


### PR DESCRIPTION
As requested by @pablogsal 
