### PR TITLE
PEP 636: Is there a typo in the example code?

### DIFF
--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -401,7 +401,7 @@ each element looking for example like these:
 Until now, our patterns have processed sequences, but there are patterns to match
 mappings based on their present keys. In this case you could use::
 
-    for action in message:
+    for action in actions:
         match action:
             case {"text": message, "color": c}:
                 ui.set_text_color(c)
@@ -437,7 +437,7 @@ are both strings. For many builtin classes (see PEP-634 for the whole list), you
 use a positional parameter as a shorthand, writing ``str(c)`` rather than ``str() as c``.
 The fully rewritten version looks like this::
 
-    for action in message:
+    for action in actions:
         match action:
             case {"text": str(message), "color": str(c)}:
                 ui.set_text_color(c)


### PR DESCRIPTION
It seems unlikely that the `message` variable in these two examples is an iterable of actions, and especially confusing since in the pattern matching inside of the for loop, there is another `message` variable that would shadow this iterable of actions.

In this PR, I'm changing the name of the iterable of actions to `actions`, leaving the `message` variable created within the for loop the same.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
