### PR TITLE
PEP 619: Update date for 3.10.0a2

### DIFF
--- a/pep-0619.rst
+++ b/pep-0619.rst
@@ -44,10 +44,10 @@ Actual:
 
 - 3.10 development begins: Monday, 2020-05-18
 - 3.10.0 alpha 1: Monday, 2020-10-05
+- 3.10.0 alpha 2: Monday, 2020-11-03
 
 Expected:
 
-- 3.10.0 alpha 2: Monday, 2020-11-02
 - 3.10.0 alpha 3: Monday, 2020-12-07
 - 3.10.0 alpha 4: Monday, 2021-01-04
 - 3.10.0 alpha 5: Monday, 2021-02-01


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3100a2/