### PR TITLE
clarifications after python-dev review: subgroup return None for empt…

### DIFF
--- a/pep-0654.rst
+++ b/pep-0654.rst
@@ -186,7 +186,9 @@ contains only those exceptions for which the condition is true:
 
 
 Empty nested ``ExceptionGroups`` are omitted from the result, as in the
-case of ``ExceptionGroup("three")`` in the example above.  The original ``eg``
+case of ``ExceptionGroup("three")`` in the example above.  If none of the
+leaf exceptions match the condition, ``subgroup`` returns ``None`` rather
+than an empty ``ExceptionGroup``. The original ``eg``
 is unchanged by ``subgroup``, but the value returned is not necessarily a full
 new copy. Leaf exceptions are not copied, nor are ``ExceptionGroups`` which are
 fully contained in the result. When it is necessary to partition an
@@ -858,6 +860,11 @@ with ``except*`` because the latter is ambiguous:
    try:
        ...
    except *ExceptionGroup:  # <- Runtime error
+       pass
+
+   try:
+       ...
+   except *(TypeError, ExceptionGroup):  # <- Runtime error
        pass
 
 


### PR DESCRIPTION
…y. except *(TypeError, ExceptionGroup) is forbidden

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
