### PR TITLE
Validate 'Created:' dates on CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,12 @@ repos:
     hooks:
       - id: rst-backticks
       - id: rst-inline-touching-normal
+
+  - repo: local
+    hooks:
+      - id: validate-created
+        name: "Lint Created: dates"
+        language: system
+        entry: python3 scripts/validate-created.py
+        files: ^pep-\d+\.(rst|txt)$
+        types: [text]

--- a/scripts/validate-created.py
+++ b/scripts/validate-created.py
@@ -1,0 +1,52 @@
+"""
+Validates the 'Created: ' field of PEPs match %d-%b-%Y as specified in PEP 1.
+
+Requires Python 3.9+
+
+Usage: python3 validate-created.py filename1 [filename2 [...]]
+"""
+import sys
+from datetime import datetime as dt
+
+COL_NUMBER = len("Created:")
+
+
+def validate_file(filename: str) -> int:
+    errors = 0
+    found = False
+    line_number = 0
+
+    with open(filename, encoding="utf8") as f:
+        for line in f:
+            line_number += 1
+            if line.startswith("Created:"):
+                found = True
+                break
+
+    if not found:
+        errors += 1
+        print(f"{filename}: 'Created:' not found")
+        return errors
+
+    date = line.removeprefix("Created:").strip()
+    try:
+        # Validate
+        dt.strptime(date, "%d-%b-%Y")
+    except ValueError as e:
+        print(f"{filename}:{line_number}:{COL_NUMBER}: {e}")
+        errors += 1
+
+    return errors
+
+
+def main(argv: list) -> None:
+    assert len(argv) >= 2, "Missing required filename parameter(s)"
+    total_errors = 0
+    for filename in argv[1:]:
+        total_errors += validate_file(filename)
+
+    sys.exit(total_errors)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/validate-created.py
+++ b/scripts/validate-created.py
@@ -1,14 +1,14 @@
 """
 Validates the 'Created: ' field of PEPs match %d-%b-%Y as specified in PEP 1.
 
-Requires Python 3.9+
+Requires Python 3.6+
 
 Usage: python3 validate-created.py filename1 [filename2 [...]]
 """
 import sys
 from datetime import datetime as dt
 
-COL_NUMBER = len("Created:")
+COL_NUMBER = len("Created: ")
 
 
 def validate_file(filename: str) -> int:
@@ -19,7 +19,7 @@ def validate_file(filename: str) -> int:
     with open(filename, encoding="utf8") as f:
         for line in f:
             line_number += 1
-            if line.startswith("Created:"):
+            if line.startswith("Created: "):
                 found = True
                 break
 
@@ -28,7 +28,7 @@ def validate_file(filename: str) -> int:
         print(f"{filename}: 'Created:' not found")
         return errors
 
-    date = line.removeprefix("Created:").strip()
+    date = line.split()[1]
     try:
         # Validate
         dt.strptime(date, "%d-%b-%Y")


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fixes #1803.

Also added to the `make lint`.

As we can see, 87 currently don't validate:

