### PR TITLE
PEP 642 v3: Explicit pattern matching syntax

### DIFF
--- a/pep-0642.rst
+++ b/pep-0642.rst
@@ -1665,6 +1665,8 @@ types in ``MATCH_CLASS`` with the more general check for the existence of
 All other modified patterns have been updated to follow this PEP rather than
 PEP 634.
 
+Unparsing for match patterns has not yet been migrated to the updated v3 AST.
+
 The AST validator for match patterns has not yet been implemented.
 
 The AST validator in general has not yet been reviewed to that it is checking
@@ -1673,6 +1675,9 @@ expected.
 
 The examples in this PEP have not yet been converted to test cases, so could
 plausibly contain typos and other errors.
+
+Several of the old PEP 634 tests are still to be converted to new SyntaxError
+tests.
 
 The documentation has not yet been updated.
 

--- a/pep-0642.rst
+++ b/pep-0642.rst
@@ -25,6 +25,29 @@ patterns that aligns more closely with the proposed mapping pattern syntax.
 While the result is necessarily more verbose than the proposed syntax in
 PEP 634, it is still less verbose than the status quo.
 
+As an example, the following match statement would extract "host" and "port"
+details from a 2 item sequence, a mapping with "host" and "port" keys, any
+object with "host" and "port" attributes, or a "host:port" string, treating
+the "port" as optional in all cases::
+
+    port = DEFAULT_PORT
+    match expr:
+        case [as host, as port]:
+            pass
+        case {"host" as host, "port": int() as port}:
+            pass
+        case {"host" as host}:
+            pass
+        case object{.host as host, .port as port}:
+            pass
+        case object{.host as host}:
+            pass
+        case str() as addr:
+            host, __, port = addr.partition(":")
+        case __ as m:
+            raise TypeError(f"Unknown address format: {m!r:.200}")
+    port = int(port)
+
 At a high level, this PEP proposes to categorise the different available pattern
 types as follows:
 
@@ -35,16 +58,16 @@ types as follows:
         * equality constraints: ``== EXPR``
         * identity contraints: ``is EXPR``
     * sequence constraint patterns: ``[PTRN, as NAME, PTRN as NAME]``
-    * mapping constraint patterns: ``{EXPR: PTRN, EXPR: == EXPR, EXPR as NAME}``
+    * mapping constraint patterns: ``{EXPR: PTRN, EXPR as NAME}``
     * instance attribute constraint patterns:
       ``CLS{.NAME, .NAME: PTRN, .NAME == EXPR, .NAME as NAME}``
     * class defined constraint patterns:
-      ``CLS(PTRN, PTRN, **{.NAME, .NAME: PTRN, .NAME: == EXPR, .NAME as NAME})``
+      ``CLS(PTRN, PTRN, **{.NAME, .NAME: PTRN, .NAME == EXPR, .NAME as NAME})``
 * OR patterns: ``PTRN | PTRN | PTRN``
 * AS patterns: ``PTRN as NAME`` (omitting the pattern implies ``__``)
 
 Several of the subpattern specifications also require parentheses to avoid
-potential ambiguity.
+potential ambiguity (including when patterns are combined with guard expressions).
 
 The intent of this approach is to:
 

--- a/pep-0642.rst
+++ b/pep-0642.rst
@@ -29,28 +29,29 @@ targets. It is (reluctantly) considered acceptable to offer syntactic sugar that
 is specific to match patterns, as long as there is an underlying more explicit
 form that is compatible (or potentially compatible) with assignment targets.
 
-As a consequence, this PEP proposes the following changes to the proposed match
-pattern syntax:
+During the PEP review process, additional points of potential confusion were
+identified in the syntax for mapping and class patterns, so alternative
+syntax is also being proposed there.
 
-* a new pattern type is introduced: "constraint patterns"
-* constraint patterns are either equality constraints or identity constraints
-* equality constraints use ``==`` as a prefix marker on an otherwise
-  arbitrary primary expression: ``== EXPR``
-* identity constraints use ``is`` as a prefix marker on an otherwise
-  arbitrary primary expression: ``is EXPR``
-* value patterns and literal patterns (with some exceptions) are redefined as
-  "inferred equality constraints", and become a syntactic shorthand for an
-  equality constraint
-* ``None`` and ``...`` are defined as "inferred identity constraints" and become
-  a syntactic shorthand for an identity constraint
-* due to ambiguity of intent, neither ``True`` nor ``False`` are accepted as
-  implying an inferred constraint (instead requiring the use of an explicit
-  constraint, a class pattern, or a capture pattern with a guard expression)
-* inferred constraints are *not* defined in the Abstract Syntax Tree. Instead,
-  inferred constraints are converted to explicit constraints by the parser
-* The wildcard pattern changes from ``_`` (single underscore) to ``__`` (double
-  underscore), and gains a dedicated ``SkippedBinding`` node in the AST
-* Mapping patterns change to allow arbitrary primary expressions as keys
+At a high level, this PEP proposes to categorise the different available pattern
+types as follows:
+
+* OR patterns
+* sequence patterns
+* mapping patterns
+* class patterns
+* explicit constraint patterns:
+  * equality constraints (with an ``==`` prefix)
+  * identity contraints (with an ``is`` prefix)
+* explicit capture patterns (with an ``as`` prefix)
+* inferred patterns:
+  * allowing ``==`` and ``is`` to be omitted for some constraint patterns
+  * allowing ``as`` to be omitted for some capture patterns
+
+This approach means that incorrect or ambiguous inferences for any of the
+inferred patterns can always be clarified by switching to their more explicit
+form, and the explicit forms can also be used as a teaching aid to help build
+correct intuitions around the shorthand forms.
 
 
 Relationship with other PEPs
@@ -62,8 +63,10 @@ be worth the additional complexity that they add to the learning process, but
 disagrees with the idea that "simple name vs literal or attribute lookup"
 really offers an adequate syntactic distinction between name binding and value
 lookup operations in match patterns. (Even though this PEP ultimately retained
-that shorthand to reduce the verbosity of common use cases, it still redefines
-it in terms of a more explicit underlying construct).
+the shorthand forms to reduce the verbosity of common use cases, it still
+redefines them in terms of more explicit underlying constructs). Appendix B
+provides a more detailed summary of the changes made between PEP 634 and this
+PEP.
 
 This PEP agrees with the spirit of PEP 640 (that the chosen wildcard pattern to
 skip a name binding should be supported everywhere, not just in match patterns),
@@ -138,37 +141,79 @@ eliminates the need for those special cases by proposing distinct syntax for
 matching by identity and matching by equality, but does accept the convenience
 and consistency argument in allowing ``None`` as a shorthand for ``is None``.
 
+The additional changes relative to PEP 634 then arose as a result of feedback
+received during the PEP review process where the PEP author considered it
+beneficial to the overall language design process to offer an alternative
+syntactic proposal to that proposed in PEP 634.
+
 
 Specification
 =============
 
-This PEP retains the overall `match`/`case` statement syntax from PEP 634, and
-retains both the syntax and semantics for the following match pattern variants:
+This PEP retains the overall `match`/`case` statement syntax and semantics from
+PEP 634, but proposes multiple changes that mean that in most cases user intent
+is explicitly specified in the concrete syntax rather than needing to be
+inferred from the pattern matching context. In the Abstract Syntax Tree, the
+semantics are always explicit, with no inference required.
 
-* class patterns
-* group patterns
-* sequence patterns
+Guard expressions remain the same as they are in PEP 634, so they are not
+covered in any further detail in this PEP.
 
-Pattern combination (both OR and AS patterns) and guard expressions also remain
-the same as they are in PEP 634.
+Capture patterns are combined with "AS patterns" to give both "explicit
+capture patterns" (``as NAME``) and inferred capture patterns (``NAME``). The
+definition of class and mapping patterns change to allow only explicit capture
+patterns. ``_`` also becomes a regular capture pattern, due to the wildcard
+pattern marker changing to ``__``.
 
-Capture patterns are essentially unchanged, except that ``_`` becomes a regular
-capture pattern, due to the wildcard pattern marker changing to ``__``.
-
-Constraint patterns are added, offering equality constraints and identity
-constraints.
+Explicit constraint patterns are added, offering equality constraints and
+identity constraints.
 
 Literal patterns and value patterns are replaced by inferred constraint
 patterns, offering inferred equality constraints for strings, numbers and
 attribute lookups, and inferred identity constraints for ``None`` and ``...``.
 
-Mapping patterns change to allow arbitrary primary expressions for keys, rather
-than being restricted to literal patterns or value patterns.
+Sequence patterns, mapping patterns, and class patterns are grouped together as
+structural patterns, allowing the changes to mapping and class patterns covered
+in their respective sections. Sequence patterns are effectively unchanged at a
+behavioural level, but the precise way they are defined changes due to the
+changes to other patterns. 
 
 Wildcard patterns are changed to use ``__`` (double underscore) rather than
 ``_`` (single underscore), and are also given a new dedicated node in the
 Abstract Syntax Tree produced by the parser.
 
+Group patterns and OR patterns change to have the effect of *turning off pattern
+inference* for their subpatterns.
+
+
+Capture patterns
+----------------
+
+Explicit capture patterns use the following simplified syntax::
+
+    capture_pattern: 'as' NAME
+
+Explicit capture patterns are accepted in the following positions:
+
+* as a standalone pattern
+* as an alternative in an OR pattern
+* as an element in a sequence pattern (including for the ``*NAME`` element)
+* as part of a mapping pattern (see below for details)
+* as part of a class pattern (see below for details)
+
+For consistency with assignment target syntax, inferred capture patterns are
+also defined, and omit the ``as`` prefix:
+
+    inferred_capture_pattern: NAME # Emits same parser output as capture_pattern
+
+Inferred capture patterns are accepted in the following positions:
+
+* as a standalone pattern
+* as an element in a sequence pattern (including for the ``*NAME`` element)
+* as part of the ``**NAME`` element in a mapping pattern
+
+Note that inferred capture patterns are NOT accepted as part of OR patterns,
+class patterns, mapping patterns, or group patterns.
 
 Constraint patterns
 -------------------
@@ -292,6 +337,9 @@ rather than as a kind of pattern, clearly separating the subelements inside
 patterns into "patterns", which define structures and name binding targets to
 match against, and "constraints", which look up existing values to compare
 against.
+
+Note that inferred constraint patterns are NOT accepted as part of OR patterns,
+class patterns, mapping patterns, or group patterns.
 
 In practice, the key differences between this PEP's inferred constraint patterns
 and PEP 634's value patterns and literal patterns are that
@@ -1101,20 +1149,22 @@ Notation used beyond standard EBNF is as per PEP 534:
     guard: 'if' named_expression
 
     patterns: open_sequence_pattern | pattern
-    pattern: as_pattern | or_pattern
-    as_pattern: or_pattern 'as' capture_pattern
+    pattern:
+        | or_pattern [capture_pattern]
+        | inferred_constraint_pattern
+        | inferred_capture_pattern
     or_pattern: '|'.closed_pattern+
-    closed_pattern:
+    explicit_pattern:
         | capture_pattern
         | wildcard_pattern
         | constraint_pattern
-        | inferred_constraint_pattern
         | group_pattern
         | sequence_pattern
         | mapping_pattern
         | class_pattern
 
-    capture_pattern: !"__" NAME !('.' | '(' | '=')
+    capture_pattern: 'as' inferred_capture_pattern
+    inferred_capture_pattern: !"__" NAME !('.' | '(' | '=')
 
     wildcard_pattern: "__"
 
@@ -1146,7 +1196,7 @@ Notation used beyond standard EBNF is as per PEP 534:
         | signed_number '-' NUMBER
     signed_number: NUMBER | '-' NUMBER
 
-    group_pattern: '(' pattern ')'
+    group_pattern: '(' or_pattern ')'
 
     sequence_pattern:
     | '[' [maybe_sequence_pattern] ']'
@@ -1159,18 +1209,68 @@ Notation used beyond standard EBNF is as per PEP 534:
     mapping_pattern: '{' [items_pattern] '}'
     items_pattern: ','.key_value_pattern+ ','?
     key_value_pattern:
-        | primary ':' pattern
+        | primary [(':' or_pattern | constraint_pattern )] [capture_pattern]
         | double_star_pattern
-    double_star_pattern: '**' capture_pattern
+    double_star_pattern: '**' (capture_pattern | inferred_capture_pattern )
 
     class_pattern:
         | name_or_attr '(' [pattern_arguments ','?] ')'
     pattern_arguments:
-        | positional_patterns [',' keyword_patterns]
-        | keyword_patterns
+        | positional_patterns ',' '/' [',' instance_attr_patterns]
+        | instance_attr_patterns
     positional_patterns: ','.pattern+
-    keyword_patterns: ','.keyword_pattern+
-    keyword_pattern: NAME '=' pattern
+    instance_attr_patterns: ','.instance_attr_pattern+
+    instance_attr_pattern:
+        | NAME [(':' or_pattern | constraint_pattern )] [capture_pattern]
+
+
+.. _Appendix B:
+
+Appendix B: Summary of changes relative to PEP 634
+==================================================
+
+Relative to PEP 634 this PEP makes the following key changes:
+
+* the wildcard pattern changes from ``_`` (single underscore) to ``__`` (double
+  underscore), and gains a dedicated ``SkippedBinding`` node in the AST
+* a new pattern type is introduced: "constraint patterns"
+* constraint patterns are either equality constraints or identity constraints
+* equality constraints use ``==`` as a prefix marker on an otherwise
+  arbitrary primary expression: ``== EXPR``
+* identity constraints use ``is`` as a prefix marker on an otherwise
+  arbitrary primary expression: ``is EXPR``
+* value patterns and literal patterns (with some exceptions) are redefined as
+  "inferred equality constraints", and become a syntactic shorthand for an
+  equality constraint
+* ``None`` and ``...`` are defined as "inferred identity constraints" and become
+  a syntactic shorthand for an identity constraint
+* due to ambiguity of intent, neither ``True`` nor ``False`` are accepted as
+  implying an inferred constraint (instead requiring the use of an explicit
+  constraint, a class pattern, or a capture pattern with a guard expression)
+* inferred constraints are *not* defined in the Abstract Syntax Tree. Instead,
+  inferred constraints are converted to explicit constraints by the parser
+* Inferred constraint patterns are allowed only for top level patterns and
+  as part of sequence patterns
+* "capture patterns" are split into "explicit capture patterns" (with the ``as``
+  prefix) and "inferred capture patterns" (without the prefix)
+* Inferred capture patterns are allowed only as top level patterns, as part of
+  sequence patterns, and to collect any additional keys in a mapping pattern
+* Sequence patterns, mapping patterns, and class patterns are grouped together
+  as "structural patterns"
+* Mapping patterns change to allow arbitrary primary expressions as keys
+* Mapping patterns change to only use ":"" as the separator for structural
+  patterns. Capture patterns use "as", equality constraint patterns use "==",
+  and identity constraint patterns use "is". No inferred constraint or capture
+  patterns are defined for mapping patterns, but a capture pattern may still be
+  used in addition to a structural pattern or equality pattern.
+* Class patterns change to treat classes as a collection of attributes by
+  default. Checks against the ``__match_args__`` attribute must be explicitly
+  requested with a ``/`` character after the patterns to be matched positionally.
+* Class patterns change to use the same separators as mapping patterns: ":" to
+  introduce a structural pattern, "==" for an equality constraint, "is" for an
+  identity contraint, and "as" for a capture pattern. No inferred constraint or
+  capture patterns are defined for mapping patterns, but a capture pattern may
+  still be used in addition to a structural pattern or equality pattern.
 
 
 Copyright

--- a/pep-0642.rst
+++ b/pep-0642.rst
@@ -1419,6 +1419,10 @@ to local variables::
         case object(host=host):
             pass
 
+In this specific case, that ambiguity doesn't matter (since the attribute and
+variable names are the same), but in the general case, knowing which is which
+will be critical to reasoning correctly about the code being read.
+
 
 Deferred Ideas
 ==============
@@ -1432,9 +1436,9 @@ inferred equality and identity constraints in the future.
 These could be particularly valuable for literals, as it is quite likely that
 many "magic" strings and numbers with self-evident meanings will be written
 directly into match patterns, rather than being stored in named variables.
-(Think constants like ``None``, or obviously special numbers like zero and one,
-or strings where their contents are as descriptive as any variable name, rather
-than cryptic checks against opaque numbers like "739452")
+(Think constants like ``None``, or obviously special numbers like ``0`` and
+``1``, or strings where their contents are as descriptive as any variable name,
+rather than cryptic checks against opaque numbers like ``739452``)
 
 
 Accepting complex literals as closed expressions
@@ -1459,6 +1463,14 @@ be able to tell the tokenizer to generate a distinct token type for
 imaginary numbers (e.g. ``INUMBER``), which would then allow the parser to
 handle ``NUMBER + INUMBER`` and ``NUMBER - INUMBER`` separately from other
 binary operations.
+
+Alternatively, a new ``ComplexNumber`` AST node type could be defined, which
+would allow the parser to notify the subsequent compiler stages that a
+particular node should specifically be a complex literal, rather than an
+arbitrary binary operation. Then the parser could accept ``NUMBER + NUMBER``
+and ``NUMBER - NUMBER`` for that node, while to the AST validation for
+``ComplexNumber`` took care of ensuring that the real and imaginary parts of
+the literal were real and imaginary numbers as expected.
 
 For now, this PEP has postponed dealing with this question, and instead just
 requires that complex literals be parenthesised in order to be used in value
@@ -1489,7 +1501,7 @@ The syntax used for equality and identity constraints would be straightforward
 to extend to membership checks: ``in container``.
 
 One downside of the proposals in both this PEP and PEP 634 is that checking
-for multiple values in the same case doesn't look like any existing set
+for multiple values in the same case doesn't look like any existing container
 membership check in Python::
 
     # PEP 634's literal patterns
@@ -1502,8 +1514,13 @@ membership check in Python::
         case == 0 | == 1 | == 2 | == 3:
             ...
 
+Allowing inferred equality contraints under this PEP would only make it look
+like the PEP 634 example, it still wouldn't look like the equivalent ``if``
+statement header (``if value in {0, 1, 2, 3}:``).
+
 Membership constraints would provide a more explicit, but still concise, way
-to check if the match subject was present in a container::
+to check if the match subject was present in a container, and it would look
+the same as an ordinary containment check::
 
     match value:
         case in {0, 1, 2, 3}:
@@ -1524,12 +1541,13 @@ to the language, so it seems more appropriate to defer it to a separate proposal
 rather than including it here.
 
 
-Inferred a default type for instance attribute constraints
-----------------------------------------------------------
+Inferring a default type for instance attribute constraints
+-----------------------------------------------------------
 
 The dedicated syntax for instance attribute constraints means that ``object``
 could be omitted from ``object{.ATTR}`` to give ``{.ATTR}`` without introducing
-any syntactic ambiguity.
+any syntactic ambiguity (if no class was given, ``object`` would be implied,
+just as it is for the base class list in class definitions).
 
 However, it's far from clear saving six characters is worth making it harder to
 visually distinguish mapping patterns from instance attribute patterns, so

--- a/pep-0642.rst
+++ b/pep-0642.rst
@@ -1,5 +1,5 @@
 PEP: 642
-Title: Constraint Pattern Syntax for Structural Pattern Matching
+Title: Explicit Pattern Syntax for Structural Pattern Matching
 Version: $Revision$
 Last-Modified: $Date$
 Author: Nick Coghlan <ncoghlan@gmail.com>
@@ -18,40 +18,47 @@ Abstract
 ========
 
 This PEP covers an alternative syntax proposal for PEP 634's structural pattern
-matching that explicitly anchors match patterns in the existing syntax for
-assignment targets, while retaining most semantic aspects of the existing
-proposal.
+matching that requires explicit prefixes on all capture patterns and value
+constraints. It also proposes an alternative syntax for instance attribute
+patterns that aligns more closely with the proposed mapping pattern syntax.
 
-Specifically, this PEP adopts an additional design restriction that PEP 634's
-authors considered unreasonable: that any novel match pattern semantics must
-offer syntax that future PEPs could plausibly propose for adoption in assignment
-targets. It is (reluctantly) considered acceptable to offer syntactic sugar that
-is specific to match patterns, as long as there is an underlying more explicit
-form that is compatible (or potentially compatible) with assignment targets.
-
-During the PEP review process, additional points of potential confusion were
-identified in the syntax for mapping and class patterns, so alternative
-syntax is also being proposed there.
+While the result is necessarily more verbose than the proposed syntax in
+PEP 634, it is still less verbose than the status quo.
 
 At a high level, this PEP proposes to categorise the different available pattern
 types as follows:
 
-* OR patterns
-* sequence patterns
-* mapping patterns
-* class patterns
-* explicit constraint patterns:
-  * equality constraints (with an ``==`` prefix)
-  * identity contraints (with an ``is`` prefix)
-* explicit capture patterns (with an ``as`` prefix)
-* inferred patterns:
-  * allowing ``==`` and ``is`` to be omitted for some constraint patterns
-  * allowing ``as`` to be omitted for some capture patterns
+* wildcard pattern: ``__``
+* group patterns: ``(PTRN)``
+* constraint patterns:
+    * value constraint patterns:
+        * equality constraints: ``== EXPR``
+        * identity contraints: ``is EXPR``
+    * sequence constraint patterns: ``[PTRN, as NAME, PTRN as NAME]``
+    * mapping constraint patterns: ``{EXPR: PTRN, EXPR == EXPR, EXPR as NAME}``
+    * attribute constraint patterns:
+      ``CLS{.NAME, .NAME: PTRN, .NAME == EXPR, .NAME as NAME}``
+    * class constraint patterns:
+      ``CLS(PTRN, PTRN, **{.NAME, .NAME: PTRN, .NAME == EXPR, .NAME as NAME})``
+* OR patterns: ``PTRN | PTRN | PTRN``
+* AS patterns: ``PTRN as NAME`` (omitting the pattern implies ``__``)
 
