### PR TITLE
PEP 597: Apply grammar, syntax and polish fixes, and clarify phrasing and terminology

### DIFF
--- a/pep-0597.rst
+++ b/pep-0597.rst
@@ -144,23 +144,26 @@ except that ``io.TextIOWrapper`` doesn't emit ``EncodingWarning`` when
 A pure Python implementation will look like this::
 
    def text_encoding(encoding, stacklevel=1):
-       """Helper function to choose the text encoding.
+       """A helper function to choose the text encoding.
 
        When *encoding* is not None, just return it.
-       Otherwise, return the default text encoding (i.e., "locale").
+       Otherwise, return the default text encoding (i.e. "locale").
 
-       This function emits EncodingWarning if *encoding* is None and
-       sys.flags.encoding_warning is true.
+       This function emits an EncodingWarning if *encoding* is None and
+       sys.flags.encoding_warning is True.
 
-       This function can be used in APIs having encoding=None option
-       and pass it to TextIOWrapper or open.
-       But please consider using encoding="utf-8" for new APIs.
+       This function can be used in APIs with an encoding=None parameter
+       that pass it to TextIOWrapper or open.
+       However, please consider using encoding="utf-8" for new APIs.
        """
        if encoding is None:
            if sys.flags.encoding_warning:
                import warnings
-               warnings.warn("'encoding' option is omitted",
-                            EncodingWarning, stacklevel + 2)
+               warnings.warn(
+                   "The 'encoding' argument was omitted; please "
+                   "explicitly specify one (e.g. 'utf-8'), or 'locale' "
+                   "to use the current system's locale encoding",
+                   EncodingWarning, stacklevel + 2)
            encoding = "locale"
        return encoding
 

--- a/pep-0597.rst
+++ b/pep-0597.rst
@@ -13,15 +13,15 @@ Abstract
 ========
 
 Add a new warning category ``EncodingWarning``. It is emitted when the
-``encoding`` option is omitted and the default encoding is a locale
-encoding.
+``encoding`` argument is omitted and the default locale-specific
+encoding is used.
 
 The warning is disabled by default. A new ``-X warn_default_encoding``
-command-line option and a ``PYTHONWARNDEFAULTENCODING`` environment
-variable are used to enable the warning.
+command-line option and a new ``PYTHONWARNDEFAULTENCODING`` environment
+variable can be used to enable it.
 
-An ``encoding="locale"`` option is added too. It is used to specify
-locale encoding explicitly.
+An ``encoding="locale"`` option is added too. It is used to
+explicitly specify that the locale encoding should be used.
 
 
 Motivation
@@ -33,23 +33,22 @@ Using the default encoding is a common mistake
 Developers using macOS or Linux may forget that the default encoding
 is not always UTF-8.
 
-For example, ``long_description = open("README.md").read()`` in
+For example, using ``long_description = open("README.md").read()`` in
 ``setup.py`` is a common mistake. Many Windows users cannot install
-the package if there is at least one non-ASCII character (e.g. emoji)
-in the ``README.md`` file which is encoded in UTF-8.
+such packages if there is at least one non-ASCII character (e.g. emoji)
+in their UTF-8-encoded ``README.md`` file.
 
-For example, 489 packages of the 4000 most downloaded packages from
-PyPI used non-ASCII characters in their README, and 82 of these
-cannot be installed from source when the locale encoding is
-ASCII, as they used the default encoding to open the README or a TOML
-file. [1]_
+Of the 4000 most downloaded packages from PyPI, 489 use non-ASCII
+characters in their README, and 82 of these do not explicitly specify
+the encoding used to open it. [1]_ Therefore, they cannot be installed
+from source in ASCII locales.
 
 Another example is ``logging.basicConfig(filename="log.txt")``.
-Some users expect it uses UTF-8 by default, but the locale encoding is
-actually what is used. [2]_
+Some users might expect it to use UTF-8 by default, but the locale
+encoding is actually what is used. [2]_
 
-Even Python experts assume that the default encoding is UTF-8.
-This creates bugs that happen only on Windows; see [3]_, [4]_, [5]_,
+Even Python experts may assume that the default encoding is UTF-8.
+This creates bugs that only happen on Windows; see [3]_, [4]_, [5]_,
 and [6]_ for example.
 
 Emitting a warning when the ``encoding`` option is omitted will help
@@ -65,11 +64,11 @@ Explicit way to use locale-specific encoding
 * UTF-8? (bug or platform-specific script)
 * The locale encoding?
 
-From this point of view, ``open(filename)`` is not readable.
+From this point of view, ``open(filename)`` is not readable code.
 
 ``encoding=locale.getpreferredencoding(False)`` can be used to
 specify the locale encoding explicitly, but it is too long and easy
-to misuse (e.g. one can forget to pass ``False`` to its parameter).
+to misuse (e.g. one can forget to pass ``False`` as its argument).
 
 This PEP provides an explicit way to specify the locale encoding.
 
@@ -78,16 +77,16 @@ Prepare to change the default encoding to UTF-8
 -----------------------------------------------
 
 Since UTF-8 has become the de-facto standard text encoding,
-we might change the default text encoding to UTF-8 in the future.
+we might default to it in the future.
 
-However, this change will affect many applications and libraries. If we
-start emitting ``DeprecationWarning`` everywhere the ``encoding`` option
-is omitted, it will be too noisy and painful.
+However, such a change will affect many applications and libraries.
+If we start emitting ``DeprecationWarning`` everywhere the ``encoding``
+option is omitted, it will be too noisy and painful.
 
-Although this PEP doesn't propose to change the default encoding,
-this PEP will help that change by:
+Although this PEP doesn't propose changing the default encoding,
+it will help enable that change by:
 
-* Reducing the number of omitted ``encoding`` options in many libraries
+* Reducing the number of omitted ``encoding`` arguments in libraries
   before we start emitting a ``DeprecationWarning`` by default.
 
 * Allowing users to pass ``encoding="locale"`` to suppress
@@ -100,9 +99,9 @@ Specification
 ``EncodingWarning``
 -------------------
 
-Add a new ``EncodingWarning`` warning class which is a subclass of
-``Warning``. It is used to warn when the ``encoding`` option is
-omitted and the default encoding is locale-specific.
+Add a new ``EncodingWarning`` warning class as a subclass of
+``Warning``. It is emitted when the ``encoding`` option is omitted and
+the default locale-specific encoding is used.
 
 
 Options to enable the warning
@@ -115,9 +114,9 @@ are used to enable ``EncodingWarning``.
 ``sys.flags.encoding_warning`` is also added. The flag indicates
 ``EncodingWarning`` is enabled.
 
-When the option is enabled, ``io.TextIOWrapper()``, ``open()`` and
-other modules using them will emit ``EncodingWarning`` when the
-``encoding`` argument is omitted.
+When the flag is set, ``io.TextIOWrapper()``, ``open()`` and other
+modules using them will emit ``EncodingWarning`` when the ``encoding``
+argument is omitted.
 
 Since ``EncodingWarning`` is a subclass of ``Warning``, they are
 shown by default, unlike ``DeprecationWarning``.
@@ -135,7 +134,7 @@ It has the same meaning as the current ``encoding=None``, except that
 ``io.text_encoding()``
 ----------------------
 
-``io.text_encoding()`` is a helper function for functions with an
+``io.text_encoding()`` is a helper for functions with an
 ``encoding=None`` option that pass it to ``io.TextIOWrapper()`` or
 ``open()``.
 
@@ -186,7 +185,7 @@ as written in the previous section.
 Where using the locale encoding as the default encoding is reasonable,
 ``encoding="locale"`` will be used instead. For example,
 the ``subprocess`` module will use the locale encoding as the default
-encoding of pipes.
+for pipes.
 
 Many tests use ``open()`` without ``encoding`` specified to read
 ASCII text files. They should be rewritten with ``encoding="ascii"``.
@@ -228,11 +227,11 @@ Forward Compatibility
 =====================
 
 The ``encoding="locale"`` option is not forward compatible. Code
-using the option will not work on Python older than 3.10, and will
+using it will not work on Python older than 3.10, and will instead
 raise ``LookupError: unknown encoding: locale``.
 
 Until developers can drop Python 3.9 support, ``EncodingWarning``
-can be used only for finding missing ``encoding="utf-8"`` options.
+can only be used for finding missing ``encoding="utf-8"`` options.
 
 
 How to Teach This
@@ -245,7 +244,7 @@ Since ``EncodingWarning`` is used to write cross-platform code,
 there is no need to teach it to new users.
 
 We can just recommend using UTF-8 for text files and using
-``encoding="utf-8"`` when opening such files.
+``encoding="utf-8"`` when opening them.
 
 
 For experienced users
@@ -287,12 +286,11 @@ https://mail.python.org/archives/list/python-dev@python.org/thread/SFYUP2TWD5JZ5
 
 * Many developers will not use the option.
 
-  * Some developers will use the option and report the warnings to
-    libraries they use, so the option is worth it even though
-    many developers won't use it.
+  * Some will, and report the warnings to libraries they use,
+    so the option is worth it even if many developers don't enable it.
 
   * For example, I found [7]_ and [8]_ by running
-    ``pip install -U pip`` and found [9]_ by running ``tox``
+    ``pip install -U pip``, and [9]_ by running ``tox``
     with the reference implementation. This demonstrates how this
     option can be used to find potential issues.
 

--- a/pep-0597.rst
+++ b/pep-0597.rst
@@ -20,8 +20,8 @@ The warning is disabled by default. A new ``-X warn_default_encoding``
 command-line option and a new ``PYTHONWARNDEFAULTENCODING`` environment
 variable can be used to enable it.
 
-An ``encoding="locale"`` option is added too. It is used to
-explicitly specify that the locale encoding should be used.
+A ``"locale"`` argument value for ``encoding`` is added too. It
+explicitly specifies that the locale encoding should be used.
 
 
 Motivation
@@ -51,7 +51,7 @@ Even Python experts may assume that the default encoding is UTF-8.
 This creates bugs that only happen on Windows; see [3]_, [4]_, [5]_,
 and [6]_ for example.
 
-Emitting a warning when the ``encoding`` option is omitted will help
+Emitting a warning when the ``encoding`` argument is omitted will help
 find such mistakes.
 
 
@@ -81,7 +81,7 @@ we might default to it in the future.
 
 However, such a change will affect many applications and libraries.
 If we start emitting ``DeprecationWarning`` everywhere the ``encoding``
-option is omitted, it will be too noisy and painful.
+argument is omitted, it will be too noisy and painful.
 
 Although this PEP doesn't propose changing the default encoding,
 it will help enable that change by:
@@ -100,7 +100,7 @@ Specification
 -------------------
 
 Add a new ``EncodingWarning`` warning class as a subclass of
-``Warning``. It is emitted when the ``encoding`` option is omitted and
+``Warning``. It is emitted when the ``encoding`` argument is omitted and
 the default locale-specific encoding is used.
 
 
@@ -122,12 +122,12 @@ Since ``EncodingWarning`` is a subclass of ``Warning``, they are
 shown by default, unlike ``DeprecationWarning``.
 
 
-``encoding="locale"`` option
-----------------------------
+``encoding="locale"``
+---------------------
 
-``io.TextIOWrapper`` will accept the ``encoding="locale"`` option.
-It has the same meaning as the current ``encoding=None``, except that
-``io.TextIOWrapper`` doesn't emit ``EncodingWarning`` when
+``io.TextIOWrapper`` will accept ``"locale"`` as a valid argument to
+``encoding``. It has the same meaning as the current ``encoding=None``,
+except that ``io.TextIOWrapper`` doesn't emit ``EncodingWarning`` when
 ``encoding="locale"`` is specified.
 
 
@@ -135,7 +135,7 @@ It has the same meaning as the current ``encoding=None``, except that
 ----------------------
 
 ``io.text_encoding()`` is a helper for functions with an
-``encoding=None`` option that pass it to ``io.TextIOWrapper()`` or
+``encoding=None`` parameter that pass it to ``io.TextIOWrapper()`` or
 ``open()``.
 
 A pure Python implementation will look like this::
@@ -198,8 +198,8 @@ Opt-in warning
 --------------
 
 Although ``DeprecationWarning`` is suppressed by default, always
-emitting ``DeprecationWarning`` when the ``encoding`` option is omitted
-would be too noisy.
+emitting ``DeprecationWarning`` when the ``encoding`` argument is
+omitted would be too noisy.
 
 Noisy warnings may lead developers to dismiss the
 ``DeprecationWarning``.
@@ -226,12 +226,12 @@ backwards-compatible.
 Forward Compatibility
 =====================
 
-The ``encoding="locale"`` option is not forward compatible. Code
-using it will not work on Python older than 3.10, and will instead
-raise ``LookupError: unknown encoding: locale``.
+Passing ``"locale"`` as the argument to ``encoding`` is not
+forward-compatible. Code using it will not work on Python older than
+3.10, and will instead raise ``LookupError: unknown encoding: locale``.
 
 Until developers can drop Python 3.9 support, ``EncodingWarning``
-can only be used for finding missing ``encoding="utf-8"`` options.
+can only be used for finding missing ``encoding="utf-8"`` arguments.
 
 
 How to Teach This
@@ -257,8 +257,8 @@ default encoding.
 You can use ``-X warn_default_encoding`` or
 ``PYTHONWARNDEFAULTENCODING=1`` to find this type of mistake.
 
-Omitting the ``encoding`` option is not a bug when opening text files
-encoded in locale encoding, but ``encoding="locale"`` is recommended
+Omitting the ``encoding`` argument is not a bug when opening text files
+encoded in the locale encoding, but ``encoding="locale"`` is recommended
 in Python 3.10 and later because it is more explicit.
 
 

--- a/pep-0597.rst
+++ b/pep-0597.rst
@@ -36,13 +36,14 @@ is not always UTF-8.
 
 For example, using ``long_description = open("README.md").read()`` in
 ``setup.py`` is a common mistake. Many Windows users cannot install
-such packages if there is at least one non-ASCII character (e.g. emoji)
+such packages if there is at least one non-ASCII character
+(e.g. emoji, author names, copyright symbols, and the like)
 in their UTF-8-encoded ``README.md`` file.
 
 Of the 4000 most downloaded packages from PyPI, 489 use non-ASCII
-characters in their README, and 82 of these do not explicitly specify
-the encoding used to open it. [1]_ Therefore, they cannot be installed
-from source in non-UTF-8 locales.
+characters in their README, and 82 fail to install from source on
+non-UTF-8 locales due to not specifying an encoding for a non-ASCII
+file. [1]_
 
 Another example is ``logging.basicConfig(filename="log.txt")``.
 Some users might expect it to use UTF-8 by default, but the locale
@@ -61,7 +62,8 @@ Explicit way to use locale-specific encoding
 
 ``open(filename)`` isn't explicit about which encoding is expected:
 
-* If ASCII is assumed, this isn't a bug, but is inefficient on Windows
+* If ASCII is assumed, this isn't a bug, but may result in decreased
+  performance on Windows, particularly with non-Latin-1 locale encodings
 * If UTF-8 is assumed, this may be a bug or a platform-specific script
 * If the locale encoding is assumed, the behavior is as expected
   (but could change if future versions of Python modify the default)
@@ -92,7 +94,9 @@ it will help enable that change by:
   before we start emitting a ``DeprecationWarning`` by default.
 
 * Allowing users to pass ``encoding="locale"`` to suppress
-  the warning, starting with Python 3.10.
+  the current warning and any ``DeprecationWarning`` added in the future,
+  as well as retaining consistent behavior if later Python versions
+  change the default, ensuring support for any Python version >=3.10.
 
 
 Specification
@@ -113,7 +117,7 @@ The ``-X warn_default_encoding`` option and the
 ``PYTHONWARNDEFAULTENCODING`` environment variable are added. They
 are used to enable ``EncodingWarning``.
 
-``sys.flags.encoding_warning`` is also added. The flag is ``True`` when
+``sys.flags.warn_default_encoding`` is also added. The flag is true when
 ``EncodingWarning`` is enabled.
 
 When the flag is set, ``io.TextIOWrapper()``, ``open()`` and other
@@ -121,7 +125,7 @@ modules using them will emit ``EncodingWarning`` when the ``encoding``
 argument is omitted.
 
 Since ``EncodingWarning`` is a subclass of ``Warning``, they are
-shown by default (if the ``encoding_warning`` flag is set), unlike
+shown by default (if the ``warn_default_encoding`` flag is set), unlike
 ``DeprecationWarning``.
 
 
@@ -150,19 +154,17 @@ A pure Python implementation will look like this::
        Otherwise, return the default text encoding (i.e. "locale").
 
        This function emits an EncodingWarning if *encoding* is None and
-       sys.flags.encoding_warning is True.
+       sys.flags.warn_default_encoding is true.
 
        This function can be used in APIs with an encoding=None parameter
        that pass it to TextIOWrapper or open.
        However, please consider using encoding="utf-8" for new APIs.
        """
        if encoding is None:
