### PR TITLE
Normalize the 'Created' field

### DIFF
--- a/pep-0004.txt
+++ b/pep-0004.txt
@@ -6,7 +6,7 @@ Author: Brett Cannon <brett@python.org>, Martin von Löwis <martin@v.loewis.de>
 Status: Active
 Type: Process
 Content-Type: text/x-rst
-Created: 1-Oct-2000
+Created: 01-Oct-2000
 Post-History:
 
 

--- a/pep-0013.rst
+++ b/pep-0013.rst
@@ -4,7 +4,7 @@ Author: The Python core team and community
 Status: Active
 Type: Informational
 Content-Type: text/x-rst
-Created: 2018-12-16
+Created: 16-Dec-2018
 
 
 Abstract

--- a/pep-0200.txt
+++ b/pep-0200.txt
@@ -6,7 +6,7 @@ Author: Jeremy Hylton <jeremy@alum.mit.edu>
 Status: Final
 Type: Informational
 Content-Type: text/x-rst
-Created:
+Created: 12-Jul-2000
 Python-Version: 2.0
 Post-History:
 

--- a/pep-0205.txt
+++ b/pep-0205.txt
@@ -6,7 +6,7 @@ Author: Fred L. Drake, Jr. <fred@fdrake.net>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created:
+Created: 14-Jul-2000
 Python-Version: 2.1
 Post-History: 11-Jan-2001
 

--- a/pep-0206.txt
+++ b/pep-0206.txt
@@ -6,7 +6,7 @@ Author: A.M. Kuchling <amk@amk.ca>
 Status: Withdrawn
 Type: Informational
 Content-Type: text/x-rst
-Created:
+Created: 14-Jul-2000
 Post-History:
 
 