-This approach means that incorrect or ambiguous inferences for any of the
-inferred patterns can always be clarified by switching to their more explicit
-form, and the explicit forms can also be used as a teaching aid to help build
-correct intuitions around the shorthand forms.
+The intent of this approach is to:
+
+* allow an initial form of pattern matching to be developed and released without
+  needing to decide up front on the best options for handling bare names,
+  attribute lookups, and literal values
+* ensure that pattern matching is defined explicitly at the Abstract Syntax Tree
+  level, allowing the specifications of the semantics and the surface syntax for
+  pattern matching to be clearly separated
+* define a clear and concise "ducktyping" syntax that could potentially be
+  adopted in ordinary expressions as a syntactic alternative to the ``getattr``
+  builtin that better facilitates easy retrieval of multiple attributes
+
+Relative to PEP 634, the proposal also deliberately elimates any syntax that
+"binds to the right" without using the ``as`` keyword (using capture patterns
+in PEP 634's mapping patterns and class patterns) or binds to both the left and
+the right in the same pattern (using PEP 634's capture patterns with AS patterns)
 
 
 Relationship with other PEPs
@@ -62,11 +69,7 @@ match statements would be a sufficiently valuable addition to the language to
 be worth the additional complexity that they add to the learning process, but
 disagrees with the idea that "simple name vs literal or attribute lookup"
 really offers an adequate syntactic distinction between name binding and value
-lookup operations in match patterns. (Even though this PEP ultimately retained
-the shorthand forms to reduce the verbosity of common use cases, it still
-redefines them in terms of more explicit underlying constructs). Appendix B
-provides a more detailed summary of the changes made between PEP 634 and this
-PEP.
+lookup operations in match patterns (at least for Python).
 
 This PEP agrees with the spirit of PEP 640 (that the chosen wildcard pattern to
 skip a name binding should be supported everywhere, not just in match patterns),
@@ -75,6 +78,14 @@ than ``?``). As such, it competes with PEP 640 as written, but would complement
 a proposal to deprecate the use of ``__`` as an ordinary identifier and instead
 turn it into a general purpose wildcard marker that always skips making a new
 local variable binding.
+
+While it has not yet been put forward as a PEP, Mark Shannon has a pre-PEP draft
+[8_] expressing several concerns about the runtime semantics of the pattern
+matching proposal in PEP 634. This PEP is somewhat complementary to that one, as
+even though this PEP is specifically about surface syntax changes rather than
+semantic changes, it does propose that the Abstract Syntax Tree definition be
+made more explicit to better separate the details of the surface syntax from the
+semantics of the code generation step.
 
 
 Motivation
@@ -110,81 +121,48 @@ explained it clearly on python-dev [1_]:
     that arguments based on what is 'intuitive' or 'consistent' just do not
     make sense _/in this case/_.
 
-PEP 635 (and PEP 622 before it) makes a strong case that treating capture
-patterns as the default usage for simple names in match patterns is the right
-approach, and provides a number of examples where having names express value
-constraints by default would be confusing (this difference from C/C++ switch
-statement semantics is also a key reason it makes sense to use ``match`` as the
-introductory keyword for the new statement rather than ``switch``).
+The first iteration of this PEP was then born out of an attempt to show that the
+second assertion was not accurate, and that match patterns could be treated
+as a variation on assignment targets without leading to inherent contradictions.
+(An earlier PR submitted to list this option in the "Rejected Ideas" section
+of the original PEP 622 had previously been declined [2_]).
 
-However, PEP 635 doesn't even *try* to make the case for the second assertion,
-that treating match patterns as a variation on assignment targets also leads to
-inherent contradictions. Even a PR submitted to explicitly list this option in
-the "Rejected Ideas" section of the original PEP 622 was declined [2_].
+However, the review process for this PEP strongly suggested that not only did
+the contradictions that Tobias mentioned in his email exist, but they were also
+concerning enough to cast doubts on the syntax proposal presented in PEP 634.
+Accordingly, this PEP was changed to go even further then PEP 634, and reduce
+the alignment between the sequence matching syntax and the existing iterable
+unpacking syntax (effectively answering "Not really" to the first question
+raised in the DLS'20 paper [9_]: "Can we extend a feature like iterable
+unpacking to work for more general object and data layouts?").
 
-This PEP instead starts from the assumption that it *is* possible to treat match
-patterns as a variation on assignment targets, and the only essential
-differences that emerge relative to the syntactic proposal in PEP 634 are:
+Finally, before completing the 3rd iteration of the proposal (which dropped
+inferred patterns entirely), the PEP author spent quite a bit of time reflecting
+on the following entries in PEP 20:
 
-* a requirement to offer an explicit marker prefix for value lookups rather than
-  only allowing them to be inferred from the use of dotted names or literals; and
-* a requirement to use a non-binding wildcard marker other than ``_``.
+* Explicit is better than implicit.
+* Special cases aren't special enough to break the rules.
+* In the face of ambiguity, refuse the temptation to guess.
 
-This PEP proposes constraint expressions as a way of addressing the first point,
-and changes the proposed non-binding wildcard marker to a double-underscore to
-address the latter.
-
-PEP 634 also proposes special casing the literals ``None``, ``True``, and
-``False`` so that they're compared by identity when written directly as a
-literal pattern, but by equality when referenced by a value pattern. This PEP
-eliminates the need for those special cases by proposing distinct syntax for
-matching by identity and matching by equality, but does accept the convenience
-and consistency argument in allowing ``None`` as a shorthand for ``is None``.
-
-The additional changes relative to PEP 634 then arose as a result of feedback
-received during the PEP review process where the PEP author considered it
-beneficial to the overall language design process to offer an alternative
-syntactic proposal to that proposed in PEP 634.
+If we start with an explicit syntax, we can always add syntactic shortcuts later
+(e.g. consider the recent proposals to add shortcuts for ``Union`` and
+``Optional`` type hints), but if we start out with only the abbreviated forms,
+then we don't have any real way to revisit those decisions in a future release.
 
 
 Specification
 =============
 
 This PEP retains the overall `match`/`case` statement syntax and semantics from
-PEP 634, but proposes multiple changes that mean that in most cases user intent
-is explicitly specified in the concrete syntax rather than needing to be
-inferred from the pattern matching context. In the Abstract Syntax Tree, the
-semantics are always explicit, with no inference required.
+PEP 634, but proposes multiple changes that mean that user intent is explicitly
+specified in the concrete syntax rather than needing to be inferred from the
+pattern matching context. In the Abstract Syntax Tree, the semantics are also
+always explicit, with no inference required.
 
 Guard expressions remain the same as they are in PEP 634, so they are not
 covered in any further detail in this PEP.
 
-Capture patterns are combined with "AS patterns" to give both "explicit
-capture patterns" (``as NAME``) and inferred capture patterns (``NAME``). The
-definition of class and mapping patterns change to allow only explicit capture
-patterns. ``_`` also becomes a regular capture pattern, due to the wildcard
-pattern marker changing to ``__``.
-
-Explicit constraint patterns are added, offering equality constraints and
-identity constraints.
-
-Literal patterns and value patterns are replaced by inferred constraint
-patterns, offering inferred equality constraints for strings, numbers and
-attribute lookups, and inferred identity constraints for ``None`` and ``...``.
-
-Sequence patterns, mapping patterns, and class patterns are grouped together as
-structural patterns, allowing the changes to mapping and class patterns covered
-in their respective sections. Sequence patterns are effectively unchanged at a
-behavioural level, but the precise way they are defined changes due to the
-changes to other patterns. 
-
-Wildcard patterns are changed to use ``__`` (double underscore) rather than
-``_`` (single underscore), and are also given a new dedicated node in the
-Abstract Syntax Tree produced by the parser.
-
-Group patterns and OR patterns change to have the effect of *turning off pattern
-inference* for their subpatterns.
-
+TODO: Update this section to match the updated Abstract/Motivation/Grammar
 
 Capture patterns
 ----------------
@@ -372,7 +350,7 @@ Mapping patterns inherit the change to replace literal patterns and
 value patterns with constraint patterns that allow arbitrary primary
 expressions::
 
-  mapping_pattern: '{' [items_pattern] '}'
+  mapping_constraint: '{' [items_pattern] '}'
   items_pattern: ','.key_value_pattern+ ','?
   key_value_pattern:
       | primary ':' or_pattern
@@ -443,6 +421,10 @@ identifier used in ``Name`` nodes.
 
 Design Discussion
 =================
+
+
+TODO: Update this section to match the updated Abstract/Motivation/Grammar
+
 
 Treating match pattern syntax as an extension of assignment target syntax
 -------------------------------------------------------------------------
@@ -857,6 +839,10 @@ be explicit when the parser's assumptions don't align with their intent.
 Deferred Ideas
 ==============
 
+
+TODO: Update this section to match the updated Abstract/Motivation/Grammar
+
+
 Allowing negated constraints in match patterns
 ----------------------------------------------
 
@@ -916,6 +902,10 @@ appropriate to defer it to a separate proposal, rather than including it here.
 
 Rejected Ideas
 ==============
+
+
+TODO: Update this section to match the updated Abstract/Motivation/Grammar
+
 
 Restricting permitted expressions in constraint patterns and mapping pattern keys
 ---------------------------------------------------------------------------------
@@ -1051,6 +1041,9 @@ would look like ordinary comparison operations, with nothing to suggest that
 Reference Implementation
 ========================
 
+TODO: Up date the reference impl to reflect v3 of the proposal (the v3 Grammar
+proposal should be stable enough to permit a first cut at this now)
+
 A reference implementation for this PEP [3_] has been derived from Brandt
 Bucher's reference implementation for PEP 634 [4_].
 
@@ -1069,6 +1062,7 @@ constraint operators in the AST. The draft implementation adds them as new
 cases on the existing ``UnaryOp`` node, but there's an argument to be made that
 they would be better implemented as a new ``Constraint`` node, since they're
 accepted at different points in the syntax tree than other unary operators.
+
 
 
 Acknowledgments
@@ -1098,6 +1092,10 @@ into a hard keyword that always skips binding a reference in any location a
 simple name is expected, rather than continuing indefinitely as the match
 pattern specific soft keyword that is proposed here.
 
+Joao Bueno and Jim Jewett for nudging the PEP author to take a closer look at
+the proposed syntax for subelement capturing within class patterns and mapping
+patterns.
+
 
 References
 ==========
@@ -1123,6 +1121,11 @@ References
 .. [7] Stack Overflow answer regarding the use cases for ``_`` as an identifier
    https://stackoverflow.com/questions/5893163/what-is-the-purpose-of-the-single-underscore-variable-in-python/5893946#5893946
 
+.. [8] Pre-publication draft of "Precise Semantics for Pattern Matching"
+   https://github.com/markshannon/pattern-matching/blob/master/precise_semantics.rst
+
+.. [9] Kohn et al., Dynamic Pattern Matching with Python
+   https://gvanrossum.github.io/docs/PyPatternMatching.pdf
 
 .. _Appendix A:
 
@@ -1148,129 +1151,149 @@ Notation used beyond standard EBNF is as per PEP 534:
     case_block: "case" patterns [guard] ':' block
     guard: 'if' named_expression
 
-    patterns: open_sequence_pattern | pattern
+    patterns: pattern
     pattern:
-        | or_pattern [capture_pattern]
-        | inferred_constraint_pattern
-        | inferred_capture_pattern
+        | as_pattern
+        | or_pattern
+
+    as_pattern: [or_pattern] pattern_as_clause
+    pattern_as_clause: 'as' pattern_capture_target
+    pattern_capture_target: !"__" NAME !('.' | '(' | '=')
+
     or_pattern: '|'.closed_pattern+
-    explicit_pattern:
-        | capture_pattern
+    closed_pattern:
         | wildcard_pattern
-        | constraint_pattern
         | group_pattern
-        | sequence_pattern
-        | mapping_pattern
-        | class_pattern
-
-    capture_pattern: 'as' inferred_capture_pattern
-    inferred_capture_pattern: !"__" NAME !('.' | '(' | '=')
-
-    wildcard_pattern: "__"
+        | constraint_pattern
 
     constraint_pattern:
         | eq_constraint
         | id_constraint
-    eq_constraint: '==' primary
-    id_constraint: 'is' primary
+        | sequence_constraint
+        | mapping_constraint
+        | attrs_constraint
+        | class_constraint
 
-    inferred_constraint_pattern:
-        | inferred_id_constraint
-        | inferred_eq_constraint
-
-    inferred_id_constraint[expr_ty]:
-        | 'None'
-        | '...'
-
-    inferred_eq_constraint:
-        | attr_constraint
-        | numeric_constraint
-        | strings
-
-    attr_constraint: attr !('.' | '(' | '=')
-    attr: name_or_attr '.' NAME
-    name_or_attr: attr | NAME
-    numeric_constraint:
-        | signed_number !('+' | '-')
-        | signed_number '+' NUMBER
-        | signed_number '-' NUMBER
-    signed_number: NUMBER | '-' NUMBER
+    wildcard_pattern: "__"
 
     group_pattern: '(' or_pattern ')'
 
-    sequence_pattern:
-    | '[' [maybe_sequence_pattern] ']'
-    | '(' [open_sequence_pattern] ')'
-    open_sequence_pattern: maybe_star_pattern ',' [maybe_sequence_pattern]
-    maybe_sequence_pattern: ','.maybe_star_pattern+ ','?
+    eq_constraint: '==' primary
+    id_constraint: 'is' primary
+
+    sequence_constraint: '[' [sequence_constraint_elements] ']'
+    sequence_constraint_elements: ','.maybe_star_pattern+ ','?
     maybe_star_pattern: star_pattern | pattern
-    star_pattern: '*' (capture_pattern | wildcard_pattern)
+    star_pattern: '*' (pattern_as_clause | wildcard_pattern)
 
-    mapping_pattern: '{' [items_pattern] '}'
-    items_pattern: ','.key_value_pattern+ ','?
-    key_value_pattern:
-        | primary [(':' or_pattern | constraint_pattern )] [capture_pattern]
-        | double_star_pattern
-    double_star_pattern: '**' (capture_pattern | inferred_capture_pattern )
+    mapping_constraint: '{' [mapping_constraint_elements] '}'
+    mapping_constraint_elements: ','.key_value_constraint+ ','?
+    key_value_constraint:
+        | primary pattern_as_clause
+        | primary eq_constraint
+        | primary id_constraint
+        | primary ':' pattern
+        | double_star_capture
+    double_star_capture: '**' pattern_as_clause
 
-    class_pattern:
-        | name_or_attr '(' [pattern_arguments ','?] ')'
-    pattern_arguments:
-        | positional_patterns ',' '/' [',' instance_attr_patterns]
-        | instance_attr_patterns
+    attrs_constraint:
+        | name_or_attr '{' [attrs_constraint_elements] '}'
+    attrs_constraint_elements: ','.attr_value_pattern+ ','?
+    attr_value_pattern:
+        | '.' NAME pattern_as_clause
+        | '.' NAME eq_constraint
+        | '.' NAME id_constraint
+        | '.' NAME ':' pattern
+        | '.' NAME
+
+    class_constraint:
+        | name_or_attr '(' [class_constraint_arguments] ')'
+    class_constraint_arguments:
+        | positional_patterns [',' [class_constraint_attrs]]
+        | class_constraint_attrs
     positional_patterns: ','.pattern+
-    instance_attr_patterns: ','.instance_attr_pattern+
-    instance_attr_pattern:
-        | NAME [(':' or_pattern | constraint_pattern )] [capture_pattern]
+    class_constraint_attrs:
+        | '**' '{' [attrs_constraint_elements] '}'
 
 
 .. _Appendix B:
 
-Appendix B: Summary of changes relative to PEP 634
+Appendix B: Summary of Abstract Syntax Tree changes
+===================================================
+
+TODO: Add this after reference implementation is updated
+
+
+.. _Appendix C:
+
+Appendix C: Summary of changes relative to PEP 634
 ==================================================
+
+The overall `match`/`case` statement syntax and the guard expression syntax
+remain the same as they are in PEP 634.
 
 Relative to PEP 634 this PEP makes the following key changes:
 
 * the wildcard pattern changes from ``_`` (single underscore) to ``__`` (double
   underscore), and gains a dedicated ``SkippedBinding`` node in the AST
-* a new pattern type is introduced: "constraint patterns"
-* constraint patterns are either equality constraints or identity constraints
+* due to ambiguity of intent, value patterns and literal patterns are removed
+* a new pattern type is introduced: "value constraint patterns"
+* value constraint patterns are either equality constraints or identity constraints
 * equality constraints use ``==`` as a prefix marker on an otherwise
   arbitrary primary expression: ``== EXPR``
 * identity constraints use ``is`` as a prefix marker on an otherwise
   arbitrary primary expression: ``is EXPR``
-* value patterns and literal patterns (with some exceptions) are redefined as
-  "inferred equality constraints", and become a syntactic shorthand for an
-  equality constraint
-* ``None`` and ``...`` are defined as "inferred identity constraints" and become
-  a syntactic shorthand for an identity constraint
-* due to ambiguity of intent, neither ``True`` nor ``False`` are accepted as
-  implying an inferred constraint (instead requiring the use of an explicit
-  constraint, a class pattern, or a capture pattern with a guard expression)
-* inferred constraints are *not* defined in the Abstract Syntax Tree. Instead,
-  inferred constraints are converted to explicit constraints by the parser
-* Inferred constraint patterns are allowed only for top level patterns and
-  as part of sequence patterns
-* "capture patterns" are split into "explicit capture patterns" (with the ``as``
-  prefix) and "inferred capture patterns" (without the prefix)
-* Inferred capture patterns are allowed only as top level patterns, as part of
-  sequence patterns, and to collect any additional keys in a mapping pattern
-* Sequence patterns, mapping patterns, and class patterns are grouped together
-  as "structural patterns"
-* Mapping patterns change to allow arbitrary primary expressions as keys
-* Mapping patterns change to only use ":"" as the separator for structural
-  patterns. Capture patterns use "as", equality constraint patterns use "==",
-  and identity constraint patterns use "is". No inferred constraint or capture
-  patterns are defined for mapping patterns, but a capture pattern may still be
-  used in addition to a structural pattern or equality pattern.
-* Class patterns change to treat classes as a collection of attributes by
-  default. Checks against the ``__match_args__`` attribute must be explicitly
-  requested with a ``/`` character after the patterns to be matched positionally.
-* Class patterns change to use the same separators as mapping patterns: ":" to
-  introduce a structural pattern, "==" for an equality constraint, "is" for an
-  identity contraint, and "as" for a capture pattern. No inferred constraint or
-  capture patterns are defined for mapping patterns, but a capture pattern may
-  still be used in addition to a structural pattern or equality pattern.
+* due to ambiguity of intent, capture patterns are removed. All capture operations
+  use the ``as`` keyword (even in sequence matching)
+* to reduce verbosity in AS patterns, ``as NAME`` is permitted, with the same
+  meaning as ``__ as NAME``
+* sequence patterns change to *require* the use of square brackets, rather than
+  offering the same syntactic flexibility as assignment targets (which allow
+  iterable unpacking to be indicated by any use of a tuple separated target,
+  with or without surrounding parentheses or square brackets)
+* mapping patterns change to allow arbitrary primary expressions as keys
+* to reduce verbosity in mapping patterns, ``:`` may be omitted when the pattern
+  to be matched starts with ``==``, ``is``, or ``as``
+* class patterns no longer use individual keyword argument syntax for attribute
+  matching. Instead they use double-star syntax, along with a variant on mapping
+  pattern syntax with a dot prefix on the attribute names
+* to reduce verbosity, class attribute matching uses the same syntactic
+  shorthand as mapping patterns: ``:`` may be omitted when the pattern
+  to be matched starts with ``==``, ``is``, or ``as``
+* dedicated syntax for ducktyping is added, such that ``case cls{...}:`` is
+  equivalent to ``case cls(**{...}):``
+
+Note that postponing literal patterns also makes it possible to postpone the
+question of whether we need an "INUMBER" token in the tokeniser for imaginary
+literals. Without it, the parser can't distinguish complex literals from other
+binary addition and subtraction operations on constants, so proposals like
+PEP 634 have to do work in later compilation steps to check for correct usage.
+
+
+.. _Appendix D:
+
+Appendix D: History of changes to this proposal
+===============================================
+
+The first published iteration of this proposal mostly followed PEP 634, but
+suggested using ``?EXPR`` for equality constraints and ``?is EXPR`` for
+identity constraints rather than PEP 634's value patterns and literal patterns.
+
+The second published iteration mostly adopted a counter-proposal from Steven
+D'Aprano that kept the PEP 634 style inferred constraints in many situations,
+but also allowed the use of ``== EXPR`` for explicit equality constraints, and
+``is EXPR`` for explicit identity constraints.
+
+The third published (and current) iteration dropped inferred patterns entirely,
+in an attempt to resolve the concerns with the fact that the patterns
+``case {key: NAME}:`` and ``case cls(attr=NAME):`` would both bind ``NAME``
+despite it appearing to the right of another subexpression without using the
+``as`` keyword. The revised proposal also eliminates the possibility of writing
+``case TARGET1 as TARGET2:``, which would bind to both of the given names. Of
+those changes, the most concerning was ``case cls(attr=NAME):``, since it
+involved the use of ``=`` with the binding target on the right, the exact
+opposite of what happens in assignment statements, function calls, and
+function signature declarations.
 
 
 Copyright

--- a/pep-0642.rst
+++ b/pep-0642.rst
@@ -19,16 +19,16 @@ Abstract
 
 This PEP covers an alternative syntax proposal for PEP 634's structural pattern
 matching that requires explicit prefixes on all capture patterns and value
-constraints. It also proposes an alternative syntax for instance attribute
+constraints. It also proposes a new dedicated syntax for instance attribute
 patterns that aligns more closely with the proposed mapping pattern syntax.
 
 While the result is necessarily more verbose than the proposed syntax in
-PEP 634, it is still less verbose than the status quo.
+PEP 634, it is still significantly less verbose than the status quo.
 
 As an example, the following match statement would extract "host" and "port"
 details from a 2 item sequence, a mapping with "host" and "port" keys, any
 object with "host" and "port" attributes, or a "host:port" string, treating
-the "port" as optional in all cases::
+the "port" as optional in the latter three cases::
 
     port = DEFAULT_PORT
     match expr:
@@ -42,8 +42,10 @@ the "port" as optional in all cases::
             pass
         case object{.host as host}:
             pass
-        case str() as addr:
-            host, __, port = addr.partition(":")
+        case str{} as addr:
+            host, __, optional_port = addr.partition(":")
+            if optional_port:
+                port = optional_port
         case __ as m:
             raise TypeError(f"Unknown address format: {m!r:.200}")
     port = int(port)
@@ -105,10 +107,14 @@ local variable binding.
 While it has not yet been put forward as a PEP, Mark Shannon has a pre-PEP draft
 [8_] expressing several concerns about the runtime semantics of the pattern
 matching proposal in PEP 634. This PEP is somewhat complementary to that one, as
-even though this PEP is specifically about surface syntax changes rather than
+even though this PEP is mostly about surface syntax changes rather than major
 semantic changes, it does propose that the Abstract Syntax Tree definition be
 made more explicit to better separate the details of the surface syntax from the
-semantics of the code generation step.
+semantics of the code generation step. There is one specific idea in that pre-PEP
+draft that this PEP explicitly rejects: the idea that the different kinds of
+matching are mutually exclusive. It's entirely possible for the same value to
+match different kinds of structural pattern, and which one takes precedence will
+be governed by the order of the cases in the match statement.
 
 
 Motivation
@@ -184,9 +190,6 @@ then we don't have any real way to revisit those decisions in a future release.
 Specification
 =============
 
-TODO: Finish updating this section to match the updated Abstract/Motivation/Grammar
-
-
 This PEP retains the overall `match`/`case` statement structure and semantics
 from PEP 634, but proposes multiple changes that mean that user intent is
 explicitly specified in the concrete syntax rather than needing to be inferred
@@ -199,7 +202,7 @@ with no inference required.
 The Match Statement
 -------------------
 
-Syntax::
+Surface syntax::
 
   match_stmt: "match" subject_expr ':' NEWLINE INDENT case_block+ DEDENT
   subject_expr:
@@ -217,6 +220,12 @@ Syntax::
       | wildcard_pattern
       | group_pattern
       | structural_constraint
+
+Abstract syntax::
+
+    Match(expr subject, match_case* cases)
+    match_case = (pattern pattern, expr? guard, stmt* body)
+
 
 The rules ``star_named_expression``, ``star_named_expressions``,
 ``named_expression`` and ``block`` are part of the `standard Python
@@ -239,19 +248,20 @@ that they are recognized as keywords when part of a match
 statement or case block only, and are allowed to be used in all
 other contexts as variable or argument names.
 
-For context, ``match_stmt`` is a new alternative for
-``compound_statement``::
+Unlike PEP 634, patterns are explicitly defined as a new kind of node in the
+abstract syntax tree - even when surface syntax is shared with existing
+expression nodes, a distinct abstract node is emitted by the parser.
 
-  compound_statement:
-      | if_stmt
-      ...
-      | match_stmt
+For context, ``match_stmt`` is a new alternative for
+``compound_statement`` in the surface syntax and ``Match`` is a new
+alternative for ``stmt`` in the abstract syntax.
 
 
 Match Semantics
 ^^^^^^^^^^^^^^^
 
-This PEP retains the overall pattern matching semantics proposed in PEP 634.
+This PEP largely retains the overall pattern matching semantics proposed in
+PEP 634.
 
 The proposed syntax for patterns changes significantly, and is discussed in
 detail below.
@@ -301,7 +311,7 @@ PEP 634:
 Patterns
 --------
 
-The top-level syntax for patterns is as follows::
+The top-level surface syntax for patterns is as follows::
 
     open_pattern: # Pattern may use multiple tokens with no closing delimiter
         | as_pattern
@@ -323,17 +333,37 @@ The top-level syntax for patterns is as follows::
 As described above, the usage of open patterns is limited to top level case
 clauses and when parenthesised in a group pattern.
 
+The abstract syntax for patterns explicitly indicates which elements are
+subpatterns and which elements are subexpressions or identifiers::
+
+    pattern = MatchAlways
+         | MatchValue(matchop op, expr value)
+         | MatchSequence(pattern* patterns)
+         | MatchMapping(expr* keys, pattern* patterns)
+         | MatchAttrs(expr cls, identifier* attrs, pattern* patterns)
+         | MatchClass(expr cls, pattern* patterns, identifier* extra_attrs, pattern* extra_patterns)
+
+         | MatchRestOfSequence(identifier? target)
+         -- A NULL entry in the MatchMapping key list handles capturing extra mapping keys
+
+         | MatchAs(pattern? pattern, identifier target)
+         | MatchOr(pattern* patterns)
+
 
 AS Patterns
 ^^^^^^^^^^^
 
-Syntax::
+Surface syntax::
 
     as_pattern: [closed_pattern] pattern_as_clause
     pattern_as_clause: 'as' pattern_capture_target
     pattern_capture_target: !"__" NAME !('.' | '(' | '=')
 
 (Note: the name on the right may not be ``__``.)
+
+Abstract syntax::
+
+    MatchAs(pattern? pattern, identifier target)
 
 An AS pattern matches the closed pattern on the left of the ``as``
 keyword against the subject.  If this fails, the AS pattern fails.
@@ -344,7 +374,6 @@ If no pattern to match is given, the wildcard pattern (``__``) is implied.
 
 To avoid confusion with the `wildcard pattern`_, the double underscore (``__``)
 is not permitted as a capture target (this is what ``!"__"`` expresses).
-
 
 A capture pattern always succeeds.  It binds the subject value to the
 name using the scoping rules for name binding established for named expressions
@@ -360,18 +389,24 @@ As an open pattern, the usage of AS patterns is limited to top level case
 clauses and when parenthesised in a group pattern. However, several of the
 structural constraints allow the use of ``pattern_as_clause`` in relevant
 locations to bind extracted elements of the matched subject to local variables.
+These are mostly represented in the abstract syntax tree as ``MatchAs`` nodes,
+aside from the dedicated ``MatchRestOfSequence`` node in sequence patterns.
 
 
 OR Patterns
 ^^^^^^^^^^^
 
-Syntax::
+Surface syntax::
 
     or_pattern: '|'.simple_pattern+
 
     simple_pattern: # Subnode where "as" and "or" patterns must be parenthesised
         | closed_pattern
         | value_constraint
+
+Abstract syntax::
+
+    MatchOr(pattern* patterns)
 
 When two or more patterns are separated by vertical bars (``|``),
 this is called an OR pattern. (A single simple pattern is just that)
@@ -387,12 +422,13 @@ If none of the subpatterns succeed the OR pattern fails.
 Subpatterns are mostly required to be closed patterns, but the parentheses may
 be omitted for value constraints.
 
+
 .. _value_constraints:
 
 Value constraints
 ^^^^^^^^^^^^^^^^^
 
-Syntax::
+Surface syntax::
 
     value_constraint:
         | eq_constraint
@@ -409,6 +445,12 @@ Syntax::
         | '+' primary
         | '-' primary
         | '~' primary
+
+Abstract syntax::
+
+    MatchValue(matchop op, expr value)
+    matchop = EqCheck | IdCheck
+
 
 The rule ``primary`` is defined in the standard Python grammar, and only
 allows expressions that either consist of a single token, or else are required
@@ -440,51 +482,136 @@ Unlike literal patterns in PEP 634, this PEP requires that complex
 literals be parenthesised to be accepted by the parser. See the Deferred
 Ideas section for discussion on that point.
 
+If this PEP were to be adopted in preference to PEP 634, then all literal and
+value patterns would instead be written more explicitly as value constraints::
+
+    # Literal patterns
+    match number: 
+        case == 0:
+            print("Nothing")
+        case == 1:
+            print("Just one")
+        case == 2:
+            print("A couple")
+        case == -1:
+            print("One less than nothing")
+        case == (1-1j):
+            print("Good luck with that...")
+
+    # Additional literal patterns
+    match value: 
+        case == True:
+            print("True or 1")
+        case == False:
+            print("False or 0")
+        case == None:
+            print("None")
+        case == "Hello":
+            print("Text 'Hello'")
+        case == b"World!":
+            print("Binary 'World!'")
+
+    # Matching by identity rather than equality
+    SENTINEL = object()
+    match value:
+        case is True:
+            print("True, not 1")
+        case is False:
+            print("False, not 0")
+        case is None:
+            print("None, following PEP 8 comparison guidelines")
+        case is ...:
+            print("May be useful when writing __getitem__ methods?")
+        case is SENTINEL:
+            print("Matches the sentinel by identity, not just value")
+
+    # Value patterns
+    from enum import Enum
+    class Sides(str, Enum):
+        SPAM = "Spam"
+        EGGS = "eggs"
+        ...
+
+    preferred_side = Sides.EGGS
+    match entree[-1]:
+        case == Sides.SPAM:  # Compares entree[-1] == Sides.SPAM.
+            response = "Have you got anything without Spam?"
+        case == preferred_side:  # Compares entree[-1] == preferred_side
+            response = f"Oh, I love {preferred_side}!"
+        case as side:  # Assigns side = entree[-1].
+            response = f"Well, could I have their Spam instead of the {side} then?"
+
+Note the ``== preferred_side`` example: using an explicit prefix marker on
+constraint expressions removes the restriction to only working with attributes
+or literals for value lookups.
+
+The ``== (1-1j)`` example illustrates the use of parentheses to turn any
+subexpression into a closed one.
+
 
 .. _wildcard_pattern:
 
 Wildcard Pattern
 ^^^^^^^^^^^^^^^^
 
-Syntax::
+Surface syntax::
 
     wildcard_pattern: "__"
 
-A wildcard pattern always succeeds.  It binds no name.
+Abstract syntax::
+
+    MatchAlways
+
+A wildcard pattern always succeeds.  As in PEP 634, it binds no name.
 
 Where PEP 634 chooses the single underscore as its wildcard pattern for
 consistency with other languages, this PEP chooses the double underscore as that
 has a clearer path towards potentially being made consistent across the entire
 language, whereas that path is blocked for ``"_"`` by i18n related use cases.
 
+Example usage::
+
+  match sequence:
+      case [__]:               # any sequence with a single element
+          return True
+      case [start, *__, end]:  # a sequence with at least two elements
+          return start == end
+      case __:                 # anything
+          return False
+
+
 
 Group Patterns
 ^^^^^^^^^^^^^^
 
-Syntax::
+Surface syntax::
 
   group_pattern: '(' open_pattern ')'
 
 For the syntax of ``open_pattern``, see Patterns above.
 
-A parenthesized pattern has no additional syntax.  It allows users to
-add parentheses around patterns to emphasize the intended grouping, and to
-allow nesting of open patterns when the grammar requires a closed pattern.
+A parenthesized pattern has no additional syntax and is not represented in the
+abstract syntax tree.  It allows users to add parentheses around patterns to
+emphasize the intended grouping, and to allow nesting of open patterns when the
+grammar requires a closed pattern.
 
-Unlike PEP 634, there is not potential ambiguity with sequence patterns, as
+Unlike PEP 634, there is no potential ambiguity with sequence patterns, as
 this PEP requires that all sequence patterns be written with square brackets.
 
 
 Structural constraints
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Syntax::
+Surface syntax::
 
     structural_constraint:
         | sequence_constraint
         | mapping_constraint
         | attrs_constraint
         | class_constraint
+
+The separate "structural constraint" subcategory isn't used in the abstract
+syntax tree.
 
 Structural constraints are patterns used to both make assertions about complex
 objects and to extract values from them.
@@ -495,9 +622,9 @@ in the definition of the pattern.
 
 
 Sequence constraints
-^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^
 
-Syntax::
+Surface syntax::
 
     sequence_constraint: '[' [sequence_constraint_elements] ']'
     sequence_constraint_elements: ','.sequence_constraint_element+ ','?
@@ -513,6 +640,12 @@ Syntax::
 
     pattern_as_clause: 'as' pattern_capture_target
 
+Abstract syntax::
+
+    MatchSequence(pattern* patterns)
+
+    MatchRestOfSequence(identifier? target)
+
 Sequence constraints allow items within a sequence to be checked and
 optionally extracted.
 
@@ -522,9 +655,11 @@ an instance of ``str``, ``bytes`` or ``bytearray`` (see Deferred Ideas for
 a discussion on potentially removing the need for this special casing).
 
 A sequence pattern may contain at most one star subpattern.  The star
-subpattern may occur in any position.  If no star subpattern is
-present, the sequence pattern is a fixed-length sequence pattern;
-otherwise it is a variable-length sequence pattern.
+subpattern may occur in any position and is represented in the AST using the
+``MatchRestOfSequence`` node.
+
+If no star subpattern is present, the sequence pattern is a fixed-length
+sequence pattern; otherwise it is a variable-length sequence pattern.
 
 A fixed-length sequence pattern fails if the length of the subject
 sequence is not equal to the number of subpatterns.
@@ -564,10 +699,11 @@ helps emphasise that iterable unpacking and sequence matching are *not* the
 same operation. It also avoids the parenthesised form's ambiguity problem
 between single element sequence patterns and group patterns.
 
+
 Mapping constraints
 ^^^^^^^^^^^^^^^^^^^
 
-Syntax::
+Surface syntax::
 
     mapping_constraint: '{' [mapping_constraint_elements] '}'
     mapping_constraint_elements: ','.key_value_constraint+ ','?
@@ -582,6 +718,10 @@ are ignored by default)
 
 closed_expr is defined above, under value constraints.
 
+Abstract syntax::
+
+    MatchMapping(expr* keys, pattern* patterns)
+
 Mapping constraints allow keys and values within a sequence to be checked and
 values to optionally be extracted.
 
@@ -590,22 +730,25 @@ A mapping pattern fails if the subject value is not an instance of
 
 A mapping pattern succeeds if every key given in the mapping pattern
 is present in the subject mapping, and the pattern for
-each key matches the corresponding item of the subject mapping. Keys
-are always compared with the ``==`` operator (TBC: is this actually true?
-Comparing by item retrieval seems more plausible, so double check the
-PEP 634 reference impl and amend both PEPs if this statement is not correct).
+each key matches the corresponding item of the subject mapping.
 
-If duplicate keys are detected in the mapping pattern, the pattern is
-considered invalid, and a ``ValueError`` is raised.
+The presence of keys is checked using the two argument form of the ``get``
+method and a unique sentinel value, which offers the following benefits:
 
-A mapping pattern may not contain duplicate key values.
-(If all key patterns are literal patterns this is considered a
-syntax error; otherwise this is a runtime error and will
-raise ``TypeError``.)
+* no exceptions need to be created in the lookup process
+* mappings that implement ``__missing__`` (such as ``collections.defaultdict``)
+  only match on keys that they already contain, they don't implicitly add keys
 
-(TBC: Moving these two paragraphs next to each other shows an internal
-inconsistency in the PEP 634 text about the runtime behaviour. Need to check
-the PEP 634 reference impl and submit a PR to clarify this)
+A mapping pattern may not contain duplicate key values. If duplicate keys are
+detected when checking the mapping pattern, the pattern is considered invalid,
+and a ``ValueError`` is raised. While it would theoretically be possible to
+checked for duplicated constant keys at compile time, no such check is currently
+defined or implemented.
+
+(Note: This semantic description is derived from the PEP 634 reference
+implementation, which differs from the PEP 634 specification text. The
+implementation seems reasonable, so amending the PEP text seems like the best
+way to resolve the discrepancy)
 
 If a ``'**' as NAME`` double star pattern is present, that name is bound to a
 ``dict`` containing any remaining key-value pairs from the subject mapping
@@ -614,25 +757,18 @@ If a ``'**' as NAME`` double star pattern is present, that name is bound to a
 A mapping pattern may contain at most one double star pattern,
 and it must be last.
 
-Key-value pairs are matched using the two-argument form of the
-subject's ``get()`` method.  As a consequence, matched key-value pairs
-must already be present in the mapping, and not created on-the-fly by
-``__missing__`` or ``__getitem__``.  For example,
-``collections.defaultdict`` instances will only be matched by patterns
-with keys that were already present when the match statement was
-entered.
-
 Value subpatterns are mostly required to be closed patterns, but the parentheses
-may be omitted for value constraints. Mapping values may also be captured
-unconditionally using the ``KEY as NAME`` form, without either parentheses or
-the ``:`` key value separator.
+may be omitted for value constraints (the ``:`` key/value separator is still
+required to ensure the entry doesn't look like an ordinary comparison operation).
 
+Mapping values may also be captured unconditionally using the ``KEY as NAME``
+form, without either parentheses or the ``:`` key/value separator.
 
 
 Instance attribute constraints
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Syntax::
+Surface syntax::
 
     attrs_constraint:
         | name_or_attr '{' [attrs_constraint_elements] '}'
@@ -643,11 +779,15 @@ Syntax::
         | '.' NAME ':' simple_pattern
         | '.' NAME
 
+Abstract syntax::
+
+    MatchAttrs(expr cls, identifier* attrs, pattern* patterns)
+
 Instance attribute constraints allow an instance's type to be checked and
 attributes to optionally be extracted.
 
 An instance attribute constraint may not repeat the same attribute name multiple
-times.
+times. Attempting to do so will result in a syntax error.
 
 An instance attribute pattern fails if the subject is not an instance of
 ``name_or_attr``. This is tested using ``isinstance()``.
@@ -672,10 +812,9 @@ If no attribute subpatterns are present, the constraint succeeds if the
 
   - If all attribute subpatterns succeed, the constraint as a whole succeeds.
 
-
 Instance attribute constraints allow ducktyping checks to be implemented by
 using ``object`` as the required instance type (e.g.
-``object{.host as host, .port as port}``).
+``case object{.host as host, .port as port}:``).
 
 The syntax being proposed here could potentially also be used as the basis for
 a new syntax for retrieving multiple attributes from an object instance in one
@@ -686,19 +825,23 @@ Deferred Ideas section for further discussion of this point.
 Class defined constraints
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Syntax::
+Surface syntax::
 
     class_constraint:
-        | name_or_attr '(' [class_constraint_arguments] ')'
-    class_constraint_arguments:
-        | positional_patterns [',' [class_constraint_attrs]]
-        | class_constraint_attrs
+        | name_or_attr '(' ')'
+        | name_or_attr '(' positional_patterns ','? ')'
+        | name_or_attr '(' class_constraint_attrs ')'
+        | name_or_attr '(' positional_patterns ',' class_constraint_attrs] ')'
     positional_patterns: ','.positional_pattern+
     positional_pattern:
         | simple_pattern
         | pattern_as_clause
     class_constraint_attrs:
         | '**' '{' [attrs_constraint_elements] '}'
+
+Abstract syntax::
+
+    MatchClass(expr cls, pattern* patterns, identifier* extra_attrs, pattern* extra_patterns)
 
 Class defined constraints allow a sequence of common attributes to be
 specified on a class and checked positionally, rather than needing to specify
@@ -750,344 +893,117 @@ casing of ``bool``, ``bytearray``, ``bytes``, ``dict``, ``float``,
 ``frozenset``, ``int``, ``list``, ``set``, ``str``, and ``tuple`` in PEP 634.
 
 
-# TODO: Delete most of the remaining specific sections as redundant with the
-#       new subsections above
-
-Capture patterns
-----------------
-
-Explicit capture patterns use the following simplified syntax::
-
-    capture_pattern: 'as' NAME
-
-Explicit capture patterns are accepted in the following positions:
-
-* as a standalone pattern
-* as an alternative in an OR pattern
-* as an element in a sequence pattern (including for the ``*NAME`` element)
-* as part of a mapping pattern (see below for details)
-* as part of a class pattern (see below for details)
-
-For consistency with assignment target syntax, inferred capture patterns are
-also defined, and omit the ``as`` prefix:
-
-    inferred_capture_pattern: NAME # Emits same parser output as capture_pattern
-
-Inferred capture patterns are accepted in the following positions:
-
-* as a standalone pattern
-* as an element in a sequence pattern (including for the ``*NAME`` element)
-* as part of the ``**NAME`` element in a mapping pattern
-
-Note that inferred capture patterns are NOT accepted as part of OR patterns,
-class patterns, mapping patterns, or group patterns.
-
-Constraint patterns
--------------------
-
-Constraint patterns use the following simplified syntax::
-
-    constraint_pattern: id_constraint | eq_constraint
-    eq_constraint: '==' primary
-    id_constraint: 'is' primary
-
-The constraint expression is an arbitrary primary expression - it can be a
-simple name, a dotted name lookup, a literal, a function call, or any other
-primary expression.
-
-If this PEP were to be adopted in preference to PEP 634, then all literal and
-value patterns could instead be written more explicitly as constraint patterns::
-
-    # Literal patterns
-    match number: 
-        case == 0:
-            print("Nothing")
-        case == 1:
-            print("Just one")
-        case == 2:
-            print("A couple")
-        case == (-1):
-            print("One less than nothing")
-        case == (1-1j):
-            print("Good luck with that...")
-
-    # Additional literal patterns
-    match value: 
-        case == True:
-            print("True or 1")
-        case == False:
-            print("False or 0")
-        case == None:
-            print("None")
-        case == "Hello":
-            print("Text 'Hello'")
-        case == b"World!":
-            print("Binary 'World!'")
-        case == ...:
-            print("May be useful when writing __getitem__ methods?")
-
-    # Matching by identity rather than equality
-    SENTINEL = object()
-    match value:
-        case is True:
-            print("True, not 1")
-        case is False:
-            print("False, not 0")
-        case is None:
-            print("None, following PEP 8 comparison guidelines")
-        case is SENTINEL:
-            print("Matches the sentinel by identity, not just value")
-
-    # Constant value patterns
-    from enum import Enum
-    class Sides(str, Enum):
-        SPAM = "Spam"
-        EGGS = "eggs"
-        ...
-
-    preferred_side = Sides.EGGS
-    match entree[-1]:
-        case == Sides.SPAM:  # Compares entree[-1] == Sides.SPAM.
-            response = "Have you got anything without Spam?"
-        case == preferred_side:  # Compares entree[-1] == preferred_side
-            response = f"Oh, I love {preferred_side}!"
-        case side:  # Assigns side = entree[-1].
-            response = f"Well, could I have their Spam instead of the {side} then?"
-
-Note the ``== preferred_side`` example: using an explicit prefix marker on
-constraint expressions removes the restriction to only working with attributes
-or literals for value lookups. The ``== (-1)`` and ``== (1-1j)`` examples
-illustrate the use of parentheses to turn any subexpression into an atomic one.
-
-This PEP retains the caching property specified for value patterns in PEP 634:
-if a particular constraint pattern occurs more than once in a given match
-statement, language implementations are explicitly permitted to cache the first
-calculation on any given match statement execution and re-use it in other
-clauses. (This implicit caching is less necessary in this PEP, given that
-explicit local variable caching becomes a valid option, but it still seems a
-useful property to preserve)
-
-
-Inferred constraint patterns
-----------------------------
-
-Inferred constraint patterns use the syntax proposed for literal and value
-patterns in PEP 634, but arrange them differently in the proposed grammar to
-allow for a straightforward transformation by the parser into explicit
-constraints in the AST output::
-
-    inferred_constraint_pattern:
-        | inferred_id_constraint # Emits same parser output as id_constraint
-        | inferred_eq_constraint # Emits same parser output as eq_constraint
-
-    inferred_id_constraint:
-        | 'None'
-        | '...'
-
-    inferred_eq_constraint:
-        | attr_constraint
-        | numeric_constraint
-        | strings
-
-    attr_constraint: attr !('.' | '(' | '=')
-    attr: name_or_attr '.' NAME
-    name_or_attr: attr | NAME
-
-    numeric_constraint:
-        | signed_number !('+' | '-')
-        | signed_number '+' NUMBER
-        | signed_number '-' NUMBER
-    signed_number: NUMBER | '-' NUMBER
-
-The terminology changes slightly to refer to them as a kind of constraint
-rather than as a kind of pattern, clearly separating the subelements inside
-patterns into "patterns", which define structures and name binding targets to
-match against, and "constraints", which look up existing values to compare
-against.
-
-Note that inferred constraint patterns are NOT accepted as part of OR patterns,
-class patterns, mapping patterns, or group patterns.
-
-In practice, the key differences between this PEP's inferred constraint patterns
-and PEP 634's value patterns and literal patterns are that
-
-* inferred constraint patterns won't actually exist in the AST definition.
-  Instead, they'll be replaced by an explicit constraint node, exactly as if
-  they had been written with the explicit ``==`` or ``is`` prefix
-* ``None`` and ``...`` are handled as part of a separate grammar rule, rather
-  than needing to be handled as a special case of literal patterns in the parser
-* equality constraints are inferred for f-strings in addition to being inferred
-  for string literals
-* inferred constraints for ``True`` and ``False`` are dropped entirely on
-  grounds of ambiguity
-* Numeric constraints don't enforce the restriction that they be limited to
-  complex literals (only that they be limited to single numbers, or the
-  addition or subtraction of two such numbers)
-
-Note: even with inferred constraints handled entirely at the parser level, it
-would still be possible to limit the inference of equality constraints to
-complex numbers if the tokeniser was amended to emit a different token type
-(e.g. ``INUMBER``) for imaginary numbers. The PEP doesn't currently propose
-making that change (in line with its generally permissive approach), but it
-could be amended to do so if desired.
-
-
-Mapping patterns
-----------------
-
-Mapping patterns inherit the change to replace literal patterns and
-value patterns with constraint patterns that allow arbitrary primary
-expressions::
-
-  mapping_constraint: '{' [items_pattern] '}'
-  items_pattern: ','.key_value_pattern+ ','?
-  key_value_pattern:
-      | primary ':' or_pattern
-      | '**' capture_pattern
-
-However, the constraint marker prefix is not needed in this case, as the fact
-this is a key to be looked up rather than a name to be bound can already be
-inferred from its position within a mapping pattern.
-
-This means that in simple cases, mapping patterns look exactly as they do in
-PEP 634::
-
-  import constants
-
-  match config:
-      case {"route": route}:
-          process_route(route)
-      case {constants.DEFAULT_PORT: sub_config, **rest}:
-          process_config(sub_config, rest)
-
-Unlike PEP 634, however, ordinary local and global variables can also be used
-to match mapping keys::
-
-  ROUTE_KEY="route"
-  ADDRESS_KEY="local_address"
-  PORT_KEY="port"
-  match config:
-      case {ROUTE_KEY: route}:
-          process_route(route)
-      case {ADDRESS_KEY: address, PORT_KEY: port}:
-          process_address(address, port)
-
-Note: as complex literals are written as binary operations that are evaluated
-at compile time, this PEP nominally requires that they be written in parentheses
-when used as a key in a mapping pattern. This requirement could be relaxed to
-match PEP 634's handling of complex numbers by also accepting
-``numeric_constraint`` as defining a valid key expression, and this is how
-the draft reference implementation currently works (so the affected PEP 634
-test cases will compile and run as expected).
-
-
-Wildcard patterns
------------------
-
-Wildcard patterns are changed to use ``__`` (double underscore) rather than
-the ``_`` (single underscore) syntax proposed in PEP 634::
-
-  match sequence:
-      case [__]:               # any sequence with a single element
-          return True
-      case [start, *__, end]:  # a sequence with at least two elements
-          return start == end
-      case __:                 # anything
-          return False
-
-This PEP explicitly requires that wildcard patterns be represented in the
-Abstract Syntax Tree as something *other than* a regular ``Name`` node.
-
-The draft reference implementation uses the node name ``SkippedBinding`` to
-indicate that the node appears where a simple name binding would ordinarily
-occur to indicate that nothing should actually be bound, but the exact name of
-the node is more an implementation decision than a design one. The key design
-requirement is to limit the special casing of ``__`` to the parser and allow the
-rest of the compiler to distinguish wildcard patterns from capture patterns
-based entirely on the kind of the AST node, rather than needing to inspect the
-identifier used in ``Name`` nodes.
-
-
 Design Discussion
 =================
 
+Requiring explicit qualification of simple names in match patterns
+------------------------------------------------------------------
 
-TODO: Update this section to match the updated Abstract/Motivation/Grammar
+The first iteration of this PEP accepted the basic premise of PEP 634 that
+iterable unpacking syntax would provide a good foundation for defining a new
+syntax for pattern matching.
+
+During the review process, however, two major and one minor ambiguity problems
+were highlighted that arise directly from that core assumption:
+
+* most problematically, when binding simple names by default is extended to
+  PEP 634's proposed class pattern syntax, the ``ATTR=TARGET_NAME`` construct
+  binds to the right without using the ``as`` keyword, and uses the normal
+  assignment sigil (``=``) to do it!
+* when binding simple names by default is extended to PEP 634's proposed mapping
+  pattern syntax, the ``KEY: TARGET_NAME`` construct binds to the right without
+  using the ``as`` keyword
+* using a PEP 634 capture pattern together with an AS pattern
+  (``TARGET_NAME_1 as TARGET_NAME_2``) gives an odd "binds to both the left and
+  right" behaviour
+
+The third revision of the proposal accounted for this problem by abandoning the
+alignment with iterable unpacking syntax, and instead requiring that all uses
+of bare simple names for anything other than a variable lookup be qualified by
+a preceding sigil or keyword:
+
+* ``as NAME``: local variable binding
+* ``.NAME``: attribute lookup
+* ``== NAME``: variable lookup
+* ``is NAME``: variable lookup
+* any other usage: variable lookup
+
+The key benefit of this approach is that it makes interpretation of simple names
+in patterns a local activity: a leading ``as`` indicates a name binding, a
+leading ``.`` indicates an attribute lookup, and anything else is a variable
+lookup (regardless of whether we're reading a subpattern or a subexpression).
+
+With the syntax now proposed in this PEP, the problematic cases identified above
+no longer read poorly:
+
+* ``.ATTR as TARGET_NAME`` is clearer than ``ATTR=TARGET_NAME``
+* ``KEY as TARGET_NAME`` is clearer than ``KEY: TARGET_NAME``
+* ``(as TARGET_NAME_1) as TARGET_NAME_2`` is clearer than
+  ``TARGET_NAME_1 as TARGET_NAME_2``
 
 
-Treating match pattern syntax as an extension of assignment target syntax
--------------------------------------------------------------------------
+Resisting the temptation to guess
+---------------------------------
 
-PEP 634 already draws inspiration from assignment target syntax in the design
-of its sequence pattern matching - while being restricted to sequences for
-performance and runtime correctness reasons, sequence patterns are otherwise
-very similar to the existing iterable unpacking and tuple packing features seen
-in regular assignment statements and function signature declarations.
+PEP 635 looks at the way pattern matching is used in other languages, and
+attempts to use that information to make plausible predictions about the way
+pattern matching will be used in Python:
 
-By requiring that any new semantics introduced by match patterns be given new
-syntax that is currently disallowed in assignment targets, one of the goals of
-this PEP is to explicitly leave the door open to one or more future PEPs that
-enhance assignment target syntax to support some of the new features introduced
-by match patterns.
+* wanting to extract values to local names will *probably* be more common than
+  wanting to match against values stored in local names
+* wanting comparison by equality will *probably* be more common than wanting
+  comparison by identity
+* users will *probably* be able to at least remember that bare names bind values
+  and attribute references look up values, even if they can't figure that out
+  for themselves without reading the documentation or having someone tell them
 
-In particular, being able to easily deconstruct mappings into local variables
-seems likely to be generally useful, even when there's only one mapping variant
-to be matched::
+To be clear, I think these predictions actually *are* plausible. However, I also
+don't think we need to guess about this up front: I think we can start out with
+a more explicit syntax that requires users to state their intent using a prefix
+marker (either ``as``, ``==``, or ``is``), and then reassess the situation in a
+few years based on how pattern matching is actually being used *in Python*.
 
-  {"host": host, "port": port, "mode": =="TCP"} = settings
+At that point, we'll be able to choose amongst at least the following options:
 
-While such code could already be written using a match statement (assuming
-either this PEP or PEP 634 were to be accepted into the language), an
-assignment statement level variant should be able to provide standardised
-exceptions for cases where the right hand side either wasn't a mapping (throwing
-``TypeError``), didn't have the specified keys (throwing ``KeyError``), or didn't
-have the specific values for the given keys (throwing ``ValueError``), avoiding
-the need to write out that exception raising logic in every case.
+* deciding the explicit syntax is concise enough, and not changing anything
+* adding inferred identity constraints for one or more of ``None``, ``...``,
+  ``True`` and ``False``
+* adding inferred equality constraints for other literals (potentially including
+  complex literals)
+* adding inferred equality constraints for attribute lookups
+* adding either inferred equality constraints or inferred capture patterns for
+  bare names
 
-PEP 635 raises the concern that enough aspects of pattern matching semantics
-will differ from assignment target semantics that pursuing syntactic parallels
-will end up creating confusion rather than reducing it. However, the primary
-examples cited as potentially causing confusion are exactly those where the
-PEP 634 syntax is *already* the same as that for assignment targets: the fact
-that case patterns use iterable unpacking syntax, but only match on sequences
-(and specifically exclude strings and byte-strings) rather than consuming
-arbitrary iterables is an aspect of PEP 634 that this PEP leaves unchanged.
+All of those ideas could be considered independently on their own merits, rather
+than being a potential barrier to introducing pattern matching in the first
+place.
 
-These semantic differences are intrinsic to the nature of pattern matching:
-whereas it is reasonable for a one-shot assignment statement to consume a
-one-shot iterator, it isn't reasonable to do that in a construct that's
-explicitly about matching a given value against multiple potential targets,
-making full use of the available runtime type information to ensure those checks
-are as side effect free as possible.
-
-It's an entirely orthogonal question to how the distinction is drawn between
-capture patterns and patterns that check for expected values (constraint
-patterns in this PEP, literal and value patterns in PEP 634), and it's a big
-logical leap to take from "these specific semantic differences between iterable
-unpacking and sequence matching are needed in order to handle checking against
-multiple potential targets" to "we can reuse attribute binding syntax to mean
-equality constraints instead and nobody is going to get confused by that".
+If any of these syntactic shortcuts were to eventually be introduced, they'd
+also be straightforward to explain in terms of the underlying more explicit
+syntax (the leading ``as``, ``==``, or ``is`` would just be getting inferred
+by the parser, without the user needing to provide it explicitly). At the
+implementation level, only the parser should need to be change, as the existing
+AST nodes could be reused.
 
 
 Interaction with caching of attribute lookups in local variables
 ----------------------------------------------------------------
 
-The major change between this PEP and PEP 634 is to offer ``== EXPR`` for value
-constraint lookups, rather than only offering ``NAME.ATTR``. The main motivation
-for this is to avoid the semantic conflict with regular assignment targets, where
-``NAME.ATTR`` is already used in assignment statements to set attributes, so if
-``NAME.ATTR`` were the *only* syntax for symbolic value matching, then
-we're pre-emptively ruling out any future attempts to allow matching against
-single patterns using the existing assignment statement syntax. We'd also be
-failing to provide users with suitable scaffolding to help build correct mental
-models of what the shorthand forms mean in match patterns (as compared to what
-they mean in assignment targets).
+One of the major changes between this PEP and PEP 634 is to use ``== EXPR``
+for equality constraint lookups, rather than only offering ``NAME.ATTR``. The
+original motivation for this was to avoid the semantic conflict with regular
+assignment targets, where ``NAME.ATTR`` is already used in assignment statements
+to set attributes, so if ``NAME.ATTR`` were the *only* syntax for symbolic value
+matching, then we're pre-emptively ruling out any future attempts to allow
+matching against single patterns using the existing assignment statement syntax.
+The current motivation is more about the general desire to avoid guessing about
+user's intent, and instead requiring them to state it explicitly in the syntax.
 
 However, even within match statements themselves, the ``name.attr`` syntax for
 value patterns has an undesirable interaction with local variable assignment,
 where routine refactorings that would be semantically neutral for any other
-Python statement introduce a major semantic change when applied to a match
-statement.
+Python statement introduce a major semantic change when applied to a PEP 634
+style match statement.
 
 Consider the following code::
 
@@ -1101,7 +1017,7 @@ once::
     while value < _limit:
         ... # Some code that adjusts "value"
 
-With the marker prefix based syntax proposal in this PEP, constraint patterns
+With the marker prefix based syntax proposal in this PEP, value constraints
 would be similarly tolerant of match patterns being refactored to use a local
 variable instead of an attribute lookup, with the following two statements
 being functionally equivalent::
@@ -1119,8 +1035,8 @@ being functionally equivalent::
         case __:
             ... # Handle the non-matching case
 
-By contrast, when using the syntactic shorthand that omits the marker prefix,
-the following two statements wouldn't be equivalent at all::
+By contrast, when using PEP 634's value and capture pattern syntaxes that omit
+the marker prefix, the following two statements wouldn't be equivalent at all::
 
     # PEP 634's value pattern syntax
     match expr:
@@ -1137,10 +1053,9 @@ the following two statements wouldn't be equivalent at all::
         case _:
             ... # Handle the non-matching case
 
-This PEP ensure the original semantics are retained under this style of
-simplistic refactoring: use ``== name`` to force interpretation
-of the result as a constraint pattern instead of a capture pattern, use
-`as name` for a name binding.
+This PEP ensures the original semantics are retained under this style of
+simplistic refactoring: use ``== name`` to force interpretation of the result
+as a value constraint, use ``as name`` for a name binding.
 
 PEP 634's proposal to offer only the shorthand syntax, with no explicitly
 prefixed form, means that the primary answer on offer is "Well, don't do that,
@@ -1155,10 +1070,10 @@ might not be the same value as returned by the LHS is a standard feature common
 to all uses of the "as" keyword).
 
 
-Using existing comparison operators as the constraint pattern prefix
+Using existing comparison operators as the value constraint prefix
 --------------------------------------------------------------------
 
-If the need for a dedicated constraint pattern prefix is accepted, then the
+If the benefit of a dedicated value constraint prefix is accepted, then the
 next question is to ask exactly what that prefix should be.
 
 The initially published version of this PEP proposed using the previously
@@ -1188,13 +1103,18 @@ Rather than introducing a completely new symbol, Steven's proposed resolution to
 this verbosity problem was to retain the ability to omit the prefix marker in
 syntactically unambiguous cases.
 
-This prompted a review of the PEP's goals and underlying concerns, and the
-determination that the author's core concern was with the idea of not even
-*offering* users the ability to be explicit when they wanted or needed to be,
-and instead telling them they could only express the intent that the compiler
-inferred that they wanted - they couldn't be more explicit and override the
-compiler's default inference when it turned out to be wrong (as it inevitably
-will be in at least some cases).
+While the idea of omitting the prefix marker was accepted for the second
+revision of the proposal, it was dropped again in the third revision due to
+ambiguity concerns. Instead, the following points apply:
+
+* for class patterns, other syntax changes allow equality constraints to be
+  written as ``.ATTR == EXPR``, and identity constraints to be written as
+  ``.ATTR is EXPR``, both of which are quite easy to read
+* for mapping patterns, the extra syntactic noise is just tolerated (at least
+  for now)
+* for OR patterns, the extra syntactic noise is just tolerated (at least
+  for now). However, `membership constraints`_ may offer a future path to
+  reducing the need to combine OR patterns with equality constraints.
 
 Given that perspective, PEP 635's arguments against using ``?`` as part of the
 pattern matching syntax held for this proposal as well, and so the PEP was
@@ -1205,7 +1125,7 @@ Using ``__`` as the wildcard pattern marker
 -------------------------------------------
 
 PEP 635 makes a solid case that introducing ``?`` *solely* as a wildcard pattern
-marker would be a bad idea. With the syntax for constraint patterns now changed
+marker would be a bad idea. With the syntax for value constraints changed
 to use existing comparison operations rather than ``?`` and ``?is``, that
 argument holds for this PEP as well.
 
@@ -1221,16 +1141,18 @@ various meanings of ``_`` in existing Python code.
 
 This PEP also proposes adopting an implementation technique that limits
 the scope of the associated special casing of ``__`` to the parser: defining a
-new AST node type (``SkippedBinding``) specifically for wildcard markers.
+new AST node type (``MatchAlways``) specifically for wildcard markers, rather
+than passing it through to the AST as a ``Name`` node.
 
-Within the parser, ``__`` would still mean either a regular name or a wildcard
+Within the parser, ``__`` still means either a regular name or a wildcard
 marker in a match pattern depending on where you were in the parse tree, but
-within the rest of the compiler, ``Name("__")`` would still be a regular name,
-while ``SkippedBinding()`` would always be a wildcard marker.
+within the rest of the compiler, ``Name("__")`` is still a normal variable name,
+while ``MatchAlways()`` is always a wildcard marker in a match pattern.
 
 Unlike ``_``, the lack of other use cases for ``__`` means that there would be
 a plausible path towards restoring identifier handling consistency with the rest
-of the language by making it mean "skip this name binding" everwhere in Python:
+of the language by making ``__`` mean "skip this name binding" everwhere in
+Python:
 
 * in the interpreter itself, deprecate loading variables with the name ``__``.
   This would make reading from ``__`` emit a deprecation warning, while writing
@@ -1239,8 +1161,8 @@ of the language by making it mean "skip this name binding" everwhere in Python:
   deprecated name, rather than using a runtime check in the standard name
   loading opcodes.
 * after a suitable number of releases, change the parser to emit
-  ``SkippedBinding`` for all uses of ``__`` as an assignment target, not just
-  those appearing inside match patterns
+  a new ``SkippedBinding`` AST node for all uses of ``__`` as an assignment
+  target, and update the rest of the compiler accordingly
 * consider making ``__`` a true hard keyword rather than a soft keyword
 
 This deprecation path couldn't be followed for ``_``, as there's no way for the
@@ -1255,217 +1177,280 @@ special methods, or class attribute name mangling, so using ``__`` here would
 be consistent with that existing approach.
 
 
-Keeping inferred equality constraints
--------------------------------------
+Representing patterns explicitly in the Abstract Syntax Tree
+------------------------------------------------------------
 
-An early (not widely publicised) draft of this proposal considered keeping
-PEP 634's literal patterns, as they don't inherently conflict with assignment
-statement syntax the way that PEP 634's value patterns do (trying to assign
-to a literal is already a syntax error, whereas assigning to a dotted name
-sets the attribute).
+PEP 634 doesn't explicitly discuss how match statements should be represented
+in the Abstract Syntax Tree, instead leaving that detail to be defined as part
+of the implementation.
 
-They were removed in the initially published version due to the fact that they
-have the same syntax sensitivity problem as attribute constraints do, where
-naively attempting to move the literal pattern out to a local variable for
-naming clarity turns the value checking literal pattern into a name binding
-capture pattern::
+As a result, while the reference implementation of PEP 634 definitely works (and
+formed the basis of the reference implementation of this PEP), it does contain
+a significant design flaw: despite the notes in PEP 635 that patterns should be
+considered as distinct from expressions, the reference implementation goes ahead
+and represents them in the AST as expression nodes.
 
-    # PEP 634's literal pattern syntax
+The result is an AST that isn't very abstract at all: nodes that should be
+compiled completely differently (because they're patterns rather than
+expressions) are represented the same way, and the type system of the
+implementation language (e.g. C for CPython) can't offer any assistance in
+keeping track of which subnodes should be ordinary expressions and which should
+be subpatterns.
+
+Rather than continuing with that approach, this PEP has instead defined a new
+explicit "pattern" node in the AST, which allows the patterns and their
+permitted subnodes to be defined explicitly in the AST itself, making the code
+implementing the new feature clearer, and allowing the C compiler to provide
+more assistance in keeping track of when the code generator is dealing with
+patterns or expressions.
+
+This change in implementation approach is actually orthogonal to the surface
+syntax changes proposed in this PEP, so it could still be adopted even if the
+rest of the PEP were to be rejected.
+
+
+Changes to mapping patterns
+---------------------------
+
+This PEP makes two notable changes to mapping patterns relative to PEP 634:
+
+* value capturing is written as ``KEY as NAME`` rather than as ``KEY: NAME``
+* a wider range of keys are permitted: any "closed expression", rather than
+  only literals and attribute references
+
+As discussed above, the first change is part of ensuring that all binding
+operations with the target name to the right of a subexpression or pattern
+use the ``as`` keyword.
+
+The second change is mostly a matter of simplifying the parser and code
+generator code by reusing the existing expression handling machinery. The
+restriction to closed expressions is designed to help reduce ambiguity as to
+where the key expression ends and the match pattern begins. This mostly allows
+a superset of what PEP 634 allows, except that complex literals must be written
+in parentheses (at least for now).
+
+Adapting PEP 635's mapping pattern examples to the syntax proposed in this PEP::
+
+  match json_pet:
+      case {"type": == "cat", "name" as name, "pattern" as pattern}:
+          return Cat(name, pattern)
+      case {"type": == "dog", "name" as name, "breed" as breed}:
+          return Dog(name, breed)
+      case __:
+          raise ValueError("Not a suitable pet")
+
+  def change_red_to_blue(json_obj):
+      match json_obj:
+          case { 'color': (== 'red' | == '#FF0000') }:
+              json_obj['color'] = 'blue'
+          case { 'children' as children }:
+              for child in children:
+                  change_red_to_blue(child)
+
+For reference, the equivalent PEP 634 syntax::
+
+  match json_pet:
+      case {"type": "cat", "name": name, "pattern": pattern}:
+          return Cat(name, pattern)
+      case {"type": "dog", "name": name, "breed": breed}:
+          return Dog(name, breed)
+      case _:
+          raise ValueError("Not a suitable pet")
+
+  def change_red_to_blue(json_obj):
+      match json_obj:
+          case { 'color': ('red' | '#FF0000') }:
+              json_obj['color'] = 'blue'
+          case { 'children': children }:
+              for child in children:
+                  change_red_to_blue(child)
+
+
+Changes to class patterns
+-------------------------
+
+This PEP makes several notable changes to class patterns relative to PEP 634:
+
+* the syntactic alignment with class instantiation is abandoned as being
+  actively misleading and unhelpful. Instead, a new dedicated syntax for
+  checking additional attributes is introduced that draws inspiration from
+  mapping patterns rather than class instantiation
+* a new dedicated syntax for simple ducktyping that will work for any class
+  is introduced
+* the special casing of various builtin and standard library types is
+  supplemented by a general check for the existence of a ``__match_args__``
+  attribute
+
+As discussed above, the first change has two purposes:
+
+* it's part of ensuring that all binding operations with the target name to the
+  right of a subexpression or pattern use the ``as`` keyword. Using ``=`` to
+  assign to the right is particularly problematic.
+* it's part of ensuring that all uses of simple names in patterns have a prefix
+  that indicates their purpose (in this case, a leading ``.`` to indicate an
+  attribute lookup)
+
+The second change is intended to make it easier to use pattern matching for the
+"ducktyping" style checks that are already common in Python.
+
+The final change just supplements a CPython-internal-only check in the PEP 634
+reference implementation by making it the default behaviour that classes get if
+they don't define ``__match_args__`` (the optimised fast path for the builtin
+and standard library types named in PEP 634 is retained).
+
+Adapting the class matching example
+`linked from PEP 635 <https://github.com/gvanrossum/patma/blob/master/examples/expr.py#L231>`_
+shows that for purely positional class matching, the main impact comes from the
+changes to value constraints and name binding, not from the class matching
+changes::
+
     match expr:
-        case {"port": 443}:
-            ... # Handle the case where 'expr["port"] == 443'
-        case _:
-            ... # Handle the non-matching case
-
-    # PEP 634's capture pattern syntax
-    HTTPS_PORT = 443
-    match expr:
-        case {"port": HTTPS_PORT}:
-            ... # Matches any mapping with "port", binding its value to HTTPS_PORT
-        case _:
-            ... # Handle the non-matching case
-
-With explicit equality constraints, this style of refactoring keeps the original
-semantics (just as it would for a value lookup in any other statement)::
-
-    # This PEP's equality constraints
-    match expr:
-        case {"port": == 443}:
-            ... # Handle the case where 'expr["port"] == 443'
+        case BinaryOp(== '+', as left, as right):
+            return eval_expr(left) + eval_expr(right)
+        case BinaryOp(== '-', as left, as right):
+            return eval_expr(left) - eval_expr(right)
+        case BinaryOp(== '*', as left, as right):
+            return eval_expr(left) * eval_expr(right)
+        case BinaryOp(== '/', as left, as right):
+            return eval_expr(left) / eval_expr(right)
+        case UnaryOp(== '+', as arg):
+            return eval_expr(arg)
+        case UnaryOp(== '-', as arg):
+            return -eval_expr(arg)
+        case VarExpr(as name):
+            raise ValueError(f"Unknown value of: {name}")
+        case float() | int():
+            return expr
         case __:
-            ... # Handle the non-matching case
+            raise ValueError(f"Invalid expression value: {repr(expr)}")
 
-    HTTPS_PORT = 443
+For reference, the equivalent PEP 634 syntax::
+
     match expr:
-        case {"port": == HTTPS_PORT}:
-            ... # Handle the case where 'expr["port"] == 443'
-        case __:
-            ... # Handle the non-matching case
+        case BinaryOp('+', left, right):
+            return eval_expr(left) + eval_expr(right)
+        case BinaryOp('-', left, right):
+            return eval_expr(left) - eval_expr(right)
+        case BinaryOp('*', left, right):
+            return eval_expr(left) * eval_expr(right)
+        case BinaryOp('/', left, right):
+            return eval_expr(left) / eval_expr(right)
+        case UnaryOp('+', arg):
+            return eval_expr(arg)
+        case UnaryOp('-', arg):
+            return -eval_expr(arg)
+        case VarExpr(name):
+            raise ValueError(f"Unknown value of: {name}")
+        case float() | int():
+            return expr
+        case _:
+            raise ValueError(f"Invalid expression value: {repr(expr)}")
 
+The changes to the class pattern syntax itself are more relevant when
+checking for named attributes and extracting their values without relying on
+``__match_args__``::
 
-Inferring equality constraints for f-strings
---------------------------------------------
+    match expr:
+        case object{.host as host, .port as port}:
+            pass
+        case object{.host as host}:
+            pass
 
-This is less a design decision in its own right, and more a consequence of
-other design decisions:
+Compare this to the PEP 634 equivalent, where it really isn't clear which names
+are referring to attributes of the match subject and which names are referring
+to local variables::
 
-* the tokeniser and parser don't distinquish f-strings from other kinds of
-  strings, so inferring an explicit equality constraint for f-strings happens
-  by default when defining the match pattern parser rule for string literals
-* the rest of the compiler then treats that output like any other explicit
-  equality constraint in an AST pattern node (i.e. allowing arbitary
-  expressions)
-
-This combination of factors makes it awkward to implement a special case that
-disallows inferring equality constraints for f-strings while accepting them for
-string literals, so the PEP instead opts to just allow them (as they're just as
-syntactically unambiguous as any other string in a match pattern).
-
-
-Keeping inferred identity constraints
--------------------------------------
-
-PEP 635 makes a reasonable case that interpreting a check against ``None``
-as ``== None`` would almost always be incorrect, whereas interpreting it as
-``is None`` (as advised in PEP 8) would almost always be what the user intended.
-
-Similar reasoning applies to checking against ``...``.
-
-Accordingly, this PEP defines the use of either of these tokens as implying an
-identity constraint.
-
-However, as with inferred equality contraints, inferred identity constraints
-become explicit identity constraints in the parser output.
-
-
-Disallowing inferred constraints for ``True`` and ``False``
------------------------------------------------------------
-
-PEP 635 makes a reasonable case that comparing the ``True``, and ``False``
-literals by equality by default is problematic. PEP 8 advises against writing
-those comparisons out explicitly in code, so it doesn't make sense for us to
-implement a construct that does so implicitly inside the interpreter.
-
-Unlike PEP 635, however, this PEP proposes to resolve the discrepancy by leaving
-these two names out of the initial iteration of the inferred constraint syntax
-definition entirely, rather than treating them as implying an identity constraint.
-
-This means comparisons against ``True`` and ``False`` in match patterns would
-need to be written in one of the following forms:
-
-* comparison by numeric value::
-
-    case 0:
-        ...
-    case 1:
-        ...
-
-* comparison by equality (equivalent to comparison by numeric value)::
-
-    case == False:
-        ...
-    case == True:
-        ...
-
-* comparison by identity::
-
-    case is False:
-        ...
-    case is True:
-        ...
-
-* comparison by value with class check (equivalent to comparison by identity)::
-
-    case bool(False):
-        ...
-    case bool(True):
-        ...
-
-* comparison by boolean coercion::
-
-    case (x, p) if not p:
-        ...
-    case (x, p) if p:
-        ...
-
-The last approach is the one that would most closely follow PEP 8's guidance
-for ``if``-``elif`` chains (comparing by boolean coercion), but it's far from
-clear at this point how ``True`` and ``False`` literals will end up being used
-in pattern matching use cases.
-
-In particular, PEP 635's assessment that users will *probably* mean "comparison
-by value with class check", which effectively becomes "comparison by identity"
-due to ``True`` and ``False`` being singletons, is a genuinely plausible
-suggestion.
-
-However, rather than attempting to guess up front, this PEP proposes that no
-shorthand form be offered for these two constants in the initial implementation,
-and we instead wait and see if a clearly preferred meaning emerges from actual
-usage of the new construct.
-
-
-Inferred constraints rather than implied constraints
-----------------------------------------------------
-
-This PEP uses the term "inferred contraint" to make it clear that the parser
-is making assumptions about the user's intent when converting an inferred
-constraint to an explicit one.
-
-Calling them "implied constraints" instead would also be reasonable, but that
-phrasing has a slightly stronger connotation that the inference is always going
-to be correct, and one of the motivations of this PEP is that the inference
-*isn't* always going to be correct, so we should be offering a way for users to
-be explicit when the parser's assumptions don't align with their intent.
+    match expr:
+        case object(host=host, port=port):
+            pass
+        case object(host=host):
+            pass
 
 
 Deferred Ideas
 ==============
 
+Inferred value constraints
+--------------------------
 
-TODO: Update this section to match the updated Abstract/Motivation/Grammar
+As discussed above, this PEP doesn't rule out the possibility of adding
+inferred equality and identity constraints in the future.
 
-TODO: Add collections.abc.AtomicSequence as a deferred idea to eliminate the
-special casing of str, bytes, and bytearray in sequence matching.
+These could be particularly valuable for literals, as it is quite likely that
+many "magic" strings and numbers with self-evident meanings will be written
+directly into match patterns, rather than being stored in named variables.
+(Think constants like ``None``, or obviously special numbers like zero and one,
+or strings where their contents are as descriptive as any variable name, rather
+than cryptic checks against opaque numbers like "739452")
+
+
+Accepting complex literals as closed expressions
+------------------------------------------------
+
+PEP 634's reference implementation includes a lot of special casing of binary
+operations in both the parser and the rest of the compiler in order to accept
+complex literals without accepting arbitrary binary numeric operations on
+literal values.
+
+Ideally, this problem would be dealt with at the parser layer, with the parser
+directly emitting a Constant AST node prepopulated with a complex number. If
+that was the way things worked, then complex literals could be accepted through
+a similar mechanism to any other literal.
+
+This isn't how complex literals are handled, however. Instead, they're passed
+through to the AST as regular ``BinOp`` nodes, and then the constant folding
+pass on the AST resolves them down to ``Constant`` nodes with a complex value.
+
+For the parser to resolve complex literals directly, the compiler would need to
+be able to tell the tokenizer to generate a distinct token type for
+imaginary numbers (e.g. ``INUMBER``), which would then allow the parser to
+handle ``NUMBER + INUMBER`` and ``NUMBER - INUMBER`` separately from other
+binary operations.
+
+For now, this PEP has postponed dealing with this question, and instead just
+requires that complex literals be parenthesised in order to be used in value
+constraints and as mapping pattern keys.
+
 
 Allowing negated constraints in match patterns
 ----------------------------------------------
 
-The requirement that constraint expressions be primary expressions means that
-it isn't permitted to write ``!= expr`` or ``is not expr``.
+With the syntax proposed in this PEP, it isn't permitted to write ``!= expr``
+or ``is not expr`` as a match pattern.
 
 Both of these forms have clear potential interpretions as a negated equality
 constraint (i.e. ``x != expr``) and a negated identity constraint
 (i.e. ``x is not expr``).
 
 However, it's far from clear either form would come up often enough to justify
-the dedicated syntax, so the extension has been deferred pending further
+the dedicated syntax, so the possible extension has been deferred pending further
 community experience with match statements.
 
 
-Allowing containment checks in match patterns
+.. _membership constraints:
+
+Allowing membership checks in match patterns
 ---------------------------------------------
 
 The syntax used for equality and identity constraints would be straightforward
-to extend to containment checks: ``in container``.
+to extend to membership checks: ``in container``.
 
 One downside of the proposals in both this PEP and PEP 634 is that checking
 for multiple values in the same case doesn't look like any existing set
 membership check in Python::
 
-    # PEP 634's literal patterns / this PEP's inferred constraints
+    # PEP 634's literal patterns
     match value:
         case 0 | 1 | 2 | 3:
             ...
 
-Explicit equality constraints also become quite verbose if they need to be
-repeated::
-
+    # This PEP's equality constraints
     match value:
-        case == one | == two | == three | == four:
+        case == 0 | == 1 | == 2 | == 3:
             ...
 
-Containment constraints would provide a more concise way to check if the
-match subject was present in a container::
+Membership constraints would provide a more explicit, but still concise, way
+to check if the match subject was present in a container::
 
     match value:
         case in {0, 1, 2, 3}:
@@ -1479,34 +1464,77 @@ Such a feature would also be readily extensible to allow all kinds of case
 clauses without any further syntax updates, simply by defining ``__contains__``
 appropriately on a custom class definition.
 
-However, while this does seem like a useful extension, it isn't essential to
-making match statements a valuable addition to the language, so it seems more
-appropriate to defer it to a separate proposal, rather than including it here.
+However, while this does seem like a useful extension, and a good way to resolve
+this PEP's verbosity problem when combining multiple equality checks in an
+OR pattern, it isn't essential to making match statements a valuable addition
+to the language, so it seems more appropriate to defer it to a separate proposal,
+rather than including it here.
+
+
+Avoiding special cases in sequence matching
+-------------------------------------------
+
+Sequence matching in both this PEP and PEP 634 currently special cases ``str``,
+``bytes``, and ``bytearray`` as specifically *never* matching a sequence
+pattern.
+
+This special casing could potentially be removed if we were to define a new
+``collections.abc.AtomicSequence`` abstract base class for types like these,
+where they're conceptually a single item, but still implement the sequence
+protocol to allow random access to their component parts.
+
+
+Expression syntax to retrieve multiple attributes from an instance
+------------------------------------------------------------------
+
+The instance attribute pattern syntax has been designed such that it could
+be used as the basis for a general purpose syntax for retrieving multiple
+attributes from an object in a single expression::
+
+    host, port = obj{.host, .port}
+
+Similar to slice syntax only being allowed inside bracket subscrpts, the
+``.attr`` syntax for naming attributes would only be allowed inside brace
+subscripts.
+
+This idea isn't required for pattern matching to be useful, so it isn't part of
+this PEP. However, it's mentioned as a possible path towards making pattern
+matching feel more integrated into the rest of the language, rather than
+existing forever in its own completely separated world.
+
+
+Expression syntax to retrieve multiple attributes from an instance
+------------------------------------------------------------------
+
+If the brace subscript syntax were to be accepted for instance attribute
+pattern matching, and then subsequently extended to offer general purpose
+extraction of multiple attributes, then it could be extended even further to
+allow for retrieval of multiple items from containers based on the syntax
+used for mapping pattern matching::
+
+    host, port = obj{"host", "port"}
+    first, last = obj{0, -1}
+
+Again, this idea isn't required for pattern matching to be useful, so it isn't
+part of this PEP. As with retrieving multiple attributes, however, it is
+included as an example of the proposed pattern matching syntax inspiring ideas
+for making object deconstruction easier in general.
 
 
 Rejected Ideas
 ==============
 
-
-TODO: Update this section to match the updated Abstract/Motivation/Grammar
-
-TODO: Add section on rejecting the idea "Make the ':' optional for value
-constraints in mapping patterns" idea. Without the ':' marker on the key
-expression, it allowed thoroughly baffling constructs like "case {0 == 0}:",
-so I dropped it. Attribute patterns weren't as obviously cryptic due to the
-'.' prefix on the attribute name so the "case object{.attr == expr}" shorthand
-was kept there.
-
-Restricting permitted expressions in constraint patterns and mapping pattern keys
----------------------------------------------------------------------------------
+Restricting permitted expressions in value constraints and mapping pattern keys
+-------------------------------------------------------------------------------
 
 While it's entirely technically possible to restrict the kinds of expressions
-permitted in constraint patterns and mapping pattern keys to just attribute
+permitted in value constraints and mapping pattern keys to just attribute
 lookups and constant literals (as PEP 634 does), there isn't any clear runtime
 value in doing so, so this PEP proposes allowing any kind of primary expression
 (primary expressions are an existing node type in the grammar that includes
 things like literals, names, attribute lookups, function calls, container
-subscripts, parenthesised groups, etc).
+subscripts, parenthesised groups, etc), as well as high precedence unary
+operations (``+``, ``-``, ``~``) on primary expressions.
 
 While PEP 635 does emphasise several times that literal patterns and value
 patterns are not full expressions, it doesn't ever articulate a concrete benefit
@@ -1537,6 +1565,7 @@ statement::
 Or else they need to be written as a combination of a capture pattern and a
 guard expression::
 
+    # Allowing arbitrary match targets with PEP 634's guard expressions
     match expr:
         case (_, _matched) if _matched == func():
             ... # Handle the case where 'expr[1] == func()'
@@ -1584,20 +1613,20 @@ Requiring the use of constraint prefix markers for mapping pattern keys
 -----------------------------------------------------------------------
 
 The initial (unpublished) draft of this proposal suggested requiring mapping
-pattern keys be constraint patterns, just as PEP 634 requires that they be valid
+pattern keys be value constraints, just as PEP 634 requires that they be valid
 literal or value patterns::
 
   import constants
 
   match config:
-      case {?"route": route}:
+      case {== "route": route}:
           process_route(route)
-      case {?constants.DEFAULT_PORT: sub_config, **rest}:
+      case {== constants.DEFAULT_PORT: sub_config, **rest}:
           process_config(sub_config, rest)
 
-However, the extra character was syntactically noisy and unlike its use in
-constraint patterns (where it distinguishes them from capture patterns), the
-prefix doesn't provide any additional information here that isn't already
+However, the extra characters were syntactically noisy and unlike its use in
+value constraints (where it distinguishes them from non-pattern expressions),
+the prefix doesn't provide any additional information here that isn't already
 conveyed by the expression's position as a key within a mapping pattern.
 
 Accordingly, the proposal was simplified to omit the marker prefix from mapping
@@ -1608,51 +1637,44 @@ identity and equality checks into their lookup process - they don't purely
 rely on equality checks, as would be incorrectly implied by the use of the
 equality constraint prefix.
 
+Allowing the key/value separator to be omitted for mapping value constraints
+----------------------------------------------------------------------------
 
-Providing dedicated syntax for binding matched constraint values
-----------------------------------------------------------------
+Instance attribute patterns allow the ``:`` separator to be omitted when
+writing attribute value constraints like ``case object{.attr == expr}``.
 
-The initial (unpublished) draft of this proposal suggested allowing ``NAME?EXPR``
-as a syntactically unambiguous shorthand for PEP 622's ``NAME := BASE.ATTR`` or
-PEP 634's ``BASE.ATTR as NAME``.
-
-This idea was dropped as it complicated the grammar for no gain in
-expressiveness over just using the general purpose approach to combining
-capture patterns with other match patterns (i.e. ``?EXPR as NAME`` at the
-time, ``== EXPR as NAME`` now) when the identity of the matching object is
-important.
-
-This idea is even less appropriate after the switch to using existing comparison
-operators as the marker prefix, as both ``NAME == EXPR`` and ``NAME is EXPR``
-would look like ordinary comparison operations, with nothing to suggest that
-``NAME`` is being bound by the pattern matching process.
+Offering a similar shorthand for mapping value constraints was considered, but
+permitting it allows thoroughly baffling constructs like ``case {0 == 0}:``
+where the compiler knows this is the key ``0`` with the value constraint
+``== 0``, but a human reader sees the tautological comparison operation
+``0 == 0``. With the key/value separate included, the intent is more obvious to a
+human reader as well: ``case {0: == 0}:``
 
 
 Reference Implementation
 ========================
 
-TODO: Update the reference impl to reflect v3 of the proposal (the v3 Grammar
-proposal should be stable enough to permit a first cut at this now)
-
-A reference implementation for this PEP [3_] has been derived from Brandt
+A draft reference implementation for this PEP [3_] has been derived from Brandt
 Bucher's reference implementation for PEP 634 [4_].
 
-Relative to the text of this PEP, the draft reference implementation currently
-implements the variant of mapping patterns where numeric constraints are
-accepted in addition to primary expressions (this allowed the PEP 634 mapping
-pattern checks for complex keys to run as written).
+Relative to the text of this PEP, the draft reference implementation has not
+yet complemented the special casing of several builtin and standard library
+types in ``MATCH_CLASS`` with the more general check for the existence of
+``__match_args__``.
 
 All other modified patterns have been updated to follow this PEP rather than
 PEP 634.
 
 The AST validator for match patterns has not yet been implemented.
 
-There is an implementation decision still to be made around representing
-constraint operators in the AST. The draft implementation adds them as new
-cases on the existing ``UnaryOp`` node, but there's an argument to be made that
-they would be better implemented as a new ``Constraint`` node, since they're
-accepted at different points in the syntax tree than other unary operators.
+The AST validator in general has not yet been reviewed to that it is checking
+that only expression nodes are being passed in where expression nodes are
+expected.
 
+The examples in this PEP have not yet been converted to test cases, so could
+plausibly contain typos and other errors.
+
+The documentation has not yet been updated.
 
 
 Acknowledgments
@@ -1747,6 +1769,7 @@ Notation used beyond standard EBNF is as per PEP 534:
         | or_pattern
 
     as_pattern: [closed_pattern] pattern_as_clause
+    as_pattern_with_inferred_wildcard: pattern_as_clause
     pattern_as_clause: 'as' pattern_capture_target
     pattern_capture_target: !"__" NAME !('.' | '(' | '=')
 
@@ -1792,7 +1815,7 @@ Notation used beyond standard EBNF is as per PEP 534:
     sequence_constraint_element:
         | star_pattern
         | simple_pattern
-        | pattern_as_clause
+        | as_pattern_with_inferred_wildcard
     star_pattern: '*' (pattern_as_clause | wildcard_pattern)
 
     mapping_constraint: '{' [mapping_constraint_elements] '}'
@@ -1805,22 +1828,24 @@ Notation used beyond standard EBNF is as per PEP 534:
 
     attrs_constraint:
         | name_or_attr '{' [attrs_constraint_elements] '}'
-    attrs_constraint_elements: ','.attr_value_pattern+ ','?
-    attr_value_pattern:
+    name_or_attr: attr | NAME
+    attr: name_or_attr '.' NAME
+    attrs_constraint_elements: ','.attr_value_constraint+ ','?
+    attr_value_constraint:
         | '.' NAME pattern_as_clause
         | '.' NAME value_constraint
         | '.' NAME ':' simple_pattern
         | '.' NAME
 
     class_constraint:
-        | name_or_attr '(' [class_constraint_arguments] ')'
-    class_constraint_arguments:
-        | positional_patterns [',' [class_constraint_attrs]]
-        | class_constraint_attrs
+        | name_or_attr '(' ')'
+        | name_or_attr '(' positional_patterns ','? ')'
+        | name_or_attr '(' class_constraint_attrs ')'
+        | name_or_attr '(' positional_patterns ',' class_constraint_attrs] ')'
     positional_patterns: ','.positional_pattern+
     positional_pattern:
         | simple_pattern