-           if sys.flags.encoding_warning:
+           if sys.flags.warn_default_encoding:
                import warnings
                warnings.warn(
-                   "The 'encoding' argument was omitted; please "
-                   "explicitly specify one (e.g. 'utf-8'), or 'locale' "
-                   "to use the current system's locale encoding",
+                   "'encoding' argument not specified.",
                    EncodingWarning, stacklevel + 2)
            encoding = "locale"
        return encoding

--- a/pep-0597.rst
+++ b/pep-0597.rst
@@ -12,15 +12,15 @@ Python-Version: 3.10
 Abstract
 ========
 
-Add a new warning category ``EncodingWarning``. It is emitted when
+Add a new warning category ``EncodingWarning``. It is emitted when the
 ``encoding`` option is omitted and the default encoding is a locale
 encoding.
 
-The warning is disabled by default. New ``-X warn_default_encoding``
-command-line option and ``PYTHONWARNDEFAULTENCODING`` environment
-variable are used to enable the warnings.
+The warning is disabled by default. A new ``-X warn_default_encoding``
+command-line option and a ``PYTHONWARNDEFAULTENCODING`` environment
+variable are used to enable the warning.
 
-``encoding="locale"`` option is added too. It is used to specify
+An ``encoding="locale"`` option is added too. It is used to specify
 locale encoding explicitly.
 
 
