### PR TITLE
PEP 637: Added notation use case for star arguments on PEP 646

### DIFF
--- a/pep-0637.rst
+++ b/pep-0637.rst
@@ -154,6 +154,9 @@ specification would improve notation and provide additional value:
      >>> # The call is now shorter, more mnemonic, and looks+works like typing
      >>> trio.run[name="func"](func, value1, param2=value2)
 
+7. Availability of star arguments would benefit PEP-646 Variadic Generics [#pep-0646]_, 
+   especially in the forms ``a[*x]`` and ``a[*x, *y, p, q, *z]``. The PEP details
+   exactly this notation in its "Unpacking: Star Operator" section.
 
 It is important to note that how the notation is interpreted is up to the
 implementation. This PEP only defines and dictates the behavior of python
@@ -1049,6 +1052,8 @@ References
        (https://www.python.org/dev/peps/pep-0001/#what-belongs-in-a-successful-pep)
 .. [#trio-run] "trio.run() should take \*\*kwargs in addition to \*args"
        (https://github.com/python-trio/trio/issues/470)
+.. [#pep-0646] "PEP 646 -- Variadic Generics"
+       (https://www.python.org/dev/peps/pep-0646)
 .. [#numpy-ml] "[Numpy-discussion] Request for comments on PEP 637 - Support for indexing with keyword arguments"
        (http://numpy-discussion.10968.n7.nabble.com/Request-for-comments-on-PEP-637-Support-for-indexing-with-keyword-arguments-td48489.html)
 .. [#reference-impl] "Reference implementation"


### PR DESCRIPTION
Adds a use case in the proposal for star arguments as needed in PEP 646 Variadic Generics.