### PR TITLE
PEP 12: Clean up and modernize guidelines.

### DIFF
--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -82,9 +82,8 @@ directions below.
 - For many PEPs, discussions will take place on python-ideas@python.org
   and/or python-dev@python.org. If there is another mailing list or
   public forum more appropriate for discussion of your new feature,
-  add a Discussions-To
-  header right after the Author header. Most Informational PEPs don't
-  need a Discussions-To header.
+  add a Discussions-To header right after the Author header. Most
+  Informational PEPs don't need a Discussions-To header.
 
 - Change the Status header to "Draft".
 
@@ -115,10 +114,10 @@ directions below.
       Python-Version: 2.2
 
 - Leave Post-History alone for now; you'll add dates to this header
-  each time you post your PEP to the designated mailing list (see the
-  Discussions-To header above). If you posted your PEP to the lists on
-  August 14, 2001 and September 3, 2001, the Post-History header would
-  look like::
+  each time you post your PEP to the designated discussion forum (see
+  the Discussions-To header above). If you posted your PEP to the lists
+  on August 14, 2001 and September 3, 2001, the Post-History header
+  would look like::
 
       Post-History: 14-Aug-2001, 03-Sept-2001
 

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -49,8 +49,8 @@ How to Use This Template
 To use this template you must first decide whether your PEP is going
 to be an Informational or Standards Track PEP.  Most PEPs are
 Standards Track because they propose a new feature for the Python
-language or standard library.  When in doubt, read PEP 1 for details
-or contact a PEP editor for assistance.
+language or standard library.  When in doubt, read PEP 1 for details,
+or open a tracker issue on the PEPs repo to ask for assistance.
 
 Once you've decided which type of PEP yours is going to be, follow the
 directions below.

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -80,8 +80,9 @@ directions below.
   header with the name of the core developer sponsoring your PEP.
 
 - For many PEPs, discussions will take place on python-ideas@python.org
-  and/or python-dev@python.org. If there is another mailing list more
-  appropriate for discussion of your new feature, add a Discussions-To
+  and/or python-dev@python.org. If there is another mailing list or
+  public forum more appropriate for discussion of your new feature,
+  add a Discussions-To
   header right after the Author header. Most Informational PEPs don't
   need a Discussions-To header.
 

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -50,26 +50,20 @@ To use this template you must first decide whether your PEP is going
 to be an Informational or Standards Track PEP.  Most PEPs are
 Standards Track because they propose a new feature for the Python
 language or standard library.  When in doubt, read PEP 1 for details
-or contact the PEP editors <peps@python.org>.
+or contact a PEP editor for assistance.
 
 Once you've decided which type of PEP yours is going to be, follow the
 directions below.
 
-- Make a copy of this file (``.txt`` or ``.rst`` file, **not** HTML!)
-  and perform the following edits. Prefer ``.rst`` extensions as this
-  will allow PEPs to be rendered on GitHub. ``.txt`` extensions still
-  exists for legacy reasons.
+- Make a copy of this file (the ``.rst`` file, **not** the HTML!) and
+  perform the following edits. The ``.rst`` extension will allow your
+  your PEP to be rendered on GitHub. (``.txt`` extensions still exist
+  for legacy reasons but are discouraged for new PEPs.)
 
-- Replace the "PEP: 12" header with "PEP: 9999" since you don't yet
-  have a PEP number assignment.
+- Replace the "PEP: 12" header with "PEP: 9999" if you don't yet
+  have a PEP number assignment, or with the actual number.
 
 - Change the Title header to the title of your PEP.
-
-- Leave the Version and Last-Modified headers alone; we'll take care
-  of those when we check your PEP into Python's Subversion repository.
-  These headers consist of keywords ("Revision" and "Date" enclosed in
-  "$"-signs) which are automatically expanded by the repository.
-  Please do not edit the expanded date or revision text.
 
 - Change the Author header to include your name, and optionally your
   email address.  Be sure to follow the format carefully: your name
@@ -78,16 +72,14 @@ directions below.
   it appears, it must appear in angle brackets.  It is okay to
   obfuscate your email address.
 
-- If none of the authors are Python core developers and this PEP is
-  ready to be submitted to the PEP repository, include a Sponsor header
-  with the name of the core developer sponsoring your PEP.
+- If none of the authors are Python core developers, include a Sponsor
+  header with the name of the core developer sponsoring your PEP.
 
