### PR TITLE
PEP 601: remove email due to lexer bug

### DIFF
--- a/pep-0601.txt
+++ b/pep-0601.txt
@@ -1,6 +1,6 @@
 PEP: 601
 Title: Forbid return/break/continue breaking out of finally
-Author: Damien George <>, Batuhan Taskaya <batuhan@python.org>
+Author: Damien George, Batuhan Taskaya
 Sponsor: Nick Coghlan
 Discussions-To: https://discuss.python.org/t/pep-601-forbid-return-break-continue-breaking-out-of-finally/2239
 Status: Rejected


### PR DESCRIPTION
Apparently the author/email lexer can't handle missing emails with authors, so temporarily I'll remove my address