### PR TITLE
PEP 621: mention that '{name} <{email}>' may need quoting

### DIFF
--- a/pep-0621.rst
+++ b/pep-0621.rst
@@ -292,7 +292,8 @@ Using the data to fill in `core metadata`_ is as follows:
    ``Author-email``/``Maintainer-email`` as appropriate.
 3. If both ``email`` and ``name`` are provided, the value goes in
    ``Author-email``/``Maintainer-email`` as appropriate, with the
-   format ``{name} <{email}>``.
+   format ``{name} <{email}>`` (with appropriate quoting, e.g. using
+   ``email.headerregistry.Address``).
 4. Multiple values should be separated by commas.
 
 ``keywords``


### PR DESCRIPTION
I interpreted the `{name} <{email}>` to mean Python string formatting, which is incorrect in some cases.

cc @Pyfisch @uranusjr @brettcannon 