### PR TITLE
Lint: Validate PEP fields against PEP 12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,3 +63,9 @@ repos:
         entry: '^Created:(?:(?! +([0-2][0-9]|(3[01]))-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(199[0-9]|20[0-9][0-9])( \([^()]+\))?$))'
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]
+      - id: validate-python-version
+        name: "Validate PEP Python-Version field"
+        language: pygrep
+        entry: '^Python-Version:(?:(?! +( ?[1-9]\.([0-9][0-9]?|x)(\.[1-9][0-9]?)?\??,?)+( \([^()]+\))?$))'
+        files: '^pep-\d+\.(rst|txt)$'
+        types: [text]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,16 +19,16 @@ repos:
 
   - repo: local
     hooks:
-      - id: check-created-exists
-        name: "Check all PEPs have created date"
+      - id: check-required-fields
+        name: "Check all PEPs have required fields"
         language: pygrep
-        entry: '^Created:'
-        args: ['--negate']
+        entry: '(?-m:^PEP:(?=[\s\S]*\nTitle:)(?=[\s\S]*\nAuthor:)(?=[\s\S]*\nStatus:)(?=[\s\S]*\nType:)(?=[\s\S]*\nContent-Type:)(?=[\s\S]*\nCreated:))'
+        args: ['--negate', '--multiline']
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]
       - id: validate-created
         name: "Validate created dates"
         language: pygrep
-        entry: '^Created:(?:(?! +([0-2][0-9]|(3[01]))-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(199[0-9]|20[0-9][0-9])( \(|$)))'
+        entry: '^Created:(?:(?! +([0-2][0-9]|(3[01]))-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(199[0-9]|20[0-9][0-9])( \([^()]+\))?$))'
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,13 @@ repos:
         args: ['--negate', '--multiline']
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]
+      - id: validate-pep-number
+        name: "Validate PEP number field"
+        language: pygrep
+        entry: '(?-m:^PEP:(?:(?! +(0|[1-9][0-9]{0,3})\n)))'
+        args: ['--multiline']
+        files: '^pep-\d+\.(rst|txt)$'
+        types: [text]
       - id: validate-created
         name: "Validate created dates"
         language: pygrep

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,12 @@ repos:
         args: ['--multiline']
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]
+      - id: validate-status
+        name: "Validate PEP status field"
+        language: pygrep
+        entry: '^Status:(?:(?! +(Draft|Withdrawn|Rejected|Accepted|Final|Active|Provisional|Deferred|Superseded|April Fool!)$))'
+        files: '^pep-\d+\.(rst|txt)$'
+        types: [text]
       - id: validate-created
         name: "Validate created dates"
         language: pygrep

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,12 @@ repos:
         entry: '^Status:(?:(?! +(Draft|Withdrawn|Rejected|Accepted|Final|Active|Provisional|Deferred|Superseded|April Fool!)$))'
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]
+      - id: validate-type
+        name: "Validate PEP type field"
+        language: pygrep
+        entry: '^Type:(?:(?! +(Standards Track|Informational|Process)$))'
+        files: '^pep-\d+\.(rst|txt)$'
+        types: [text]
       - id: validate-created
         name: "Validate created dates"
         language: pygrep

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,12 @@ repos:
         entry: '^Content-Type:(?:(?! +text\/x-rst$))'
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]
+      - id: validate-pep-references
+        name: "Validate PEP reference fields"
+        language: pygrep
+        entry: '^(Requires|Replaces|Superseded-By):(?:(?! +( ?(0|[1-9][0-9]{0,3}),?)+$))'
+        files: '^pep-\d+\.(rst|txt)$'
+        types: [text]
       - id: validate-created
         name: "Validate created dates"
         language: pygrep

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,15 +34,21 @@ repos:
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]
       - id: validate-status
-        name: "Validate PEP status field"
+        name: "Validate PEP Status field"
         language: pygrep
         entry: '^Status:(?:(?! +(Draft|Withdrawn|Rejected|Accepted|Final|Active|Provisional|Deferred|Superseded|April Fool!)$))'
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]
       - id: validate-type
-        name: "Validate PEP type field"
+        name: "Validate PEP Type field"
         language: pygrep
         entry: '^Type:(?:(?! +(Standards Track|Informational|Process)$))'