-- If there is a mailing list for discussion of your new feature, add a
-  Discussions-To header right after the Author header.  You should not
-  add a Discussions-To header if the mailing list to be used is either
-  python-ideas@python.org or python-dev@python.org, or if discussions
-  should be sent to you directly.  Most Informational PEPs don't have
-  a Discussions-To header.
+- For many PEPs, discussions will take place on python-ideas@python.org
+  and/or python-dev@python.org. If there is another mailing list more
+  appropriate for discussion of your new feature, add a Discussions-To
+  header right after the Author header. Most Informational PEPs don't
+  need a Discussions-To header.
 
 - Change the Status header to "Draft".
 
@@ -118,15 +110,15 @@ directions below.
       Python-Version: 2.2
 
 - Leave Post-History alone for now; you'll add dates to this header
-  each time you post your PEP to python-ideas@python.org and/or
-  python-dev@python.org.  If you posted your PEP to the lists on
+  each time you post your PEP to the designated mailing list (see the
+  Discussions-To header above). If you posted your PEP to the lists on
   August 14, 2001 and September 3, 2001, the Post-History header would
   look like::
 
       Post-History: 14-Aug-2001, 03-Sept-2001
 
-  You must manually add new dates and check them in.  If you don't
-  have check-in privileges, send your changes to the PEP editors.
+  You must manually add new dates and commit them (with a pull request
+  if you don't have push privileges).
 
 - Add a Replaces header if your PEP obsoletes an earlier PEP.  The
   value of this header is the number of the PEP that your new PEP is
@@ -151,7 +143,8 @@ directions below.
 - Leave the Emacs stanza at the end of this file alone, including the
   formfeed character ("^L", or ``\f``).
 
-- Send your PEP submission to the PEP editors at peps@python.org.
+- Create a pull request against the https://github.com/python/peps
+  repository.
 
 For reference, here are all of the possible header fields (everything
 in brackets should either be replaced or have the field removed if
@@ -516,7 +509,7 @@ the URL template::
     http://www.python.org/dev/peps/pep-xxxx
 
 PEP numbers in URLs must be padded with zeros from the left, so as to
-be exactly 4 characters wide, however PEP numbers in the text are
+be exactly 4 characters wide; however, PEP numbers in the text are
 never padded.
 
 During the course of developing your PEP, you may have to add, remove,

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -56,8 +56,8 @@ Once you've decided which type of PEP yours is going to be, follow the
 directions below.
 
 - Make a copy of this file (the ``.rst`` file, **not** the HTML!) and
-  perform the following edits. Name the new file ``pep-9999.txt`` if
-  you don't yet have a PEP number assignment, or ``pep-NNNN.txt`` if
+  perform the following edits. Name the new file ``pep-9999.rst`` if
+  you don't yet have a PEP number assignment, or ``pep-NNNN.rst`` if
   you do. Those with push permissions are welcome to claim the next
   available number (ignoring the special blocks 3000 and 8000, and a
   handful of special allocations - currently 666, 754, and 801) and

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -56,12 +56,16 @@ Once you've decided which type of PEP yours is going to be, follow the
 directions below.
 
 - Make a copy of this file (the ``.rst`` file, **not** the HTML!) and
-  perform the following edits. The ``.rst`` extension will allow your
-  your PEP to be rendered on GitHub. (``.txt`` extensions still exist
-  for legacy reasons but are discouraged for new PEPs.)
+  perform the following edits. Name the new file ``pep-9999.txt`` if
+  you don't yet have a PEP number assignment, or ``pep-NNNN.txt`` if
+  you do. Those with push permissions are welcome to claim the next
+  available number (ignoring the special blocks 3000 and 8000, and a
+  handful of special allocations - currently 666, 754, and 801) and
+  push it directly.
 
-- Replace the "PEP: 12" header with "PEP: 9999" if you don't yet
-  have a PEP number assignment, or with the actual number.
+- Replace the "PEP: 12" header with "PEP: 9999" or "PEP: NNNN",
+  matching the file name. Note that the file name should be padded with
+  zeros (eg ``pep-0012.rst``), but the header should not (``PEP: 12``).
 
 - Change the Title header to the title of your PEP.
 


### PR DESCRIPTION
The peps@python.org list has been shut down, and everything is done via
GitHub pull requests. Also, we no longer need some of the older steps,
and it's easier to read if some of the obscure/unusual options are
buried away in parentheses.

Open to discussion, can split this up if it's controversial.
