### PR TITLE
PEP 637 Allow notations for empty star arguments.

### DIFF
--- a/pep-0637.rst
+++ b/pep-0637.rst
@@ -287,7 +287,7 @@ example use case 1, where a slice is accepted.
 
 The successful implementation of this PEP will result in the following behavior:
 
-1. An empty subscript is still illegal, regardless of context::
+1. An empty subscript is still illegal, regardless of context (see Rejected Ideas)::
 
        obj[]  # SyntaxError
 
@@ -391,7 +391,7 @@ The successful implementation of this PEP will result in the following behavior:
    The following notation equivalence should be honored::
 
        obj[*()]        
-       # Error. Equivalent to obj[]
+       # Equivalent to obj[()]
        
        obj[*(), foo=3] 
        # Equivalent to obj[foo=3]
@@ -411,7 +411,7 @@ The successful implementation of this PEP will result in the following behavior:
    The following notation equivalent should be honored::
 
        obj[**{}]    
-       # Error. Equivalent to obj[]
+       # Equivalent to obj[()]
        
        obj[3, **{}] 
        # Equivalent to obj[3]
@@ -807,7 +807,15 @@ This proposal already established that, in case no positional index is given, th
 passed value must be the empty tuple. Allowing for the empty index notation would
 make the dictionary type accept it automatically, to insert or refer to the value with
 the empty tuple as key. Moreover, a typing notation such as ``Tuple[]`` can easily
-be written as ``Tuple`` without the indexing notation.
+be written as ``Tuple`` without the indexing notation. 
+
+However, subsequent discussion with Brandt Bucher during implementation has revealed
+that the case ``obj[]`` would fit a natural evolution for default generics, giving 
+more strength to the above comment. In the end, after a discussion between D'Aprano,
+Bucher and the author, we decided to leave the ``obj[]`` notation as a syntax
+error for now, and possibly extend the notation with an additional PEP to hold
+the equivalence ``obj[]`` as ``obj[()]``. 
+
 
 Sentinel value for no given positional index
 --------------------------------------------

--- a/pep-0637.rst
+++ b/pep-0637.rst
@@ -810,7 +810,7 @@ the empty tuple as key. Moreover, a typing notation such as ``Tuple[]`` can easi
 be written as ``Tuple`` without the indexing notation. 
 
 However, subsequent discussion with Brandt Bucher during implementation has revealed
-that the case ``obj[]`` would fit a natural evolution for default generics, giving 
+that the case ``obj[]`` would fit a natural evolution for variadic generics, giving 
 more strength to the above comment. In the end, after a discussion between D'Aprano,
 Bucher and the author, we decided to leave the ``obj[]`` notation as a syntax
 error for now, and possibly extend the notation with an additional PEP to hold


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Allows the notation with empty star, double star args as from discussion with @brandtbucher 