### PR TITLE
PEP 619: Update 3.10.0a4 to be marked as released

### DIFF
--- a/pep-0619.rst
+++ b/pep-0619.rst
@@ -46,10 +46,10 @@ Actual:
 - 3.10.0 alpha 1: Monday, 2020-10-05
 - 3.10.0 alpha 2: Monday, 2020-11-03
 - 3.10.0 alpha 3: Monday, 2020-12-07
+- 3.10.0 alpha 4: Monday, 2021-01-04
 
 Expected:
 
-- 3.10.0 alpha 4: Monday, 2021-01-04
 - 3.10.0 alpha 5: Monday, 2021-02-01
 - 3.10.0 alpha 6: Monday, 2021-03-01
 - 3.10.0 alpha 7: Monday, 2021-04-05


### PR DESCRIPTION
3.10.0a4 was released https://www.python.org/downloads/release/python-3100a4/