### PR TITLE
PEP 634: Allow keyword patterns for int, str etc.

### DIFF
--- a/pep-0634.rst
+++ b/pep-0634.rst
@@ -489,7 +489,7 @@ as follows:
 
 - For a number of built-in types (specified below),
   a single positional subpattern is accepted which will match
-  the entire subject; for these types no keyword patterns are accepted.
+  the entire subject. (Keyword patterns work as for other types here.)
 - The equivalent of ``getattr(cls, "__match_args__", ()))`` is called.
 - If this raises an exception the exception bubbles up.
 - If the returned value is not a list or tuple, the conversion fails


### PR DESCRIPTION
This resolves a discrepancy between the specification and the implementation, in favor of the current implementation. The spec used to state that you can't have patterns like these:
```
    case int(x, real=0): ...
    case int(real=1): ...
```
The implementation allows this and there is no good reason to disallow it, so it makes sense to rule that the PEP was mistaken here. (I don't recall why I put it in the PEP and in fact I was surprised to find it there.)