### PR TITLE
PEP 650: Fix typos, improve example

### DIFF
--- a/pep-0650.rst
+++ b/pep-0650.rst
@@ -480,20 +480,26 @@ Let's consider implementing an *installer backend* that uses pip and
 its requirements files for *dependency groups*. An implementation may
 (very roughly) look like the following::
 
-  import os
-  import pathlib
   import subprocess
   import sys
 
 
   def invoke_install(path, *, dependency_group=None, **kwargs):
-      file_name = "requirements.txt"
-      if dependency_group:
-          file_name = f"{dependency_group}-{file_name}"
-      requirements_path = pathlib.Path(path) / file_name
-      return subprocess.call(
-          [sys.executable, "-m", "pip", "install", "-r", os.fspath(requirements_path)]
-      )
+      try:
+          return subprocess.call(
+              [
+                  sys.executable,
+                  "-m",
+                  "pip",
+                  "install",
+                  "-r",
+                  dependency_group or "requirements.txt",
+              ],
+              cwd=path,
+          )
+      except subprocess.CalledProcessError as e:
+          return e.returncode
+      return 0
 
 If we named this package ``pep650pip``, then we could specify in
 ``pyproject.toml``::

--- a/pep-0650.rst
+++ b/pep-0650.rst
@@ -49,7 +49,7 @@ Installer interface
 Universal installer
     An installer that can invoke an *installer backend* by calling the
     optional invocation methods of the *installer interface*. This can
-    also be thought of as the installer frontend, ala the build_
+    also be thought of as the installer frontend, à la the build_
     project for :pep:`517`.
 
 Installer backend
@@ -338,7 +338,7 @@ Installs the dependencies::
   group that the *installer backend* should install. The install will
   error if the dependency group doesn't exist. A user can find all
   dependency groups by calling
-  ``get_dependencies_groups()`` if dependency groups are
+  ``get_dependency_groups()`` if dependency groups are
   supported by the *installer backend*.
 * ``**kwargs`` : Arbitrary parameters that a *installer backend* may
   require that are not already specified, allows for backwards

--- a/pep-0650.rst
+++ b/pep-0650.rst
@@ -486,7 +486,7 @@ its requirements files for *dependency groups*. An implementation may
 
   def invoke_install(path, *, dependency_group=None, **kwargs):
       try:
-          return subprocess.call(
+          return subprocess.run(
               [
                   sys.executable,
                   "-m",
@@ -496,10 +496,9 @@ its requirements files for *dependency groups*. An implementation may
                   dependency_group or "requirements.txt",
               ],
               cwd=path,
-          )
+          ).returncode
       except subprocess.CalledProcessError as e:
           return e.returncode
-      return 0
 
 If we named this package ``pep650pip``, then we could specify in
 ``pyproject.toml``::
@@ -669,4 +668,3 @@ CC0-1.0-Universal license, whichever is more permissive.
     fill-column: 70
     coding: utf-8
     End:
-


### PR DESCRIPTION
I think it's simpler to just consider the dependency group to be the requirements filename in the case of pip (and default to `requirements.txt` if the dependency group is `None`). Properly using the `path` argument means that this can be relative.

If we're adhering to the current API, the example should also return an exit code, not the result of `subprocess.call()`.

(cc @brettcannon)