### PR TITLE
PEP 626: Allow zero-width entries in code.co_lines(), to allow better bytecode generation.

### DIFF
--- a/pep-0626.rst
+++ b/pep-0626.rst
@@ -166,12 +166,19 @@ each representing the line number of a range of bytecodes. Each tuple will consi
 The sequence generated will have the following properties:
 
 * The first range in the sequence with have a ``start`` of ``0``
-* The ``(start, end)`` ranges will be strictly increasing and consecutive.
+* The ``(start, end)`` ranges will be non-decreasing and consecutive.
   That is, for any pair of tuples the ``start`` of the second
   will equal to the ``end`` of the first.
-* No range will be empty, that is ``end`` > ``start`` for all triples.
+* No range will be backwards, that is ``end >= start`` for all triples.
 * The final range in the sequence with have ``end`` equal to the size of the bytecode.
 * ``line`` will either be a positive integer, or ``None``
+
+Zero width ranges
+-----------------
+
+Zero width range, that is ranges where ``start == end`` are allowed.
+Zero width ranges are used for lines that are present in the source code,
+but have been eliminated by the bytecode compiler.
 
 The co_linetable attribute
 ''''''''''''''''''''''''''


### PR DESCRIPTION

See https://bugs.python.org/issue42718

Currently we either have to emit NOPs in the bytecode *or* break PEP 626.

This minor change to the PEP allows us more freedom in bytecode generation,
while keeping the promise of accurate tracing and debugging.