-        | pattern_as_clause
+        | as_pattern_with_inferred_wildcard
     class_constraint_attrs:
         | '**' '{' [attrs_constraint_elements] '}'
 
@@ -1830,7 +1855,32 @@ Notation used beyond standard EBNF is as per PEP 534:
 Appendix B: Summary of Abstract Syntax Tree changes
 ===================================================
 
-TODO: Add this after reference implementation is updated
+The following new nodes are added to the AST by this PEP::
+
+    stmt = ...
+          | ...
+          | Match(expr subject, match_case* cases)
+          | ...
+          ...
+
+    match_case = (pattern pattern, expr? guard, stmt* body)
+
+    pattern = MatchAlways
+         | MatchValue(matchop op, expr value)
+         | MatchSequence(pattern* patterns)
+         | MatchMapping(expr* keys, pattern* patterns)
+         | MatchAttrs(expr cls, identifier* attrs, pattern* patterns)
+         | MatchClass(expr cls, pattern* patterns, identifier* extra_attrs, pattern* extra_patterns)
+
+         | MatchRestOfSequence(identifier? target)
+         -- A NULL entry in the MatchMapping key list handles capturing extra mapping keys
+
+         | MatchAs(pattern? pattern, identifier target)
+         | MatchOr(pattern* patterns)
+
+          attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
+
+    matchop = EqCheck | IdCheck
 
 
 .. _Appendix C:
