### PR TITLE
PEP 636: add missing @dataclass

### DIFF
--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -509,6 +509,9 @@ If you are using classes to structure your data
 you can use the class name followed by an argument list resembling a
 constructor, but with the ability to capture attributes into variables::
 
+    from dataclasses import dataclass
+
+    @dataclass
     class Point:
         x: int
         y: int


### PR DESCRIPTION
otherwise, on trying this example

```python
>>> where_is(Point(x=0, y=42))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Point() takes no arguments
```
