### PR TITLE
Various typo/grammar/style fixes

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -350,7 +350,7 @@ on potential use cases for the Provisional status.
 
 A PEP can also be assigned the status "Deferred".  The PEP author or an
 editor can assign the PEP this status when no progress is being made
-on the PEP.  Once a PEP is deferred, a PEP editor can re-assign it
+on the PEP.  Once a PEP is deferred, a PEP editor can reassign it
 to draft status.
 
 A PEP can also be "Rejected".  Perhaps after all is said and done it

--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -209,7 +209,7 @@ For flowing long blocks of text with fewer structural restrictions
 characters.
 
 Limiting the required editor window width makes it possible to have
-several files open side-by-side, and works well when using code
+several files open side by side, and works well when using code
 review tools that present the two versions in adjacent columns.
 
 The default wrapping in most tools disrupts the visual structure of the

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -169,7 +169,7 @@ your PEP)::
   Python-Version: [M.N]
   Post-History: [YYYY-MM-DD]
   Replaces: *[NNN]
-  Superceded-By: *[NNN]
+  Superseded-By: *[NNN]
   Resolution:
 
 

--- a/pep-0013.rst
+++ b/pep-0013.rst
@@ -188,7 +188,7 @@ In exceptional circumstances, the core team may remove a sitting
 council member, or the entire council, via a vote of no confidence.
 
 A no-confidence vote is triggered when a core team member calls for
-one publically on an appropriate project communication channel, and
+one publicly on an appropriate project communication channel, and
 another core team member seconds the proposal.
 
 The vote lasts for two weeks. Core team members vote for or against.

--- a/pep-0101.txt
+++ b/pep-0101.txt
@@ -243,7 +243,7 @@ to perform some manual editing steps.
 - Consider running ``autoconf`` using the currently accepted standard version
   in case ``configure`` or other autoconf-generated files were last
   committed with a newer or older version and may contain spurious or
-  harmful differences.  Currently, autoconf 2.69 is our de-facto standard.
+  harmful differences.  Currently, autoconf 2.69 is our de facto standard.
   if there are differences, commit them.
 
 - Make sure the ``SOURCE_URI`` in ``Doc/tools/extensions/pyspecific.py``

--- a/pep-0241.txt
+++ b/pep-0241.txt
@@ -93,7 +93,7 @@ necessarily incomplete.
 
 ::
 
-    POSIX, MacOS, Windows, BeOS, PalmOS.
+    POSIX, MacOS, Windows, BeOS, Palm OS.
 
 Binary distributions will use the Supported-Platform field in
 their metadata to specify the OS and CPU for which the binary

--- a/pep-0250.txt
+++ b/pep-0250.txt
@@ -16,7 +16,7 @@ Abstract
 
 The standard Python distribution includes a directory
 ``Lib/site-packages``, which is used on Unix platforms to hold
-locally-installed modules and packages.  The ``site.py`` module
+locally installed modules and packages.  The ``site.py`` module
 distributed with Python includes support for locating other
 modules in the site-packages directory.
 

--- a/pep-0275.txt
+++ b/pep-0275.txt
@@ -230,7 +230,7 @@ Issues
 
 The switch statement should not implement fall-through
 behaviour (as does the switch statement in C). Each case
-defines a complete and independent suite; much like in a
+defines a complete and independent suite; much like in an
 if-elif-else statement. This also enables using break in
 switch statements inside loops.
 

--- a/pep-0283.txt
+++ b/pep-0283.txt
@@ -293,7 +293,7 @@ Features that did not make it into Python 2.3
   has made a little progress with a new compiler, but it's going
   slow and the compiler is only the first step.  Maybe we'll be
   able to refactor the compiler in this release.  I'm tempted to
-  say we won't hold our breath.  In the mean time, Oren Tirosh has
+  say we won't hold our breath.  In the meantime, Oren Tirosh has
   a much simpler idea that may give a serious boost to the
   performance of accessing globals and built-ins, by optimizing
   and inlining the dict access: http://tothink.com/python/fastnames/

--- a/pep-0289.txt
+++ b/pep-0289.txt
@@ -277,7 +277,7 @@ Acknowledgements
   Hye-Shik Chang and Raymond Hettinger teased out the issues surrounding
   early versus late binding [5]_.
 
-* Jiwon Seo single handedly implemented various versions of the proposal
+* Jiwon Seo single-handedly implemented various versions of the proposal
   including the final version loaded into CVS.  Along the way, there
   were periodic code reviews by Hye-Shik Chang and Raymond Hettinger.
   Guido van Rossum made the key design decisions after comments from

