### PR TITLE
PEP 636: fix typo

### DIFF
--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -317,7 +317,7 @@ different kinds of objects, and also apply patterns to its attributes::
             raise ValueError(f"Unrecognized event: {other_event}")
 
 A pattern like ``Click(position=(x, y))`` only matches if the type of the event is
-a subclass of the ``Click`` class. It will also requires that the event has a ``position``
+a subclass of the ``Click`` class. It will also require that the event has a ``position``
 attribute that matches the ``(x, y)`` pattern. If there's a match, the locals ``x`` and
 ``y`` will get the expected values.
 


### PR DESCRIPTION
This was brought up by codeofdusk@gmail.com on the python-dev list.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