+        files: '^pep-\d+\.(rst|txt)$'
+        types: [text]
+      - id: validate-content-type
+        name: "Validate PEP Content-Type field"
+        language: pygrep
+        entry: '^Content-Type:(?:(?! +text\/x-rst$))'
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]
       - id: validate-created

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,3 +69,10 @@ repos:
         entry: '^Python-Version:(?:(?! +( ?[1-9]\.([0-9][0-9]?|x)(\.[1-9][0-9]?)?\??,?)+( \([^()]+\))?$))'
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]
+      - id: validate-resolution
+        name: "Validate PEP Resolution field"
+        language: pygrep
+        entry: '(?<!\n\n)^Resolution: (?:(?!https:\/\/\S*\n))'
+        args: ['--multiline']
+        files: '^pep-\d+\.(rst|txt)$'
+        types: [text]

--- a/pep-0316.txt
+++ b/pep-0316.txt
@@ -7,7 +7,6 @@ Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 02-May-2003
-Python-Version:
 Post-History:
 
 

--- a/pep-0328.txt
+++ b/pep-0328.txt
@@ -7,7 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 21-Dec-2003
-Python-Version: 2.4, 2,5, 2.6
+Python-Version: 2.4, 2.5, 2.6
 Post-History: 8-Mar-2004
 
 

--- a/pep-0361.txt
+++ b/pep-0361.txt
@@ -7,7 +7,7 @@ Status: Final
 Type: Informational
 Content-Type: text/x-rst
 Created: 29-Jun-2006
-Python-Version: 2.6 and 3.0
+Python-Version: 2.6, 3.0
 Post-History: 17-Mar-2008
 
 

--- a/pep-0371.txt
+++ b/pep-0371.txt
@@ -8,7 +8,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 06-May-2008
-Python-Version: 2.6 / 3.0
+Python-Version: 2.6, 3.0
 Post-History:
 
 

--- a/pep-0378.txt
+++ b/pep-0378.txt
@@ -7,7 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 12-Mar-2009
-Python-Version: 2.7 and 3.1
+Python-Version: 2.7, 3.1
 Post-History: 12-Mar-2009
 
 

--- a/pep-0381.txt
+++ b/pep-0381.txt
@@ -7,7 +7,6 @@ Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 21-Mar-2009
-Python-Version: N.A.
 Post-History:
 
 

--- a/pep-0389.txt
+++ b/pep-0389.txt
@@ -7,7 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 25-Sep-2009
-Python-Version: 2.7 and 3.2
+Python-Version: 2.7, 3.2
 Post-History: 27-Sep-2009, 24-Oct-2009
 
 

--- a/pep-0390.txt
+++ b/pep-0390.txt
@@ -9,7 +9,7 @@ Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 10-Oct-2009
-Python-Version: 2.7 and 3.2
+Python-Version: 2.7, 3.2
 Post-History:
 Resolution: https://mail.python.org/pipermail/distutils-sig/2013-April/020597.html
 

--- a/pep-0403.txt
+++ b/pep-0403.txt
@@ -9,7 +9,6 @@ Content-Type: text/x-rst
 Created: 13-Oct-2011
 Python-Version: 3.4
 Post-History: 2011-10-13
-Resolution: TBD
 
 
 Abstract

--- a/pep-0407.txt
+++ b/pep-0407.txt
@@ -10,7 +10,6 @@ Type: Process
 Content-Type: text/x-rst
 Created: 12-Jan-2012
 Post-History: 17-Jan-2012
-Resolution: TBD
 
 
 Abstract

--- a/pep-0412.txt
+++ b/pep-0412.txt
@@ -7,7 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 08-Feb-2012
-Python-Version: 3.3 or 3.4
+Python-Version: 3.3
 Post-History: 08-Feb-2012
 
 

--- a/pep-0413.txt
+++ b/pep-0413.txt
@@ -8,7 +8,6 @@ Type: Process
 Content-Type: text/x-rst
 Created: 24-Feb-2012
 Post-History: 2012-02-24, 2012-02-25
-Resolution: TBD
 
 
 PEP Withdrawal

--- a/pep-0482.txt
+++ b/pep-0482.txt
@@ -9,7 +9,7 @@ Type: Informational
 Content-Type: text/x-rst
 Created: 08-Jan-2015
 Post-History:
-Resolution:
+
 
 Abstract
 ========

--- a/pep-0483.txt
+++ b/pep-0483.txt
@@ -9,7 +9,7 @@ Type: Informational
 Content-Type: text/x-rst
 Created: 19-Dec-2014
 Post-History:
