### PR TITLE
PEP 427: Amend wheel's filename escaping rules

### DIFF
--- a/pep-0427.txt
+++ b/pep-0427.txt
@@ -9,7 +9,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 20-Sep-2012
-Post-History: 18-Oct-2012, 15-Feb-2013
+Post-History: 18-Oct-2012, 15-Feb-2013, 20-Feb-2021
 Resolution: https://mail.python.org/pipermail/python-dev/2013-February/124103.html
 
 Abstract
@@ -158,10 +158,10 @@ package's basic interpreter requirements and are detailed in PEP 425.
 Escaping and Unicode
 ''''''''''''''''''''
 
-Each component of the filename is escaped by replacing runs of
-non-alphanumeric characters with an underscore ``_``::
-
-    re.sub("[^\w\d.]+", "_", distribution, re.UNICODE)
+The ``distribution`` and ``version`` components of the filename should
+follow the same rules as the ``.dist-info`` directory. [2]_ Each
+component is then escaped by replacing each dash ``-`` with an
+underscore ``_``.
 
 The archive filename is Unicode.  It will be some time before the tools
 are updated to support non-ASCII filenames, but they are supported in
@@ -446,6 +446,9 @@ References
 
 .. [1] PEP acceptance
    (https://mail.python.org/pipermail/python-dev/2013-February/124103.html)
+
+.. [2] Recording installed projects
+   (https://packaging.python.org/specifications/recording-installed-packages/)
 
 
 Appendix


### PR DESCRIPTION
This builds on the last solution [proposed on Discourse](https://discuss.python.org/t/5605). It delegates most of the normalization logic to existing specifications, and only perform simple dash-to-underscore substitution in the wheel's filename. This makes the unescaping logic the easiest, while producing an esacping logic that's easy to implement (since wheel builders should already know how to produce valid .dist-info names).

cc @dholth @jwodder 