### PR TITLE
PEP 636: Minor typo

### DIFF
--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -578,7 +578,7 @@ Several other key features:
 - Mapping patterns: ``{"bandwidth": b, "latency": l}`` captures the
   ``"bandwidth"`` and ``"latency"`` values from a dict.  Unlike sequence
   patterns, extra keys are ignored.  A wildcard ``**rest`` is also
-  supported.  (But ``**_`` would be redundant, so it not allowed.)
+  supported.  (But ``**_`` would be redundant, so it is not allowed.)
 
 - Subpatterns may be captured using the ``as`` keyword::
 


### PR DESCRIPTION
Fix minor typo:  
"But ``**_`` would be redundant, so it not allowed."
--> "But ``**_`` would be redundant, so it **is** not allowed."

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
