### PR TITLE
PEP 634: Fix error typo in mapping patterns (TypeError ->ValueError)

### DIFF
--- a/pep-0634.rst
+++ b/pep-0634.rst
@@ -412,7 +412,7 @@ and it must be last.
 A mapping pattern may not contain duplicate key values.
 (If all key patterns are literal patterns this is considered a
 syntax error; otherwise this is a runtime error and will
-raise ``TypeError``.)
+raise ``ValueError``.)
 
 A mapping pattern fails if the subject value is not an instance of
 ``collections.abc.Mapping``.


### PR DESCRIPTION
I don't think mapping patterns are supposed to raise TypeError on duplicate keys, instead it's probably ValueError.  A few paragraphs down the PEP mentions:

> If duplicate keys are detected in the mapping pattern, the pattern is considered invalid, and a ValueError is raised.

So it seems like a contradiction.

The implementation seems to only raise TypeError for class patterns too:
https://github.com/python/cpython/pull/22917/files