### PR TITLE
PEP 647: comment about backwards-compatibility

### DIFF
--- a/pep-0647.rst
+++ b/pep-0647.rst
@@ -234,6 +234,9 @@ Backwards Compatibility
 =======================
 Existing code that does not use this new functionality will be unaffected.
 
+Notably, code which uses annotations in a manner incompatible with the
+stdlib typing library should simply not import TypeGuard.
+
 
 Reference Implementation
 ========================


### PR DESCRIPTION
backwards compatibility for non-typing annnotations

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