@@ -34,26 +34,26 @@ Developers using macOS or Linux may forget that the default encoding
 is not always UTF-8.
 
 For example, ``long_description = open("README.md").read()`` in
-``setup.py`` is a common mistake. Many Windows users can not install
+``setup.py`` is a common mistake. Many Windows users cannot install
 the package if there is at least one non-ASCII character (e.g. emoji)
 in the ``README.md`` file which is encoded in UTF-8.
 
 For example, 489 packages of the 4000 most downloaded packages from
-PyPI used non-ASCII characters in README. And 82 packages of them
-can not be installed from source package when locale encoding is
-ASCII. [1]_ They used the default encoding to read README or TOML
-file.
+PyPI used non-ASCII characters in their README, and 82 of these
+cannot be installed from source when the locale encoding is
+ASCII, as they used the default encoding to open the README or a TOML
+file. [1]_
 
 Another example is ``logging.basicConfig(filename="log.txt")``.
-Some users expect UTF-8 is used by default, but locale encoding is
-used actually. [2]_
+Some users expect it uses UTF-8 by default, but the locale encoding is
+actually what is used. [2]_
 
-Even Python experts assume that default encoding is UTF-8.
-It creates bugs that happen only on Windows. See [3]_, [4]_, [5]_,
+Even Python experts assume that the default encoding is UTF-8.
+This creates bugs that happen only on Windows; see [3]_, [4]_, [5]_,
 and [6]_ for example.
 
 Emitting a warning when the ``encoding`` option is omitted will help