@@ -1843,32 +1893,49 @@ remain the same as they are in PEP 634.
 
 Relative to PEP 634 this PEP makes the following key changes:
 
+* a new ``pattern`` type is defined in the AST, rather then reusing the ``expr``
+  type for patterns
+* the new ``MatchAs`` and ``MatchOr`` AST nodes are moved from the ``expr``
+  type to the ``pattern`` type
 * the wildcard pattern changes from ``_`` (single underscore) to ``__`` (double
-  underscore), and gains a dedicated ``SkippedBinding`` node in the AST
+  underscore), and gains a dedicated ``MatchAlways`` node in the AST
 * due to ambiguity of intent, value patterns and literal patterns are removed
+* a new expression category is introduced: "closed expressions"
+* closed expressions are either primary expressions, or a closed expression
+  preceded by one of the high precedence unary operators (``+``, ``-``, ``~``)
 * a new pattern type is introduced: "value constraint patterns"
+* value constraints have a dedicated ``MatchValue`` AST node rather than
+  allowing a combination of ``Constant`` (literals), ``UnaryOp``
+  (negative numbers), ``BinOp`` (complex numbers), and ``Attribute`` (attribute
+  lookups)
 * value constraint patterns are either equality constraints or identity constraints
 * equality constraints use ``==`` as a prefix marker on an otherwise
