### PR TITLE
PEP 637: added new slots to the C interface changes

### DIFF
--- a/pep-0637.rst
+++ b/pep-0637.rst
@@ -606,13 +606,22 @@ need to be implemented to support the extended call. We propose
 - ``PyObject_SetItemWithKeywords(PyObject *o, PyObject *key, PyObject *value, PyObject *kwargs)``
 - ``PyObject_GetItemWithKeywords(PyObject *o, PyObject *key, PyObject *kwargs)``
 
-Additionally, new opcodes will be needed for the enhanced call.  Currently, the
+New opcodes will be needed for the enhanced call.  Currently, the
 implementation uses ``BINARY_SUBSCR``, ``STORE_SUBSCR`` and ``DELETE_SUBSCR``
 to invoke the old functions. We propose ``BINARY_SUBSCR_KW``,
 ``STORE_SUBSCR_KW`` and ``DELETE_SUBSCR_KW`` for the new operations. The
 compiler will have to generate these new opcodes. The
 old C implementations will call the extended methods passing ``NULL`` 
 as kwargs.
+
+Finally, the following new slots must be added to the ``PyMappingMethods`` struct:
+
+- ``mp_subscript_kw``
+- ``mp_ass_subscript_kw``
+
+These slots will have the appropriate signature to handle the dictionary object
+containing the keywords.
+
 
 Reference Implementation
 ========================


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Adds the required changes to the PyMappingMethods struct. Two new slots must be added for the dispatch.