### PR TITLE
PEP 597: Use longer option name

### DIFF
--- a/pep-0597.rst
+++ b/pep-0597.rst
@@ -17,9 +17,9 @@ Add a new warning category ``EncodingWarning``. It is emitted when
 ``encoding`` option is omitted and the default encoding is a locale
 encoding.
 
-The warning is disabled by default. New ``-X warn_encoding``
-command-line option and ``PYTHONWARNENCODING`` environment variable
-are used to enable the warnings.
+The warning is disabled by default. New ``-X warn_default_encoding``
+command-line option and ``PYTHONWARNDEFAULTENCODING`` environment
+variable are used to enable the warnings.
 
 ``encoding="locale"`` option is added too. It is used to specify
 locale encoding explicitly.
@@ -109,9 +109,9 @@ omitted and the default encoding is locale-specific.
 Options to enable the warning
 ------------------------------
 
-``-X warn_encoding`` option and the ``PYTHONWARNENCODING``
-environment variable are added. They are used to enable the
-``EncodingWarning``.
+``-X warn_default_encoding`` option and the
+``PYTHONWARNDEFAULTENCODING`` environment variable are added. They
+are used to enable the ``EncodingWarning``.
 
 ``sys.flags.encoding_warning`` is also added. The flag represents
 ``EncodingWarning`` is enabled.
@@ -255,8 +255,8 @@ Using ``open(filename)`` to read text files encoded in UTF-8 is a
 common mistake. It may not work on Windows because UTF-8 is not the
 default encoding.
 
-You can use ``-X warn_encoding`` or ``PYTHONWARNENCODING=1`` to find
-this type of mistake.
+You can use ``-X warn_default_encoding`` or
+``PYTHONWARNDEFAULTENCODING=1`` to find this type of mistake.
 
 Omitting ``encoding`` option is not a bug when opening text files
 encoded in locale encoding. But ``encoding="locale"`` is recommended


### PR DESCRIPTION
warn_encoding -> warn_default_encoding