### PR TITLE
PEP 630: change to Active and link to the new xxlimited module

### DIFF
--- a/pep-0630.rst
+++ b/pep-0630.rst
@@ -2,7 +2,7 @@ PEP: 630
 Title: Isolating Extension Modules
 Author: Petr Viktorin <encukou@gmail.com>
 Discussions-To: capi-sig@python.org
-Status: Draft
+Status: Active
 Type: Informational
 Content-Type: text/x-rst
 Created: 25-Aug-2020
@@ -140,10 +140,8 @@ write such a module, or to convert an existing module.
 Note that support is a work in progress; the API for some features your
 module needs might not yet be ready.
 
-A full example module is currently available in `a fork on
-GitHub <https://github.com/encukou/cpython/blob/xxlimited-facelift/Modules/xxlimited.c>`__.
-
-.. XXX: Later, it should be in the CPython source tree.
+A full example module is available as
+`xxlimited <https://github.com/python/cpython/blob/master/Modules/xxlimited.c>`__.
 
 This section assumes that “*you*” are an extension module author.
 
@@ -254,12 +252,9 @@ must hold references to those objects and implement module-level hooks
 require some work and make the code longer; this is the price for
 modules which can be unloaded cleanly.
 
-An example of a module with per-module state is currently available in
-`a fork on GitHub <https://github.com/encukou/cpython/blob/xxlimited-facelift/Modules/xxlimited.c>`__;
-later it should be in the CPython source tree, with module
-initialization is at the bottom of the file.
-
-.. XXX: Later, it should be in the CPython source tree.
+An example of a module with per-module state is currently available as
+`xxlimited <https://github.com/python/cpython/blob/master/Modules/xxlimited.c>`__;
+example module initialization shown at the bottom of the file.
 
 
 Opt-Out: Limiting to One Module Object per Process


### PR DESCRIPTION
[bpo-42111] is resolved, which closes the remaining "XXX" notes in the PEP.
It's ready for Active status (see https://github.com/python/peps/pull/1574#issuecomment-680145163).

[bpo-42111]: https://bugs.python.org/issue42111

