### PR TITLE
PEP 650: Updates to the API

### DIFF
--- a/pep-0650.rst
+++ b/pep-0650.rst
@@ -341,12 +341,16 @@ invoke_uninstall
 Uninstall the specified dependencies::
 
     def invoke_uninstall(
+        path: Union[str, bytes, PathLike[str]],
         *,
         dependency_group: str = None,
         **kwargs
     ) -> int:
         ...
 
+* ``path`` : An absolute path where the *installer backend* should be
+  invoked from (e.g. the directory where ``pyproject.toml`` is
+  located).
 * ``dependency_group`` : An optional flag specifying a dependency
   group that the *installer backend* should uninstall.
 * ``**kwargs`` : Arbitrary parameters that a *installer backend* may
@@ -370,11 +374,16 @@ Returns the dependencies that would be installed by
 installed without parsing the dependency file::
 
     def get_dependencies_to_install(
+        path: Union[str, bytes, PathLike[str]],
+        *,
         dependency_group: str = None,
         **kwargs
     ) -> List[str]:
         ...
 
+* ``path`` : An absolute path where the *installer backend* should be
+  invoked from (e.g. the directory where ``pyproject.toml`` is
+  located).
 * ``dependency_group`` : Specify a dependency group to get the
   dependencies ``invoke_install(...)`` would install for that
   dependency group.
@@ -402,10 +411,14 @@ Returns the dependency groups available to be installed. This allows
 *installer backend* is aware of::
 
     def get_dependency_groups(
+        path: Union[str, bytes, PathLike[str]],
         **kwargs
     ) -> FrozenSet[str]:
         ...
 
+* ``path`` : An absolute path where the *installer backend* should be
+  invoked from (e.g. the directory where ``pyproject.toml`` is
+  located).
 * ``**kwargs`` : Arbitrary parameters that a *installer backend* may
   require that are not already specified, allows for backwards
   compatibility.
@@ -418,6 +431,7 @@ update_dependencies
 Outputs a dependency file based off of inputted package list::
 
     def update_dependencies(
+        path: Union[str, bytes, PathLike[str]],
         dependency_specifiers: Iterable[str],
         *,
         dependency_group=None,
@@ -425,6 +439,9 @@ Outputs a dependency file based off of inputted package list::
     ) -> int:
         ...
 
+* ``path`` : An absolute path where the *installer backend* should be
+  invoked from (e.g. the directory where ``pyproject.toml`` is
+  located).
 * ``dependency_specifiers`` : An iterable of dependencies as
   :pep:`508` strings that are being updated, for example :
   ``["requests==2.8.1", ...]``. Optionally for a specific dependency

--- a/pep-0650.rst
+++ b/pep-0650.rst
@@ -306,10 +306,10 @@ invoke_install
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Installs the dependencies::
 
-    def  invoke_install(
-        path : typing.Union[str, bytes, os.PathLike[str]],
+    def invoke_install(
+        path: Union[str, bytes, PathLike[str]],
         *,
-        dependency_group : string = None,
+        dependency_group: str = None,
         **kwargs
     ) -> int:
         ...
@@ -340,9 +340,9 @@ invoke_uninstall
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Uninstall the specified dependencies::
 
-    def  invoke_uninstall(
+    def invoke_uninstall(
         *,
-        dependency_group : string = None,
+        dependency_group: str = None,
         **kwargs
     ) -> int:
         ...
@@ -370,7 +370,7 @@ Returns the dependencies that would be installed by
 installed without parsing the dependency file::
 
     def get_dependencies_to_install(
-        dependency_group : string = None,
+        dependency_group: str = None,
         **kwargs
     ) -> List[str]:
         ...
@@ -403,7 +403,8 @@ Returns the dependency groups available to be installed. This allows
 
     def get_dependency_groups(
         **kwargs
-    ) -> FrozenSet[str]
+    ) -> FrozenSet[str]:
+        ...
 
 * ``**kwargs`` : Arbitrary parameters that a *installer backend* may
   require that are not already specified, allows for backwards
@@ -417,7 +418,7 @@ update_dependencies
 Outputs a dependency file based off of inputted package list::
 
     def update_dependencies(
-        dependency_specifiers : Iterable[str],
+        dependency_specifiers: Iterable[str],
         *,
         dependency_group=None,
         **kwargs


### PR DESCRIPTION
This fixes some minor formatting issues with the provided API functions.

It also adds the `path` argument to all functions: this is required for any installer that stores it's dependency information in a file in a local directory -- the backend must always know which directory it should be running from.

(cc @brettcannon)
