### PR TITLE
PEP 647: clarify why type guards are not just a boolean

### DIFF
--- a/pep-0647.rst
+++ b/pep-0647.rst
@@ -93,7 +93,9 @@ are supported by type checkers.
 
 Using this new mechanism, the ``is_str_list`` function in the above example
 would be modified slightly. Its return type would be changed from ``bool``
-to ``TypeGuard[List[str]]``.
+to ``TypeGuard[List[str]]``.  This promises not merely that the return value
+is boolean, but that a true indicates the input to the function was of the 
+specified type.
 
 ::
 
@@ -198,10 +200,10 @@ allows for cases like the example above where ``List[str]`` is not assignable
 to ``List[object]``.
 
 When a conditional statement includes a call to a user-defined type guard
-function, the expression passed as the first positional argument to the type
-guard function should be assumed by a static type checker to take on the type
-specified in the TypeGuard return type, unless and until it is further
-narrowed within the conditional code block.
+function, and that function returns true, the expression passed as the first 
+positional argument to the type guard function should be assumed by a static 
+type checker to take on the type specified in the TypeGuard return type, 
+unless and until it is further narrowed within the conditional code block.
 
 Some built-in type guards provide narrowing for both positive and negative
 tests (in both the ``if`` and ``else`` clauses). For example, consider the
@@ -233,7 +235,6 @@ is not narrowed in the negative case.
 Backwards Compatibility
 =======================
 Existing code that does not use this new functionality will be unaffected.
-
 
 Reference Implementation
 ========================


### PR DESCRIPTION
clarify some points I was confused on ... why TypeGuard isn't just a boolean,

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
