### PR TITLE
PEP 656: Platform Tag for Linux Distributions Using Musl

### DIFF
--- a/pep-0656.rst
+++ b/pep-0656.rst
@@ -1,4 +1,4 @@
-PEP: 9999
+PEP: 656
 Title: Platform Tag for Linux Distributions Using Musl
 Author: Tzu-ping Chung <uranusjr@gmail.com>
 Sponsor: Brett Cannon <brett@python.org>

--- a/pep-0656.rst
+++ b/pep-0656.rst
@@ -23,9 +23,9 @@ targeting platforms based on musl instead.
 Motivation
 ==========
 
-With the wide use of containers, distributions such as Alpine Linux,
-[alpine]_ have been gaining more popularity than ever. Many of them
-based on musl, [musl]_ a different libc implementation from glibc, and
+With the wide use of containers, distributions such as Alpine Linux
+[alpine]_, have been gaining more popularity than ever. Many of them
+based on musl [musl]_, a different libc implementation from glibc, and
 therefore cannot use the existing ``manylinux`` platform tags. This
 means that Python package projects cannot deploy binary distributions
 on PyPI for them. Users of such projects demand build constraints from

--- a/pep-0656.rst
+++ b/pep-0656.rst
@@ -62,10 +62,25 @@ in :pep:`600`, including:
 2. The distribution's ``${ARCH}`` matches the return value of
    ``sysconfig.get_platform()`` on the host system.
 
+Example values::
+
+    musllinux_1_1_x86_64   # musl 1.1 running on x86-64.
+    musllinux_1_2_aarch64  # musl 1.2 running on ARM 64-bit.
+
+The value can be formatted with the following Python code::
+
+    import sysconfig
+
+    def format_musllinux(musl_version: tuple[int, int]) -> str:
+        os_name, sep, arch = sysconfig.get_platform().partition("-")
+        assert os_name == "linux" and sep, "Not a Linux"
+        arch = arch.replace("-", "_")
+        return f"musllinux_{musl_version[0]}_{musl_version[1]}_{arch}"
+
 It is recommended for Python package repositories, including PyPI, to
 accept platform tags matching the following regular expression::
 
-   musllinux_([0-9]+)_([0-9]+)_([^-]+)
+    musllinux_([0-9]+)_([0-9]+)_([^-]+)
 
 Python package repositories may impose additional requirements to
 reject Wheels with known issues, including but not limited to:

--- a/pep-0656.rst
+++ b/pep-0656.rst
@@ -36,9 +36,9 @@ Rationale
 =========
 
 According to the documentation, musl has a stable ABI, and maintains
-backwards compatibility, [musl-compatibility]_ [compare-libcs]_ so a
+backwards compatibility [musl-compatibility]_ [compare-libcs]_, so a
 binary compiled against an earlier version of musl is guaranteed to
-run against a newer musl runtime. [musl-compat-ml]_ Therefore, we use
+run against a newer musl runtime [musl-compat-ml]_. Therefore, we use
 a scheme similar to the glibc-version-based manylinux tags, but
 against musl versions instead of glibc.
 

--- a/pep-0656.rst
+++ b/pep-0656.rst
@@ -85,11 +85,11 @@ accept platform tags matching the following regular expression::
 Python package repositories may impose additional requirements to
 reject Wheels with known issues, including but not limited to:
 
-* A ``musl_1_1`` wheel containing symbols only available in musl 1.2.
+* A ``musllinux_1_1`` wheel containing symbols only available in musl 1.2.
 * Wheel that depends on external libraries not considered generally
   available to the intended audience of the package index.
 * A platform tag claiming compatibility to a non-existent musl version
-  (like ``musl_9000_0``).
+  (like ``musllinux_9000_0``).
 
 Such policies are ultimately up to individual package repositories.
 It is not the author's intention to impose restrictions to the

--- a/pep-0656.rst
+++ b/pep-0656.rst
@@ -54,7 +54,7 @@ Tags using the new scheme will take the form::
 
     musllinux_${MUSLMAJOR}_${MUSLMINOR}_${ARCH}
 
-Distributions using the tag make similar promises to those discribed
+Distributions using the tag make similar promises to those described
 in :pep:`600`, including:
 
 1. The distribution works on any mainstream Linux distributions with

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -35,6 +35,13 @@ those projects, putting unnecessary burden on project maintainers.
 Rationale
 =========
 