--- a/pep-0207.txt
+++ b/pep-0207.txt
@@ -6,7 +6,7 @@ Author: guido@python.org (Guido van Rossum), DavidA@ActiveState.com (David Asche
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created:
+Created: 25-Jul-2000
 Python-Version: 2.1
 Post-History:
 

--- a/pep-0228.txt
+++ b/pep-0228.txt
@@ -6,7 +6,7 @@ Author: moshez@zadka.site.co.il (Moshe Zadka), guido@python.org (Guido van Rossu
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 4-Nov-2000
+Created: 04-Nov-2000
 Post-History:
 
 

--- a/pep-0230.txt
+++ b/pep-0230.txt
@@ -6,7 +6,7 @@ Author: guido@python.org (Guido van Rossum)
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created:
+Created: 28-Nov-2000
 Python-Version: 2.1
 Post-History: 05-Nov-2000
 

--- a/pep-0235.txt
+++ b/pep-0235.txt
@@ -6,7 +6,7 @@ Author: Tim Peters <tim.peters@gmail.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created:
+Created: 21-Feb-2001
 Python-Version: 2.1
 Post-History: 16 February 2001
 

--- a/pep-0248.txt
+++ b/pep-0248.txt
@@ -7,7 +7,7 @@ Discussions-To: db-sig@python.org
 Status: Final
 Type: Informational
 Content-Type: text/x-rst
-Created:
+Created: 29-Mar-2001
 Post-History:
 Superseded-By: 249
 

--- a/pep-0249.txt
+++ b/pep-0249.txt
@@ -7,7 +7,7 @@ Discussions-To: db-sig@python.org
 Status: Final
 Type: Informational
 Content-Type: text/x-rst
-Created:
+Created: 29-Mar-2001
 Post-History:
 Replaces: 248
 

--- a/pep-0254.txt
+++ b/pep-0254.txt
@@ -6,7 +6,7 @@ Author: guido@python.org (Guido van Rossum)
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 18-June-2001
+Created: 18-Jun-2001
 Python-Version: 2.2
 Post-History:
 

--- a/pep-0265.txt
+++ b/pep-0265.txt
@@ -6,7 +6,7 @@ Author: g2@iowegian.com (Grant Griffin)
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 8-Aug-2001
+Created: 08-Aug-2001
 Python-Version: 2.2
 Post-History:
 

--- a/pep-0282.txt
+++ b/pep-0282.txt
@@ -6,7 +6,7 @@ Author: vinay_sajip at red-dove.com (Vinay Sajip), trentm@activestate.com (Trent
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 4-Feb-2002
+Created: 04-Feb-2002
 Python-Version: 2.3
 Post-History:
 

--- a/pep-0284.txt
+++ b/pep-0284.txt
@@ -7,7 +7,7 @@ Author: David Eppstein <eppstein@ics.uci.edu>,
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 1-Mar-2002
+Created: 01-Mar-2002
 Python-Version: 2.3
 Post-History:
 

--- a/pep-0285.txt
+++ b/pep-0285.txt
@@ -6,7 +6,7 @@ Author: guido@python.org (Guido van Rossum)
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 8-Mar-2002
+Created: 08-Mar-2002
 Python-Version: 2.3
 Post-History: 8-Mar-2002, 30-Mar-2002, 3-Apr-2002
 

--- a/pep-0286.txt
+++ b/pep-0286.txt
@@ -6,7 +6,7 @@ Author: martin@v.loewis.de (Martin von Löwis)
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 3-Mar-2002
+Created: 03-Mar-2002
 Python-Version: 2.3
 Post-History:
 

--- a/pep-0290.txt
+++ b/pep-0290.txt
@@ -6,7 +6,7 @@ Author: Raymond Hettinger <python@rcn.com>
 Status: Active
 Type: Informational
 Content-Type: text/x-rst
-Created: 6-Jun-2002
+Created: 06-Jun-2002
 Post-History:
 
 

--- a/pep-0308.txt
+++ b/pep-0308.txt
@@ -6,7 +6,7 @@ Author: Guido van Rossum, Raymond Hettinger
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 7-Feb-2003
+Created: 07-Feb-2003
 Post-History: 7-Feb-2003, 11-Feb-2003
 
 

--- a/pep-0346.txt
+++ b/pep-0346.txt
@@ -6,7 +6,7 @@ Author: Nick Coghlan <ncoghlan@gmail.com>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 6-May-2005
+Created: 06-May-2005
 Python-Version: 2.5
 Post-History:
 

--- a/pep-0361.txt
+++ b/pep-0361.txt
@@ -6,7 +6,7 @@ Author: Neal Norwitz, Barry Warsaw
 Status: Final
 Type: Informational
 Content-Type: text/x-rst
-Created: 29-June-2006
+Created: 29-Jun-2006
 Python-Version: 2.6 and 3.0
 Post-History: 17-Mar-2008
 

--- a/pep-0366.txt
+++ b/pep-0366.txt
@@ -6,7 +6,7 @@ Author: Nick Coghlan <ncoghlan@gmail.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 1-May-2007
+Created: 01-May-2007
 Python-Version: 2.6, 3.0
 Post-History: 1-May-2007, 4-Jul-2007, 7-Jul-2007, 23-Nov-2007
 

--- a/pep-0373.txt
+++ b/pep-0373.txt
@@ -6,7 +6,7 @@ Author: Benjamin Peterson <benjamin@python.org>
 Status: Final
 Type: Informational
 Content-Type: text/x-rst
-Created: 3-Nov-2008
+Created: 03-Nov-2008
 Python-Version: 2.7
 
 

--- a/pep-0375.txt
+++ b/pep-0375.txt
@@ -6,7 +6,7 @@ Author: Benjamin Peterson <benjamin@python.org>
 Status: Final
 Type: Informational
 Content-Type: text/x-rst
-Created: 8-Feb-2009
+Created: 08-Feb-2009
 Python-Version: 3.1
 
 

--- a/pep-0377.txt
+++ b/pep-0377.txt
@@ -6,9 +6,9 @@ Author: Nick Coghlan <ncoghlan@gmail.com>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 8-Mar-2009
+Created: 08-Mar-2009
 Python-Version: 2.7, 3.1
-Post-History: 8-Mar-2009
+Post-History: 08-Mar-2009
 
 
 Abstract

--- a/pep-0381.txt
+++ b/pep-0381.txt
@@ -6,7 +6,7 @@ Author: Tarek Ziadé <tarek@ziade.org>, Martin v. Löwis <martin@v.loewis.de>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 21-March-2009
+Created: 21-Mar-2009
 Python-Version: N.A.
 Post-History:
 

--- a/pep-0386.txt
+++ b/pep-0386.txt
@@ -6,7 +6,7 @@ Author: Tarek Ziadé <tarek@ziade.org>
 Status: Superseded
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 4-June-2009
+Created: 04-Jun-2009
 Superseded-By: 440
 
 

--- a/pep-0390.txt
+++ b/pep-0390.txt
@@ -8,7 +8,7 @@ Discussions-To: <distutils-sig@python.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 10-October-2009
+Created: 10-Oct-2009
 Python-Version: 2.7 and 3.2
 Post-History:
 Resolution: https://mail.python.org/pipermail/distutils-sig/2013-April/020597.html

--- a/pep-0395.txt
+++ b/pep-0395.txt
@@ -6,7 +6,7 @@ Author: Nick Coghlan <ncoghlan@gmail.com>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 4-Mar-2011
+Created: 04-Mar-2011
 Python-Version: 3.4
 Post-History: 5-Mar-2011, 19-Nov-2011
 

--- a/pep-0396.txt
+++ b/pep-0396.txt
@@ -6,7 +6,7 @@ Author: Barry Warsaw <barry@python.org>
 Status: Deferred
 Type: Informational
 Content-Type: text/x-rst
-Created: 2011-03-16
+Created: 16-Mar-2011
 Post-History: 2011-04-05
 
 

--- a/pep-0403.txt
+++ b/pep-0403.txt
@@ -6,7 +6,7 @@ Author: Nick Coghlan <ncoghlan@gmail.com>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2011-10-13
+Created: 13-Oct-2011
 Python-Version: 3.4
 Post-History: 2011-10-13
 Resolution: TBD

--- a/pep-0404.txt
+++ b/pep-0404.txt
@@ -6,7 +6,7 @@ Author: Barry Warsaw <barry@python.org>
 Status: Final
 Type: Informational
 Content-Type: text/x-rst
-Created: 2011-11-09
+Created: 09-Nov-2011
 Python-Version: 2.8
 
 

--- a/pep-0406.txt
+++ b/pep-0406.txt
@@ -6,7 +6,7 @@ Author: Nick Coghlan <ncoghlan@gmail.com>, Greg Slodkowicz <jergosh@gmail.com>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 4-Jul-2011
+Created: 04-Jul-2011
 Python-Version: 3.4
 Post-History: 31-Jul-2011, 13-Nov-2011, 4-Dec-2011
 

--- a/pep-0407.txt
+++ b/pep-0407.txt
@@ -8,7 +8,7 @@ Author: Antoine Pitrou <solipsis@pitrou.net>,
 Status: Deferred
 Type: Process
 Content-Type: text/x-rst
-Created: 2012-01-12
+Created: 12-Jan-2012
 Post-History: 17-Jan-2012
 Resolution: TBD
 

--- a/pep-0408.txt
+++ b/pep-0408.txt
@@ -7,7 +7,7 @@ Author: Nick Coghlan <ncoghlan@gmail.com>,
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2012-01-07
+Created: 07-Jan-2012
 Python-Version: 3.3
 Post-History: 2012-01-27
 Resolution: https://mail.python.org/pipermail/python-dev/2012-January/115962.html

--- a/pep-0410.txt
+++ b/pep-0410.txt
@@ -6,7 +6,7 @@ Author: Victor Stinner <vstinner@python.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 01-February-2012
+Created: 01-Feb-2012
 Python-Version: 3.3
 Resolution: https://mail.python.org/pipermail/python-dev/2012-February/116837.html
 

--- a/pep-0411.txt
+++ b/pep-0411.txt
@@ -7,7 +7,7 @@ Author: Nick Coghlan <ncoghlan@gmail.com>,
 Status: Active
 Type: Informational
 Content-Type: text/x-rst
-Created: 2012-02-10
+Created: 10-Feb-2012
 Python-Version: 3.3
 Post-History: 2012-02-10, 2012-03-24
 

--- a/pep-0413.txt
+++ b/pep-0413.txt
@@ -6,7 +6,7 @@ Author: Nick Coghlan <ncoghlan@gmail.com>
 Status: Withdrawn
 Type: Process
 Content-Type: text/x-rst
-Created: 2012-02-24
+Created: 24-Feb-2012
 Post-History: 2012-02-24, 2012-02-25
 Resolution: TBD
 

--- a/pep-0416.txt
+++ b/pep-0416.txt
@@ -6,7 +6,7 @@ Author: Victor Stinner <vstinner@python.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 29-February-2012
+Created: 29-Feb-2012
 Python-Version: 3.3
 
 

--- a/pep-0418.txt
+++ b/pep-0418.txt
@@ -6,7 +6,7 @@ Author: Cameron Simpson <cs@cskk.id.au>, Jim Jewett <jimjjewett@gmail.com>, Step
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 26-March-2012
+Created: 26-Mar-2012
 Python-Version: 3.3
 
 

--- a/pep-0421.txt
+++ b/pep-0421.txt
@@ -7,7 +7,7 @@ BDFL-Delegate: Barry Warsaw
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 26-April-2012
+Created: 26-Apr-2012
 Post-History: 26-April-2012
 Resolution: https://mail.python.org/pipermail/python-dev/2012-May/119683.html
 

--- a/pep-0422.txt
+++ b/pep-0422.txt
@@ -7,7 +7,7 @@ Author: Nick Coghlan <ncoghlan@gmail.com>,
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 5-Jun-2012
+Created: 05-Jun-2012
 Python-Version: 3.5
 Post-History: 5-Jun-2012, 10-Feb-2013
 

--- a/pep-0424.txt
+++ b/pep-0424.txt
@@ -6,7 +6,7 @@ Author: Alex Gaynor <alex.gaynor@gmail.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 14-July-2012
+Created: 14-Jul-2012
 Python-Version: 3.4
 Post-History: https://mail.python.org/pipermail/python-dev/2012-July/120920.html
 

--- a/pep-0426.txt
+++ b/pep-0426.txt
@@ -11,7 +11,7 @@ Status: Withdrawn
 Type: Informational
 Content-Type: text/x-rst
 Requires: 440, 508, 518
-Created: 30 Aug 2012
+Created: 30-Aug-2012
 Post-History: 14 Nov 2012, 5 Feb 2013, 7 Feb 2013, 9 Feb 2013,
               27 May 2013, 20 Jun 2013, 23 Jun 2013, 14 Jul 2013,
               21 Dec 2013

--- a/pep-0428.txt
+++ b/pep-0428.txt
@@ -6,7 +6,7 @@ Author: Antoine Pitrou <solipsis@pitrou.net>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 30-July-2012
+Created: 30-Jul-2012
 Python-Version: 3.4
 Post-History: https://mail.python.org/pipermail/python-ideas/2012-October/016338.html
 Resolution: https://mail.python.org/pipermail/python-dev/2013-November/130424.html

--- a/pep-0433.txt
+++ b/pep-0433.txt
@@ -6,7 +6,7 @@ Author: Victor Stinner <vstinner@python.org>
 Status: Superseded
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 10-January-2013
+Created: 10-Jan-2013
 Python-Version: 3.4
 Superseded-By: 446
 

--- a/pep-0435.txt
+++ b/pep-0435.txt
@@ -8,7 +8,7 @@ Author: Barry Warsaw <barry@python.org>,
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2013-02-23
+Created: 23-Feb-2013
 Python-Version: 3.4
 Post-History: 2013-02-23, 2013-05-02
 Replaces: 354

--- a/pep-0437.txt
+++ b/pep-0437.txt
@@ -6,7 +6,7 @@ Author: Stefan Krah <skrah@bytereef.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2013-03-11
+Created: 11-Mar-2013
 Python-Version: 3.4
 Post-History:
 Resolution: https://mail.python.org/pipermail/python-dev/2013-May/126117.html

--- a/pep-0440.txt
+++ b/pep-0440.txt
@@ -9,7 +9,7 @@ Discussions-To: Distutils SIG <distutils-sig@python.org>
 Status: Active
 Type: Informational
 Content-Type: text/x-rst
-Created: 18 Mar 2013
+Created: 18-Mar-2013
 Post-History: 30 Mar 2013, 27 May 2013, 20 Jun 2013,
               21 Dec 2013, 28 Jan 2014, 08 Aug 2014
               22 Aug 2014

--- a/pep-0441.txt
+++ b/pep-0441.txt
@@ -8,7 +8,7 @@ Discussions-To: https://mail.python.org/pipermail/python-dev/2015-February/13827
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 30 March 2013
+Created: 30-Mar-2013
 Post-History: 30 March 2013, 1 April 2013, 16 February 2015
 Resolution: https://mail.python.org/pipermail/python-dev/2015-February/138578.html
 

--- a/pep-0442.txt
+++ b/pep-0442.txt
@@ -7,7 +7,7 @@ BDFL-Delegate: Benjamin Peterson <benjamin@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2013-05-18
+Created: 18-May-2013
 Python-Version: 3.4
 Post-History: 2013-05-18
 Resolution: https://mail.python.org/pipermail/python-dev/2013-June/126746.html

--- a/pep-0446.txt
+++ b/pep-0446.txt
@@ -6,7 +6,7 @@ Author: Victor Stinner <vstinner@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 5-August-2013
+Created: 05-Aug-2013
 Python-Version: 3.4
 Replaces: 433
 

--- a/pep-0451.txt
+++ b/pep-0451.txt
@@ -8,7 +8,7 @@ Discussions-To: import-sig@python.org
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 8-Aug-2013
+Created: 08-Aug-2013
 Python-Version: 3.4
 Post-History: 8-Aug-2013, 28-Aug-2013, 18-Sep-2013, 24-Sep-2013, 4-Oct-2013
 Resolution: https://mail.python.org/pipermail/python-dev/2013-November/130104.html

--- a/pep-0454.txt
+++ b/pep-0454.txt
@@ -7,7 +7,7 @@ BDFL-Delegate: Charles-François Natali <cf.natali@gmail.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 3-September-2013
+Created: 03-Sep-2013
 Python-Version: 3.4
 Resolution: https://mail.python.org/pipermail/python-dev/2013-November/130491.html
 

--- a/pep-0459.txt
+++ b/pep-0459.txt
@@ -9,7 +9,7 @@ Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst
 Requires: 426
-Created: 11 Nov 2013
+Created: 11-Nov-2013
 Post-History: 21 Dec 2013
 
 

--- a/pep-0460.txt
+++ b/pep-0460.txt
@@ -6,7 +6,7 @@ Author: Antoine Pitrou <solipsis@pitrou.net>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 6-Jan-2014
+Created: 06-Jan-2014
 Python-Version: 3.5
 
 

--- a/pep-0461.txt
+++ b/pep-0461.txt
@@ -6,7 +6,7 @@ Author: Ethan Furman <ethan@stoneleaf.us>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2014-01-13
+Created: 13-Jan-2014
 Python-Version: 3.5
 Post-History: 2014-01-14, 2014-01-15, 2014-01-17, 2014-02-22, 2014-03-25,
               2014-03-27

--- a/pep-0467.txt
+++ b/pep-0467.txt
@@ -6,7 +6,7 @@ Author: Nick Coghlan <ncoghlan@gmail.com>, Ethan Furman <ethan@stoneleaf.us>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2014-03-30
+Created: 30-Mar-2014
 Python-Version: 3.9
 Post-History: 2014-03-30 2014-08-15 2014-08-16 2016-06-07 2016-09-01
 

--- a/pep-0468.txt
+++ b/pep-0468.txt
@@ -7,7 +7,7 @@ Discussions-To: python-ideas@python.org
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 5-Apr-2014
+Created: 05-Apr-2014
 Python-Version: 3.6
 Post-History: 5-Apr-2014,8-Sep-2016
 Resolution: https://mail.python.org/pipermail/python-dev/2016-September/146329.html

--- a/pep-0469.txt
+++ b/pep-0469.txt
@@ -6,7 +6,7 @@ Author: Nick Coghlan <ncoghlan@gmail.com>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2014-04-18
+Created: 18-Apr-2014
 Python-Version: 3.5
 Post-History: 2014-04-18, 2014-04-21
 

--- a/pep-0475.txt
+++ b/pep-0475.txt
@@ -7,7 +7,7 @@ BDFL-Delegate: Antoine Pitrou <solipsis@pitrou.net>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 29-July-2014
+Created: 29-Jul-2014
 Python-Version: 3.5
 Resolution: https://mail.python.org/pipermail/python-dev/2015-February/138018.html
 

--- a/pep-0476.txt
+++ b/pep-0476.txt
@@ -6,7 +6,7 @@ Author: Alex Gaynor <alex.gaynor@gmail.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 28-August-2014
+Created: 28-Aug-2014
 Resolution: https://mail.python.org/pipermail/python-dev/2014-October/136676.html
 
 Abstract

--- a/pep-0480.txt
+++ b/pep-0480.txt
@@ -11,7 +11,7 @@ Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst
 Requires:  458
-Created: 8-Oct-2014
+Created: 08-Oct-2014
 
 
 Abstract

--- a/pep-0490.txt
+++ b/pep-0490.txt
@@ -6,7 +6,7 @@ Author: Victor Stinner <vstinner@python.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 25-March-2015
+Created: 25-Mar-2015
 Python-Version: 3.6
 
 

--- a/pep-0491.txt
+++ b/pep-0491.txt
@@ -7,7 +7,7 @@ Discussions-To: <distutils-sig@python.org>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 16 April 2015
+Created: 16-Apr-2015
 
 Abstract
 ========

--- a/pep-0507.txt
+++ b/pep-0507.txt
@@ -6,7 +6,7 @@ Author: Barry Warsaw <barry@python.org>
 Status: Rejected
 Type: Process
 Content-Type: text/x-rst
-Created: 2015-09-30
+Created: 30-Sep-2015
 Post-History:
 Resolution: https://mail.python.org/pipermail/core-workflow/2016-January/000345.html
 

--- a/pep-0509.txt
+++ b/pep-0509.txt
@@ -6,7 +6,7 @@ Author: Victor Stinner <vstinner@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 4-January-2016
+Created: 04-Jan-2016
 Python-Version: 3.6
 
 

--- a/pep-0510.txt
+++ b/pep-0510.txt
@@ -6,7 +6,7 @@ Author: Victor Stinner <vstinner@python.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 4-January-2016
+Created: 04-Jan-2016
 Python-Version: 3.6
 
 

--- a/pep-0511.txt
+++ b/pep-0511.txt
@@ -6,7 +6,7 @@ Author: Victor Stinner <vstinner@python.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 4-January-2016
+Created: 04-Jan-2016
 Python-Version: 3.6
 
 Rejection Notice

--- a/pep-0520.txt
+++ b/pep-0520.txt
@@ -6,7 +6,7 @@ Author: Eric Snow <ericsnowcurrently@gmail.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 7-Jun-2016
+Created: 07-Jun-2016
 Python-Version: 3.6
 Post-History: 7-Jun-2016, 11-Jun-2016, 20-Jun-2016, 24-Jun-2016
 Resolution: https://mail.python.org/pipermail/python-dev/2016-June/145442.html

--- a/pep-0522.txt
+++ b/pep-0522.txt
@@ -7,7 +7,7 @@ Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
 Requires: 506
-Created: 16 June 2016
+Created: 16-Jun-2016
 Python-Version: 3.6
 Resolution: https://mail.python.org/pipermail/security-sig/2016-August/000101.html
 

--- a/pep-0524.txt
+++ b/pep-0524.txt
@@ -6,7 +6,7 @@ Author: Victor Stinner <vstinner@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 20-June-2016
+Created: 20-Jun-2016
 Python-Version: 3.6
 
 

--- a/pep-0534.txt
+++ b/pep-0534.txt
@@ -8,7 +8,7 @@ Author: Tomáš Orsava <tomas.n@orsava.cz>,
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 5-Sep-2016
+Created: 05-Sep-2016
 Post-History:
 
 

--- a/pep-0540.txt
+++ b/pep-0540.txt
@@ -7,7 +7,7 @@ BDFL-Delegate: INADA Naoki
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 5-January-2016
+Created: 05-Jan-2016
 Python-Version: 3.7
 Resolution: https://mail.python.org/pipermail/python-dev/2017-December/151173.html
 

--- a/pep-0541.txt
+++ b/pep-0541.txt
@@ -8,7 +8,7 @@ Discussions-To: distutils-sig <distutils-sig@python.org>
 Status: Final
 Type: Process
 Content-Type: text/x-rst
-Created: 12-January-2017
+Created: 12-Jan-2017
 Post-History:
 Resolution:  https://mail.python.org/pipermail/distutils-sig/2018-March/032089.html
 

--- a/pep-0542.txt
+++ b/pep-0542.txt
@@ -6,7 +6,7 @@ Author: Markus Meskanen <markusmeskanen@gmail.com>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 10-February-2017
+Created: 10-Feb-2017
 Resolution: https://mail.python.org/pipermail/python-dev/2019-March/156695.html
 
 

--- a/pep-0549.rst
+++ b/pep-0549.rst
@@ -7,7 +7,7 @@ Discussions-To: Python-Dev <python-dev@python.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 4-Sep-2017
+Created: 04-Sep-2017
 Python-Version: 3.7
 Post-History: 4-Sep-2017
 

--- a/pep-0552.rst
+++ b/pep-0552.rst
@@ -6,7 +6,7 @@ Author: Benjamin Peterson <benjamin@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2017-09-04
+Created: 04-Sep-2017
 Python-Version: 3.7
 Post-History: 2017-09-07
 Resolution: https://mail.python.org/pipermail/python-dev/2017-September/149649.html

--- a/pep-0553.rst
+++ b/pep-0553.rst
@@ -4,7 +4,7 @@ Author: Barry Warsaw <barry@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2017-09-05
+Created: 05-Sep-2017
 Python-Version: 3.7
 Post-History: 2017-09-05, 2017-09-07, 2017-09-13
 Resolution: https://mail.python.org/pipermail/python-dev/2017-October/149705.html

--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -5,7 +5,7 @@ BDFL-Delegate: Antoine Pitrou <antoine@python.org>
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2017-09-05
+Created: 05-Sep-2017
 Python-Version: 3.10
 Post-History: 07-Sep-2017, 08-Sep-2017, 13-Sep-2017, 05-Dec-2017,
               09-May-2018, 20-Apr-2020, 04-May-2020

--- a/pep-0556.rst
+++ b/pep-0556.rst
@@ -4,7 +4,7 @@ Author: Antoine Pitrou <solipsis@pitrou.net>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2017-09-08
+Created: 08-Sep-2017
 Python-Version: 3.7
 Post-History: 2017-09-08
 

--- a/pep-0558.rst
+++ b/pep-0558.rst
@@ -6,7 +6,7 @@ Discussions-To: https://discuss.python.org/t/pep-558-defined-semantics-for-local
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2017-09-08
+Created: 08-Sep-2017
 Python-Version: 3.10
 Post-History: 2017-09-08, 2019-05-22, 2019-05-30, 2019-12-30
 

--- a/pep-0559.rst
+++ b/pep-0559.rst
@@ -4,9 +4,9 @@ Author: Barry Warsaw <barry@python.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2017-09-08
+Created: 08-Sep-2017
 Python-Version: 3.7
-Post-History: 2017-09-09
+Post-History: 09-Sep-2017
 Resolution: https://mail.python.org/pipermail/python-dev/2017-September/149438.html
 
 

--- a/pep-0563.rst
+++ b/pep-0563.rst
@@ -7,7 +7,7 @@ Discussions-To: Python-Dev <python-dev@python.org>
 Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 8-Sep-2017
+Created: 08-Sep-2017
 Python-Version: 3.7
 Post-History: 1-Nov-2017, 21-Nov-2017
 Resolution: https://mail.python.org/pipermail/python-dev/2017-December/151042.html

--- a/pep-0564.rst
+++ b/pep-0564.rst
@@ -6,7 +6,7 @@ Author: Victor Stinner <vstinner@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 16-October-2017
+Created: 16-Oct-2017
 Python-Version: 3.7
 Resolution: https://mail.python.org/pipermail/python-dev/2017-October/150046.html
 

--- a/pep-0566.rst
+++ b/pep-0566.rst
@@ -8,7 +8,7 @@ Discussions-To: distutils-sig <distutils-sig at python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 1-Dec-2017
+Created: 01-Dec-2017
 Python-Version: 3.x
 Post-History:
 Replaces: 345

--- a/pep-0571.rst
+++ b/pep-0571.rst
@@ -10,7 +10,7 @@ Discussions-To: Distutils SIG <distutils-sig@python.org>
 Status: Active
 Type: Informational
 Content-Type: text/x-rst
-Created:
+Created: 05-Feb-2018
 Post-History:
 Resolution: https://mail.python.org/pipermail/distutils-sig/2018-April/032156.html
 

--- a/pep-0593.rst
+++ b/pep-0593.rst
@@ -6,7 +6,7 @@ Discussions-To: typing-sig@python.org
 Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 26-April-2019
+Created: 26-Apr-2019
 Python-Version: 3.9
 Post-History: 20-May-2019
 

--- a/pep-0599.rst
+++ b/pep-0599.rst
@@ -9,7 +9,7 @@ Discussions-To: https://discuss.python.org/t/the-next-manylinux-specification/
 Status: Final
 Type: Informational
 Content-Type: text/x-rst
-Created: 29-April-2019
+Created: 29-Apr-2019
 Post-History: 29-April-2019
 Resolution: https://discuss.python.org/t/the-next-manylinux-specification/1043/199
 

--- a/pep-0600.rst
+++ b/pep-0600.rst
@@ -10,7 +10,7 @@ Discussions-To: Discourse https://discuss.python.org/t/the-next-manylinux-specif
 Status: Accepted
 Type: Informational
 Content-Type: text/x-rst
-Created: 3-May-2019
+Created: 03-May-2019
 Post-History: 3-May-2019
 Resolution: https://discuss.python.org/t/pep-600-future-manylinux-platform-tags-for-portable-linux-built-distributions/2414/27
 

--- a/pep-0615.rst
+++ b/pep-0615.rst
@@ -5,7 +5,7 @@ Discussions-To: https://discuss.python.org/t/3468
 Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2020-02-22
+Created: 22-Feb-2020
 Python-Version: 3.9
 Post-History: 2020-02-25, 2020-03-29
 Replaces: 431

--- a/pep-0617.rst
+++ b/pep-0617.rst
@@ -9,7 +9,7 @@ Discussions-To: Python-Dev <python-dev@python.org>
 Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 24-March-2020
+Created: 24-Mar-2020
 Python-Version: 3.9
 Post-History: 02-Apr-2020
 

--- a/pep-0620.rst
+++ b/pep-0620.rst
@@ -4,7 +4,7 @@ Author: Victor Stinner <vstinner@python.org>
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 19-June-2020
+Created: 19-Jun-2020
 Python-Version: 3.10
 
 Abstract

--- a/pep-0628.txt
+++ b/pep-0628.txt
@@ -6,9 +6,9 @@ Author: Nick Coghlan <ncoghlan@gmail.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2011-06-28
+Created: 28-Jun-2011
 Python-Version: 3.6
-Post-History: 2011-06-28
+Post-History: 28-Jun-2011
 Resolution: http://bugs.python.org/issue12345
 
 

--- a/pep-0633.rst
+++ b/pep-0633.rst
@@ -7,7 +7,7 @@ Discussions-To: https://discuss.python.org/t/dependency-specification-in-pyproje
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2020-09-02
+Created: 02-Sep-2020
 Post-History: 2020-09-02
 Resolution: https://discuss.python.org/t/how-to-specify-dependencies-pep-508-strings-or-a-table-in-toml/5243/38
 

--- a/pep-0641.rst
+++ b/pep-0641.rst
@@ -8,7 +8,7 @@ Discussions-To: https://discuss.python.org/t/pep-641-using-an-underscore-in-the-
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2020-10-20
+Created: 20-Oct-2020
 Python-Version: 3.10
 Post-History: 2020-10-21
 Resolution: https://discuss.python.org/t/pep-641-using-an-underscore-in-the-version-portion-of-python-3-10-compatibility-tags/5513/42

--- a/pep-0666.txt
+++ b/pep-0666.txt
@@ -6,7 +6,7 @@ Author: lac@strakt.com (Laura Creighton)
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 3-Dec-2001
+Created: 03-Dec-2001
 Python-Version: 2.2
 Post-History: 5-Dec-2001
 

--- a/pep-3107.txt
+++ b/pep-3107.txt
@@ -7,7 +7,7 @@ Author: Collin Winter <collinwinter@google.com>,
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2-Dec-2006
+Created: 02-Dec-2006
 Python-Version: 3.0
 Post-History:
 

--- a/pep-3129.txt
+++ b/pep-3129.txt
@@ -6,7 +6,7 @@ Author: Collin Winter <collinwinter@google.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 1-May-2007
+Created: 01-May-2007
 Python-Version: 3.0
 Post-History: 7-May-2007
 

--- a/pep-3131.txt
+++ b/pep-3131.txt
@@ -6,7 +6,7 @@ Author: Martin von Löwis <martin@v.loewis.de>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 1-May-2007
+Created: 01-May-2007
 Python-Version: 3.0
 Post-History:
 

--- a/pep-3133.txt
+++ b/pep-3133.txt
@@ -7,7 +7,7 @@ Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
 Requires: 3115, 3129
-Created: 1-May-2007
+Created: 01-May-2007
 Python-Version: 3.0
 Post-History: 13-May-2007
 

--- a/pep-3139.txt
+++ b/pep-3139.txt
@@ -6,7 +6,7 @@ Author: Benjamin Peterson <benjamin@python.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 4-April-2008
+Created: 04-Apr-2008
 Python-Version: 3.0
 
 

--- a/pep-3143.txt
+++ b/pep-3143.txt
@@ -6,7 +6,7 @@ Author:            Ben Finney <ben+python@benfinney.id.au>
 Status:            Deferred
 Type:              Standards Track
 Content-Type:      text/x-rst
-Created:           2009-01-26
+Created:           26-Jan-2009
 Python-Version:    3.x
 Post-History:
 

--- a/pep-3144.txt
+++ b/pep-3144.txt
@@ -8,7 +8,7 @@ Discussions-To: <ipaddr-py-dev@googlegroups.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 6-Feb-2012
+Created: 06-Feb-2012
 Python-Version: 3.3
 Resolution: https://mail.python.org/pipermail/python-dev/2012-May/119474.html
 

--- a/pep-3146.txt
+++ b/pep-3146.txt
@@ -8,7 +8,7 @@ Author: Collin Winter <collinwinter@google.com>,
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 1-Jan-2010
+Created: 01-Jan-2010
 Python-Version: 3.3
 Post-History:
 

--- a/pep-3147.txt
+++ b/pep-3147.txt
@@ -6,7 +6,7 @@ Author: Barry Warsaw <barry@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2009-12-16
+Created: 16-Dec-2009
 Python-Version: 3.2
 Post-History: 2010-01-30, 2010-02-25, 2010-03-03, 2010-04-12
 Resolution: https://mail.python.org/pipermail/python-dev/2010-April/099414.html

--- a/pep-3149.txt
+++ b/pep-3149.txt
@@ -6,7 +6,7 @@ Author: Barry Warsaw <barry@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2010-07-09
+Created: 09-Jul-2010
 Python-Version: 3.2
 Post-History: 2010-07-14, 2010-07-22
 Resolution: https://mail.python.org/pipermail/python-dev/2010-September/103408.html

--- a/pep-3150.txt
+++ b/pep-3150.txt
@@ -6,7 +6,7 @@ Author: Nick Coghlan <ncoghlan@gmail.com>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2010-07-09
+Created: 09-Jul-2010
 Python-Version: 3.4
 Post-History: 2010-07-14, 2011-04-21, 2011-06-13
 Resolution: TBD

--- a/pep-3151.txt
+++ b/pep-3151.txt
@@ -7,7 +7,7 @@ BDFL-Delegate: Barry Warsaw
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2010-07-21
+Created: 21-Jul-2010
 Python-Version: 3.3
 Post-History:
 Resolution: https://mail.python.org/pipermail/python-dev/2011-October/114033.html

--- a/pep-3154.txt
+++ b/pep-3154.txt
@@ -6,7 +6,7 @@ Author: Antoine Pitrou <solipsis@pitrou.net>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2011-08-11
+Created: 11-Aug-2011
 Python-Version: 3.4
 Post-History:
     https://mail.python.org/pipermail/python-dev/2011-August/112821.html

--- a/pep-3155.txt
+++ b/pep-3155.txt
@@ -6,7 +6,7 @@ Author: Antoine Pitrou <solipsis@pitrou.net>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2011-10-29
+Created: 29-Oct-2011
 Python-Version: 3.3
 Post-History:
 Resolution: https://mail.python.org/pipermail/python-dev/2011-November/114545.html

--- a/pep-8000.rst
+++ b/pep-8000.rst
@@ -4,7 +4,7 @@ Author: Barry Warsaw <barry@python.org>
 Status: Active
 Type: Informational
 Content-Type: text/x-rst
-Created: 2018-08-24
+Created: 24-Aug-2018
 
 
 Abstract

--- a/pep-8001.rst
+++ b/pep-8001.rst
@@ -16,7 +16,7 @@ Author: Brett Cannon <brett@python.org>,
 Status: Accepted
 Type: Process
 Content-Type: text/x-rst
-Created: 2018-08-24
+Created: 24-Aug-2018
 
 
 Abstract

--- a/pep-8002.rst
+++ b/pep-8002.rst
@@ -6,7 +6,7 @@ Author: Barry Warsaw <barry@python.org>, Łukasz Langa <lukasz@python.org>,
 Status: Active
 Type: Informational
 Content-Type: text/x-rst
-Created: 2018-08-24
+Created: 24-Aug-2018
 
 
 Abstract

--- a/pep-8010.rst
+++ b/pep-8010.rst
@@ -4,7 +4,7 @@ Author: Barry Warsaw <barry@python.org>
 Status: Rejected
 Type: Informational
 Content-Type: text/x-rst
-Created: 2018-08-24
+Created: 24-Aug-2018
 
 
 Abstract

--- a/pep-8011.rst
+++ b/pep-8011.rst
@@ -4,7 +4,7 @@ Author: Mariatta <mariatta@python.org>, Barry Warsaw <barry@python.org>
 Status: Rejected
 Type: Informational
 Content-Type: text/x-rst
-Created: 2018-08-24
+Created: 24-Aug-2018
 
 
 Abstract

--- a/pep-8012.rst
+++ b/pep-8012.rst
@@ -4,7 +4,7 @@ Author: Łukasz Langa <lukasz@python.org>
 Status: Rejected
 Type: Informational
 Content-Type: text/x-rst
-Created: 2018-10-03
+Created: 03-Oct-2018
 
 
 PEP Rejection

--- a/pep-8013.rst
+++ b/pep-8013.rst
@@ -4,7 +4,7 @@ Author: Steve Dower <steve.dower@python.org>
 Status: Rejected
 Type: Informational
 Content-Type: text/x-rst
-Created: 2018-09-14
+Created: 14-Sep-2018
 
 Abstract
 ========

--- a/pep-8014.rst
+++ b/pep-8014.rst
@@ -4,7 +4,7 @@ Author: Jack Jansen
 Status: Rejected
 Type: Informational
 Content-Type: text/x-rst
-Created: 2018-09-16
+Created: 16-Sep-2018
 
 Abstract
 ========

--- a/pep-8015.rst
+++ b/pep-8015.rst
@@ -4,7 +4,7 @@ Author: Victor Stinner
 Status: Rejected
 Type: Informational
 Content-Type: text/x-rst
-Created: 2018-10-04
+Created: 04-Oct-2018
 
 Abstract
 ========

--- a/pep-8016.rst
+++ b/pep-8016.rst
@@ -4,7 +4,7 @@ Author: Nathaniel J. Smith, Donald Stufft
 Status: Accepted
 Type: Informational
 Content-Type: text/x-rst
-Created: 2018-11-01
+Created: 01-Nov-2018
 
 Note
 ====

--- a/pep-8100.rst
+++ b/pep-8100.rst
@@ -6,7 +6,7 @@ Author: Nathaniel J. Smith <njs@pobox.com>, Ee W. Durbin III <ee@python.org>
 Status: Active
 Type: Informational
 Content-Type: text/x-rst
-Created: 3-Jan-2019
+Created: 03-Jan-2019
 
 
 Abstract


### PR DESCRIPTION
All PEPs now follow the format specified in PEP 1: `dd-mmm-yyyy` which corresponds to `%d-%b-%Y`.