### PR TITLE
PEP 616: Replace a misleading example

### DIFF
--- a/pep-0616.rst
+++ b/pep-0616.rst
@@ -161,6 +161,22 @@ cookiejar.py
         return text.removeprefix('"').removesuffix('"')
 
 
+test_i18n.py
+------------
+
+- Current::
+
+    creationDate = header['POT-Creation-Date']
+
+    # peel off the escaped newline at the end of string
+    if creationDate.endswith('\\n'):
+        creationDate = creationDate[:-len('\\n')]
+
+- Improved::
+
+    creationDate = header['POT-Creation-Date'].removesuffix('\\n')
+
+
 There were many other such examples in the stdlib.
 
 

--- a/pep-0616.rst
+++ b/pep-0616.rst
@@ -161,28 +161,6 @@ cookiejar.py
         return text.removeprefix('"').removesuffix('"')
 
 
-test_concurrent_futures.py
---------------------------
-
-In the following example, the meaning of the code changes slightly,
-but in context, it behaves the same.
-
-- Current::
-
-    if name.endswith(('Mixin', 'Tests')):
-        return name[:-5]
-    elif name.endswith('Test'):
-        return name[:-4]
-    else:
-        return name
-
-- Improved::
-
-    return (name.removesuffix('Mixin')
-                .removesuffix('Tests')
-                .removesuffix('Test'))
-
-
 There were many other such examples in the stdlib.
 
 


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

In https://github.com/python/peps/issues/1639 , it looks like at least two people have taken issue with the example, and I don't think much is lost by removing it, except a lack of examples of `removesuffix()`. I think this is a reasonable replacement.
