### PR TITLE
PEP 12: Make date format in template match prose, and mark Python-Version as optional

### DIFF
--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -166,7 +166,7 @@ your PEP)::
   Content-Type: text/x-rst
   Requires: *[NNN]
   Created: [DD-MMM-YYYY]
-  Python-Version: [M.N]
+  Python-Version: *[M.N]
   Post-History: [DD-MMM-YYYY]
   Replaces: *[NNN]
   Superseded-By: *[NNN]

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -165,9 +165,9 @@ your PEP)::
   Type: [Standards Track | Informational | Process]
   Content-Type: text/x-rst
   Requires: *[NNN]
-  Created: [YYYY-MM-DD]
+  Created: [DD-MMM-YYYY]
   Python-Version: [M.N]
-  Post-History: [YYYY-MM-DD]
+  Post-History: [DD-MMM-YYYY]
   Replaces: *[NNN]
   Superseded-By: *[NNN]
   Resolution:


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

As a small followup to PR #1886 , I noticed that the date format in the PEP 12 template is actually given as YYYY-MM-DD, while in the text it is described as dd-mmm-yyyy. Presuming the latter is correct, I've modified the former to be consistent with it. Also, I noticed that the `Python-Version` field was not marked as optional, despite being described as such in the text (and is certainly so in practice), so I fixed that as well.