### PR TITLE
PEP 423: Replace dead "terminology" link

### DIFF
--- a/pep-0423.txt
+++ b/pep-0423.txt
@@ -787,7 +787,7 @@ Additional background:
 References and footnotes:
 
 .. _`packaging terminology in Python documentation`:
-   http://docs.python.org/dev/packaging/introduction.html#general-python-terminology
+   https://packaging.python.org/glossary/
 .. _`PEP 8`:
    http://www.python.org/dev/peps/pep-0008/#package-and-module-names
 .. _`PEP 345`: http://www.python.org/dev/peps/pep-0345/


### PR DESCRIPTION
The existing link in the "Terminology" section is broken. If that page is still alive at another URL, I couldn't find it.

This new link (https://packaging.python.org/glossary/) seems to cover the same topics.