```console
$ make lint
pre-commit --version > /dev/null || python3 -m pip install pre-commit
pre-commit run --all-files
rst ``code`` is two backticks............................................Passed
rst ``inline code`` next to normal text..................................Passed
Lint Created: dates......................................................Failed
- hook id: validate-created
- exit code: 25

pep-0542.txt:9:8: time data '10-February-2017' does not match format '%d-%b-%Y'
pep-0013.rst:7:8: time data '2018-12-16' does not match format '%d-%b-%Y'
pep-3155.txt:9:8: time data '2011-10-29' does not match format '%d-%b-%Y'
pep-0511.txt:9:8: time data '4-January-2016' does not match format '%d-%b-%Y'
pep-8011.rst:7:8: time data '2018-08-24' does not match format '%d-%b-%Y'
pep-0628.txt:9:8: time data '2011-06-28' does not match format '%d-%b-%Y'
pep-0254.txt:9:8: time data '18-June-2001' does not match format '%d-%b-%Y'
pep-8013.rst:7:8: time data '2018-09-14' does not match format '%d-%b-%Y'
pep-0510.txt:9:8: time data '4-January-2016' does not match format '%d-%b-%Y'
pep-0641.rst:11:8: time data '2020-10-20' does not match format '%d-%b-%Y'
pep-0554.rst:8:8: time data '2017-09-05' does not match format '%d-%b-%Y'
pep-0469.txt:9:8: time data '2014-04-18' does not match format '%d-%b-%Y'
pep-0426.txt:14:8: time data '30 Aug 2012' does not match format '%d-%b-%Y'
pep-8012.rst:7:8: time data '2018-10-03' does not match format '%d-%b-%Y'
pep-0564.rst:9:8: time data '16-October-2017' does not match format '%d-%b-%Y'
pep-0248.txt:10:8: time data '' does not match format '%d-%b-%Y'
pep-0615.rst:8:8: time data '2020-02-22' does not match format '%d-%b-%Y'
pep-0381.txt:9:8: time data '21-March-2009' does not match format '%d-%b-%Y'
pep-0421.txt:10:8: time data '26-April-2012' does not match format '%d-%b-%Y'
pep-0433.txt:9:8: time data '10-January-2013' does not match format '%d-%b-%Y'
pep-0424.txt:9:8: time data '14-July-2012' does not match format '%d-%b-%Y'
pep-0435.txt:11:8: time data '2013-02-23' does not match format '%d-%b-%Y'
pep-0440.txt:12:8: time data '18 Mar 2013' does not match format '%d-%b-%Y'
pep-0390.txt:11:8: time data '10-October-2009' does not match format '%d-%b-%Y'
pep-0207.txt:9:8: time data '' does not match format '%d-%b-%Y'
pep-0633.rst:10:8: time data '2020-09-02' does not match format '%d-%b-%Y'
pep-8014.rst:7:8: time data '2018-09-16' does not match format '%d-%b-%Y'
pep-8001.rst:19:8: time data '2018-08-24' does not match format '%d-%b-%Y'
pep-0411.txt:10:8: time data '2012-02-10' does not match format '%d-%b-%Y'
pep-0206.txt:9:8: time data '' does not match format '%d-%b-%Y'
pep-3150.txt:9:8: time data '2010-07-09' does not match format '%d-%b-%Y'
pep-0620.rst:7:8: time data '19-June-2020' does not match format '%d-%b-%Y'
pep-0418.txt:9:8: time data '26-March-2012' does not match format '%d-%b-%Y'
pep-0491.txt:10:8: time data '16 April 2015' does not match format '%d-%b-%Y'
pep-3147.txt:9:8: time data '2009-12-16' does not match format '%d-%b-%Y'
pep-0454.txt:10:8: time data '3-September-2013' does not match format '%d-%b-%Y'
pep-0416.txt:9:8: time data '29-February-2012' does not match format '%d-%b-%Y'
pep-0403.txt:9:8: time data '2011-10-13' does not match format '%d-%b-%Y'
pep-8000.rst:7:8: time data '2018-08-24' does not match format '%d-%b-%Y'
pep-0361.txt:9:8: time data '29-June-2006' does not match format '%d-%b-%Y'
pep-0404.txt:9:8: time data '2011-11-09' does not match format '%d-%b-%Y'
pep-8010.rst:7:8: time data '2018-08-24' does not match format '%d-%b-%Y'
pep-0617.rst:12:8: time data '24-March-2020' does not match format '%d-%b-%Y'
pep-3139.txt:9:8: time data '4-April-2008' does not match format '%d-%b-%Y'
pep-0490.txt:9:8: time data '25-March-2015' does not match format '%d-%b-%Y'
pep-0509.txt:9:8: time data '4-January-2016' does not match format '%d-%b-%Y'
pep-0540.txt:10:8: time data '5-January-2016' does not match format '%d-%b-%Y'
pep-0541.txt:11:8: time data '12-January-2017' does not match format '%d-%b-%Y'
pep-0524.txt:9:8: time data '20-June-2016' does not match format '%d-%b-%Y'
pep-8002.rst:9:8: time data '2018-08-24' does not match format '%d-%b-%Y'
pep-0249.txt:10:8: time data '' does not match format '%d-%b-%Y'
pep-0446.txt:9:8: time data '5-August-2013' does not match format '%d-%b-%Y'
pep-0205.txt:9:8: time data '' does not match format '%d-%b-%Y'
pep-0408.txt:10:8: time data '2012-01-07' does not match format '%d-%b-%Y'
pep-0571.rst:13:8: time data '' does not match format '%d-%b-%Y'
pep-0599.rst:12:8: time data '29-April-2019' does not match format '%d-%b-%Y'
pep-0102.txt:11:8: unconverted data remains:  (edited down on 9-Jan-2002 to become PEP 102)
pep-0235.txt:9:8: time data '' does not match format '%d-%b-%Y'
pep-0556.rst:7:8: time data '2017-09-08' does not match format '%d-%b-%Y'
pep-8016.rst:7:8: time data '2018-11-01' does not match format '%d-%b-%Y'
pep-0410.txt:9:8: time data '01-February-2012' does not match format '%d-%b-%Y'
pep-0552.rst:9:8: time data '2017-09-04' does not match format '%d-%b-%Y'
pep-0461.txt:9:8: time data '2014-01-13' does not match format '%d-%b-%Y'
pep-0396.txt:9:8: time data '2011-03-16' does not match format '%d-%b-%Y'
pep-0507.txt:9:8: time data '2015-09-30' does not match format '%d-%b-%Y'
pep-0437.txt:9:8: time data '2013-03-11' does not match format '%d-%b-%Y'
pep-0230.txt:9:8: time data '' does not match format '%d-%b-%Y'
pep-3151.txt:10:8: time data '2010-07-21' does not match format '%d-%b-%Y'
pep-0428.txt:9:8: time data '30-July-2012' does not match format '%d-%b-%Y'
pep-3154.txt:9:8: time data '2011-08-11' does not match format '%d-%b-%Y'
pep-0442.txt:10:8: time data '2013-05-18' does not match format '%d-%b-%Y'
pep-0476.txt:9:8: time data '28-August-2014' does not match format '%d-%b-%Y'
pep-0441.txt:11:8: time data '30 March 2013' does not match format '%d-%b-%Y'
pep-3149.txt:9:8: time data '2010-07-09' does not match format '%d-%b-%Y'
pep-0559.rst:7:8: time data '2017-09-08' does not match format '%d-%b-%Y'
pep-0553.rst:7:8: time data '2017-09-05' does not match format '%d-%b-%Y'
pep-0386.txt:9:8: time data '4-June-2009' does not match format '%d-%b-%Y'
pep-3143.txt:9:8: time data '2009-01-26' does not match format '%d-%b-%Y'
pep-0407.txt:11:8: time data '2012-01-12' does not match format '%d-%b-%Y'
pep-0522.txt:10:8: time data '16 June 2016' does not match format '%d-%b-%Y'
pep-0475.txt:10:8: time data '29-July-2014' does not match format '%d-%b-%Y'
pep-0459.txt:12:8: time data '11 Nov 2013' does not match format '%d-%b-%Y'
pep-0467.txt:9:8: time data '2014-03-30' does not match format '%d-%b-%Y'
pep-8015.rst:7:8: time data '2018-10-04' does not match format '%d-%b-%Y'
pep-0413.txt:9:8: time data '2012-02-24' does not match format '%d-%b-%Y'
pep-0200.txt:9:8: time data '' does not match format '%d-%b-%Y'
pep-0558.rst:9:8: time data '2017-09-08' does not match format '%d-%b-%Y'
pep-0593.rst:9:8: time data '26-April-2019' does not match format '%d-%b-%Y'

make: *** [lint] Error 1
```

I'll fix them and update the PR.
