### PR TITLE
PEP 637 Added "how to teach" section

### DIFF
--- a/pep-0637.rst
+++ b/pep-0637.rst
@@ -646,6 +646,33 @@ Finally, the following new slots must be added to the ``PyMappingMethods`` struc
 These slots will have the appropriate signature to handle the dictionary object
 containing the keywords.
 
+"How to teach" recommendations
+==============================
+
+One request that occurred during feedback sessions was to detail a possible narrative
+for teaching the feature, e.g. to students, data scientists, and similar audience.
+This section addresses that need.
+
+We will only describe the indexing from the perspective of use, not of
+implementation, because it is the aspect that the above mentioned audience will
+likely encounter. Only a subset of the users will have to implement their own
+dunder functions, and can be considered advanced usage. A proper explanation could be:
+
+    The indexing operation is generally used to refer to a subset of a larger
+    dataset by means of an index. In the commonly seen cases, the index is made by
+    one or more numbers, strings, slices, etc.
+
+    Some types may allow indexing to occur not only with the index, but also with
+    named values. These named values are given between square brackets using the
+    same syntax used for function call keyword arguments. The meaning of the names
+    and their use is found in the documentation of the type, as it varies from one
+    type to another.
+
+The teacher will now show some practical real world examples, explaining the
+semantics of the feature in the shown library. At the time of writing these
+examples do not exist, obviously, but the libraries most likely to implement
+the feature are pandas and numpy, possibly as a method to refer to columns by
+name.
 
 Reference Implementation
 ========================


### PR DESCRIPTION
Added a "how to teach" section explaining a possible phrase to use when explaining the feature in a training course, as suggested by @encukou on python-dev


<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
