### PR TITLE
PEP 635: Explain why mapping patterns ignore extra keys

### DIFF
--- a/foo.py
+++ b/foo.py
@@ -1,0 +1,1 @@
+"""Test program"""

--- a/pep-0635.rst
+++ b/pep-0635.rst
@@ -1003,8 +1003,13 @@ dictionary.  Particularly common are string keys.
 
 The mapping pattern reflects the common usage of dictionary lookup: it allows
 the user to extract some values from a mapping by means of constant/known
-keys and have the values match given subpatterns.  Moreover, the mapping
-pattern does not check for the presence of additional keys.  Should it be
+keys and have the values match given subpatterns.
+Extra keys in the subject are ignored even if ``**rest`` is not present.
+This is different from sequence patterns, where extra items will cause a
+match to fail.  But mappings are actually different from sequences: they
+have natural structural sub-typing behavior, i.e., passing a dictionary
+with extra keys somewhere will likely just work.
+Should it be
 necessary to impose an upper bound on the mapping and ensure that no
 additional keys are present, then the usual double-star-pattern ``**rest``
 can be used.  The special case ``**_`` with a wildcard, however, is not


### PR DESCRIPTION
@davidfstr, on python-dev, recommended we bring back this explanation from PEP 622.

CC @Tobias-Kohn 