### PR TITLE
PEP 427: clarify how the build tag plays into wheel file selection

### DIFF
--- a/pep-0427.txt
+++ b/pep-0427.txt
@@ -130,10 +130,12 @@ version
     Distribution version, e.g. 1.0.
 
 build tag
-    Optional build number.  Must start with a digit.  A tie breaker
-    if two wheels have the same version.  Sort as the empty string
-    if unspecified, else sort the initial digits as a number, and the
-    remainder lexicographically.
+    Optional build number.  Must start with a digit.  Acts as a
+    tie-breaker if two wheel file names are the same in all other
+    respects (i.e. name, version, and other tags).  Sort as an
+    empty tuple if unspecified, else sort as a two-item tuple with
+    the first item being the initial digits as an ``int``, and the
+    second item being the remainder of the tag as a ``str``.
 
 language implementation and version tag
     E.g. 'py27', 'py2', 'py3'.


### PR DESCRIPTION
See https://discuss.python.org/t/requesting-clarification-for-pep-427-wheel-file-names-and-build-numbers/6988/ for the discussion leading to this clarification.
