### PR TITLE
PEP-517: On Windows the subprocess calls don't start resolving from the PATH

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -474,7 +474,8 @@ following criteria:
   work as a mechanism for running the flit command-line tool::
 
     import subprocess
-    subprocess.check_call(["flit", ...])
+    import shutil
+    subprocess.check_call([shutil.which("flit"), ...])
 
 A build backend MUST be prepared to function in any environment which
 meets the above criteria. In particular, it MUST NOT assume that it


### PR DESCRIPTION
As per https://bugs.python.org/issue38905

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>

cc @pfmoore 
