### PR TITLE
PEP 612: Clean up code examples, link to CPython implementation

### DIFF
--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -299,7 +299,7 @@ evaluated in the same way.
 
 .. code-block::
 
-   U = TypeVar("T")
+   U = TypeVar("U")
 
    class Y(Generic[U, P]):
      f: Callable[P, str]

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -216,7 +216,6 @@ inheriting from ``Generic[P]`` makes a class generic on
 .. code-block::
 
    T = TypeVar("T")
-   S = TypeVar("S")
    P_2 = ParamSpec("P_2")
 
    class X(Generic[T, P]):
@@ -577,7 +576,9 @@ Reference Implementation
 
 The `Pyre <https://pyre-check.org/>`_ type checker supports all of the behavior
 described above.  A reference implementation of the runtime components needed
-for those uses is provided in the ``pyre_extensions`` module.
+for those uses is provided in the ``pyre_extensions`` module.  A reference
+implementation for CPython can be found 
+`here <https://github.com/python/cpython/pull/23702>`_.
 
 Rejected Alternatives
 ---------------------


### PR DESCRIPTION
An unused variable was removed from the code example.

I also added a line to point to the [CPython implementation](https://github.com/python/cpython/pull/23702) for posterity.