-to find such mistakes.
+find such mistakes.
 
 
 Explicit way to use locale-specific encoding
@@ -61,15 +61,15 @@ Explicit way to use locale-specific encoding
 
 ``open(filename)`` isn't explicit about which encoding is expected:
 
-* Expects ASCII (not a bug, but inefficient on Windows)
-* Expects UTF-8 (bug or platform-specific script)
-* Expects the locale encoding.
+* ASCII? (not a bug, but inefficient on Windows)
+* UTF-8? (bug or platform-specific script)
+* The locale encoding?
 
-In this point of view, ``open(filename)`` is not readable.
+From this point of view, ``open(filename)`` is not readable.
 
 ``encoding=locale.getpreferredencoding(False)`` can be used to
-specify the locale encoding explicitly. But it is too long and easy
-to misuse. (e.g. forget to pass ``False`` to its parameter)
+specify the locale encoding explicitly, but it is too long and easy
+to misuse (e.g. one can forget to pass ``False`` to its parameter).
 
 This PEP provides an explicit way to specify the locale encoding.
 
@@ -77,20 +77,20 @@ This PEP provides an explicit way to specify the locale encoding.
 Prepare to change the default encoding to UTF-8
 -----------------------------------------------
 
-Since UTF-8 becomes de-facto standard text encoding, we might change
-the default text encoding to UTF-8 in the future.
+Since UTF-8 has become the de-facto standard text encoding,
+we might change the default text encoding to UTF-8 in the future.
 
