### PR TITLE
docs: fix simple typo, survery -> survey

### DIFF
--- a/pep-0550.rst
+++ b/pep-0550.rst
@@ -1505,7 +1505,7 @@ Replication of threading.local() interface
 Choosing the ``threading.local()``-like interface for context
 variables was considered and rejected for the following reasons:
 
-* A survery of the standard library and Django has shown that the
+* A survey of the standard library and Django has shown that the
   vast majority of ``threading.local()`` uses involve a single
   attribute, which indicates that the namespace approach is not
   as helpful in the field.


### PR DESCRIPTION
There is a small typo in pep-0550.rst.

Should read `survey` rather than `survery`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md