### PR TITLE
PEP 646: Add note of alternatives that exist

### DIFF
--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -685,7 +685,7 @@ Alternatives
 
 It should be noted that the approach outlined in this PEP to solve the
 issue of shape checking in numerical libraries is *not* the only approach
-possible. Examples of lighter-weight alternatives include
+possible. Examples of lighter-weight alternatives based on *runtime* checking include
 ShapeGuard [#shapeguard]_, tsanley [#tsanley]_, and PyContracts [#pycontracts]_.
 
 While these existing approaches improve significantly on the default
@@ -694,7 +694,8 @@ assert statements, none of them enable *static* analysis of shape correctness.
 As mentioned in `Motivation`_, this is particularly desirable for
 machine learning applications where, due to library and infrastructure complexity,
 even relatively simple programs must suffer long startup times; iterating
-by running the program until it crashes can be a tedious and frustrating
+by running the program until it crashes, as is necessary with these
+existing runtime-based approaches, can be a tedious and frustrating
 experience.
 
 Our hope with this PEP is to begin to codify generic type annotations as

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -680,6 +680,30 @@ between old unannotated code and new versions of libraries which do use
 these type annotations.
 
 
+Alternatives
+============
+
+It should be noted that the approach outlined in this PEP to solve the
+issue of shape checking in numerical libraries is *not* the only approach
+possible. Examples of lighter-weight alternatives include
+ShapeGuard [#shapeguard]_, tsanley [#tsanley]_, and PyContracts [#pycontracts]_.
+
+While these existing approaches improve significantly on the default
+situation of shape checking only being possible through lengthy and verbose
+assert statements, none of them enable *static* analysis of shape correctness.
+As mentioned in `Motivation`_, this is particularly desirable for
+machine learning applications where, due to library and infrastructure complexity,
+even relatively simple programs must suffer long startup times; iterating
+by running the program until it crashes can be a tedious and frustrating
+experience.
+
+Our hope with this PEP is to begin to codify generic type annotations as
+an official, language-supported way of dealing with shape correctness.
+With something of a standard in place, in the long run, this will
+hopefully enable a thriving ecosystem of tools for analysing and verifying
+shape properties of numerical computing programs.
+
+
 Backwards Compatibility
 =======================
 
@@ -776,6 +800,12 @@ References
 
 .. [#arbitrary_len] Discussion on Python typing-sig mailing list:
    https://mail.python.org/archives/list/typing-sig@python.org/thread/SQVTQYWIOI4TIO7NNBTFFWFMSMS2TA4J/
+
+.. [#tsanley] tsanley: https://github.com/ofnote/tsanley
+
+.. [#pycontracts] PyContracts: https://github.com/AndreaCensi/contracts
+
+.. [#shapeguard] ShapeGuard: https://github.com/Qwlouse/shapeguard
 
 .. _cpython/23527: https://github.com/python/cpython/pull/24527
 


### PR DESCRIPTION
A pretty reasonable reason for the SC to reject PEP 646 would be that alternatives for shape checking do already exist; let's be honest about that.

But let's also highlight the difference to the alternatives out there: _static_ checking, enabled by the beginnings of a standard that can act as a central point of reference.

@pradeep90 Do you wanna take a look over this? Maybe I've gone too far; my late-night writing can be a bit hit or miss...