-But this change will affect many applications and libraries. If we
-start emitting ``DeprecationWarning`` everywhere ``encoding`` option
+However, this change will affect many applications and libraries. If we
+start emitting ``DeprecationWarning`` everywhere the ``encoding`` option
 is omitted, it will be too noisy and painful.
 
 Although this PEP doesn't propose to change the default encoding,
-this PEP will help the change:
+this PEP will help that change by:
 
-* Reduce the number of omitted ``encoding`` options in many libraries
-  before we start emitting the ``DeprecationWarning`` by default.
+* Reducing the number of omitted ``encoding`` options in many libraries
+  before we start emitting a ``DeprecationWarning`` by default.
 
-* Users will be able to use ``encoding="locale"`` option to suppress
+* Allowing users to pass ``encoding="locale"`` to suppress
   the warning without dropping Python 3.10 support.
 
 
@@ -98,7 +98,7 @@ Specification
 =============
 
 ``EncodingWarning``
---------------------
+-------------------
 
 Add a new ``EncodingWarning`` warning class which is a subclass of
 ``Warning``. It is used to warn when the ``encoding`` option is
@@ -106,18 +106,18 @@ omitted and the default encoding is locale-specific.
 
 
 Options to enable the warning
-------------------------------
+-----------------------------
 
-``-X warn_default_encoding`` option and the
+The ``-X warn_default_encoding`` option and the
 ``PYTHONWARNDEFAULTENCODING`` environment variable are added. They
 are used to enable ``EncodingWarning``.
 
-``sys.flags.encoding_warning`` is also added. The flag represents
+``sys.flags.encoding_warning`` is also added. The flag indicates
 ``EncodingWarning`` is enabled.
 