-  arbitrary primary expression: ``== EXPR``
+  arbitrary closed expression: ``== EXPR``
 * identity constraints use ``is`` as a prefix marker on an otherwise
-  arbitrary primary expression: ``is EXPR``
+  arbitrary closed expression: ``is EXPR``
 * due to ambiguity of intent, capture patterns are removed. All capture operations
-  use the ``as`` keyword (even in sequence matching)
+  use the ``as`` keyword (even in sequence matching) and are represented in the
+  AST as either ``MatchAs`` or ``MatchRestOfSequence`` nodes.
 * to reduce verbosity in AS patterns, ``as NAME`` is permitted, with the same
   meaning as ``__ as NAME``
 * sequence patterns change to *require* the use of square brackets, rather than
-  offering the same syntactic flexibility as assignment targets (which allow
-  iterable unpacking to be indicated by any use of a tuple separated target,
-  with or without surrounding parentheses or square brackets)
-* mapping patterns change to allow arbitrary primary expressions as keys
-* to reduce verbosity in mapping patterns, ``:`` may be omitted when the pattern
-  to be matched starts with ``==``, ``is``, or ``as``
+  offering the same syntactic flexibility as assignment targets (assignment
+  statements allow iterable unpacking to be indicated by any use of a tuple
+  separated target, with or without surrounding parentheses or square brackets)
+* sequence patterns gain a dedicated ``MatchSequence`` AST node rather than
+  reusing ``List``
+* mapping patterns change to allow arbitrary closed expressions as keys
+* mapping patterns gain a dedicated ``MatchMapping`` AST node rather than
+  reusing ``Dict``
+* to reduce verbosity in mapping patterns, ``KEY : __ as NAME`` may be shortened
+  to ``KEY as NAME``
 * class patterns no longer use individual keyword argument syntax for attribute
   matching. Instead they use double-star syntax, along with a variant on mapping
   pattern syntax with a dot prefix on the attribute names
