### PR TITLE
PEP 656: Also replace dots to match PEPs 425 and 427

### DIFF
--- a/pep-0656.rst
+++ b/pep-0656.rst
@@ -110,7 +110,9 @@ in :pep:`600`, including:
 1. The distribution works on any mainstream Linux distributions with
    musl version ``${MUSLMAJOR}.${MUSLMINOR}`` or later.
 2. The distribution's ``${ARCH}`` matches the return value of
-   ``sysconfig.get_platform()`` on the host system.
+   ``sysconfig.get_platform()`` on the host system, replacing period
+   (``.``) and hyphen (``-``) characters with underscores (``_``), as
+   outlined in :pep:`425` and :pep:`427`.
 
 Example values::
 
@@ -124,7 +126,7 @@ The value can be formatted with the following Python code::
     def format_musllinux(musl_version: tuple[int, int]) -> str:
         os_name, sep, arch = sysconfig.get_platform().partition("-")
         assert os_name == "linux" and sep, "Not a Linux"
-        arch = arch.replace("-", "_")
+        arch = arch.replace(".", "_").replace("-", "_")
         return f"musllinux_{musl_version[0]}_{musl_version[1]}_{arch}"
 
 Recommendations to package indexes
@@ -133,7 +135,7 @@ Recommendations to package indexes
 It is recommended for Python package repositories, including PyPI, to
 accept platform tags matching the following regular expression::
 
-    musllinux_([0-9]+)_([0-9]+)_([^-]+)
+    musllinux_([0-9]+)_([0-9]+)_([^.-]+)
 
 Python package repositories may impose additional requirements to
 reject Wheels with known issues, including but not limited to:


### PR DESCRIPTION
I was made realised the current ``${ARCH}`` rule is potentially incompatible with previous PEPs.