-When the option is enabled, ``io.TextIOWrapper()``, ``open()``, and
+When the option is enabled, ``io.TextIOWrapper()``, ``open()`` and
 other modules using them will emit ``EncodingWarning`` when the
-``encoding`` is omitted.
+``encoding`` argument is omitted.
 
 Since ``EncodingWarning`` is a subclass of ``Warning``, they are
 shown by default, unlike ``DeprecationWarning``.
@@ -126,19 +126,20 @@ shown by default, unlike ``DeprecationWarning``.
 ``encoding="locale"`` option
 ----------------------------
 
-``io.TextIOWrapper`` accepts ``encoding="locale"`` option. It means
-same to current ``encoding=None``. But ``io.TextIOWrapper`` doesn't
-emit ``EncodingWarning`` when ``encoding="locale"`` is specified.
+``io.TextIOWrapper`` will accept the ``encoding="locale"`` option.
+It has the same meaning as the current ``encoding=None``, except that
+``io.TextIOWrapper`` doesn't emit ``EncodingWarning`` when
+``encoding="locale"`` is specified.
 
 
 ``io.text_encoding()``
------------------------
+----------------------
 
-``io.text_encoding()`` is a helper function for functions having
-``encoding=None`` option and passing it to ``io.TextIOWrapper()`` or
+``io.text_encoding()`` is a helper function for functions with an
+``encoding=None`` option that pass it to ``io.TextIOWrapper()`` or
 ``open()``.
 