-* to reduce verbosity, class attribute matching uses the same syntactic
-  shorthand as mapping patterns: ``:`` may be omitted when the pattern
-  to be matched starts with ``==``, ``is``, or ``as``
+* class patterns gain a dedicated ``MatchClass`` AST node rather than
+  reusing ``Call``
+* to reduce verbosity, class attribute matching allows ``:`` to be omitted when
+  the pattern to be matched starts with ``==``, ``is``, or ``as``
 * dedicated syntax for ducktyping is added, such that ``case cls{...}:`` is
   equivalent to ``case cls(**{...}):``
 
@@ -1899,7 +1966,7 @@ in an attempt to resolve the concerns with the fact that the patterns
 despite it appearing to the right of another subexpression without using the
 ``as`` keyword. The revised proposal also eliminates the possibility of writing
 ``case TARGET1 as TARGET2:``, which would bind to both of the given names. Of
-those changes, the most concerning was ``case cls(attr=NAME):``, since it
+those changes, the most concerning was ``case cls(attr=TARGET_NAME):``, since it
 involved the use of ``=`` with the binding target on the right, the exact
 opposite of what happens in assignment statements, function calls, and
 function signature declarations.

--- a/pep-0642.rst
+++ b/pep-0642.rst
@@ -271,7 +271,7 @@ There are also some proposed changes to the semantics of class defined
 constraints (class patterns in PEP 634) to eliminate the need to special case
 any builtin types (instead, the introduction of dedicated syntax for instance
 attribute constraints allows the behaviour needed by those builtin types to be
-specified as applying to any type that doesn't define ``__match_args__``)
+specified as applying to any type that sets ``__match_args__`` to ``None``)
 
 
 .. _guards:
@@ -285,7 +285,11 @@ However, the syntax is changed slightly to require that when a guard clause
 is present, the case pattern must be a *closed* pattern.
 
 This makes it clearer to the reader where the pattern ends and the guard clause
-begins.
+begins. (This is mainly a potential problem with OR patterns, where the guard
+clause looks kind of like the start of a conditional expression in the final
+pattern. Actually doing that isn't legal syntax, so there's no ambiguity as far
+as the compiler is concerned, but the distinction may not be as clear to a human
+reader)
 
 
 Irrefutable case blocks
@@ -925,7 +929,7 @@ were highlighted that arise directly from that core assumption:
   (``TARGET_NAME_1 as TARGET_NAME_2``) gives an odd "binds to both the left and
   right" behaviour
 
-The third revision of the proposal accounted for this problem by abandoning the
+The third revision of this PEP accounted for this problem by abandoning the
 alignment with iterable unpacking syntax, and instead requiring that all uses
 of bare simple names for anything other than a variable lookup be qualified by
 a preceding sigil or keyword:
@@ -1441,6 +1445,28 @@ directly into match patterns, rather than being stored in named variables.
 rather than cryptic checks against opaque numbers like ``739452``)
 
 
+Making some required parentheses optional
+-----------------------------------------
+
+The PEP currently errs heavily on the side of requiring parentheses in the face
+of potential ambiguity.
+
+However, there are a number of cases where it at least arguably goes too far,
+mostly involving AS patterns with an explicit pattern.
+
+In any position that requires a closed pattern, AS patterns may end up starting
+with doubled parentheses, as the nested pattern is also required to be a closed
+pattern: ``((OPEN PTRN) as NAME)``
+
+Due to the requirement that the subpattern be closed, it should be reasonable
+in many of these cases (e.g. sequence pattern subpatterns) to accept
+``CLOSED_PTRN as NAME`` directly.
+
+Further consideration of this point has been deferred, as making required
+parentheses optional is a backwards compatible change, and hence relaxing the
+restrictions later can be considered on a case by case basis.
+
+
 Accepting complex literals as closed expressions
 ------------------------------------------------
 
@@ -1468,8 +1494,8 @@ Alternatively, a new ``ComplexNumber`` AST node type could be defined, which
 would allow the parser to notify the subsequent compiler stages that a
 particular node should specifically be a complex literal, rather than an
 arbitrary binary operation. Then the parser could accept ``NUMBER + NUMBER``
-and ``NUMBER - NUMBER`` for that node, while to the AST validation for
-``ComplexNumber`` took care of ensuring that the real and imaginary parts of
+and ``NUMBER - NUMBER`` for that node, while letting the AST validation for
+``ComplexNumber`` take care of ensuring that the real and imaginary parts of
 the literal were real and imaginary numbers as expected.
 
 For now, this PEP has postponed dealing with this question, and instead just
@@ -1483,7 +1509,7 @@ Allowing negated constraints in match patterns
 With the syntax proposed in this PEP, it isn't permitted to write ``!= expr``
 or ``is not expr`` as a match pattern.
 
-Both of these forms have clear potential interpretions as a negated equality
+Both of these forms have clear potential interpretations as a negated equality
 constraint (i.e. ``x != expr``) and a negated identity constraint
 (i.e. ``x is not expr``).
 
@@ -1731,8 +1757,8 @@ Offering a similar shorthand for mapping value constraints was considered, but
 permitting it allows thoroughly baffling constructs like ``case {0 == 0}:``
 where the compiler knows this is the key ``0`` with the value constraint
 ``== 0``, but a human reader sees the tautological comparison operation
-``0 == 0``. With the key/value separate included, the intent is more obvious to a
-human reader as well: ``case {0: == 0}:``
+``0 == 0``. With the key/value separator included, the intent is more obvious to
+a human reader as well: ``case {0: == 0}:``
 
 
 Reference Implementation
@@ -1754,9 +1780,9 @@ Unparsing for match patterns has not yet been migrated to the updated v3 AST.
 
 The AST validator for match patterns has not yet been implemented.
 
-The AST validator in general has not yet been reviewed to that it is checking
-that only expression nodes are being passed in where expression nodes are
-expected.
+The AST validator in general has not yet been reviewed to ensure that it is
+checking that only expression nodes are being passed in where expression nodes
+are expected.
 
 The examples in this PEP have not yet been converted to test cases, so could
 plausibly contain typos and other errors.

--- a/pep-0642.rst
+++ b/pep-0642.rst
@@ -11,7 +11,7 @@ Content-Type: text/x-rst
 Requires: 634
 Created: 26-Sep-2020
 Python-Version: 3.10
-Post-History: 31-Oct-2020, 8-Nov-2020
+Post-History: 31-Oct-2020, 8-Nov-2020, 3-Jan-2021
 Resolution:
 
 Abstract
@@ -50,6 +50,7 @@ the "port" as optional in the latter three cases::
             raise TypeError(f"Unknown address format: {m!r:.200}")
     port = int(port)
 
+
 At a high level, this PEP proposes to categorise the different available pattern
 types as follows:
 
@@ -71,14 +72,14 @@ types as follows:
 The intent of this approach is to:
 
 * allow an initial form of pattern matching to be developed and released without
-  needing to decide up front on the best options for handling bare names,
+  needing to decide up front on the best default options for handling bare names,
   attribute lookups, and literal values
 * ensure that pattern matching is defined explicitly at the Abstract Syntax Tree
   level, allowing the specifications of the semantics and the surface syntax for
   pattern matching to be clearly separated
 * define a clear and concise "ducktyping" syntax that could potentially be
-  adopted in ordinary expressions as a syntactic alternative to the ``getattr``
-  builtin that better facilitates easy retrieval of multiple attributes
+  adopted in ordinary expressions as a way to more easily retrieve a tuple
+  containing multiple attributes from the same object
 
 Relative to PEP 634, the proposal also deliberately eliminates any syntax that
 "binds to the right" without using the ``as`` keyword (using capture patterns
@@ -114,7 +115,7 @@ semantics of the code generation step. There is one specific idea in that pre-PE
 draft that this PEP explicitly rejects: the idea that the different kinds of
 matching are mutually exclusive. It's entirely possible for the same value to
 match different kinds of structural pattern, and which one takes precedence will
-be governed by the order of the cases in the match statement.
+intentionally be governed by the order of the cases in the match statement.
 
 
 Motivation
@@ -168,9 +169,9 @@ object and data layouts?").
 
 This resulted in a complete reversal of the goals of the PEP: rather than
 attempting to emphasise the similarities between assignment and pattern matching,
-the PEP now attempts to make sure that assignment syntax isn't being reused
-*at all*, reducing the likelihood of incorrect inferences being drawn about the
-new construct based on experience with existing ones.
+the PEP now attempts to make sure that assignment target syntax isn't being
+reused *at all*, reducing the likelihood of incorrect inferences being drawn
+about the new construct based on experience with existing ones.
 
 Finally, before completing the 3rd iteration of the proposal (which dropped
 inferred patterns entirely), the PEP author spent quite a bit of time reflecting
@@ -182,7 +183,7 @@ on the following entries in PEP 20:
 
 If we start with an explicit syntax, we can always add syntactic shortcuts later
 (e.g. consider the recent proposals to add shortcuts for ``Union`` and
-``Optional`` type hints only after years of experience with the existing more
+``Optional`` type hints only after years of experience with the original more
 verbose forms), while if we start out with only the abbreviated forms,
 then we don't have any real way to revisit those decisions in a future release.
 
@@ -291,7 +292,8 @@ Irrefutable case blocks
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 The definition of irrefutable case blocks changes slightly in this PEP relative
-to PEP 634, as capture patterns no longer exist.
+to PEP 634, as capture patterns no longer exist as a separate concept from
+AS patterns.
 
 Aside from that caveat, the handling of irrefutable cases is the same as in
 PEP 634:
@@ -525,7 +527,7 @@ value patterns would instead be written more explicitly as value constraints::
         case is SENTINEL:
             print("Matches the sentinel by identity, not just value")
 
-    # Value patterns
+    # Matching against variables and attributes
     from enum import Enum
     class Sides(str, Enum):
         SPAM = "Spam"
@@ -610,8 +612,9 @@ Surface syntax::
         | attrs_constraint
         | class_constraint
 
-The separate "structural constraint" subcategory isn't used in the abstract
-syntax tree.
+Note: the separate "structural constraint" subcategory isn't used in the
+abstract syntax tree, it's merely used as a convenient grouping node in the
+surface syntax definition.
 
 Structural constraints are patterns used to both make assertions about complex
 objects and to extract values from them.
@@ -713,8 +716,8 @@ Surface syntax::
         | double_star_capture
     double_star_capture: '**' pattern_as_clause
 
-(Note that ``**__`` is disallowed by this syntax, as additional mapping entries
-are ignored by default)
+(Note that ``**__`` is deliberately disallowed by this syntax, as additional
+mapping entries are ignored by default)
 
 closed_expr is defined above, under value constraints.
 
@@ -746,9 +749,9 @@ checked for duplicated constant keys at compile time, no such check is currently
 defined or implemented.
 
 (Note: This semantic description is derived from the PEP 634 reference
-implementation, which differs from the PEP 634 specification text. The
-implementation seems reasonable, so amending the PEP text seems like the best
-way to resolve the discrepancy)
+implementation, which differs from the PEP 634 specification text at time of
+writing. The implementation seems reasonable, so amending the PEP text seems
+like the best way to resolve the discrepancy)
 
 If a ``'**' as NAME`` double star pattern is present, that name is bound to a
 ``dict`` containing any remaining key-value pairs from the subject mapping
@@ -853,18 +856,21 @@ As for instance attribute patterns:
   ``name_or_attr``. This is tested using ``isinstance()``.
 - if ``name_or_attr`` is not an instance of the builtin ``type``,
   ``TypeError`` is raised.
-- if no arguments are present, the pattern succeeds if the ``isinstance()``
-  check succeeds.
 
-If any arguments are present, the subject is checked for a ``__match_args__``
-attribute using the equivalent of ``getattr(cls, "__match_args__", None))``.
+Regardless of whether or not any arguments are present, the subject is checked
+for a ``__match_args__`` attribute using the equivalent of
+``getattr(cls, "__match_args__", _SENTINEL))``.
 
 If this raises an exception the exception bubbles up.
 
 If the returned value is not a list, tuple, or ``None``, the conversion fails
 and ``TypeError`` is raised at runtime.
 
-If ``__match_args__`` is None, then only a single positional subpattern is
+This means that only types that actually define ``__match_args__`` will be
+usable in class defined patterns. Types that don't define ``__match_args__``
+will still be usable in instance attribute patterns.
+
+If ``__match_args__`` is ``None``, then only a single positional subpattern is
 permitted. Attempting to specify additional attribute patterns either
 positionally or using the double star syntax will cause ``TypeError`` to be
 raised at runtime.
@@ -884,13 +890,15 @@ converted to an instance attributes constraint as follows:
   using ``__match_args__[i]`` as the attribute name.
 - if any element in ``__match_args__`` is not a string, ``TypeError`` is raised.
 - once the positional patterns have been converted to attribute patterns, then
-  they are combined with any atribute constrains given in the double star
+  they are combined with any atribute constraints given in the double star
   attribute constraints subpattern, and matching proceeds as if for the
   equivalent instance attributes constraint.
 
 Note: the ``__match_args__ is None`` handling in this PEP replaces the special
 casing of ``bool``, ``bytearray``, ``bytes``, ``dict``, ``float``,
 ``frozenset``, ``int``, ``list``, ``set``, ``str``, and ``tuple`` in PEP 634.
+However, the optimised fast path for those types is retained in the
+implementation.
 
 
 Design Discussion
@@ -909,7 +917,7 @@ were highlighted that arise directly from that core assumption:
 * most problematically, when binding simple names by default is extended to
   PEP 634's proposed class pattern syntax, the ``ATTR=TARGET_NAME`` construct
   binds to the right without using the ``as`` keyword, and uses the normal
-  assignment sigil (``=``) to do it!
+  assignment-to-the-left sigil (``=``) to do it!
 * when binding simple names by default is extended to PEP 634's proposed mapping
   pattern syntax, the ``KEY: TARGET_NAME`` construct binds to the right without
   using the ``as`` keyword
@@ -936,9 +944,9 @@ lookup (regardless of whether we're reading a subpattern or a subexpression).
 With the syntax now proposed in this PEP, the problematic cases identified above
 no longer read poorly:
 
-* ``.ATTR as TARGET_NAME`` is clearer than ``ATTR=TARGET_NAME``
-* ``KEY as TARGET_NAME`` is clearer than ``KEY: TARGET_NAME``
-* ``(as TARGET_NAME_1) as TARGET_NAME_2`` is clearer than
+* ``.ATTR as TARGET_NAME`` is more obviously a binding than ``ATTR=TARGET_NAME``
+* ``KEY as TARGET_NAME`` is more obviously a binding than ``KEY: TARGET_NAME``
+* ``(as TARGET_NAME_1) as TARGET_NAME_2`` is more obviously two bindings than
   ``TARGET_NAME_1 as TARGET_NAME_2``
 
 
@@ -1089,15 +1097,15 @@ chosen as the prefix in the initial iteration of the PEP:
   folks with PEP 8 trained aesthetic sensibilities are going to want to put
   a space between it and the following expression, effectively making it a 3
   character prefix instead of 1
-* when used in a class pattern, there needs to be a space between the ``=``
-  keyword separator and the ``==`` prefix, or the tokeniser will split them
-  up incorrectly (getting ``==`` and ``=`` instead of ``=`` and ``==``)
 * when used in a mapping pattern, there needs to be a space between the ``:``
   key/value separator and the ``==`` prefix, or the tokeniser will split them
   up incorrectly (getting ``:=`` and ``=`` instead of ``:`` and ``==``)
 * when used in an OR pattern, there needs to be a space between the ``|``
   pattern separator and the ``==`` prefix, or the tokeniser will split them
   up incorrectly (getting ``|=`` and ``=`` instead of ``|`` and ``==``)
+* if used in a PEP 634 style class pattern, there needs to be a space between
+  the ``=`` keyword separator and the ``==`` prefix, or the tokeniser will split
+  them up incorrectly (getting ``==`` and ``=`` instead of ``=`` and ``==``)
 
 Rather than introducing a completely new symbol, Steven's proposed resolution to
 this verbosity problem was to retain the ability to omit the prefix marker in
@@ -1114,7 +1122,8 @@ ambiguity concerns. Instead, the following points apply:
   for now)
 * for OR patterns, the extra syntactic noise is just tolerated (at least
   for now). However, `membership constraints`_ may offer a future path to
-  reducing the need to combine OR patterns with equality constraints.
+  reducing the need to combine OR patterns with equality constraints (instead,
+  the values to be checked against would be collected as a set, list, or tuple).
 
 Given that perspective, PEP 635's arguments against using ``?`` as part of the
 pattern matching syntax held for this proposal as well, and so the PEP was