--- a/pep-0302.txt
+++ b/pep-0302.txt
@@ -100,7 +100,7 @@ Squeeze, Installer and py2exe use an ``__import__`` based scheme (py2exe
 currently uses Installer's ``iu.py``, Squeeze used ``ihooks.py``), MacPython
 has two Mac-specific import hooks hard wired into ``import.c``, that are
 similar to the Freeze hook.  The hooks proposed in this PEP enables us (at
-least in theory; it's not a short term goal) to get rid of the hard coded
+least in theory; it's not a short-term goal) to get rid of the hard coded
 hooks in ``import.c``, and would allow the ``__import__``-based tools to get
 rid of most of their ``import.c`` emulation code.
 
@@ -134,7 +134,7 @@ objects.  This avoids some breakage, and seems to work well for Jython (where
 it is used to load modules from ``.jar`` files), but it was perceived as an
 "ugly hack".
 
-This lead to a more elaborate scheme, (mostly copied from McMillan's
+This led to a more elaborate scheme, (mostly copied from McMillan's
 ``iu.py``) in which each in a list of candidates is asked whether it can
 handle the ``sys.path`` item, until one is found that can.  This list of
 candidates is a new object in the ``sys`` module: ``sys.path_hooks``.

--- a/pep-0319.txt
+++ b/pep-0319.txt
@@ -54,7 +54,7 @@ The 'synchronize' Keyword
 The 'asynchronize' Keyword
     While executing a 'synchronize' block of code a programmer may
     want to "drop back" to running asynchronously momentarily to run
-    blocking input/output routines or something else that might take a
+    blocking input/output routines or something else that might take an
     indeterminate amount of time and does not require synchronization.
     This code usually follows the pattern::
 

--- a/pep-0327.txt
+++ b/pep-0327.txt
@@ -104,7 +104,7 @@ implement a fixed point data type over Decimal.
 
 But why can't we have a floating point number with infinite precision?
 It's not so easy, because of inexact divisions.  E.g.: 1/3 =
-0.3333333333333... ad infinitum.  In this case you should store a
+0.3333333333333... ad infinitum.  In this case you should store an
 infinite amount of 3s, which takes too much memory, ;).
 
 John Roth proposed to eliminate the division operator and force the

--- a/pep-0333.txt
+++ b/pep-0333.txt
@@ -292,7 +292,7 @@ such functions as:
 * Routing a request to different application objects based on the
   target URL, after rewriting the ``environ`` accordingly.
 
-* Allowing multiple applications or frameworks to run side-by-side
+* Allowing multiple applications or frameworks to run side by side
   in the same process
 
 * Load balancing and remote processing, by forwarding requests and

--- a/pep-0349.txt
+++ b/pep-0349.txt
@@ -29,7 +29,7 @@ Rationale
 Python has had a Unicode string type for some time now but use of
 it is not yet widespread.  There is a large amount of Python code
 that assumes that string data is represented as str instances.
-The long term plan for Python is to phase out the str type and use
+The long-term plan for Python is to phase out the str type and use
 unicode for all string data.  Clearly, a smooth migration path
 must be provided.
 

--- a/pep-0408.txt
+++ b/pep-0408.txt
@@ -208,12 +208,12 @@ releases every 6 months (perhaps limited to standard library updates). If
 such a change to the release cycle is made, the following policy for the
 ``__preview__`` namespace is suggested:
 
-* For long term support releases, the ``__preview__`` namespace would always
+* For long-term support releases, the ``__preview__`` namespace would always
   be empty.
 * New modules would be accepted into the ``__preview__`` namespace only in
-  interim releases that immediately follow a long term support release.
+  interim releases that immediately follow a long-term support release.
 * All modules added will either be migrated to their final location in the
-  standard library or dropped entirely prior to the next long term support
+  standard library or dropped entirely prior to the next long-term support
   release.
 
 

--- a/pep-0410.txt
+++ b/pep-0410.txt
@@ -456,7 +456,7 @@ The new fields can be timestamps with nanosecond resolution (e.g. Decimal) or
 the nanosecond part of each timestamp (int).
 
 If the new fields are timestamps with nanosecond resolution, populating the
-extra fields would be time consuming. Any call to os.stat() would be slower,
+extra fields would be time-consuming. Any call to os.stat() would be slower,
 even if os.stat() is only called to check if a file exists. A parameter can be
 added to os.stat() to make these fields optional, the structure would have a
 variable number of fields.

--- a/pep-0431.txt
+++ b/pep-0431.txt
@@ -70,7 +70,7 @@ can be easily installed with the Python packaging tools such as
 ``easy_install`` or ``pip``. This could also be done on Unices that are no
 longer receiving updates and therefore have an outdated database.
 
-With such a mechanism Python would have full time zone support in the
+With such a mechanism Python would have full-time zone support in the
 standard library on any platform, and a simple package installation would
 provide an updated time zone database on those platforms where the zoneinfo
 database isn't included, such as Windows, or on platforms where OS updates

--- a/pep-0432.txt
+++ b/pep-0432.txt
@@ -1040,7 +1040,7 @@ the relevant locations.
 One acknowledged incompatibility is that some environment variables which
 are currently read lazily may instead be read once during interpreter
 initialization. As the reference implementation matures, these will be
-discussed in more detail on a case by case basis. The environment variables
+discussed in more detail on a case-by-case basis. The environment variables
 which are currently known to be looked up dynamically are:
 
 * ``PYTHONCASEOK``: writing to ``os.environ['PYTHONCASEOK']`` will no longer

--- a/pep-0444.txt
+++ b/pep-0444.txt
@@ -316,7 +316,7 @@ functions as:
 * Routing a request to different application objects based on the
   target URL, after rewriting the ``environ`` accordingly.
 
-* Allowing multiple applications or frameworks to run side-by-side in
+* Allowing multiple applications or frameworks to run side by side in
   the same process.
 
 * Load balancing and remote processing, by forwarding requests and

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -1092,7 +1092,7 @@ that have been compromised, and the columns to its right show whether the
 compromised roles leave clients susceptible to malicious updates, a freeze
 attack, or metadata inconsistency attacks. Note that if the timestamp, snapshot,
 and bin-n roles are stored in the same online location, a compromise of one
-means they will all be compromised. Therefore the table considers these
+means they will all be compromised. Therefore, the table considers these
 roles together. A version of this table that considers these roles separately
 is included in PEP 480 [21]_.
 

--- a/pep-0462.txt
+++ b/pep-0462.txt
@@ -14,8 +14,8 @@ Post-History: 25-Jan-2014, 27-Jan-2014, 01-Feb-2015
 Abstract
 ========
 
-This PEP proposes investing in automation of several of the tedious, time
-consuming activities that are currently required for the core development
+This PEP proposes investing in automation of several of the tedious,
+time-consuming activities that are currently required for the core development
 team to incorporate changes into CPython. This proposal is intended to
 allow core developers to make more effective use of the time they have
 available to contribute to CPython, which should also result in an improved
@@ -341,7 +341,7 @@ developer present (such as the sprints at PyCon AU for the last
 few years), the merge queue would allow that developer to focus more of
 their time on reviewing patches and helping the other contributors at the
 sprint, since accepting a patch for inclusion would now be a single click
-in the Kallithea UI, rather than the relatively time consuming process that
+in the Kallithea UI, rather than the relatively time-consuming process that
 it is currently. Even when multiple core developers are present, it is
 better to enable them to spend their time and effort on interacting with
 the other sprint participants than it is on things that are sufficiently

--- a/pep-0466.txt
+++ b/pep-0466.txt
@@ -596,7 +596,7 @@ That approach created unnecessary uncertainty, so it has been simplified to
 propose backport a specific concrete set of changes. Future feature
 backport proposals can refer back to this PEP as precedent, but it will
 still be necessary to make a specific case for each feature addition to
-the Python 2.7 long term support release.
+the Python 2.7 long-term support release.
 
 
 Disclosure of Interest

--- a/pep-0469.txt
+++ b/pep-0469.txt
@@ -354,7 +354,7 @@ versions are pretty much equivalent from a readability perspective.
 So unless I've missed something critical, readily available ``listvalues()``
 and ``listitems()`` helper functions look like they will improve the
 readability of hybrid code more than anything we could add back to the
-Python 3.5+ mapping API, and won't have any long term impact on the
+Python 3.5+ mapping API, and won't have any long-term impact on the
 complexity of Python 3 itself.
 
 

--- a/pep-0474.txt
+++ b/pep-0474.txt
@@ -42,7 +42,7 @@ repository management system be deployed as "forge.python.org".
 
 Individual repositories (such as the developer guide or the PEPs repository)
 may then be migrated from the existing hg.python.org infrastructure to the
-new forge.python.org infrastructure on a case by case basis. Each migration
+new forge.python.org infrastructure on a case-by-case basis. Each migration
 will need to decide whether to retain a read-only mirror on hg.python.org,
 or whether to just migrate wholesale to the new location.
 

--- a/pep-0475.txt
+++ b/pep-0475.txt
@@ -67,8 +67,8 @@ Status in Python 3.4
 --------------------
 
 In Python 3.4, handling the ``InterruptedError`` exception (``EINTR``'s
-dedicated exception class) is duplicated at every call site on a case by
-case basis.  Only a few Python modules actually handle this exception,
+dedicated exception class) is duplicated at every call site on a case-by-case
+basis.  Only a few Python modules actually handle this exception,
 and fixes usually took several years to cover a whole module.  Example of
 code retrying ``file.read()`` on ``InterruptedError``::
 

--- a/pep-0480.txt
+++ b/pep-0480.txt
@@ -345,7 +345,7 @@ Distutils
 ---------
 
 `Distutils`__ MAY be modified to sign metadata and to upload signed distributions
-to PyPI.  Distutils comes packaged with CPython and is the most widely-used
+to PyPI.  Distutils comes packaged with CPython and is the most widely used
 tool for uploading distributions to PyPI.
 
 __ https://docs.python.org/2/distutils/index.html#distutils-index

--- a/pep-0481.txt
+++ b/pep-0481.txt
@@ -198,7 +198,7 @@ require installing the ``arc`` command line tool to upload patches to
 Phabricator.
 
 Whether to enable Phabricator for any particular repository can be chosen on
-a case by case basis, this PEP only proposes that it must be enabled for the
+a case-by-case basis, this PEP only proposes that it must be enabled for the
 CPython repository, however for smaller repositories such as the PEP repository
 it may not be worth the effort.
 

--- a/pep-0499.txt
+++ b/pep-0499.txt
@@ -113,7 +113,7 @@ do something very similar to this proposal:
 the __init__.py file is bound to the module's canonical name
 and the __main__.py file is bound to "__main__".
 As such, the double import issue does not occur.
-Therefore this PEP proposes to affect only simple non-package modules.
+Therefore, this PEP proposes to affect only simple non-package modules.
 
 
 Considerations and Prerequisites
@@ -143,7 +143,7 @@ Chris Angelico points out that it becomes possible to import a
 module whose ``__name__`` is not what you gave to "import", since
 "__main__" is now present at "module.name", so a subsequent
 ``import module.name`` finds it already present.
-Therefore ``__name__`` is no longer the canonical name for some normal imports.
+Therefore, ``__name__`` is no longer the canonical name for some normal imports.
 
 Some counter arguments follow:
 

--- a/pep-0505.rst
+++ b/pep-0505.rst
@@ -600,7 +600,7 @@ In the specification section, all uses of ``x is None`` would be replaced with
 ``not x.__has_value__()``.
 
 This generalization would allow for domain-specific "no-value" objects to be
-coalesced just like ``None``. For example the ``pyasn1`` package has a type
+coalesced just like ``None``. For example, the ``pyasn1`` package has a type
 called ``Null`` that represents an ASN.1 ``null``::
 
     >>> from pyasn1.type import univ

--- a/pep-0509.txt
+++ b/pep-0509.txt
@@ -551,10 +551,10 @@ Thread on the mailing lists:
   <https://mail.python.org/pipermail/python-dev/2016-April/144137.html>`_
 * python-dev: `PEP 509: Add a private version to dict
   <https://mail.python.org/pipermail/python-dev/2016-January/142685.html>`_
-  (january 2016)
+  (January 2016)
 * python-ideas: `RFC: PEP: Add dict.__version__
   <https://mail.python.org/pipermail/python-ideas/2016-January/037702.html>`_
-  (january 2016)
+  (January 2016)
 
 
 Acceptance

--- a/pep-0519.txt
+++ b/pep-0519.txt
@@ -460,7 +460,7 @@ the protocol helpfully avoids any accidental opting into the protocol.
 Provide specific type hinting support
 -------------------------------------
 
-There was some consideration to provding a generic ``typing.PathLike``
+There was some consideration to providing a generic ``typing.PathLike``
 class which would allow for e.g. ``typing.PathLike[str]`` to specify
 a type hint for a path object which returned a string representation.
 While potentially beneficial, the usefulness was deemed too small to

--- a/pep-0525.txt
+++ b/pep-0525.txt
@@ -586,7 +586,7 @@ accomplish that.
 
 In terms of implementation, ``asend()`` is a slightly more generic
 version of ``__anext__``, and ``athrow()`` is very similar to
-``aclose()``.  Therefore having these methods defined for asynchronous
+``aclose()``.  Therefore, having these methods defined for asynchronous
 generators does not add any extra complexity.
 
 

--- a/pep-0526.txt
+++ b/pep-0526.txt
@@ -487,7 +487,7 @@ Note that if annotations are not found statically, then the
 ``__annotations__`` dictionary is not created at all. Also the
 value of having annotations available locally does not offset
 the cost of having to create and populate the annotations dictionary
-on every function call. Therefore annotations at function level are
+on every function call. Therefore, annotations at function level are
 not evaluated and not stored.
 
 Other uses of annotations

--- a/pep-0527.txt
+++ b/pep-0527.txt
@@ -206,7 +206,7 @@ A sdist on PyPI should be a single source of truth for a particular release of
 software. However, currently PyPI allows you to upload one sdist for each of
 the sdist file extensions it allows. Currently this allows something like 10
 different sdists for a project, but even with this PEP it allows two different
-sources of truth for a single version. Having multiple sdists often times can
+sources of truth for a single version. Having multiple sdists oftentimes can
 account for strange bugs that only expose themselves based on which sdist that
 the person used.
 

--- a/pep-0542.txt
+++ b/pep-0542.txt
@@ -42,7 +42,7 @@ attribute, it requires an additional assignment statement to be made::
   # Assign to class attribute
   MyClass.my_function = my_function
 
-  # Or assign to instance attribtue
+  # Or assign to instance attribute
   my_instance.my_function = my_function
 
 While this isn't usually an inconvenience, using dot notation to

--- a/pep-0544.txt
+++ b/pep-0544.txt
@@ -223,7 +223,7 @@ approaches related to structural subtyping in Python and other languages:
   Note that optional interface members are supported. Also, TypeScript
   prohibits redundant members in implementations. While the idea of
   optional members looks interesting, it would complicate this proposal and
-  it is not clear how useful it will be. Therefore it is proposed to postpone
+  it is not clear how useful it will be. Therefore, it is proposed to postpone
   this; see `rejected`_ ideas. In general, the idea of static protocol
   checking without runtime implications looks reasonable, and basically
   this proposal follows the same line.
@@ -548,7 +548,7 @@ the declared variance. Examples::
   another_var: Proto[int]
   var = another_var  # Error! 'Proto[float]' is incompatible with 'Proto[int]'.
 
-Note that unlike nominal classes, de-facto covariant protocols cannot be
+Note that unlike nominal classes, de facto covariant protocols cannot be
 declared as invariant, since this can break transitivity of subtyping
 (see `rejected`_ ideas for details). For example::
 
@@ -1205,7 +1205,7 @@ the code probably would not make any sense to an average reader
 to construct an instance of ``A``, which could be problematic if this requires
 accessing or allocating some resources such as files or sockets.
 We could work around the latter by using a cast, for example, but then
-the code would be ugly. Therefore we discourage the use of this pattern.
+the code would be ugly. Therefore, we discourage the use of this pattern.
 
 
 Support ``isinstance()`` checks by default
@@ -1286,7 +1286,7 @@ This was rejected for the following reasons:
 
 * Convenience: There are existing protocol-like ABCs (that may be turned
   into protocols) that have many useful "mix-in" (non-abstract) methods.
-  For example in the case of ``Sequence`` one only needs to implement
+  For example, in the case of ``Sequence`` one only needs to implement
   ``__getitem__`` and ``__len__`` in an explicit subclass, and one gets
   ``__iter__``, ``__contains__``, ``__reversed__``, ``index``, and ``count``
   for free.

--- a/pep-0545.txt
+++ b/pep-0545.txt
@@ -375,7 +375,7 @@ Simplified English
 ''''''''''''''''''
 
 It would be possible to introduce a "simplified English" version like
-wikipedia did [10]_, as discussed on python-dev [11]_, targeting
+Wikipedia did [10]_, as discussed on python-dev [11]_, targeting
 English learners and children.
 
 Pros: It yields a single translation, theoretically readable by

--- a/pep-0549.rst
+++ b/pep-0549.rst
@@ -77,7 +77,7 @@ members of *instances* of a class without the member being declared
 as a class variable.
 
 Although this is being proposed as a general mechanism, the author
-currently only forsees this as being useful for module objects.
+currently only foresees this as being useful for module objects.
 
 Implementation
 ==============

--- a/pep-0550.rst
+++ b/pep-0550.rst
@@ -29,7 +29,7 @@ PEP Status
 ==========
 
 Due to its breadth and the lack of general consensus on some aspects, this
-PEP has been withdrawn and superceded by a simpler :pep:`567`, which has
+PEP has been withdrawn and superseded by a simpler :pep:`567`, which has
 been accepted and included in Python 3.7.
 
 :pep:`567` implements the same core idea, but limits the ContextVar support
@@ -1361,7 +1361,7 @@ APIs like redirecting stdout by overwriting ``sys.stdout``, or
 specifying new exception display hooks by overwriting the
 ``sys.displayhook`` function are affecting the whole Python process
 **by design**.  Their users assume that the effect of changing
-them will be visible across OS threads.  Therefore we cannot
+them will be visible across OS threads.  Therefore, we cannot
 just make these APIs to use the new Execution Context.
 
 That said we think it is possible to design new APIs that will

--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -584,7 +584,7 @@ reason about concurrency when objects only exist in one interpreter
 at a time.  At a technical level, CPython's current memory model
 limits how Python *objects* may be shared safely between interpreters;
 effectively objects are bound to the interpreter in which they were
-created.  Furthermore the complexity of *object* sharing increases as
+created.  Furthermore, the complexity of *object* sharing increases as
 subinterpreters become more isolated, e.g. after GIL removal.
 
 Consequently,the mechanism for sharing needs to be carefully considered.
@@ -671,7 +671,7 @@ Existing Usage
 --------------
 
 Subinterpreters are not a widely used feature.  In fact, the only
-documented cases of wide-spread usage are
+documented cases of widespread usage are
 `mod_wsgi <https://github.com/GrahamDumpleton/mod_wsgi>`_,
 `OpenStack Ceph <https://github.com/ceph/ceph/pull/14971>`_, and
 `JEP <https://github.com/ninia/jep>`_.  On the one hand, these cases
@@ -1009,7 +1009,7 @@ the following:
 * brief examples of how to use subinterpreters and channels
 * a summary of the limitations of subinterpreters
 * (for extension maintainers) a link to the resources for ensuring
-  subinterpreter compatibilty
+  subinterpreter compatibility
 * much of the API information in this PEP
 
 A separate page will be added to the docs for resources to help
@@ -1031,7 +1031,7 @@ Note that the documentation will play a large part in mitigating any
 negative impact that the new ``interpreters`` module might have on
 extension module maintainers.
 
-Also, the ``ImportError`` for imcompatible extgension modules will have
+Also, the ``ImportError`` for incompatible extgension modules will have
 a message that clearly says it is due to missing subinterpreter
 compatibility and that extensions are not required to provide it.  This
 will help set user expectations properly.
@@ -1319,7 +1319,7 @@ Make RunFailedError.__cause__ lazy
 An uncaught exception in a subinterpreter (from ``run()``) is copied
 to the calling interpreter and set as ``__cause__`` on a
 ``RunFailedError`` which is then raised.  That copying part involves
-some sort of deserialization in the calling intepreter, which can be
+some sort of deserialization in the calling interpreter, which can be
 expensive (e.g. due to imports) yet is not always necessary.
 
 So it may be useful to use an ``ExceptionProxy`` type to wrap the
@@ -1369,11 +1369,11 @@ interpreters would actually share the underlying mutex.  This would
 provide much better efficiency than blocking channel ops.  The main
 concern is that locks and channels don't mix well (as learned in Go).
 
-Note that the same functionality as a lock can be acheived by passing
+Note that the same functionality as a lock can be achieved by passing
 some sort of "token" object through a channel.  "send()" would be
 equivalent to releasing the lock and "recv()" to acquiring the lock.
 
-We can add this later if it proves desireable without much trouble.
+We can add this later if it proves desirable without much trouble.
 
 Propagate SystemExit and KeyboardInterrupt Differently
 ------------------------------------------------------

--- a/pep-0557.rst
+++ b/pep-0557.rst
@@ -705,7 +705,7 @@ Why not just use namedtuple?
   same number of fields. For example: ``Point3D(2017, 6, 2) ==
   Date(2017, 6, 2)``.  With Data Classes, this would return False.
 
-- A namedtuple can be accidentally compared to a tuple.  For example
+- A namedtuple can be accidentally compared to a tuple.  For example,
   ``Point2D(1, 10) == (1, 10)``.  With Data Classes, this would return
   False.
 

--- a/pep-0558.rst
+++ b/pep-0558.rst
@@ -355,7 +355,7 @@ This means it is desirable to offer C APIs that give predictable, scope
 independent, behaviour. However, it is also desirable to allow C code to
 exactly mimic the behaviour of Python code at the same scope.
 
-To enable mimicing the behaviour of Python code, the stable C ABI would gain
+To enable mimicking the behaviour of Python code, the stable C ABI would gain
 the following new functions::
 
     PyObject * PyLocals_Get();

--- a/pep-0560.rst
+++ b/pep-0560.rst
@@ -97,7 +97,7 @@ Hacks and bugs that will be removed by this proposal
   subscription thus allowing generics with ``__slots__``.
 
 - General complexity of the ``typing`` module. The new proposal will not
-  only allow to remove the above mentioned hacks/bugs, but also simplify
+  only allow to remove the above-mentioned hacks/bugs, but also simplify
   the implementation, so that it will be easier to maintain.
 
 

--- a/pep-0565.rst
+++ b/pep-0565.rst
@@ -323,7 +323,7 @@ changes in 3.7:
   settings (including ``-Wd``) into one command line flag:
   https://bugs.python.org/issue32043
 * changing the behaviour in debug builds to show more of the warnings that are
-  off by default in regular interpeter builds: https://bugs.python.org/issue32088
+  off by default in regular interpreter builds: https://bugs.python.org/issue32088
 
 Independently of the proposed changes to the default filters in this PEP,
 issue 32229 [9_] is a proposal to add a ``warnings.hide_warnings`` API to

--- a/pep-0567.rst
+++ b/pep-0567.rst
@@ -91,7 +91,7 @@ use the new mechanism should:
 
 The notion of "current value" deserves special consideration:
 different asynchronous tasks that exist and execute concurrently
-may have different values for the same key.  This idea is well-known
+may have different values for the same key.  This idea is well known
 from thread-local storage but in this case the locality of the value is
 not necessarily bound to a thread.  Instead, there is the notion of the
 "current ``Context``" which is stored in thread-local storage.

--- a/pep-0570.rst
+++ b/pep-0570.rst
@@ -456,7 +456,7 @@ The following would apply:
 * Positional-only parameters which do not have default
   values are *required* positional-only parameters.
 
-Therefore the following would be valid function definitions::
+Therefore, the following would be valid function definitions::
 
     def name(p1, p2, /, p_or_kw, *, kw):
     def name(p1, p2=None, /, p_or_kw=None, *, kw):

--- a/pep-0571.rst
+++ b/pep-0571.rst
@@ -165,7 +165,7 @@ the ``manylinux2010`` tag:
    ABI tag indicating its Unicode ABI.  A ``manylinux2010`` wheel built
    against Python 2, then, must include either the ``cpy27mu`` tag
    indicating it was built against an interpreter with the UCS-4 ABI
-   or the ``cpy27m`` tag indicating an interpeter with the UCS-2
+   or the ``cpy27m`` tag indicating an interpreter with the UCS-2
    ABI. [8]_ [9]_
 5. A wheel *must not* require the ``PyFPE_jbuf`` symbol.  This is
    achieved by building it against a Python compiled *without* the

--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -63,7 +63,7 @@ obfuscated").
 
 Yet there is some use for both extremely simple and extremely complex
 examples: they are helpful to clarify the intended semantics.
-Therefore there will be some of each below.
+Therefore, there will be some of each below.
 
 However, in order to be *compelling*, examples should be rooted in
 real code, i.e. code that was written without any thought of this PEP,

--- a/pep-0579.rst
+++ b/pep-0579.rst
@@ -21,7 +21,7 @@ As noted in `PEP 1 <https://www.python.org/dev/peps/pep-0001/#pep-types>`_:
    consensus or recommendation, so users and implementers are free to
    ignore Informational PEPs or follow their advice.
 
-While there is no concensus on whether the issues or the solutions in
+While there is no consensus on whether the issues or the solutions in
 this PEP are valid, the list is still useful to guide further design.
 
 

--- a/pep-0584.rst
+++ b/pep-0584.rst
@@ -290,7 +290,7 @@ expected behavior, and will remain expected behavior regardless of
 whether it is spelled as ``update()`` or ``|``.
 
 Other types of union are also lossy, in the sense of not being
-reversable; you cannot get back the two operands given only the union.
+reversible; you cannot get back the two operands given only the union.
 ``a | b == 365``... what are ``a`` and ``b``?
 
 

--- a/pep-0586.rst
+++ b/pep-0586.rst
@@ -63,7 +63,7 @@ considered to be of type ``MyEnum``.
 
 Currently, type checkers work around this limitation by adding ad hoc
 extensions for important builtins and standard library functions. For
-example mypy comes bundled with a plugin that attempts to infer more
+example, mypy comes bundled with a plugin that attempts to infer more
 precise types for ``open(...)``. While this approach works for standard
 library functions, it’s unsustainable in general: it’s not reasonable to
 expect 3rd party library authors to maintain plugins for N different
@@ -493,7 +493,7 @@ by using ``S = Literal["foo"]`` instead.
 
 **Note:** Literal types and generics deliberately interact in only very
 basic and limited ways. In particular, libraries that want to type check
-code containing an heavy amount of numeric or numpy-style manipulation will
+code containing a heavy amount of numeric or numpy-style manipulation will
 almost certainly likely find Literal types as proposed in this PEP to be
 insufficient for their needs.
 
@@ -654,7 +654,7 @@ we very likely will need some form of dependent typing along with other
 extensions like variadic generics to support popular libraries like numpy.
 
 This PEP should be seen as a stepping stone towards this goal,
-rather then an attempt at providing a comprehensive solution.
+rather than an attempt at providing a comprehensive solution.
 
 Adding more concise syntax
 --------------------------

--- a/pep-0592.rst
+++ b/pep-0592.rst
@@ -26,7 +26,7 @@ Motivation
 ==========
 
 Whenever a project detects that a particular release on PyPI might be
-broken, they often times will want to prevent further users from
+broken, they oftentimes will want to prevent further users from
 inadvertently using that version. However, the obvious solution of
 deleting the existing file from a repository will break users who have
 followed best practices and pinned to a specific version of the project.

--- a/pep-0593.rst
+++ b/pep-0593.rst
@@ -20,13 +20,13 @@ Motivation
 ----------
 
 PEP 484 provides a standard semantic for the annotations introduced in
-PEP 3107. PEP 484 is prescriptive but it is the de-facto standard
+PEP 3107. PEP 484 is prescriptive but it is the de facto standard
 for most of the consumers of annotations; in many statically checked
 code bases, where type annotations are widely used, they have
 effectively crowded out any other form of annotation. Some of the use
 cases for annotations described in PEP 3107 (database mapping,
 foreign languages bridge) are not currently realistic given the
-prevalence of type annotations. Furthermore the standardisation of type
+prevalence of type annotations. Furthermore, the standardisation of type
 annotations rules out advanced features only supported by specific type
 checkers.
 
@@ -235,7 +235,7 @@ cause ``Annotated`` to not integrate cleanly with the other typing annotations:
 
 * ``Annotated`` cannot infer the decorated type. You could imagine that
   ``Annotated[..., Immutable]`` could be used to mark a value as immutable
-  while still infering its type. Typing does not support using the
+  while still inferring its type. Typing does not support using the
   inferred type anywhere else [issue-276]_; it's best to not add this as a
   special case.
 

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -61,7 +61,7 @@ for several reasons.
   development team. The team has limited resources, reduced maintenance cost
   frees development time for other improvements.
 * Modules in the standard library are generally favored and seen as the
-  de-facto solution for a problem. A majority of users only pick third-party
+  de facto solution for a problem. A majority of users only pick third-party
   modules to replace a stdlib module, when they have a compelling reason, e.g.
   ``lxml`` instead of ``xml``. The removal of an unmaintained stdlib module
   increases the chances of a community-contributed module to become widely
@@ -86,7 +86,7 @@ an option. This can be corporate environments or classrooms where external
 code is not permitted without legal approval.
 
 * The usage of FTP is declining, but some files are still provided over
-  the FTP protocol or hosters offer FTP to upload content. Therefore
+  the FTP protocol or hosters offer FTP to upload content. Therefore,
   ``ftplib`` is going to stay.
 * The ``optparse`` and ``getopt`` modules are widely used. They are mature
   modules with very low maintenance overhead.
@@ -216,7 +216,7 @@ audio processing.
 
 Some module deprecations proposed by :pep:`3108` for 3.0 and :pep:`206` for
 2.0. The *added in* column illustrates, when a module was originally designed
-and added to the standard library. The *has maintainer* colum refers to the
+and added to the standard library. The *has maintainer* column refers to the
 `expert index <https://devguide.python.org/experts/>`_, a list of domain
 experts and maintainers in the DevGuide.
 
@@ -925,7 +925,7 @@ The `lib2to3 <https://docs.python.org/3/library/2to3.html>`_ package provides
 the ``2to3`` command to transpile Python 2 code to Python 3 code.
 
 The package is useful for other tasks besides porting code from Python 2 to
-3. For example `Black`_ uses it for code reformatting.
+3. For example, `Black`_ uses it for code reformatting.
 
 Module type
   pure Python
@@ -994,7 +994,7 @@ Future maintenance of removed modules
 =====================================
 
 The main goal of the PEP is to reduce the burden and workload on the Python
-core developer team. Therefore removed modules will not be maintained by
+core developer team. Therefore, removed modules will not be maintained by
 the core team as separate PyPI packages. However the removed code, tests and
 documentation may be moved into a new Git repository, so community members
 have a place from which they can pick up and fork code.
@@ -1006,7 +1006,7 @@ the packages. It is my hope that members of the Python community will
 adopt, maintain, and perhaps improve the deprecated modules.
 
 It's my hope that some of the deprecated modules will be picked up and
-adopted by users that actually care about them. For example ``colorsys`` and
+adopted by users that actually care about them. For example, ``colorsys`` and
 ``imghdr`` are useful modules, but have limited feature set. A fork of
 ``imghdr`` can add new features and support for more image formats, without
 being constrained by Python's release cycle.
@@ -1015,7 +1015,7 @@ Most of the modules are in pure Python and can be easily packaged. Some
 depend on a simple C module, e.g. `audioop`_ and `crypt`_. Since `audioop`_
 does not depend on any external libraries, it can be shipped as binary
 wheels with some effort. Other C modules can be replaced with ``ctypes`` or ``cffi``.
-For example I created `legacycrypt`_, which provides a full implementation of
+For example, I created `legacycrypt`_, which provides a full implementation of
 ``crypt``. It is implemented on top of a ctypes wrapper around ``libxcrypt``
 and ``libcrypt`` instead of a C extension like the original ``_crypt``
 module.

--- a/pep-0595.rst
+++ b/pep-0595.rst
@@ -527,7 +527,7 @@ References
 
    https://python.zulipchat.com/#narrow/stream/130206-pep581/topic/s.2Fn.20ratio
 
-.. [#] For example this and other related PRs:
+.. [#] For example, this and other related PRs:
 
    https://github.com/python/cpython/pull/9099
 

--- a/pep-0598.rst
+++ b/pep-0598.rst
@@ -45,8 +45,8 @@ Summary
 
 The proposal to keep the current CPython release compatibility management
 process, but go through it more often has significant practical downsides,
-as a CPython feature release carries certain expectations (most notably, a 5
-year maintenance lifecycle, support for parallel installation with the previous
+as a CPython feature release carries certain expectations (most notably, a 5-year
+maintenance lifecycle, support for parallel installation with the previous
 feature release, and the possibility of breaking changes to the CPython-specific
 ABI, requiring recompilation of all extension modules) that mean faster feature
 releases in their current form have the potential to significantly increase the
@@ -62,7 +62,7 @@ today).
 
 This PEP presents a competing proposal to instead *slow down* the frequency of
 parallel installable feature releases that change the filesystem layout
-and CPython ABI to a consistent 24 month cycle, but to compensate for this by
+and CPython ABI to a consistent 24-month cycle, but to compensate for this by
 introducing the notion of build compatible incremental feature releases, and
 then deferring the full feature freeze of a given feature release series from
 the initial baseline X.Y.0 release to a subsequent X.Y.Z feature complete
@@ -620,21 +620,21 @@ While the exact formulation of that policy is still being discussed, the initial
 proposal was very simple: support any Python feature release published within
 the last 42 months.
 
-For an 18 month feature release cadence, that works out to always supporting at
+For an 18-month feature release cadence, that works out to always supporting at
 least the two most recent feature releases, and then dropping support for all
 X.Y.z releases around 6 months after X.(Y+2).0 is released. This means there is
-a 6 month period roughly every other year where the three most recent feature
+a 6-month period roughly every other year where the three most recent feature
 releases are supported.
 
-For a 12 month release cadence, it would work out to always supporting at
+For a 12-month release cadence, it would work out to always supporting at
 least the three most recent feature releases, and then dropping support for all
 X.Y.z releases around 6 months after X.(Y+3).0 is released. This means that
 for half of each year, the four most recent feature releases would be supported.
 
-For a 24 month release cadence, a 42 month support cycle works out to always
+For a 24-month release cadence, a 42-month support cycle works out to always
 supporting at least the most recent feature release, and then dropping support
 for all X.Y.z feature releases around 18 months after X.(Y+1).0 is released.
-This means there is a 6 month period every other year where only one feature
+This means there is a 6-month period every other year where only one feature
 release is supported (and that period overlaps with the pre-release testing
 period for the X.(Y+2).0 baseline feature release).
 

--- a/pep-0600.rst
+++ b/pep-0600.rst
@@ -51,7 +51,7 @@ OpenSuSE, Ubuntu, RHEL, etc. – and then we did whatever it takes to
 make wheels that work across all these platforms.
 
 This approach requires many compromises. Manylinux wheels can only
-rely on a external libraries that maintain a consistent ABI and are
+rely on external libraries that maintain a consistent ABI and are
 universally available across all these distributions, which in
 practice restricts them to a small set of core libraries like glibc
 and a few others. Wheels have to be built on carefully-chosen

--- a/pep-0602.rst
+++ b/pep-0602.rst
@@ -64,7 +64,7 @@ Annual release cadence
 ----------------------
 
 Feature development of Python 3.(X+1).0 starts as soon as
-Python 3.X.0 Beta 1 is released.  This creates a twelve month delta
+Python 3.X.0 Beta 1 is released.  This creates a twelve-month delta
 between major Python versions.
 
 

--- a/pep-0605.rst
+++ b/pep-0605.rst
@@ -455,7 +455,7 @@ beneficial for all members of the wider Python ecosystem:
   availability of pre-built wheel archives, switching to adopting a new release
   every 12 months may be an acceptable rate increase, while moving consistently
   to the 24 month end of the historical 18-24 month cadence would be an
-  undesirable rate reduction relative to the 18 month cycle used for recent
+  undesirable rate reduction relative to the 18-month cycle used for recent
   releases. Whether this proposal would be a net negative for these users will
   depend on whether or not we're able to persuade library maintainers that
   it's worth their while to support the upcoming stable release throughout its
@@ -482,10 +482,10 @@ around two years after the release of Python 3.8.0).
 
 This change is arguably orthogonal to the proposed changes to the handling of
 the pre-freeze release period, but the connection is that without those
-pre-release management changes, the downsides of a two year full release cadence
-would probably outweigh the upsides, whereas the opposite is true for a 12
-month release cadence (i.e. with the pre-release management changes proposed
-in this PEP in place, the downsides of a 12 month full release cadence would
+pre-release management changes, the downsides of a two-year full release cadence
+would probably outweigh the upsides, whereas the opposite is true for a
+12-month release cadence (i.e. with the pre-release management changes proposed
+in this PEP in place, the downsides of a 12-month full release cadence would
 outweigh the upsides).
 
 
@@ -1129,20 +1129,20 @@ proposal (as of October 20, 2019) recommends that projects support any Python
 feature release published within the last 42 months, with a minimum of
 supporting the latest 2 Python feature releases.
 
-For an 18 month feature release cadence, that works out to always supporting at
+For an 18-month feature release cadence, that works out to always supporting at
 least the two most recent feature releases, and then dropping support for all
 X.Y.Z releases around 6 months after X.(Y+2).0 is released. This means there is
-a 6 month period roughly every other year where the three most recent feature
+a 6-month period roughly every other year where the three most recent feature
 releases are supported.
 
-For a 12 month release cadence, it would work out to always supporting at
+For a 12-month release cadence, it would work out to always supporting at
 least the three most recent feature releases, and then dropping support for all
 X.Y.Z releases around 6 months after X.(Y+3).0 is released. This means that
 for half of each year, the four most recent feature releases would be supported,
 with the other half of each year hopefully being used to get ready for that
 year's feature release.
 
-For a 24 month release cadence, the second clause takes priority over the first,
+For a 24-month release cadence, the second clause takes priority over the first,
 and the recommended Python version support period increases to 48 months from
 the initial X.Y.0 release in order to consistently support the two most recent
 CPython feature releases. For projects that also support the rolling release
@@ -1154,7 +1154,7 @@ Release cycle alignment for core development sprints
 
 With the proposal in this PEP, it is expected that the focus of core
 development sprints would shift slightly based on the current location
-in the two year cycle.
+in the two-year cycle.
 
 In release years, the timing of PyCon US is suitable for new contributors to
 work on bug fixes and smaller features before the first release candidate goes
@@ -1213,7 +1213,7 @@ With the annual release proposal in PEP 602, both Debian and Ubuntu LTS would
 consistently get a system Python version that is around 6 months old, but
 would also consistently select different Python versions from each other.
 
-With a two year cadence, and CPython releases in the latter half of the year,
+With a two-year cadence, and CPython releases in the latter half of the year,
 they're likely to select the same version as each other, but one of them will
 be choosing a CPython release that is more than 18 months behind the latest beta
 releases by the time the Linux distribution ships.
@@ -1267,7 +1267,7 @@ Finally, it would also be reasonable to just not worry about it until something
 actually breaks, and then handle it like any other library compatibility issue
 found in a new alpha or beta release.
 
-Aside from extension module ABI compatibilty, the other main point of additional
+Aside from extension module ABI compatibility, the other main point of additional
 complexity when using the rolling pre-freeze releases would be "roll-back"
 compatibility for independently versioned features, such as pickle and SQLite,
 where use of new or provisional features in the beta stream may create files

--- a/pep-0606.rst
+++ b/pep-0606.rst
@@ -61,7 +61,7 @@ Each change introducing backport compatibility to a function should be
 properly discussed to estimate the maintenance cost in the long-term.
 
 Backward compatibility code will be dropped on each Python release, on a
-case by case basis. Each compatibility function can be supported for a
+case-by-case basis. Each compatibility function can be supported for a
 different number of Python releases depending on its maintenance cost
 and the estimated risk (number of broken projects) if it's removed.
 
@@ -101,7 +101,7 @@ The new ``DeprecationWarning`` and ``PendingDeprecatingWarning`` warnings
 in Python 3.9 will not be disabled in Python 3.8 compatibility mode.
 If a project runs its test suite using ``-Werror`` (treat any warning as
 an error), these warnings must be fixed, or specific deprecation
-warnings must be ignored on a case by case basis.
+warnings must be ignored on a case-by-case basis.
 
 
 Upgrading a project to a newer Python
@@ -268,7 +268,7 @@ Command line
 ------------
 
 Add ``-X compat_version=VERSION`` and ``-X min_compat_version=VERSION``
-command line options: call respectivelly
+command line options: call respectively
 ``sys.set_python_compat_version()`` and
 ``sys.set_python_min_compat_version()``. ``VERSION`` is a version string
 with 2 or 3 numbers (``major.minor.micro`` or ``major.minor``). For
@@ -277,7 +277,7 @@ example, ``-X compat_version=3.8`` calls
 
 Add ``PYTHONCOMPATVERSIONVERSION=VERSION`` and
 ``PYTHONCOMPATMINVERSION=VERSION=VERSION`` environment variables: call
-respectivelly ``sys.set_python_compat_version()`` and
+respectively ``sys.set_python_compat_version()`` and
 ``sys.set_python_min_compat_version()``.  ``VERSION`` is a version
 string with the same format as the command line options.
 
@@ -407,7 +407,7 @@ down Python changes: see the python-dev thread `Slow down...
     I don’t believe that the way for Python to remain relevant and
     useful for the next 10 years is to cease all language evolution.
     Who knows what the computing landscape will look like in 5 years,
-    let alone 10?  Something as arbitrary as a 10 year moratorium is
+    let alone 10?  Something as arbitrary as a 10-year moratorium is
     (again, IMHO) a death sentence for the language.
 
 PEP 387

--- a/pep-0607.rst
+++ b/pep-0607.rst
@@ -22,7 +22,7 @@ current approach of offering new feature releases every 18-24 months, with
 the first binary alpha release taking place 6-8 months before the final release).
 
 Both PEPs also propose moving to a release cadence that results in full releases
-occuring at a consistent time of year (every year for PEP 602, every other
+occurring at a consistent time of year (every year for PEP 602, every other
 year for PEP 605).
 
 This PEP (from the authors of both competing proposals) provides common
@@ -140,7 +140,7 @@ Impact on users and redistributors that already skip some releases
 
 It is already the case that not all users and redistributors update to every
 published CPython release series (for example, Debian stable and Ubuntu LTS
-sometimes skip releases due to the mismatch between their 24 month release
+sometimes skip releases due to the mismatch between their 24-month release
 cycles and CPython's typically 18-month cycle).
 
 The faster 12-month full release cadence in PEP 602 means that users in this

--- a/pep-0608.rst
+++ b/pep-0608.rst
@@ -134,7 +134,7 @@ which are not tested on the next Python yet.
 
 Once selected projects issues are known, exceptions can be discussed
 between the Python release manager and involved project maintainers on a
-case by case basis. Not all issues deserve to block a Python release.
+case-by-case basis. Not all issues deserve to block a Python release.
 
 Selected projects
 -----------------

--- a/pep-0609.rst
+++ b/pep-0609.rst
@@ -194,7 +194,7 @@ public PyPA communication channel. A PyPA committer vote is triggered
 when a PyPA committer (not the proposer) seconds the proposal.
 
 The proposal will be put to a vote on the `PyPA-Committers`_ mailing
-list, over a 7 day period. Each PyPA committer can vote once, and can
+list, over a 7-day period. Each PyPA committer can vote once, and can
 choose one of ``+1`` and ``-1``. If at least two thirds of recorded
 votes are ``+1``, then the vote succeeds.
 
@@ -237,7 +237,7 @@ Such requests can made by a committer of the project, on the
 user/organization to transfer the repository to.
 
 If the request is not opposed by another committer of the same project
-over a 7 day period, the project would leave the PyPA and be
+over a 7-day period, the project would leave the PyPA and be
 transferred out of the PyPA organization as per the request.
 
 Code of Conduct enforcement

--- a/pep-0610.rst
+++ b/pep-0610.rst
@@ -57,7 +57,7 @@ and installing source code from requirements specifying arbitrary URLs of
 source archives and Version Control Systems (VCS) repositories,
 as standardized in `PEP440 Direct References`_.
 
-In other words two relevant installation modes exist.
+In other words, two relevant installation modes exist.
 
 1. the package to install is specified as a name and version specifier:
 
@@ -153,7 +153,7 @@ The editable installation mode of pip roughly lets a user insert a
 local directory in sys.path for development purpose. This mode is somewhat
 abused to work around the fact that a non-editable install from a VCS URL
 loses track of the origin after installation.
-Indeed editable installs implicitly record the VCS origin in the checkout
+Indeed, editable installs implicitly record the VCS origin in the checkout
 directory, so the information can be recovered when running "freeze".
 
 The use of this workaround, although useful, is fragile, creates confusion
@@ -290,7 +290,7 @@ to specify where ``pyproject.toml`` or ``setup.py`` is located.
 
    As a general rule, installers should as much as possible preserve the
    information that was provided in the requested URL when generating
-   ``direct_url.json``. For example user:password environment variables
+   ``direct_url.json``. For example, user:password environment variables
    should be preserved and ``requested_revision`` should reflect the revision that was
    provided in the requested URL as faithfully as possible. This information is
    however *enriched* with more precise data, such as ``commit_id``.

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -405,7 +405,7 @@ These "properties" can only be used as the annotated types for
 Furthermore, because the default kind of parameter in Python (\ ``(x: int)``\ )
 may be addressed both positionally and through its name, two valid invocations
 of a ``(*args: P.args, **kwargs: P.kwargs)`` function may give different
-partitions of the same set of parameters. Therefore we need to make sure that
+partitions of the same set of parameters. Therefore, we need to make sure that
 these special types are only brought into the world together, and are used
 together, so that our usage is valid for all possible partitions.
 
@@ -598,7 +598,7 @@ so:
    class BetterCallable(typing.Protocol[Tpositionals, Tkeywords, R]):
      def __call__(*args: Tpositionals, **kwargs: Tkeywords) -> R: ...
 
-However there are some problems with trying to come up with a consistent
+However, there are some problems with trying to come up with a consistent
 solution for those type variables for a given callable. This problem comes up
 with even the simplest of callables:
 

--- a/pep-0615.rst
+++ b/pep-0615.rst
@@ -817,7 +817,7 @@ Arguments against this:
    module-level ``__getattr__`` and ``__dir__`` per PEP 562, but this would
    add some complexity to the implementation of the ``datetime`` module. This
    sort of behavior in modules or classes tends to confuse static analysis
-   tools, which may not be desirable for a library as widely-used and critical
+   tools, which may not be desirable for a library as widely used and critical
    as ``datetime``.
 
 2. Nesting the implementation under ``datetime`` would likely require

--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -343,7 +343,7 @@ Patterns
 The **pattern** is a new syntactic construct, that could be considered a loose
 generalization of assignment targets. The key properties of a pattern are what
 types and shapes of subjects it accepts, what variables it captures and how
-it extracts them from the subject. For example the pattern ``[a, b]`` matches
+it extracts them from the subject. For example, the pattern ``[a, b]`` matches
 only sequences of exactly 2 elements, extracting the first element into ``a``
 and the second one into ``b``.
 
@@ -1327,7 +1327,7 @@ time with the new syntax.
 
 It has been noted that a number of these third-party tools leverage common parsing
 libraries (Black for example uses a fork of the lib2to3 parser). It may be helpful
-to identify widely-used parsing libraries (such as parso [10]_ and libCST [11]_)
+to identify widely used parsing libraries (such as parso [10]_ and libCST [11]_)
 and upgrade them to be PEG compatible.
 
 However, since this work would need to be done not only for the match statement,
@@ -1532,7 +1532,7 @@ This is probably the trickiest item. Matching against some pre-defined
 constants is very common, but the dynamic nature of Python also makes it
 ambiguous with capture patterns. Five other alternatives were considered:
 
-* Use some implicit rules. For example if a name was defined in the global
+* Use some implicit rules. For example, if a name was defined in the global
   scope, then it refers to a constant, rather than representing a
   capture pattern::
 

--- a/pep-0624.rst
+++ b/pep-0624.rst
@@ -142,7 +142,7 @@ Remove these APIs in Python 3.11. They have been deprecated already.
 Alternative ideas
 =================
 
-Instead of just removing deprecated APIs, we may be able to use thier
+Instead of just removing deprecated APIs, we may be able to use their
 names with different signature.
 
 

--- a/pep-0627.rst
+++ b/pep-0627.rst
@@ -28,7 +28,7 @@ Motivation
 ==========
 
 Python packaging is moving from relying on specific tools (Setuptools and pip)
-toward a ecosystem of tools and tool-agnostic interoperability standards.
+toward an ecosystem of tools and tool-agnostic interoperability standards.
 
 PEP 376 is not written as an interoperability standard.
 It describes implementation details of specific tools and libraries,

--- a/pep-0629.rst
+++ b/pep-0629.rst
@@ -31,7 +31,7 @@ Rationale
 When evolving the simple API, clients wish to be able to determine
 which features the repository supports. Currently there is no
 mechanism to do this, except by attempting to detect new features
-by looking at the data in the reponses and see if it appears like
+by looking at the data in the responses and see if it appears like
 a particular feature is in use.
 
 This works reasonably well for a modern version of a client to determine
@@ -52,7 +52,7 @@ Overview
 ========
 
 This PEP proposes the inclusion of a meta tag on the responses of every
-sucessful request to a simple API page, which contains a name attribute
+successful request to a simple API page, which contains a name attribute
 of "pypi:repository-version", and a content that is a PEP 440 compatible
 version number, which is further constrained to ONLY be Major.Minor, and
 none of the additional features supported by PEP 440.
@@ -96,10 +96,10 @@ response for the repository version, and if that data does not exist
 **MUST** assume that it is version 1.0.
 
 When encountering a major version greater than expected, clients
-**MUST** hard fail with an appropiate error message for the user.
+**MUST** hard fail with an appropriate error message for the user.
 
 When encountering a minor version greater than expected, clients
-**SHOULD** warn users with an appropiate message.
+**SHOULD** warn users with an appropriate message.
 
 Clients **MAY** still continue to use feature detection in order to
 determine what features a repository uses.

--- a/pep-0630.rst
+++ b/pep-0630.rst
@@ -296,7 +296,7 @@ the state there is ``PyModule_GetState``::
        // ... rest of logic
    }
 
-(Note that ``PyModule_GetState`` may return NULL without seting an
+(Note that ``PyModule_GetState`` may return NULL without setting an
 exception if there is no module state, i.e. ``PyModuleDef.m_size`` was
 zero. In your own module, you're in control of ``m_size``, so this is
 easy to prevent.)

--- a/pep-0633.rst
+++ b/pep-0633.rst
@@ -33,7 +33,7 @@ Motivation
 ==========
 
 There are multiple benefits to using TOML tables and other data-types to
-represent requirements rather then :pep:`508` strings:
+represent requirements rather than :pep:`508` strings:
 
 - Easy initial validation via the TOML syntax.
 

--- a/pep-0635.rst
+++ b/pep-0635.rst
@@ -715,7 +715,7 @@ a secondary use case at the expense of additional syntactic clutter for
 core cases.
 
 It has been proposed that capture patterns are not needed at all,
-since the equivalent effect can be obtained by combining a AS
+since the equivalent effect can be obtained by combining an AS
 pattern with a wildcard pattern (e.g., ``case _ as x`` is equivalent
 to ``case x``).  However, this would be unpleasantly verbose,
 especially given that we expect capture patterns to be very common.

--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -90,7 +90,7 @@ Matching multiple patterns
 --------------------------
 
 Even if most commands have the action/object form, you might want to have user commands
-of different lengths. For example you might want to add single verbs with no object like
+of different lengths. For example, you might want to add single verbs with no object like
 ``look`` or ``quit``. A match statement can (and is likely to) have more than one
 ``case``::
 

--- a/pep-0637.rst
+++ b/pep-0637.rst
@@ -370,7 +370,7 @@ The successful implementation of this PEP will result in the following behavior:
 6. The same rules apply with respect to keyword subscripts as for
    keywords in function calls:
 
-   - the interpeter matches up each keyword subscript to a named parameter
+   - the interpreter matches up each keyword subscript to a named parameter
      in the appropriate method;
 
    - if a named parameter is used twice, that is an error;

--- a/pep-0639.rst
+++ b/pep-0639.rst
@@ -149,7 +149,7 @@ There are a few takeaways from the survey:
   optionally combine more than one license identifiers together. SPDX and
   SPDX-like syntaxes are the most popular in use.
 
-- SPDX license identifiers are becoming a de-facto way to reference common licenses
+- SPDX license identifiers are becoming a de facto way to reference common licenses
   everywhere, whether or not a license expression syntax is used.
 
 - Several package formats support documenting both a license expression and
@@ -787,7 +787,7 @@ Conventions used by other ecosystems
 
 - The Android Open Source Project [#android]_ use ``MODULE_LICENSE_XXX`` empty
   tag files where ``XXX`` is a license code such as BSD, APACHE, GPL, etc. And
-  side-by-side with this ``MODULE_LICENSE`` file there is a ``NOTICE`` file
+  side by side with this ``MODULE_LICENSE`` file there is a ``NOTICE`` file
   that contains license and notices texts.
 
 

--- a/pep-0642.rst
+++ b/pep-0642.rst
@@ -894,7 +894,7 @@ converted to an instance attributes constraint as follows:
   using ``__match_args__[i]`` as the attribute name.
 - if any element in ``__match_args__`` is not a string, ``TypeError`` is raised.
 - once the positional patterns have been converted to attribute patterns, then
-  they are combined with any atribute constraints given in the double star
+  they are combined with any attribute constraints given in the double star
   attribute constraints subpattern, and matching proceeds as if for the
   equivalent instance attributes constraint.
 
@@ -1164,7 +1164,7 @@ while ``MatchAlways()`` is always a wildcard marker in a match pattern.
 
 Unlike ``_``, the lack of other use cases for ``__`` means that there would be
 a plausible path towards restoring identifier handling consistency with the rest
-of the language by making ``__`` mean "skip this name binding" everwhere in
+of the language by making ``__`` mean "skip this name binding" everywhere in
 Python:
 
 * in the interpreter itself, deprecate loading variables with the name ``__``.
@@ -1464,7 +1464,7 @@ in many of these cases (e.g. sequence pattern subpatterns) to accept
 
 Further consideration of this point has been deferred, as making required
 parentheses optional is a backwards compatible change, and hence relaxing the
-restrictions later can be considered on a case by case basis.
+restrictions later can be considered on a case-by-case basis.
 
 
 Accepting complex literals as closed expressions
@@ -1770,7 +1770,7 @@ Bucher's reference implementation for PEP 634 [4_].
 Relative to the text of this PEP, the draft reference implementation has not
 yet complemented the special casing of several builtin and standard library
 types in ``MATCH_CLASS`` with the more general check for ``__match_args__``
-being set to ``None``. Class defined patterns also currenty still accept
+being set to ``None``. Class defined patterns also currently still accept
 classes that don't define ``__match_args__``.
 
 All other modified patterns have been updated to follow this PEP rather than
@@ -2012,7 +2012,7 @@ remain the same as they are in PEP 634.
 
 Relative to PEP 634 this PEP makes the following key changes:
 
-* a new ``pattern`` type is defined in the AST, rather then reusing the ``expr``
+* a new ``pattern`` type is defined in the AST, rather than reusing the ``expr``
   type for patterns
 * the new ``MatchAs`` and ``MatchOr`` AST nodes are moved from the ``expr``
   type to the ``pattern`` type

--- a/pep-0644.rst
+++ b/pep-0644.rst
@@ -70,12 +70,12 @@ OpenSSL version.
 
 As of October 2020 and according to DistroWatch [1]_ most current BSD and
 Linux distributions ship with OpenSSL 1.1.1 as well. Some older releases of
-long term support (LTS) and enterprise distributions have older versions of
+long-term support (LTS) and enterprise distributions have older versions of
 OpenSSL or LibreSSL. By the time Python 3.10 will be generally available,
 several of these distributions will have reached end of lifetime, end of
 general support, or moved from LibreSSL to OpenSSL.
 
-Other software has dropped support for OpenSSL 1.0.2 as well. For example
+Other software has dropped support for OpenSSL 1.0.2 as well. For example,
 PyCA cryptography 3.2 (2020-10-25) removed compatibility with OpenSSL 1.0.2.
 
 
@@ -219,7 +219,7 @@ OpenSSL downstream patches and options
 OpenSSL features more than 70 configure and build time options in the form
 of  `OPENSSL_NO_*` macros. Around 60 options affect the presence of features
 like cryptographic algorithms and TLS versions. Some distributions apply
-patches to alter settings. Furthermore default values for settings like
+patches to alter settings. Furthermore, default values for settings like
 security level, ciphers, TLS version range, and signature algorithms can
 be set in OpenSSL config file.
 

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -765,7 +765,7 @@ Backwards Compatibility
 TODO
 
 * ``Tuple`` needs to be upgraded to support parameterization with a
-  a type variable tuple.
+  type variable tuple.
 
 
 Reference Implementation

--- a/pep-0648.rst
+++ b/pep-0648.rst
@@ -132,7 +132,7 @@ order, but that could result in different results depending on how the
 interpreter chooses to pick up those files. So even if it won't be a good
 practice to rely on other files being executed, we think that is better than
 having randomly different results on interpreter startup.
-We chose to run the scripts after the ``pth`` files in case an user needs to
+We chose to run the scripts after the ``pth`` files in case a user needs to
 add items to the path before running a script.
 
 Impact on startup time

--- a/pep-0649.rst
+++ b/pep-0649.rst
@@ -38,7 +38,7 @@ preserves the result.
 If accepted, these new semantics for annotations would initially
 be gated behind ``from __future__ import co_annotations``.  However,
 these semantics would eventually be promoted to be the default behavior.
-Thus this PEP would *supercede* PEP 563, and PEP 563's behavior would
+Thus this PEP would *supersede* PEP 563, and PEP 563's behavior would
 be deprecated and eventually removed.
 
 Overview
@@ -318,7 +318,7 @@ new light.
 PEP 563 semantics have shipped in three major Python releases.
 These semantics are now widely used in organizations depending
 on static type analysis.  Evaluating annotations at module-level
-scope is clearly acceptable to all interested parties.  Therefore
+scope is clearly acceptable to all interested parties.  Therefore,
 delayed evaluation of annotations with code using the same scoping
 rules is obviously also completely viable.
 
@@ -594,7 +594,7 @@ For Future Discussion
 __globals__
 -----------
 
-Is it permissable to add the ``__globals__`` reference to class
+Is it permissible to add the ``__globals__`` reference to class
 objects as proposed here?  It's not clear why this hasn't already
 been done; PEP 563 could have made use of class globals, but instead
 makes do with looking up classes inside ``sys.modules``.  Yet Python

--- a/pep-0650.rst
+++ b/pep-0650.rst
@@ -15,7 +15,7 @@ Abstract
 ========
 
 Python package installers are not completely interoperable with each
-other. While pip is the most widely used installer and a de-facto
+other. While pip is the most widely used installer and a de facto
 standard, other installers such as Poetry_ or Pipenv_ are popular as
 well due to offering unique features which are optimal for certain
 workflows and not directly in line with how pip operates.
@@ -199,7 +199,7 @@ Open Source Community
 
 Specifying installer requirements and adopting this PEP will reduce
 the friction between Python package installers and people's workflows.
-Consequently it will reduce the friction between Python package
+Consequently, it will reduce the friction between Python package
 installers and 3rd party infrastructure/technologies such as PaaS or
 IDEs. Overall, it will allow for easier development, deployment and
 maintenance of Python projects as Python package installation becomes
@@ -261,7 +261,7 @@ Additional parameters or tool specific data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Additional parameters or tool (*installer backend*) data may also be
 stored in the ``pyproject.toml`` file. This would be in the “tool.*”
-table as specified by :pep:`518`. For example if the
+table as specified by :pep:`518`. For example, if the
 *installer backend* is Poetry and you wanted to specify multiple
 dependency groups, the tool.poetry tables could look like this:
 
@@ -445,7 +445,7 @@ Returns the dependency groups available to be installed. This allows
 
 update_dependencies
 ^^^^^^^^^^^^^^^^^^^
-Outputs a dependency file based off of inputted package list::
+Outputs a dependency file based on inputted package list::
 
     def update_dependencies(
         path: Union[str, bytes, PathLike[str]],

--- a/pep-0651.rst
+++ b/pep-0651.rst
@@ -165,7 +165,7 @@ It will no longer be possible to crash the CPython virtual machine through recur
 Performance Impact
 ==================
 
-It is unlikely that the performance impact will be signficant.
+It is unlikely that the performance impact will be significant.
 
 The additional logic required will probably have a very small negative impact on performance.
 The improved locality of reference from reduced C stack use should have some small positive impact.

--- a/pep-3103.txt
+++ b/pep-3103.txt
@@ -615,7 +615,7 @@ Conclusion
 ==========
 
 It is too early to decide.  I'd like to see at least one completed
-proposal for pre-computed values before deciding.  In the mean time,
+proposal for pre-computed values before deciding.  In the meantime,
 Python is fine without a switch statement, and perhaps those who claim
 it would be a mistake to add one are right.
 

--- a/pep-3127.txt
+++ b/pep-3127.txt
@@ -159,7 +159,7 @@ that prepending a "0" to a string of digits changes the meaning of
 that digit string entirely.
 
 It was pointed out during this discussion that a similar, but shorter,
-discussion on the subject occurred in January of 2006, prompted by a
+discussion on the subject occurred in January 2006, prompted by a
 discovery of the same issue.
 
 Background

--- a/pep-3146.txt
+++ b/pep-3146.txt
@@ -250,7 +250,7 @@ simulate real applications as well as possible, when running a whole application
 is not feasible. Along a different axis, our benchmark collection originally
 focused on the kinds of workloads seen by Google's Python code (webapps, text
 processing), though we have since expanded the collection to include workloads
-Google cares nothing about. We have so far shied away from heavily-numerical
+Google cares nothing about. We have so far shied away from heavily numerical
 workloads, since NumPy [#numpy]_ already does an excellent job on such code and
 so improving numerical performance was not an initial high priority for the
 team; we have begun to incorporate such benchmarks into the collection
@@ -1049,7 +1049,7 @@ without human intervention.
 If an ahead-of-time FDO compiler is required, it should be able to leverage a
 large percentage of the code and infrastructure already developed for Unladen
 Swallow's JIT compiler. Indeed, these two compilation strategies could exist
-side-by-side.
+side by side.
 
 
 Future Work
@@ -1064,7 +1064,7 @@ had time to fully implement. Examples:
   inlining between pure-Python functions. Work on this is on-going
   [#us-inlining]_.
 - Unboxing [#unboxing]_. Unboxing is critical for numerical performance. PyPy
-  in particular has demonstrated the value of unboxing to heavily-numeric
+  in particular has demonstrated the value of unboxing to heavily numeric
   workloads.
 - Recompilation, adaptation. Unladen Swallow currently only compiles a Python
   function once, based on its usage pattern up to that point. If the usage

--- a/pep-3156.txt
+++ b/pep-3156.txt
@@ -1302,7 +1302,7 @@ Bidirectional stream transports have the following public methods:
   limit.  Neither value can be negative.
 
   The defaults are implementation-specific.  If only the high-water
-  limit is given, the low-water limit defaults to a
+  limit is given, the low-water limit defaults to an
   implementation-specific value less than or equal to the high-water
   limit.  Setting high to zero forces low to zero as well, and causes
   ``pause_writing()`` to be called whenever the buffer becomes

--- a/pep-3333.txt
+++ b/pep-3333.txt
@@ -367,7 +367,7 @@ such functions as:
 * Routing a request to different application objects based on the
   target URL, after rewriting the ``environ`` accordingly.
 
-* Allowing multiple applications or frameworks to run side-by-side
+* Allowing multiple applications or frameworks to run side by side
   in the same process
 
 * Load balancing and remote processing, by forwarding requests and

--- a/pep-8000.rst
+++ b/pep-8000.rst
@@ -79,7 +79,7 @@ PEPs.
   majority of the Python community before being accepted. Unlike some of the
   other governance PEPs it explicitly does *not* specify who has voting
   rights and what a majority vote consists of. In stead this is determined
-  by the council of elders on a case by case basis.
+  by the council of elders on a case-by-case basis.
 
 * PEP 8015 - Organization of the Python community
 

--- a/pep-8002.rst
+++ b/pep-8002.rst
@@ -116,7 +116,7 @@ The other possible results of the "final comment period" are to:
 * *postpone* the RFC (similar to the Deferred status in PEPs),
 * get it *back into discussion* if blocking concerns can be addressed, or
 * *close it* if blocking concerns are not solvable.  When an RFC is marked as
-  *closed*, there is a 7 day grace period to debate whether it should be closed.
+  *closed*, there is a 7-day grace period to debate whether it should be closed.
 
 In practice registering concerns with an RFC happens very often initially but rarely
 causes for the RFC to be entirely killed.
@@ -536,7 +536,7 @@ roughly modeled after PEPs and documented in `DEP 1
 DEPs are mostly used to design major new features, but also for
 information on general guidelines and process.
 
-An idea for a DEP should be first publically vetted on the
+An idea for a DEP should be first publicly vetted on the
 django-developers mailing list.  After it was roughly validated, the
 author forms a team with three roles:
 

--- a/pep-8010.rst
+++ b/pep-8010.rst
@@ -133,7 +133,7 @@ support the authority of the Delegate as the final arbiter of the PEP.
 
 The GUIDO has full authority to shut down unproductive discussions,
 ideas, and proposals, when it is clear that the proposal runs counter
-to the long term vision for Python.  This is done with compassion for
+to the long-term vision for Python.  This is done with compassion for
 the advocates of the change, but with the health and well-being of all
 community members in mind.  A toxic discussion on a dead-end proposal
 does no one any good, and they can be terminated by fiat.
@@ -149,7 +149,7 @@ Authority comes from the community
 The GUIDO's authority ultimately resides with the community.  A rogue
 GUIDO that loses the confidence of the majority of the community can
 be recalled and a new vote conducted.  This is an exceedingly rare and
-unlikely event.  This is a sufficient stopgap for the worst case
+unlikely event.  This is a sufficient stopgap for the worst-case
 scenario, so it should not be undertaken lightly.  The GUIDO should
 not fear being deposed because of one decision, even if that decision
 isn't favored by the majority of Python developers.  Recall should be
@@ -236,7 +236,7 @@ All ties in voting will be broken with a procedure to be determined in
 PEP 8001.
 
 The nomination and voting process is similar as with the GUIDO.  There
-is a three week nomination period, where self-nominations are allowed
+is a three-week nomination period, where self-nominations are allowed
 and must be seconded, followed by a period of time for posting
 position statements, followed by a vote.
 
@@ -261,7 +261,7 @@ holder.  During the time in which there is no GUIDO, major decisions
 are put on hold, but normal Python operations may of course continue.
 
 
-Day to day operations
+Day-to-day operations
 =====================
 
 The GUIDO is not needed for all -- or even most -- decisions.  Python

--- a/pep-8011.rst
+++ b/pep-8011.rst
@@ -212,7 +212,7 @@ the more difficult it will be in coming up with decision.
 This is also for the benefit of the members of the trio. Learning to
 collaborate with other people in a team is not something that happen organically
 and takes a lot of effort. It is expected that members of the trio will be part
-of the team for a long term period. Having to deal with two other people is
+of the team for a long-term period. Having to deal with two other people is
 probably difficult enough. We want the trio to be able to do their duties and
 responsibilities as efficient as possible.
 
@@ -228,7 +228,7 @@ Roles and responsibilities of Python Core Developers to the trio
   be seen as authoritative and coming from the trio.
 - Once the trio has pronounced a decision, core devs will be supportive, even if
   they were not supportive in the beginning (before the trio made such decision)
-- Continue with day to day decision making in the bug tracker, and defer to the
+- Continue with day-to-day decision making in the bug tracker, and defer to the
   trio if there is major disagreement
 - Python core developers do not handle CoC cases, those are responsibilities of
   the CoC workgroup, but will speak out if they witness those cases

--- a/pep-8012.rst
+++ b/pep-8012.rst
@@ -132,7 +132,7 @@ and so on.
 Risk: Dilution and confusion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This model favors a small group, between three to five people.
+This model favors a small group, between three and five people.
 That way it shares most of the criticism with the Dictator model,
 amplified.  Having not one but, say, three people in position of power
 dilutes responsibility while still providing high risk of lobbying,

--- a/pep-8014.rst
+++ b/pep-8014.rst
@@ -15,7 +15,7 @@ but uses *Commons* for now because of possible negative connotations of the
 term *Anarchist* to some audiences.
 
 The basic idea is that all decisions are in principle voted on by the whole
-community, but in practice voted on by a only subset of the
+community, but in practice voted on by only a subset of the
 community. A subset, because although the whole community is
 entitled to vote in practice it will always be only a small subset that vote
 on a specific decision. The vote is overseen by an impartial council that
@@ -62,7 +62,7 @@ cases.
 
 The model proposes creating a *Council of Elders* that oversees the decision
 process, determining whether a specific proposal has enough support on a
-case by case basis. There will be a vote on every individual PEP,
+case-by-case basis. There will be a vote on every individual PEP,
 and the Council of Elders will declare whether the
 outcome of the vote is sufficient to carry the decision *in this specific case*.
 
@@ -170,7 +170,7 @@ definitely not like the Spanish Inquisition, because fear, surprise and
 ruthless efficiency are things we can do without (but there is some merit in
 using the cute scarlet regalia).
 
-The council is somewhat like the dutch
+The council is somewhat like the Dutch
 `Hoge Raad`_ (which is unfortunately often translated as Supreme Court in
 English) in that they judge the process and the procedures followed and can
 only send cases back for a renewed judgement.
@@ -263,7 +263,7 @@ Council membership
 
 Because the powers of the council are purely procedural it is probably good
 if members serve for a fairly long time. However, it would still be good if
-the council was reinstated regularly. Therefore the suggestion is to have the council
+the council was reinstated regularly. Therefore, the suggestion is to have the council
 operate under the PSF umbrella and be subject of a yearly vote of confidence. This
 vote is for the council as a whole: people who vote against the council should be
 aware that they are basically saying "Python is better off without a Council of Elders

--- a/pep-8015.rst
+++ b/pep-8015.rst
@@ -113,7 +113,7 @@ a Python contributor.
 Python Teams
 ============
 
-Python became too big to work as an unique team anymore, people
+Python became too big to work as a unique team anymore, people
 naturally have grouped themselves as teams to work more closely on
 specific topics, sometimes called "Special Interest Group" (SIG).
 

--- a/pep-8016.rst
+++ b/pep-8016.rst
@@ -224,7 +224,7 @@ In exceptional circumstances, the core team may remove a sitting
 council member, or the entire council, via a vote of no confidence.
 
 A no-confidence vote is triggered when a core team member calls for
-one publically on an appropriate project communication channel, and
+one publicly on an appropriate project communication channel, and
 another core team member seconds the proposal.
 
 The vote lasts for two weeks. Core team members vote for or against.

--- a/pep-8102.rst
+++ b/pep-8102.rst
@@ -24,7 +24,7 @@ Election Administration
 The steering council appointed the
 `Python Software Foundation <https://www.python.org/psf-landing/>`__
 Director of Infrastructure, Ee W. Durbin III,
-and Accouting Manager, Joe Carey, to coadminster the election.
+and Accounting Manager, Joe Carey, to coadminister the election.
 
 `Python Software Foundation <https://www.python.org/psf-landing/>`__
 Executive Director, Ewa Jodlowska, will communicate announcements


### PR DESCRIPTION
This is a follow-up to #52.

Changes detected by Topy (https://github.com/intgr/topy), all changes
verified by hand, false positives have been omitted.

These range from straight-out misspellings to debatable hyphen placement.
The hyphen changes are supported by grammar manuals of style.

I'll be happy to revert parts of it or split up this PR into separate ones, if deemed necessary.