-Pure Python implementation will be like this::
+A pure Python implementation will look like this::
 
    def text_encoding(encoding, stacklevel=1):
        """Helper function to choose the text encoding.
@@ -161,7 +162,7 @@ Pure Python implementation will be like this::
            encoding = "locale"
        return encoding
 
-For example, ``pathlib.Path.read_text()`` can use the function like:
+For example, ``pathlib.Path.read_text()`` can use it like this:
 
 .. code-block::
 
@@ -174,18 +175,18 @@ By using ``io.text_encoding()``, ``EncodingWarning`` is emitted for
 the caller of ``read_text()`` instead of ``read_text()`` itself.
 
 
-Affected stdlibs
------------------
+Affected standard library modules
+---------------------------------
 
-Many stdlibs will be affected by this change.
+Many standard library modules will be affected by this change.
 
 Most APIs accepting ``encoding=None`` will use ``io.text_encoding()``
 as written in the previous section.
 
-Where using locale encoding as the default encoding is reasonable,
+Where using the locale encoding as the default encoding is reasonable,
 ``encoding="locale"`` will be used instead. For example,
-the ``subprocess`` module will use locale encoding for the default
-encoding of the pipes.
+the ``subprocess`` module will use the locale encoding as the default
+encoding of pipes.
 
 Many tests use ``open()`` without ``encoding`` specified to read
 ASCII text files. They should be rewritten with ``encoding="ascii"``.
@@ -195,10 +196,10 @@ Rationale
 =========
 
 Opt-in warning
----------------
+--------------
 
-Although ``DeprecationWarning`` is suppressed by default, emitting
-``DeprecationWarning`` always when the ``encoding`` option is omitted
+Although ``DeprecationWarning`` is suppressed by default, always
+emitting ``DeprecationWarning`` when the ``encoding`` option is omitted
 would be too noisy.
 
 Noisy warnings may lead developers to dismiss the
@@ -208,43 +209,43 @@ Noisy warnings may lead developers to dismiss the
 "locale" is not a codec alias
 -----------------------------
 
-We don't add the "locale" to the codec alias because locale can be
-changed in runtime.
+We don't add "locale" as a codec alias because the locale can be
+changed at runtime.
 
 Additionally, ``TextIOWrapper`` checks ``os.device_encoding()``
-when ``encoding=None``. This behavior can not be implemented in
-the codec.
+when ``encoding=None``. This behavior cannot be implemented in
+a codec.
 
 
 Backward Compatibility
 ======================
 
-The new warning is not emitted by default. So this PEP is 100%
-backward compatible.
+The new warning is not emitted by default, so this PEP is 100%
+backwards-compatible.
 
 
 Forward Compatibility
 =====================
 
-``encoding="locale"`` option is not forward compatible. Codes
-using the option will not work on Python older than 3.10. It will
+The ``encoding="locale"`` option is not forward compatible. Code
+using the option will not work on Python older than 3.10, and will
 raise ``LookupError: unknown encoding: locale``.
 
 Until developers can drop Python 3.9 support, ``EncodingWarning``
 can be used only for finding missing ``encoding="utf-8"`` options.
 
 
-How to teach this
+How to Teach This
 =================
 
 For new users
 -------------
 
-Since ``EncodingWarning`` is used to write a cross-platform code,
-no need to teach it to new users.
+Since ``EncodingWarning`` is used to write cross-platform code,
+there is no need to teach it to new users.
 
-We can just recommend using UTF-8 for text files and use
-``encoding="utf-8"`` when opening test files.
+We can just recommend using UTF-8 for text files and using
+``encoding="utf-8"`` when opening such files.
 
 
 For experienced users
@@ -257,9 +258,9 @@ default encoding.
 You can use ``-X warn_default_encoding`` or
 ``PYTHONWARNDEFAULTENCODING=1`` to find this type of mistake.
 
-Omitting ``encoding`` option is not a bug when opening text files
-encoded in locale encoding. But ``encoding="locale"`` is recommended
-after Python 3.10 because it is more explicit.
+Omitting the ``encoding`` option is not a bug when opening text files
+encoded in locale encoding, but ``encoding="locale"`` is recommended
+in Python 3.10 and later because it is more explicit.
 
 
 Reference Implementation
@@ -280,19 +281,19 @@ https://mail.python.org/archives/list/python-dev@python.org/thread/SFYUP2TWD5JZ5
   * ``encoding="locale"`` and ``io.text_encoding()`` must be in
     Python.
 
-  * It is difficult to find all caller of functions wrapping
-    ``open()`` or ``TextIOWrapper()``. (See ``io.text_encoding()``
-    section.)
+  * It is difficult to find all callers of functions wrapping
+    ``open()`` or ``TextIOWrapper()`` (see the ``io.text_encoding()``
+    section).
 
 * Many developers will not use the option.
 
-  * Some developers use the option and report the warnings to
-    libraries they use. So the option is worth enough even though
+  * Some developers will use the option and report the warnings to
+    libraries they use, so the option is worth it even though
     many developers won't use it.
 
-  * For example, I find [7]_ and [8]_ by running
-    ``pip install -U pip`` and find [9]_ by running ``tox``
-    with the reference implementation. It demonstrates how this
+  * For example, I found [7]_ and [8]_ by running
+    ``pip install -U pip`` and found [9]_ by running ``tox``
+    with the reference implementation. This demonstrates how this
     option can be used to find potential issues.
 
 

--- a/pep-0597.rst
+++ b/pep-0597.rst
@@ -13,15 +13,16 @@ Abstract
 ========
 
 Add a new warning category ``EncodingWarning``. It is emitted when the
-``encoding`` argument is omitted and the default locale-specific
-encoding is used.
+``encoding`` argument to ``open()`` is omitted and the default
+locale-specific encoding is used.
 
 The warning is disabled by default. A new ``-X warn_default_encoding``
 command-line option and a new ``PYTHONWARNDEFAULTENCODING`` environment
 variable can be used to enable it.
 
 A ``"locale"`` argument value for ``encoding`` is added too. It
-explicitly specifies that the locale encoding should be used.
+explicitly specifies that the locale encoding should be used, silencing
+the warning.
 
 
 Motivation
@@ -41,7 +42,7 @@ in their UTF-8-encoded ``README.md`` file.
 Of the 4000 most downloaded packages from PyPI, 489 use non-ASCII
 characters in their README, and 82 of these do not explicitly specify
 the encoding used to open it. [1]_ Therefore, they cannot be installed
-from source in ASCII locales.
+from source in non-UTF-8 locales.
 
 Another example is ``logging.basicConfig(filename="log.txt")``.
 Some users might expect it to use UTF-8 by default, but the locale
@@ -60,9 +61,10 @@ Explicit way to use locale-specific encoding
 
 ``open(filename)`` isn't explicit about which encoding is expected:
 
-* ASCII? (not a bug, but inefficient on Windows)
-* UTF-8? (bug or platform-specific script)
-* The locale encoding?
+* If ASCII is assumed, this isn't a bug, but is inefficient on Windows
+* If UTF-8 is assumed, this may be a bug or a platform-specific script
+* If the locale encoding is assumed, the behavior is as expected
+  (but could change if future versions of Python modify the default)
 
 From this point of view, ``open(filename)`` is not readable code.
 
@@ -77,7 +79,7 @@ Prepare to change the default encoding to UTF-8
 -----------------------------------------------
 
 Since UTF-8 has become the de-facto standard text encoding,
-we might default to it in the future.
+we might default to it for opening files in the future.
 
 However, such a change will affect many applications and libraries.
 If we start emitting ``DeprecationWarning`` everywhere the ``encoding``
@@ -90,7 +92,7 @@ it will help enable that change by:
   before we start emitting a ``DeprecationWarning`` by default.
 
 * Allowing users to pass ``encoding="locale"`` to suppress
-  the warning without dropping Python 3.10 support.
+  the warning, starting with Python 3.10.
 
 
 Specification
@@ -111,7 +113,7 @@ The ``-X warn_default_encoding`` option and the
 ``PYTHONWARNDEFAULTENCODING`` environment variable are added. They
 are used to enable ``EncodingWarning``.
 
-``sys.flags.encoding_warning`` is also added. The flag indicates
+``sys.flags.encoding_warning`` is also added. The flag is ``True`` when
 ``EncodingWarning`` is enabled.
 
 When the flag is set, ``io.TextIOWrapper()``, ``open()`` and other
@@ -119,7 +121,8 @@ modules using them will emit ``EncodingWarning`` when the ``encoding``
 argument is omitted.
 
 Since ``EncodingWarning`` is a subclass of ``Warning``, they are
-shown by default, unlike ``DeprecationWarning``.
+shown by default (if the ``encoding_warning`` flag is set), unlike
+``DeprecationWarning``.
 
 
 ``encoding="locale"``
@@ -277,8 +280,8 @@ https://mail.python.org/archives/list/python-dev@python.org/thread/SFYUP2TWD5JZ5
 
 * Why not implement this in linters?
 
-  * ``encoding="locale"`` and ``io.text_encoding()`` must be in
-    Python.
+  * ``encoding="locale"`` and ``io.text_encoding()`` must be implemented
+    in Python.
 
   * It is difficult to find all callers of functions wrapping
     ``open()`` or ``TextIOWrapper()`` (see the ``io.text_encoding()``


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Hello @methane ! Thanks so much for all your hard work on this and congratulations on the acceptance of PEP 597; I've personally been very much looking forward to this change, as I have run into issues with other libraries, tools and applications not explicitly specifying their encoding (particularly in the scientific Python realm) and breaking on Windows or other non-UTF-8 platforms countless times over the years, including just a few days ago in regebro/pyroma#28 .

Since I moonlight as a technical writer and copyeditor (and docs, theme and website maintainer for the Spyder IDE), I had noticed a number of minor grammar/textual issues with the prose, so thanks to @JelleZijlstra 's kind encouragement on @corona10 's PR #1885 that accepted this, I went ahead with suggesting some textual fixes and clarifications.

I've broken down the change into several commits to make it easier to review:

* The first commit just fixes unambiguous grammar and syntax errors, mostly missing articles ("a"/"the"), phrasing issues, incomplete sentences and minor formatting tweaks, so it shouldn't require much review
* The second commit is a light copyediting pass on the prose, focused on making the existing text more clear, idiomatic, polished and readable, cleaning up awkward phrasing, choppy flow, repeated words and potentially ambiguous syntax; while I made an effort to avoid any changes that might impact meaning in this pass, you should you're happy with it
* In the third commit, I apply clearer and more consistent terminology for the `encoding` _parameter_, the _arguments_ to it, and the `-X warn_default_encoding` _option_. Previously, _option_ was inaccurately used to refer to all three, sometimes even within the same sentence, creating significant potential for confusion and not following the correct meaning. While I did attempt to be consistent, in some cases where the meaning was clear I sacrificed absolute rigor to avoid excessive verbosity, but I'm happy to revise that.
* In the forth commit, I added several miscellaneous clarifications throughout the text that went beyond the restrictive scope of the second commit; in particular:
  * Mention what function the `encoding` parameter is to in the abstract, given the number of different places that use encoding
  * Mention the primary purpose of the new `locale` argument there as well, to silence the warning 
  * Clarify that the install error occurs in any non-UTF-8 locale, not just ASCII (which is in fact not the default for any locale on Windows; in fact, nothing guarantees that the default locale encoding on an OS is even ASCII-compatible)
  * Be more explicit about the potential assumed meanings for `open()` without an `encoding` argument, and add a parenthetical mentioning that future versions of Python could potentially modify the default, making it even more important to be explicit
  * Specify the specific purpose (opening files) for which `utf-8` might be made the default in the future (as there are many other places a default encoding is used, some UTF-8 and some platform-specific)
  * Try to clarify what is meant in the rationale for the `locale` argument with regards to Python 3.10 compatibility
  * Be explicit about the value of the `encoding_warning` flag
  * Clarify that the `EncodingWarning` is only shown by default if the `encoding_warning` flag is set, as this is otherwise very confusing
* In the final commit, I apply the relevant previous changes to the docstring and warning text for the `text_encoding` function, and make the latter more descriptive and provide basic instructions on how to respond to it; if the latter is not desired, everything after the semicolon `;` can be removed, which will restore the previous text with just fixes to the grammar and terminology. I will also take a look at python/cpython#19481 if similar changes are desired there.

I will also leave a few comments on things that might need particular attention from you. Looking forward to hearing what you think, and let me know if you have any questions about anything. Thanks again!