-Resolution:
+
 
 Abstract
 ========

--- a/pep-0541.txt
+++ b/pep-0541.txt
@@ -10,7 +10,7 @@ Type: Process
 Content-Type: text/x-rst
 Created: 12-Jan-2017
 Post-History:
-Resolution:  https://mail.python.org/pipermail/distutils-sig/2018-March/032089.html
+Resolution: https://mail.python.org/pipermail/distutils-sig/2018-March/032089.html
 
 
 Abstract

--- a/pep-0617.rst
+++ b/pep-0617.rst
@@ -1,4 +1,4 @@
-PEP: 0617
+PEP: 617
 Title: New PEG parser for CPython
 Version: $Revision$
 Last-Modified: $Date$

--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -17,7 +17,6 @@ Created: 23-Jun-2020
 Python-Version: 3.10
 Post-History: 23-Jun-2020, 8-Jul-2020
 Superseded-By: 634
-Resolution:
 
 
 Abstract

--- a/pep-0628.txt
+++ b/pep-0628.txt
@@ -9,7 +9,7 @@ Content-Type: text/x-rst
 Created: 28-Jun-2011
 Python-Version: 3.6
 Post-History: 28-Jun-2011
-Resolution: http://bugs.python.org/issue12345
+Resolution: https://bugs.python.org/issue12345
 
 
 Abstract

--- a/pep-0648.rst
+++ b/pep-0648.rst
@@ -1,4 +1,4 @@
-PEP: 0648
+PEP: 648
 Title: Extensible customizations of the interpreter at startup
 Author: Mario Corchero <mariocj89@gmail.com>
 Sponsor: Pablo Galindo

--- a/pep-3118.txt
+++ b/pep-3118.txt
@@ -7,7 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 28-Aug-2006
-Python-Version: 3000
+Python-Version: 3.0
 Post-History:
 
 Abstract

--- a/pep-3128.txt
+++ b/pep-3128.txt
@@ -8,7 +8,7 @@ Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 30-Apr-2007
-Python-Version: 2.6 and/or 3.0
+Python-Version: 2.6, 3.0
 Post-History: 30-Apr-2007
 
 

--- a/pep-3150.txt
+++ b/pep-3150.txt
@@ -9,7 +9,6 @@ Content-Type: text/x-rst
 Created: 09-Jul-2010
 Python-Version: 3.4
 Post-History: 2010-07-14, 2011-04-21, 2011-06-13
-Resolution: TBD
 
 
 Abstract


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Adds some more cheap Pygrep checks to conservatively validate the formally-specified PEP fields against PEP 12 (i.e. the required fields are present, and non-empty fields match any required format), with a few exceptions:

* The Author/Sponsor/PEP-Delegate have a strictly-defined format in the spec, and I prototypes a regex to enforce it; however, due to numerous deviations in practice and the non-triviality of conforming them automatically, I don't attempt to enforce that here, and leave that to a future PR, if interest exists
* Similarly, it was straightforward to modify the `Created` regex to also check `Post-History`, but given the number of deviations that would need to be corrected, the non-triviality of doing so programmatically, and the likely lesser interest in parsing the data, I didn't go through with that for now
* The `Discussions-To` fields doesn't have a strictly defined format in PEP 12; in practice it conforms to either {URL}, {email_address}, or {name} <{URL or email_address> following the Author/etc field, but as this is complex to parse/validate and not formally specified, I left this out

This caught a number of minor issues, which I fixed:
* A couple leading zeros on PEP numbers, as prohibited by PEP 12
* Some isolated instances of Python-Version not following the specified X.Y(.Z) format: e.g. `2.6 / 3.0` instead of the standard `2.6, 3.0`, 3000 instead of 3.0, N/A/blank on non-standards-track PEPs that are not required to have them, etc.
* A URL missing HTTPS, and one with an errant space
* A few rejected/differed/withdrawn PEPs that had out of date TBD or empty Resolved fields (though the validation allows this, so as to not break intentional use)
* Some misc typos in fields

In some cases, some of the fields had extra information in parenthesis after the validated value; I allowed this in the regexes, and didn't modify or remove any such instances; nor did I remove any fields with non-empty values just to conform to the specification.

Running the full suite on the entire repo adds around ≈10 extra seconds to the lint job, but as this is still far faster than the build job, it makes no significant difference in practice.