### PR TITLE
PEP 618: Fix typo

### DIFF
--- a/pep-0618.rst
+++ b/pep-0618.rst
@@ -164,7 +164,7 @@ Add ``itertools.zip_strict``
 ----------------------------
 
 This is the alternative with the most support on the Python-Ideas
-mailing list, so it deserves do be discussed in some detail here.  It
+mailing list, so it deserves to be discussed in some detail here.  It
 does not have any disqualifying flaws, and could work well enough as a
 substitute if this PEP is rejected.
 


### PR DESCRIPTION
"deserves to" instead of "deserves do"