+According to the documentation, musl has a stable ABI, and maintains
+backwards compatibility, [musl-compatibility]_ [compare-libcs]_ so a
+binary compiled against an earlier version of musl is guaranteed to
+run against a newer musl runtime. [musl-compat-ml]_ Therefore, we use
+a scheme similar to the glibc-version-based manylinux tags, but
+against musl versions instead of glibc.
+
 Logic behind the new platform tag largely follows :pep:`600`, and
 require wheels using this tag make similar promises. Please refer to
 the PEP for more details on rationale and reasoning behind the design.
@@ -79,6 +86,12 @@ References
 .. [alpine] https://alpinelinux.org/
 
 .. [musl] https://musl.libc.org
+
+.. [musl-compatibility] https://wiki.musl-libc.org/compatibility.html
+
+.. [compare-libcs] https://www.etalabs.net/compare_libcs.html
+
+.. [musl-compat-ml] https://mail.python.org/archives/list/distutils-sig@python.org/message/VRXSTNXWHPAVUW253ZCWWMP7WDTBAQDL/
 
 
 Copyright

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -1,7 +1,7 @@
 PEP: 9999
 Title: Platform Tag for Linux Distributions Using Musl
 Author: Tzu-ping Chung <uranusjr@gmail.com>
-Sponsor: TBD
+Sponsor: Brett Cannon <brett@python.org>
 PEP-Delegate: TBD
 Discussions-To: https://discuss.python.org/t/7165
 Status: Draft

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -55,14 +55,6 @@ in :pep:`600`, including:
 2. The distribution's ``${ARCH}`` matches the return value of
    ``sysconfig.get_platform()`` on the host system.
 
-One exception is made to the first promise: If a project chooses to
-publish a distribution using musl 1.2 or later on, it does not need to
-promise distributions on the same architecture built against musl 1.1
-or earlier to work on musl 1.2 or later. This is due to a potentially
-ABI incompatible change in musl 1.2 that switched ``time_t`` to a
-64-bit type, and may cause breakage to libraries built on musl 1.1 and
-earlier. [musl-time64]_
-
 
 Backwards Compatibility
 =======================
@@ -87,8 +79,6 @@ References
 .. [alpine] https://alpinelinux.org/
 
 .. [musl] https://musl.libc.org
-
-.. [musl-time64] https://musl.libc.org/time64.html
 
 
 Copyright

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -23,12 +23,12 @@ targeting platforms based on musl instead.
 Motivation
 ==========
 
-With the wide use of containers, distributions such as `Alpine Linux`_
-have been gaining more popularity than ever. Many of them based on
-`musl`_, a different libc implementation from glibc, and therefore
-cannot use the existing ``manylinux`` platform tags. This means that
-Python package projects cannot deploy binary distributions on PyPI
-for them. Users of such projects demand build-time constraints from
+With the wide use of containers, distributions such as Alpine Linux,
+[alpine]_ have been gaining more popularity than ever. Many of them
+based on musl, [musl]_ a different libc implementation from glibc, and
+therefore cannot use the existing ``manylinux`` platform tags. This
+means that Python package projects cannot deploy binary distributions
+on PyPI for them. Users of such projects demand build constraints from
 those projects, putting unnecessary burden on project maintainers.
 
 
@@ -61,7 +61,7 @@ promise distributions on the same architecture built against musl 1.1
 or earlier to work on musl 1.2 or later. This is due to a potentially
 ABI incompatible change in musl 1.2 that switched ``time_t`` to a
 64-bit type, and may cause breakage to libraries built on musl 1.1 and
-earlier. [1]_
+earlier. [musl-time64]_
 
 
 Backwards Compatibility
@@ -84,11 +84,11 @@ others" rule both is more inclusive and works well enough in practice.
 References
 ==========
 
-.. _`Alpine Linux`: https://alpinelinux.org/
+.. [alpine] https://alpinelinux.org/
 
-.. _musl: https://musl.libc.org
+.. [musl] https://musl.libc.org
 