@@ -1209,6 +1218,34 @@ syntax changes proposed in this PEP, so it could still be adopted even if the
 rest of the PEP were to be rejected.
 
 
+Changes to sequence patterns
+----------------------------
+
+This PEP makes one notable change to sequence patterns relative to PEP 634:
+
+* only the square bracket form of sequence pattern is supported. Neither open
+  (no delimeters) nor tuple style (parentheses as delimiters) sequence patterns
+  are supported.
+
+Relative to PEP 634, sequence patterns are also significantly affected by the
+change to require explicit qualification of capture patterns and value
+constraints, as it means ``case [a, b, c]:`` must instead be written as
+``case [as a, as b, as c]:`` and ``case [0, 1]:`` must instead be written as
+``case [== 0, == 1]:``.
+
+With the syntax for sequence patterns no longer being derived directly from the
+syntax for iterable unpacking, it no longer made sense to keep the syntactic
+flexibility that had been included in the original syntax proposal purely for
+consistency with iterable unpacking.
+
+Allowing open and tuple style sequence patterns didn't increase expressivity,
+only ambiguity of intent (especially relative to group paterns), and encouraged
+readers down the path of viewing pattern matching syntax as intrinsically linked
+to assignment target syntax (which the PEP 634 authors have stated multiple
+times is not a desirable path to have readers take, and a view the author of
+this PEP now shares, despite disagreeing with it originally).
+
+
 Changes to mapping patterns
 ---------------------------
 
@@ -1279,7 +1316,7 @@ This PEP makes several notable changes to class patterns relative to PEP 634:
   is introduced
 * the special casing of various builtin and standard library types is
   supplemented by a general check for the existence of a ``__match_args__``
-  attribute
+  attribute with the value of ``None``
 
 As discussed above, the first change has two purposes:
 
@@ -1290,8 +1327,24 @@ As discussed above, the first change has two purposes:
   that indicates their purpose (in this case, a leading ``.`` to indicate an
   attribute lookup)
 
+The syntactic alignment with class instantion was also judged to be unhelpful
+in general, as class patterns are about matching patterns against attributes,
+while class instantiation is about matching call arguments to parameters in
+class constructors, which may not bear much resemblance to the resulting
+instance attributes at all.
+
 The second change is intended to make it easier to use pattern matching for the
 "ducktyping" style checks that are already common in Python.
+
+The concrete syntax proposal for these patterns then arose from viewing
+instances as mappings of attribute names to values, and combining the attribute
+lookup syntax (``.ATTR``), with the mapping pattern syntax ``{KEY: PATTERN}``
+to give ``cls{.ATTR: PATTERN}``.
+
+Allowing ``cls{.ATTR}`` to mean the same thing as ``cls{.ATTR: __}`` was a
+matter of considering the leading ``.`` sufficient to render the name usage
+unambiguous (it's clearly an attribute reference, whereas matching against a variable
+key in a mapping pattern would be arguably ambiguous)
 
 The final change just supplements a CPython-internal-only check in the PEP 634
 reference implementation by making it the default behaviour that classes get if
@@ -1471,10 +1524,22 @@ to the language, so it seems more appropriate to defer it to a separate proposal
 rather than including it here.
 
 
-Avoiding special cases in sequence matching
+Inferred a default type for instance attribute constraints
+----------------------------------------------------------
+
+The dedicated syntax for instance attribute constraints means that ``object``
+could be omitted from ``object{.ATTR}`` to give ``{.ATTR}`` without introducing
+any syntactic ambiguity.
+
+However, it's far from clear saving six characters is worth making it harder to
+visually distinguish mapping patterns from instance attribute patterns, so
+allowing this has been deferred as a topic for possible future consideration.
+
+
+Avoiding special cases in sequence patterns
 -------------------------------------------
 
-Sequence matching in both this PEP and PEP 634 currently special cases ``str``,
+Sequence patterns in both this PEP and PEP 634 currently special case ``str``,
 ``bytes``, and ``bytearray`` as specifically *never* matching a sequence
 pattern.
 
@@ -1637,6 +1702,7 @@ identity and equality checks into their lookup process - they don't purely
 rely on equality checks, as would be incorrectly implied by the use of the
 equality constraint prefix.
 
+
 Allowing the key/value separator to be omitted for mapping value constraints
 ----------------------------------------------------------------------------
 
@@ -1659,8 +1725,9 @@ Bucher's reference implementation for PEP 634 [4_].
 
 Relative to the text of this PEP, the draft reference implementation has not
 yet complemented the special casing of several builtin and standard library
-types in ``MATCH_CLASS`` with the more general check for the existence of
-``__match_args__``.
+types in ``MATCH_CLASS`` with the more general check for ``__match_args__``
+being set to ``None``. Class defined patterns also currenty still accept
+classes that don't define ``__match_args__``.
 
 All other modified patterns have been updated to follow this PEP rather than
 PEP 634.
@@ -1694,8 +1761,8 @@ specification where the two PEPs are the same (or at least very similar), the
 text describing the intended behaviour in this PEP is often derived directly
 from the PEP 634 text.
 
-Steven D'Aprano, who made a convincing case that the key goals of this PEP could
-be achieved by using existing comparison tokens to add the ability to override
+Steven D'Aprano, who made a compelling case that the key goals of this PEP could
+be achieved by using existing comparison tokens to tell the ability to override
 the compiler when our guesses as to "what most users will want most of the time"
 are inevitably incorrect for at least some users some of the time, and retaining
 some of PEP 634's syntactic sugar (with a slightly different semantic definition)
@@ -1712,7 +1779,9 @@ pattern specific soft keyword that is proposed here.
 
 Joao Bueno and Jim Jewett for nudging the PEP author to take a closer look at
 the proposed syntax for subelement capturing within class patterns and mapping
-patterns (particularly the problems with "capturing to the right").
+patterns (particularly the problems with "capturing to the right"). This
+review is what prompted the significant changes between v2 and v3 of the
+proposal.
 
 
 References
@@ -1744,6 +1813,7 @@ References
 
 .. [9] Kohn et al., Dynamic Pattern Matching with Python
    https://gvanrossum.github.io/docs/PyPatternMatching.pdf
+
 
 .. _Appendix A:
 
@@ -1941,8 +2011,15 @@ Relative to PEP 634 this PEP makes the following key changes:
   reusing ``Call``
 * to reduce verbosity, class attribute matching allows ``:`` to be omitted when
   the pattern to be matched starts with ``==``, ``is``, or ``as``
