### PR TITLE
PEP 636: Add missing colons at the end of case statement

### DIFF
--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -408,9 +408,9 @@ mappings based on their present keys. In this case you could use::
                 ui.display(message)
             case {"sleep": duration}:
                 ui.wait(duration)
-            case {"sound": url, "format": "ogg"}
+            case {"sound": url, "format": "ogg"}:
                 ui.play(url)
-            case {"sound": _, "format": _}
+            case {"sound": _, "format": _}:
                 warning("Unsupported audio format")
 
 The keys in your mapping pattern need to be literals, but the values can be any
@@ -444,9 +444,9 @@ The fully rewritten version looks like this::
                 ui.display(message)
             case {"sleep": float(duration)}:
                 ui.wait(duration)
-            case {"sound": str(url), "format": "ogg"}
+            case {"sound": str(url), "format": "ogg"}:
                 ui.play(url)
-            case {"sound": _, "format": _}
+            case {"sound": _, "format": _}:
                 warning("Unsupported audio format")
 
 


### PR DESCRIPTION
Signed-off-by: Matej Dujava <mdujava@kocurkovo.cz>