-.. [1] https://musl.libc.org/time64.html
+.. [musl-time64] https://musl.libc.org/time64.html
 
 
 Copyright

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -1,0 +1,108 @@
+PEP: 9999
+Title: Platform Tag for Linux Distributions Using Musl
+Author: Tzu-ping Chung <uranusjr@gmail.com>
+Sponsor: TBD
+PEP-Delegate: TBD
+Discussions-To: https://discuss.python.org/t/7165
+Status: Draft
+Type: Informational
+Content-Type: text/x-rst
+Created: TBA
+
+
+Abstract
+========
+
+This PEP proposes a new platfrom tag series ``musllinux`` for
+binary Python package distributions for a Python installation linked
+against musl on a Linux distribution. The tag works similarly to the
+"perennial manylinux" platform tags specified in :pep:`600`, but
+targeting platforms based on musl instead.
+
+
+Motivation
+==========
+
+With the wide use of containers, distributions such as `Alpine Linux`_
+have been gaining more popularity than ever. Many of them based on
+`musl`_, a different libc implementation from glibc, and therefore
+cannot use the existing ``manylinux`` platform tags. This means that
+Python package projects cannot deploy binary distributions on PyPI
+for them. Users of such projects demand build-time constraints from
+those projects, putting unnecessary burden on project maintainers.
+
+
+Rationale
+=========
+
+Logic behind the new platform tag largely follows :pep:`600`, and
+require wheels using this tag make similar promises. Please refer to
+the PEP for more details on rationale and reasoning behind the design.
+
+
+Specification
+=============
+
+Tags using the new scheme will take the form::
+
+    musllinux_${MUSLMAJOR}_${MUSLMINOR}_${ARCH}
+
+Distributions using the tag make similar promises to those discribed
+in :pep:`600`, including:
+
+1. The distribution works on any mainstream Linux distributions with
+   musl version ``${MUSLMAJOR}.${MUSLMINOR}`` or later.
+2. The distribution's ``${ARCH}`` matches the return value of
+   ``sysconfig.get_platform()`` on the host system.
+
+One exception is made to the first promise: If a project chooses to
+publish a distribution using musl 1.2 or later on, it does not need to
+promise distributions on the same architecture built against musl 1.1
+or earlier to work on musl 1.2 or later. This is due to a potentially
+ABI incompatible change in musl 1.2 that switched ``time_t`` to a
+64-bit type, and may cause breakage to libraries built on musl 1.1 and
+earlier. [1]_
+
+
+Backwards Compatibility
+=======================
+
+There are no backwards compatibility concerns in this PEP.
+
+
+Rejected Ideas
+==============
+
+Create a platform tag based specifically for Alpine Linux
+---------------------------------------------------------
+
+Past experience on the ``manylinux`` tag series shows this approach
+would be too costly time-wise. The author feels the "works well with
+others" rule both is more inclusive and works well enough in practice.
+
+
+References
+==========
+
+.. _`Alpine Linux`: https://alpinelinux.org/
+
+.. _musl: https://musl.libc.org
+
+.. [1] https://musl.libc.org/time64.html
+
+
+Copyright
+=========
+
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -7,7 +7,7 @@ Discussions-To: https://discuss.python.org/t/7165
 Status: Draft
 Type: Informational
 Content-Type: text/x-rst
-Created: TBA
+Created: 2021-03-17
 
 
 Abstract

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -62,6 +62,24 @@ in :pep:`600`, including:
 2. The distribution's ``${ARCH}`` matches the return value of
    ``sysconfig.get_platform()`` on the host system.
 
+It is recommended for Python package repositories, including PyPI, to
+accept platform tags matching the following regular expression::
+
+   musllinux_([0-9]+)_([0-9]+)_([^-]+)
+
+Python package repositories may impose additional requirements to
+reject Wheels with known issues, including but not limited to:
+
+* A ``musl_1_1`` wheel containing symbols only available in musl 1.2.
+* Wheel that depends on external libraries not considered generally
+  available to the intended audience of the package index.
+* A platform tag claiming compatibility to a non-existent musl version
+  (like ``musl_9000_0``).
+
+Such policies are ultimately up to individual package repositories.
+It is not the author's intention to impose restrictions to the
+maintainers.
+
 
 Backwards Compatibility
 =======================


### PR DESCRIPTION
As proposed in https://discuss.python.org/t/wheels-for-musl-alpine/7084

cc @brettcannon @tiran