+* class patterns treat any class that sets ``__match_args__`` to ``None`` as
+  accepting a single positional pattern that is matched against the entire
+  object (avoiding the special casing required in PEP 634)
+* class patterns raise ``TypeError` when used with an object that does not
+  define ``__match_args__``
 * dedicated syntax for ducktyping is added, such that ``case cls{...}:`` is
-  equivalent to ``case cls(**{...}):``
+  roughly equivalent to ``case cls(**{...}):``, but skips the check for the
+  existence of ``__match_args__``. This pattern also has a dedicated AST node,
+  ``MatchAttrs``
 
 Note that postponing literal patterns also makes it possible to postpone the
 question of whether we need an "INUMBER" token in the tokeniser for imaginary

--- a/pep-0642.rst
+++ b/pep-0642.rst
@@ -527,26 +527,27 @@ being functionally equivalent::
     match expr:
         case {"key": == self.target}:
             ... # Handle the case where 'expr["key"] == self.target'
-        case _:
+        case __:
             ... # Handle the non-matching case
 
     _target = self.target
     match expr:
         case {"key": == _target}:
             ... # Handle the case where 'expr["key"] == self.target'
-        case _:
+        case __:
             ... # Handle the non-matching case
 
 By contrast, when using the syntactic shorthand that omits the marker prefix,
 the following two statements wouldn't be equivalent at all::
 
-    # PEP 634's value pattern syntax / this PEP's attribute constraint syntax
+    # PEP 634's value pattern syntax
     match expr:
         case {"key": self.target}:
             ... # Handle the case where 'expr["key"] == self.target'
         case _:
             ... # Handle the non-matching case
 
+    # PEP 634's capture pattern syntax
     _target = self.target
     match expr:
         case {"key": _target}:
@@ -554,10 +555,10 @@ the following two statements wouldn't be equivalent at all::
         case _:
             ... # Handle the non-matching case
 
-This PEP offers a straightforward way to retain the original semantics under
-this style of simplistic refactoring: use ``== _target`` to force interpretation
-of the result as a constraint pattern instead of a capture pattern (i.e. drop
-the no longer applicable syntactic shorthand, and switch to the explicit form).
+This PEP ensure the original semantics are retained under this style of
+simplistic refactoring: use ``== name`` to force interpretation
+of the result as a constraint pattern instead of a capture pattern, use
+`as name` for a name binding.
 
 PEP 634's proposal to offer only the shorthand syntax, with no explicitly
 prefixed form, means that the primary answer on offer is "Well, don't do that,
@@ -687,13 +688,14 @@ naively attempting to move the literal pattern out to a local variable for
 naming clarity turns the value checking literal pattern into a name binding
 capture pattern::
 
-    # PEP 634's literal pattern syntax / this PEP's literal constraint syntax
+    # PEP 634's literal pattern syntax
     match expr:
         case {"port": 443}:
             ... # Handle the case where 'expr["port"] == 443'
         case _:
             ... # Handle the non-matching case
 
+    # PEP 634's capture pattern syntax
     HTTPS_PORT = 443
     match expr:
         case {"port": HTTPS_PORT}:
@@ -708,24 +710,15 @@ semantics (just as it would for a value lookup in any other statement)::
     match expr:
         case {"port": == 443}:
             ... # Handle the case where 'expr["port"] == 443'
-        case _:
+        case __:
             ... # Handle the non-matching case
 
     HTTPS_PORT = 443
     match expr:
         case {"port": == HTTPS_PORT}:
             ... # Handle the case where 'expr["port"] == 443'
-        case _:
+        case __:
             ... # Handle the non-matching case
-
-As noted above, both literal patterns and value patterns made their return (in
-the form of inferred equality constraints) as a way to address the verbosity
-problem of offering explicit ``==`` prefixed equality constraints as the *only*
-way to express equality checks.
-
-However, the presence of the explicit constraint nodes in the AST means that
-these special cases can be limited to the parser, with the implicit forms
-emitting the same AST nodes as their explicit counterparts.
 
 
 Inferring equality constraints for f-strings

--- a/pep-0642.rst
+++ b/pep-0642.rst
@@ -35,13 +35,16 @@ types as follows:
         * equality constraints: ``== EXPR``
         * identity contraints: ``is EXPR``
     * sequence constraint patterns: ``[PTRN, as NAME, PTRN as NAME]``
-    * mapping constraint patterns: ``{EXPR: PTRN, EXPR == EXPR, EXPR as NAME}``
-    * attribute constraint patterns:
+    * mapping constraint patterns: ``{EXPR: PTRN, EXPR: == EXPR, EXPR as NAME}``
+    * instance attribute constraint patterns:
       ``CLS{.NAME, .NAME: PTRN, .NAME == EXPR, .NAME as NAME}``
-    * class constraint patterns:
-      ``CLS(PTRN, PTRN, **{.NAME, .NAME: PTRN, .NAME == EXPR, .NAME as NAME})``
+    * class defined constraint patterns:
+      ``CLS(PTRN, PTRN, **{.NAME, .NAME: PTRN, .NAME: == EXPR, .NAME as NAME})``
 * OR patterns: ``PTRN | PTRN | PTRN``
 * AS patterns: ``PTRN as NAME`` (omitting the pattern implies ``__``)
+
+Several of the subpattern specifications also require parentheses to avoid
+potential ambiguity.
 
 The intent of this approach is to:
 
@@ -55,7 +58,7 @@ The intent of this approach is to:
   adopted in ordinary expressions as a syntactic alternative to the ``getattr``
   builtin that better facilitates easy retrieval of multiple attributes
 
-Relative to PEP 634, the proposal also deliberately elimates any syntax that
+Relative to PEP 634, the proposal also deliberately eliminates any syntax that
 "binds to the right" without using the ``as`` keyword (using capture patterns
 in PEP 634's mapping patterns and class patterns) or binds to both the left and
 the right in the same pattern (using PEP 634's capture patterns with AS patterns)
@@ -130,11 +133,12 @@ of the original PEP 622 had previously been declined [2_]).
 However, the review process for this PEP strongly suggested that not only did
 the contradictions that Tobias mentioned in his email exist, but they were also
 concerning enough to cast doubts on the syntax proposal presented in PEP 634.
-Accordingly, this PEP was changed to go even further then PEP 634, and reduce
-the alignment between the sequence matching syntax and the existing iterable
-unpacking syntax (effectively answering "Not really" to the first question
-raised in the DLS'20 paper [9_]: "Can we extend a feature like iterable
-unpacking to work for more general object and data layouts?").
+Accordingly, this PEP was changed to go even further than PEP 634, and largely
+abandon alignment between the sequence matching syntax and the existing iterable
+unpacking syntax (effectively answering "Not really, as least as far as the
+exact syntax is concerned" to the first question raised in the DLS'20 paper
+[9_]: "Can we extend a feature like iterable unpacking to work for more general
+object and data layouts?").
 
 Finally, before completing the 3rd iteration of the proposal (which dropped
 inferred patterns entirely), the PEP author spent quite a bit of time reflecting
@@ -152,6 +156,9 @@ then we don't have any real way to revisit those decisions in a future release.
 
 Specification
 =============
+
+TODO: Update this section to match the updated Abstract/Motivation/Grammar
+
 
 This PEP retains the overall `match`/`case` statement syntax and semantics from
 PEP 634, but proposes multiple changes that mean that user intent is explicitly
@@ -906,6 +913,12 @@ Rejected Ideas
 
 TODO: Update this section to match the updated Abstract/Motivation/Grammar
 
+TODO: Add section on rejecting the idea "Make the ':' optional for value
+constraints in mapping patterns" idea. Without the ':' marker on the key
+expression, it allowed thoroughly baffling constructs like "case {0 == 0}:",
+so I dropped it. Attribute patterns weren't as obviously cryptic due to the
+'.' prefix on the attribute name so the "case object{.attr == expr}" shorthand
+ was kept there.
 
 Restricting permitted expressions in constraint patterns and mapping pattern keys
 ---------------------------------------------------------------------------------
@@ -1041,7 +1054,7 @@ would look like ordinary comparison operations, with nothing to suggest that
 Reference Implementation
 ========================
 
-TODO: Up date the reference impl to reflect v3 of the proposal (the v3 Grammar
+TODO: Update the reference impl to reflect v3 of the proposal (the v3 Grammar
 proposal should be stable enough to permit a first cut at this now)
 
 A reference implementation for this PEP [3_] has been derived from Brandt
@@ -1148,51 +1161,67 @@ Notation used beyond standard EBNF is as per PEP 534:
     subject_expr:
         | star_named_expression ',' [star_named_expressions]
         | named_expression
-    case_block: "case" patterns [guard] ':' block
-    guard: 'if' named_expression
+    case_block: "case" (guarded_pattern | open_pattern) ':' block
 
-    patterns: pattern
-    pattern:
+    guarded_pattern: closed_pattern 'if' named_expression
+    open_pattern: # Pattern may use multiple tokens with no closing delimiter
         | as_pattern
         | or_pattern
 
-    as_pattern: [or_pattern] pattern_as_clause
+    as_pattern: [closed_pattern] pattern_as_clause
     pattern_as_clause: 'as' pattern_capture_target
     pattern_capture_target: !"__" NAME !('.' | '(' | '=')
 
-    or_pattern: '|'.closed_pattern+
-    closed_pattern:
-        | wildcard_pattern
-        | group_pattern
-        | constraint_pattern
+    or_pattern: '|'.simple_pattern+
 
-    constraint_pattern:
+    simple_pattern: # Subnode where "as" and "or" patterns must be parenthesised
+        | closed_pattern
+        | value_constraint
+
+    value_constraint:
         | eq_constraint
         | id_constraint
+
+    eq_constraint: '==' closed_expr
+    id_constraint: 'is' closed_expr
+
+    closed_expr: # Require a single token or a closing delimiter in expression
+        | primary
+        | closed_factor
+
+    closed_factor: # "factor" is the main grammar node for these unary ops
+        | '+' primary
+        | '-' primary
+        | '~' primary
+
+    closed_pattern: # Require a single token or a closing delimiter in pattern
+        | wildcard_pattern
+        | group_pattern
+        | structural_constraint
+
+    wildcard_pattern: "__"
+
+    group_pattern: '(' open_pattern ')'
+
+    structural_constraint:
         | sequence_constraint
         | mapping_constraint
         | attrs_constraint
         | class_constraint
 
-    wildcard_pattern: "__"
-
-    group_pattern: '(' or_pattern ')'
-
-    eq_constraint: '==' primary
-    id_constraint: 'is' primary
-
     sequence_constraint: '[' [sequence_constraint_elements] ']'
-    sequence_constraint_elements: ','.maybe_star_pattern+ ','?
-    maybe_star_pattern: star_pattern | pattern
+    sequence_constraint_elements: ','.sequence_constraint_element+ ','?
+    sequence_constraint_element:
+        | star_pattern
+        | simple_named_pattern
+        | pattern_as_clause
     star_pattern: '*' (pattern_as_clause | wildcard_pattern)
 
     mapping_constraint: '{' [mapping_constraint_elements] '}'
     mapping_constraint_elements: ','.key_value_constraint+ ','?
     key_value_constraint:
-        | primary pattern_as_clause
-        | primary eq_constraint
-        | primary id_constraint
-        | primary ':' pattern
+        | closed_expr pattern_as_clause
+        | closed_expr ':' simple_pattern
         | double_star_capture
     double_star_capture: '**' pattern_as_clause
 
@@ -1201,9 +1230,8 @@ Notation used beyond standard EBNF is as per PEP 534:
     attrs_constraint_elements: ','.attr_value_pattern+ ','?
     attr_value_pattern:
         | '.' NAME pattern_as_clause
-        | '.' NAME eq_constraint
-        | '.' NAME id_constraint
-        | '.' NAME ':' pattern
+        | '.' NAME value_constraint
+        | '.' NAME ':' simple_pattern
         | '.' NAME
 
     class_constraint:
@@ -1211,7 +1239,10 @@ Notation used beyond standard EBNF is as per PEP 534:
     class_constraint_arguments:
         | positional_patterns [',' [class_constraint_attrs]]
         | class_constraint_attrs
-    positional_patterns: ','.pattern+
+    positional_patterns: ','.positional_pattern+
+    positional_pattern:
+        | simple_pattern
+        | pattern_as_clause
     class_constraint_attrs:
         | '**' '{' [attrs_constraint_elements] '}'
 

--- a/pep-0642.rst
+++ b/pep-0642.rst
@@ -53,10 +53,10 @@ types as follows:
 
 * wildcard pattern: ``__``
 * group patterns: ``(PTRN)``
-* constraint patterns:
-    * value constraint patterns:
-        * equality constraints: ``== EXPR``
-        * identity contraints: ``is EXPR``
+* value constraint patterns:
+    * equality constraints: ``== EXPR``
+    * identity contraints: ``is EXPR``
+* structural constraint patterns:
     * sequence constraint patterns: ``[PTRN, as NAME, PTRN as NAME]``
     * mapping constraint patterns: ``{EXPR: PTRN, EXPR as NAME}``
     * instance attribute constraint patterns:
@@ -65,9 +65,6 @@ types as follows:
       ``CLS(PTRN, PTRN, **{.NAME, .NAME: PTRN, .NAME == EXPR, .NAME as NAME})``
 * OR patterns: ``PTRN | PTRN | PTRN``
 * AS patterns: ``PTRN as NAME`` (omitting the pattern implies ``__``)
-
-Several of the subpattern specifications also require parentheses to avoid
-potential ambiguity (including when patterns are combined with guard expressions).
 
 The intent of this approach is to:
 
@@ -163,6 +160,12 @@ exact syntax is concerned" to the first question raised in the DLS'20 paper
 [9_]: "Can we extend a feature like iterable unpacking to work for more general
 object and data layouts?").
 
+This resulted in a complete reversal of the goals of the PEP: rather than
+attempting to emphasise the similarities between assignment and pattern matching,
+the PEP now attempts to make sure that assignment syntax isn't being reused
+*at all*, reducing the likelihood of incorrect inferences being drawn about the
+new construct based on experience with existing ones.
+
 Finally, before completing the 3rd iteration of the proposal (which dropped
 inferred patterns entirely), the PEP author spent quite a bit of time reflecting
 on the following entries in PEP 20:
@@ -173,26 +176,582 @@ on the following entries in PEP 20:
 
 If we start with an explicit syntax, we can always add syntactic shortcuts later
 (e.g. consider the recent proposals to add shortcuts for ``Union`` and
-``Optional`` type hints), but if we start out with only the abbreviated forms,
+``Optional`` type hints only after years of experience with the existing more
+verbose forms), while if we start out with only the abbreviated forms,
 then we don't have any real way to revisit those decisions in a future release.
 
 
 Specification
 =============
 
-TODO: Update this section to match the updated Abstract/Motivation/Grammar
+TODO: Finish updating this section to match the updated Abstract/Motivation/Grammar
 
 
-This PEP retains the overall `match`/`case` statement syntax and semantics from
-PEP 634, but proposes multiple changes that mean that user intent is explicitly
-specified in the concrete syntax rather than needing to be inferred from the
-pattern matching context. In the Abstract Syntax Tree, the semantics are also
-always explicit, with no inference required.
+This PEP retains the overall `match`/`case` statement structure and semantics
+from PEP 634, but proposes multiple changes that mean that user intent is
+explicitly specified in the concrete syntax rather than needing to be inferred
+from the pattern matching context.
 
-Guard expressions remain the same as they are in PEP 634, so they are not
-covered in any further detail in this PEP.
+In the proposed Abstract Syntax Tree, the semantics are also always explicit,
+with no inference required.
 
-TODO: Update this section to match the updated Abstract/Motivation/Grammar
+
+The Match Statement
+-------------------
+
+Syntax::
+
+  match_stmt: "match" subject_expr ':' NEWLINE INDENT case_block+ DEDENT
+  subject_expr:
+      | star_named_expression ',' star_named_expressions?
+      | named_expression
+  case_block: "case" (guarded_pattern | open_pattern) ':' block
+
+  guarded_pattern: closed_pattern 'if' named_expression
+
+  open_pattern:
+      | as_pattern
+      | or_pattern
+
+  closed_pattern:
+      | wildcard_pattern
+      | group_pattern
+      | structural_constraint
+
+The rules ``star_named_expression``, ``star_named_expressions``,
+``named_expression`` and ``block`` are part of the `standard Python
+grammar <https://docs.python.org/3.10/reference/grammar.html>`_.
+
+Open patterns are patterns which consist of multiple tokens, and aren't
+necessarily terminated by a closing delimiter (for example, ``__ as x``,
+``int() | bool()``). To avoid ambiguity for human readers, their usage is
+restricted to top level patterns and to group patterns (which are patterns
+surrounded by parentheses).
+
+Closed patterns are patterns which either consist of a single token
+(i.e. ``__``), or else have a closing delimeter as a required part of their
+syntax (e.g. ``[as x, as y]``, ``object{.x as x, .y as y}``).
+
+As in PEP 634, the ``match`` and ``case`` keywords are soft keywords, i.e. they
+are not reserved words in other grammatical contexts (including at the
+start of a line if there is no colon where expected).  This means
+that they are recognized as keywords when part of a match
+statement or case block only, and are allowed to be used in all
+other contexts as variable or argument names.
+
+For context, ``match_stmt`` is a new alternative for
+``compound_statement``::
+
+  compound_statement:
+      | if_stmt
+      ...
+      | match_stmt
+
+
+Match Semantics
+^^^^^^^^^^^^^^^
+
+This PEP retains the overall pattern matching semantics proposed in PEP 634.
+
+The proposed syntax for patterns changes significantly, and is discussed in
+detail below.
+
+There are also some proposed changes to the semantics of class defined
+constraints (class patterns in PEP 634) to eliminate the need to special case
+any builtin types (instead, the introduction of dedicated syntax for instance
+attribute constraints allows the behaviour needed by those builtin types to be
+specified as applying to any type that doesn't define ``__match_args__``)
+
+
+.. _guards:
+
+Guards
+^^^^^^
+
+This PEP retains the guard clause semantics proposed in PEP 634.
+
+However, the syntax is changed slightly to require that when a guard clause
+is present, the case pattern must be a *closed* pattern.
+
+This makes it clearer to the reader where the pattern ends and the guard clause
+begins.
+
+
+Irrefutable case blocks
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The definition of irrefutable case blocks changes slightly in this PEP relative
+to PEP 634, as capture patterns no longer exist.
+
+Aside from that caveat, the handling of irrefutable cases is the same as in
+PEP 634:
+
+* wildcard patterns are irrefutable
+* AS patterns whose left-hand side is irrefutable
+* OR patterns containing at least one irrefutable pattern
+* parenthesized irrefutable patterns
+* a case block is considered irrefutable if it has no guard and its
+  pattern is irrefutable.
+* a match statement may have at most one irrefutable case block, and it
+  must be last.
+
+
+.. _patterns:
+
+Patterns
+--------
+
+The top-level syntax for patterns is as follows::
+
+    open_pattern: # Pattern may use multiple tokens with no closing delimiter
+        | as_pattern
+        | or_pattern
+
+    as_pattern: [closed_pattern] pattern_as_clause
+
+    or_pattern: '|'.simple_pattern+
+
+    simple_pattern: # Subnode where "as" and "or" patterns must be parenthesised
+        | closed_pattern
+        | value_constraint
+
+    closed_pattern: # Require a single token or a closing delimiter in pattern
+        | wildcard_pattern
+        | group_pattern
+        | structural_constraint
+
+As described above, the usage of open patterns is limited to top level case
+clauses and when parenthesised in a group pattern.
+
+
+AS Patterns
+^^^^^^^^^^^
+
+Syntax::
+
+    as_pattern: [closed_pattern] pattern_as_clause
+    pattern_as_clause: 'as' pattern_capture_target
+    pattern_capture_target: !"__" NAME !('.' | '(' | '=')
+
+(Note: the name on the right may not be ``__``.)
+
+An AS pattern matches the closed pattern on the left of the ``as``
+keyword against the subject.  If this fails, the AS pattern fails.
+Otherwise, the AS pattern binds the subject to the name on the right
+of the ``as`` keyword and succeeds.
+
+If no pattern to match is given, the wildcard pattern (``__``) is implied.
+
+To avoid confusion with the `wildcard pattern`_, the double underscore (``__``)
+is not permitted as a capture target (this is what ``!"__"`` expresses).
+
+
+A capture pattern always succeeds.  It binds the subject value to the
+name using the scoping rules for name binding established for named expressions
+in PEP 572.  (Summary: the name becomes a local
+variable in the closest containing function scope unless there's an
+applicable ``nonlocal`` or ``global`` statement.)
+
+In a given pattern, a given name may be bound only once.  This
+disallows for example ``case [as x, as x]: ...`` but allows
+``case [as x] | (as x)``:
+
+As an open pattern, the usage of AS patterns is limited to top level case
+clauses and when parenthesised in a group pattern. However, several of the
+structural constraints allow the use of ``pattern_as_clause`` in relevant
+locations to bind extracted elements of the matched subject to local variables.
+
+
+OR Patterns
+^^^^^^^^^^^
+
+Syntax::
+
+    or_pattern: '|'.simple_pattern+
+
+    simple_pattern: # Subnode where "as" and "or" patterns must be parenthesised
+        | closed_pattern
+        | value_constraint
+
+When two or more patterns are separated by vertical bars (``|``),
+this is called an OR pattern. (A single simple pattern is just that)
+
+Only the final subpattern may be irrefutable.
+
+Each subpattern must bind the same set of names.
+
+An OR pattern matches each of its subpatterns in turn to the subject,
+until one succeeds.  The OR pattern is then deemed to succeed.
+If none of the subpatterns succeed the OR pattern fails.
+
+Subpatterns are mostly required to be closed patterns, but the parentheses may
+be omitted for value constraints.
+
+.. _value_constraints:
+
+Value constraints
+^^^^^^^^^^^^^^^^^
+
+Syntax::
+
+    value_constraint:
+        | eq_constraint
+        | id_constraint
+
+    eq_constraint: '==' closed_expr
+    id_constraint: 'is' closed_expr
+
+    closed_expr: # Require a single token or a closing delimiter in expression
+        | primary
+        | closed_factor
+
+    closed_factor: # "factor" is the main grammar node for these unary ops
+        | '+' primary
+        | '-' primary
+        | '~' primary
+
+The rule ``primary`` is defined in the standard Python grammar, and only
+allows expressions that either consist of a single token, or else are required
+to end with a closing delimiter.
+
+Value constraints replace PEP 634's literal patterns and value patterns.
+
+Equality constraints are written as ``== EXPR``, while identity constraints are
+written as ``is EXPR``.
+
+An equality constraint succeeds if the subject value compares equal to the
+value given on the right, while an identity constraint succeeds only if they are
+the exact same object.
+
+The expressions to be compared against are largely restricted to either
+single tokens (e.g. names, strings, numbers, builtin constants), or else to
+expressions that are required to end with a closing delimiter.
+
+The use of the high precedence unary operators is also permitted, as the risk of
+perceived ambiguity is low, and being able to specify negative numbers without
+parentheses is desirable.
+
+When the same constraint expression occurs multiple times in the same match
+statement, the interpreter may cache the first value calculated and reuse it,
+rather than repeat the expression evaluation. (As for PEP 634 value patterns,
+this cache is strictly tied to a given execution of a given match statement.)
+
+Unlike literal patterns in PEP 634, this PEP requires that complex
+literals be parenthesised to be accepted by the parser. See the Deferred
+Ideas section for discussion on that point.
+
+
+.. _wildcard_pattern:
+
+Wildcard Pattern
+^^^^^^^^^^^^^^^^
+
+Syntax::
+
+    wildcard_pattern: "__"
+
+A wildcard pattern always succeeds.  It binds no name.
+
+Where PEP 634 chooses the single underscore as its wildcard pattern for
+consistency with other languages, this PEP chooses the double underscore as that
+has a clearer path towards potentially being made consistent across the entire
+language, whereas that path is blocked for ``"_"`` by i18n related use cases.
+
+
+Group Patterns
+^^^^^^^^^^^^^^
+
+Syntax::
+
+  group_pattern: '(' open_pattern ')'
+
+For the syntax of ``open_pattern``, see Patterns above.
+
+A parenthesized pattern has no additional syntax.  It allows users to
+add parentheses around patterns to emphasize the intended grouping, and to
+allow nesting of open patterns when the grammar requires a closed pattern.
+
+Unlike PEP 634, there is not potential ambiguity with sequence patterns, as
+this PEP requires that all sequence patterns be written with square brackets.
+
+
+Structural constraints
+^^^^^^^^^^^^^^^^^^^^^^
+
+Syntax::
+
+    structural_constraint:
+        | sequence_constraint
+        | mapping_constraint
+        | attrs_constraint
+        | class_constraint
+
+Structural constraints are patterns used to both make assertions about complex
+objects and to extract values from them.
+
+These patterns may all bind multiple values, either through the use of nested
+AS patterns, or else through the use of ``pattern_as_clause`` elements included
+in the definition of the pattern.
+
+
+Sequence constraints
+^^^^^^^^^^^^^^^^^^^^^^
+
+Syntax::
+
+    sequence_constraint: '[' [sequence_constraint_elements] ']'
+    sequence_constraint_elements: ','.sequence_constraint_element+ ','?
+    sequence_constraint_element:
+        | star_pattern
+        | simple_pattern
+        | pattern_as_clause
+    star_pattern: '*' (pattern_as_clause | wildcard_pattern)
+
+    simple_pattern: # Subnode where "as" and "or" patterns must be parenthesised
+        | closed_pattern
+        | value_constraint
+
+    pattern_as_clause: 'as' pattern_capture_target
+
+Sequence constraints allow items within a sequence to be checked and
+optionally extracted.
+
+A sequence pattern fails if the subject value is not an instance of
+``collections.abc.Sequence``.  It also fails if the subject value is
+an instance of ``str``, ``bytes`` or ``bytearray`` (see Deferred Ideas for
+a discussion on potentially removing the need for this special casing).
+
+A sequence pattern may contain at most one star subpattern.  The star
+subpattern may occur in any position.  If no star subpattern is
+present, the sequence pattern is a fixed-length sequence pattern;
+otherwise it is a variable-length sequence pattern.
+
+A fixed-length sequence pattern fails if the length of the subject
+sequence is not equal to the number of subpatterns.
+
+A variable-length sequence pattern fails if the length of the subject
+sequence is less than the number of non-star subpatterns.
+
+The length of the subject sequence is obtained using the builtin
+``len()`` function (i.e., via the ``__len__`` protocol).  However, the
+interpreter may cache this value in a similar manner as described for
+value constraint expressions.
+
+A fixed-length sequence pattern matches the subpatterns to
+corresponding items of the subject sequence, from left to right.
+Matching stops (with a failure) as soon as a subpattern fails.  If all
+subpatterns succeed in matching their corresponding item, the sequence
+pattern succeeds.
+
+A variable-length sequence pattern first matches the leading non-star
+subpatterns to the corresponding items of the subject sequence, as for
+a fixed-length sequence.  If this succeeds, the star subpattern
+matches a list formed of the remaining subject items, with items
+removed from the end corresponding to the non-star subpatterns
+following the star subpattern.  The remaining non-star subpatterns are
+then matched to the corresponding subject items, as for a fixed-length
+sequence.
+
+Subpatterns are mostly required to be closed patterns, but the parentheses may
+be omitted for value constraints. Sequence elements may also be captured
+unconditionally without parentheses. 
+
+Note: where PEP 634 allows all the same syntactic flexibility as iterable
+unpacking in assignment statements, this PEP restricts sequence patterns
+specifically to the square bracket form. Given that the open and parenthesised
+forms are far more popular than square brackets for iterable unpacking, this
+helps emphasise that iterable unpacking and sequence matching are *not* the
+same operation. It also avoids the parenthesised form's ambiguity problem
+between single element sequence patterns and group patterns.
+
+Mapping constraints
+^^^^^^^^^^^^^^^^^^^
+
+Syntax::
+
+    mapping_constraint: '{' [mapping_constraint_elements] '}'
+    mapping_constraint_elements: ','.key_value_constraint+ ','?
+    key_value_constraint:
+        | closed_expr pattern_as_clause
+        | closed_expr ':' simple_pattern
+        | double_star_capture
+    double_star_capture: '**' pattern_as_clause
+
+(Note that ``**__`` is disallowed by this syntax, as additional mapping entries
+are ignored by default)
+
+closed_expr is defined above, under value constraints.
+
+Mapping constraints allow keys and values within a sequence to be checked and
+values to optionally be extracted.
+
+A mapping pattern fails if the subject value is not an instance of
+``collections.abc.Mapping``.
+
+A mapping pattern succeeds if every key given in the mapping pattern
+is present in the subject mapping, and the pattern for
+each key matches the corresponding item of the subject mapping. Keys
+are always compared with the ``==`` operator (TBC: is this actually true?
+Comparing by item retrieval seems more plausible, so double check the
+PEP 634 reference impl and amend both PEPs if this statement is not correct).
+
+If duplicate keys are detected in the mapping pattern, the pattern is
+considered invalid, and a ``ValueError`` is raised.
+
+A mapping pattern may not contain duplicate key values.
+(If all key patterns are literal patterns this is considered a
+syntax error; otherwise this is a runtime error and will
+raise ``TypeError``.)
+
+(TBC: Moving these two paragraphs next to each other shows an internal
+inconsistency in the PEP 634 text about the runtime behaviour. Need to check
+the PEP 634 reference impl and submit a PR to clarify this)
+
+If a ``'**' as NAME`` double star pattern is present, that name is bound to a
+``dict`` containing any remaining key-value pairs from the subject mapping
+(the dict will be empty if there are no additional key-value pairs).
+
+A mapping pattern may contain at most one double star pattern,
+and it must be last.
+
+Key-value pairs are matched using the two-argument form of the
+subject's ``get()`` method.  As a consequence, matched key-value pairs
+must already be present in the mapping, and not created on-the-fly by
+``__missing__`` or ``__getitem__``.  For example,
+``collections.defaultdict`` instances will only be matched by patterns
+with keys that were already present when the match statement was
+entered.
+
+Value subpatterns are mostly required to be closed patterns, but the parentheses
+may be omitted for value constraints. Mapping values may also be captured
+unconditionally using the ``KEY as NAME`` form, without either parentheses or
+the ``:`` key value separator.
+
+
+
+Instance attribute constraints
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Syntax::
+
+    attrs_constraint:
+        | name_or_attr '{' [attrs_constraint_elements] '}'
+    attrs_constraint_elements: ','.attr_value_pattern+ ','?
+    attr_value_pattern:
+        | '.' NAME pattern_as_clause
+        | '.' NAME value_constraint
+        | '.' NAME ':' simple_pattern
+        | '.' NAME
+
+Instance attribute constraints allow an instance's type to be checked and
+attributes to optionally be extracted.
+
+An instance attribute constraint may not repeat the same attribute name multiple
+times.
+
+An instance attribute pattern fails if the subject is not an instance of
+``name_or_attr``. This is tested using ``isinstance()``.
+
+If ``name_or_attr`` is not an instance of the builtin ``type``,
+``TypeError`` is raised.
+
+If no attribute subpatterns are present, the constraint succeeds if the
+``isinstance()`` check succeeds. Otherwise:
+
+  - Each given attribute name is looked up as an attribute on the subject.
+
+    - If this raises an exception other than ``AttributeError``,
+      the exception bubbles up.
+
+    - If this raises ``AttributeError`` the constraint fails.
+
+    - Otherwise, the subpattern associated with the keyword is matched
+      against the attribute value. If no subpattern is specified, the wildcard
+      pattern is assumed. If this fails, the constraint fails.
+      If it succeeds, the match proceeds to the next attribute.
+
+  - If all attribute subpatterns succeed, the constraint as a whole succeeds.
+
+
+Instance attribute constraints allow ducktyping checks to be implemented by
+using ``object`` as the required instance type (e.g.
+``object{.host as host, .port as port}``).
+
+The syntax being proposed here could potentially also be used as the basis for
+a new syntax for retrieving multiple attributes from an object instance in one
+assignment statement (e.g. ``host, port = addr{.host, .port}``). See the
+Deferred Ideas section for further discussion of this point.
+
+
+Class defined constraints
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Syntax::
+
+    class_constraint:
+        | name_or_attr '(' [class_constraint_arguments] ')'
+    class_constraint_arguments:
+        | positional_patterns [',' [class_constraint_attrs]]
+        | class_constraint_attrs
+    positional_patterns: ','.positional_pattern+
+    positional_pattern:
+        | simple_pattern
+        | pattern_as_clause
+    class_constraint_attrs:
+        | '**' '{' [attrs_constraint_elements] '}'
+
+Class defined constraints allow a sequence of common attributes to be
+specified on a class and checked positionally, rather than needing to specify
+the attribute names in every related match pattern.
+
+As for instance attribute patterns:
+
+- a class defined pattern fails if the subject is not an instance of
+  ``name_or_attr``. This is tested using ``isinstance()``.
+- if ``name_or_attr`` is not an instance of the builtin ``type``,
+  ``TypeError`` is raised.
+- if no arguments are present, the pattern succeeds if the ``isinstance()``
+  check succeeds.
+
+If any arguments are present, the subject is checked for a ``__match_args__``
+attribute using the equivalent of ``getattr(cls, "__match_args__", None))``.
+
+If this raises an exception the exception bubbles up.
+
+If the returned value is not a list, tuple, or ``None``, the conversion fails
+and ``TypeError`` is raised at runtime.
+
+If ``__match_args__`` is None, then only a single positional subpattern is
+permitted. Attempting to specify additional attribute patterns either
+positionally or using the double star syntax will cause ``TypeError`` to be
+raised at runtime.
+
+This positional subpattern is then matched against the entire subject, allowing
+a type check to be combined with another match pattern (e.g. checking both
+the type and contents of a container, or the type and value of a number).
+
+If ``__match_args__`` is a list or tuple, then the class defined constraint is
+converted to an instance attributes constraint as follows:
+
+- if only the double star attribute constraints subpattern is present, matching
+  proceeds as if for the equivalent instance attributes constraint.
+- if there are more positional subpatterns than the length of
+  ``__match_args__``` (as obtained using ``len()``), ``TypeError`` is raised.
+- Otherwise, positional pattern ``i`` is converted to an attribute pattern
+  using ``__match_args__[i]`` as the attribute name.
+- if any element in ``__match_args__`` is not a string, ``TypeError`` is raised.
+- once the positional patterns have been converted to attribute patterns, then
+  they are combined with any atribute constrains given in the double star
+  attribute constraints subpattern, and matching proceeds as if for the
+  equivalent instance attributes constraint.
+
+Note: the ``__match_args__ is None`` handling in this PEP replaces the special
+casing of ``bool``, ``bytearray``, ``bytes``, ``dict``, ``float``,
+``frozenset``, ``int``, ``list``, ``set``, ``str``, and ``tuple`` in PEP 634.
+
+
+# TODO: Delete most of the remaining specific sections as redundant with the
+#       new subsections above
 
 Capture patterns
 ----------------
@@ -865,6 +1424,8 @@ Deferred Ideas
 
 TODO: Update this section to match the updated Abstract/Motivation/Grammar
 
+TODO: Add collections.abc.AtomicSequence as a deferred idea to eliminate the
+special casing of str, bytes, and bytearray in sequence matching.
 
 Allowing negated constraints in match patterns
 ----------------------------------------------
@@ -934,7 +1495,7 @@ constraints in mapping patterns" idea. Without the ':' marker on the key
 expression, it allowed thoroughly baffling constructs like "case {0 == 0}:",
 so I dropped it. Attribute patterns weren't as obviously cryptic due to the
 '.' prefix on the attribute name so the "case object{.attr == expr}" shorthand
- was kept there.
+was kept there.
 
 Restricting permitted expressions in constraint patterns and mapping pattern keys
 ---------------------------------------------------------------------------------
@@ -1099,11 +1660,12 @@ Acknowledgments
 
 The PEP 622 and PEP 634/635/636 authors, as the proposal in this PEP is merely
 an attempt to improve the readability of an already well-constructed idea by
-proposing that reusing the existing attribute binding syntax to mean an
-attribute lookup will be more easily understood as syntactic sugar for a more
-explicit underlying expression that's compatible with the existing binding
-target syntax than it will be as the *only* way to spell such comparisons in
-match patterns.
+proposing that starting with a more explicit syntax and potentially introducing
+syntactic shortcuts for particularly common operations later is a better option
+than attempting to *only* define the shortcut version. For areas of the
+specification where the two PEPs are the same (or at least very similar), the
+text describing the intended behaviour in this PEP is often derived directly
+from the PEP 634 text.
 
 Steven D'Aprano, who made a convincing case that the key goals of this PEP could
 be achieved by using existing comparison tokens to add the ability to override
@@ -1123,7 +1685,7 @@ pattern specific soft keyword that is proposed here.
 
 Joao Bueno and Jim Jewett for nudging the PEP author to take a closer look at
 the proposed syntax for subelement capturing within class patterns and mapping
-patterns.
+patterns (particularly the problems with "capturing to the right").
 
 
 References
@@ -1229,7 +1791,7 @@ Notation used beyond standard EBNF is as per PEP 534:
     sequence_constraint_elements: ','.sequence_constraint_element+ ','?
     sequence_constraint_element:
         | star_pattern
-        | simple_named_pattern
+        | simple_pattern
         | pattern_as_clause
     star_pattern: '*' (pattern_as_clause | wildcard_pattern)
 

--- a/pep-0642.rst
+++ b/pep-0642.rst
@@ -34,7 +34,7 @@ the "port" as optional in all cases::
     match expr:
         case [as host, as port]:
             pass
-        case {"host" as host, "port": int() as port}:
+        case {"host" as host, "port" as port}:
             pass
         case {"host" as host}:
             pass


### PR DESCRIPTION
* requires that all uses of bare names be qualified with the user's intent
* ensures that all name binding operations in patterns use the ``as`` keyword
* drops alignment with iterable unpacking syntax (always requires square brackets)
* drops alignment with class instantiation syntax (defines a new dedicated instance attribute matching syntax instead)