### PR TITLE
Lint RST on GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,11 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.7.1
+    hooks:
+      - id: rst-backticks
+      - id: rst-inline-touching-normal

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,7 @@ package: all rss
 	cp *.png build/peps/
 	cp *.rss build/peps/
 	tar -C build -czf build/peps.tar.gz peps
+
+lint:
+	pre-commit --version > /dev/null || python3 -m pip install pre-commit
+	pre-commit run --all-files

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -401,9 +401,9 @@ Type variable tuples can also be used in the arguments section of a
 
 However, note that as of this PEP, if a type variable tuple does appear in
 the arguments section of a ``Callable``, it must appear alone.
-That is, `Type Prefixing` is not supported in the context of ``Callable``.
+That is, `Type Prefixing`_ is not supported in the context of ``Callable``.
 (Use cases where this might otherwise be desirable are likely covered through use
-of either a `ParamSpec` from PEP 612, or a type variable tuple in the `__call__`
+of either a ``ParamSpec`` from PEP 612, or a type variable tuple in the ``__call__``
 signature of a callback protocol from PEP 544.)
 
 Type Variable Tuples with ``Union``
@@ -473,7 +473,7 @@ Normal ``TypeVar`` instances can also be used in such aliases:
     # T is bound to `int`; Ts is bound to `bool, str`
     Foo[int, bool, str]
 
-Note that the same rules for `Type Prefixing` apply for aliases.
+Note that the same rules for `Type Prefixing`_ apply for aliases.
 In particular, only one ``TypeVarTuple`` may occur within an alias,
 and the ``TypeVarTuple`` must be at the end of the alias.
 

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -360,7 +360,7 @@ parameterised with the same types.
     foo((0,), (1, 2))  # Error
     foo((0,), ('1',))  # Error
 
-Following `Type Variable Tuples Must Have Finite Length When Bound`, note
+Following `Type Variable Tuples Must Have Known Length`_, note
 that the following should *not* type-check as valid (even though it is, of
 course, valid at runtime):
 

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -281,7 +281,7 @@ As of this PEP, only a single type variable tuple may appear in a type parameter
 
     class Array(Generic[*Ts1, *Ts2]): ...  # Error
 
-(``Union`` is the one exception to this rule; see `Type Variable Tuples with ``Union```.)
+(``Union`` is the one exception to this rule; see `Type Variable Tuples with Union`_.)
 
 Type Prefixing
 --------------


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

New version of https://github.com/python/peps/pull/1668, main difference is the linter has been updated so the `rst-backticks` skips code blocks (lines beginning with four spaces).

---

# Lint rules

This PR adds two reStructuredText lint rules and runs them on the CI using GitHub Actions. [Example run.](https://github.com/hugovk/peps/runs/1848734386?check_suite_focus=true)

1. Detect single backticks, which should be double in RST for inline code, e.g. stuff fixed in https://github.com/python/peps/pull/1554.

2. Detect inline code touching normal text, e.g. stuff fixed in https://github.com/python/peps/pull/1560.

# make lint

It adds a standalone `make` command to lint locally:

```sh
make lint
```

The pre-commit dependency is installed if needed.

# Optional git pre-commit hook

This uses the [pre-commit](https://pre-commit.com/) tool for linting. It's possible, but completely optional, to use it locally and it'll check your changes when you're committing, and fail before commit if something is found.

Optional local set up (run once):

```sh
pip install -U pre-commit && pre-commit install
```

Then make changes and commit as normal:

```sh
git commit -m "PEP XXX: etc"
```

Lint all files:

```sh
pre-commit run --all-files

# Or this does the same thing
make lint
```

The very first run takes a little while to set things up, after that it's quick.

But again, local use of pre-commit is completely optional for those who aren't keen, and the CI will run the checks anyway.

And `make lint` can be used completely independently of the git pre-commit hook.
