### PR TITLE
PEP 634: Change so __match_args__ must be a tuple

### DIFF
--- a/pep-0634.rst
+++ b/pep-0634.rst
@@ -492,7 +492,7 @@ as follows:
   the entire subject; for these types no keyword patterns are accepted.
 - The equivalent of ``getattr(cls, "__match_args__", ()))`` is called.
 - If this raises an exception the exception bubbles up.
-- If the returned value is not a list or tuple, the conversion fails
+- If the returned value is not a tuple, the conversion fails
   and ``TypeError`` is raised.
 - If there are more positional patterns than the length of
   ``__match_args__``` (as obtained using ``len()``), ``TypeError`` is raised.
@@ -513,7 +513,7 @@ positional subpatterns is different:
 This behavior is roughly equivalent to the following::
 
   class C:
-      __match_args__ = ["__match_self_prop__"]
+      __match_args__ = ("__match_self_prop__",)
       @property
       def __match_self_prop__(self):
           return self

--- a/pep-0634.rst
+++ b/pep-0634.rst
@@ -495,7 +495,7 @@ as follows:
 - If the returned value is not a tuple, the conversion fails
   and ``TypeError`` is raised.
 - If there are more positional patterns than the length of
-  ``__match_args__``` (as obtained using ``len()``), ``TypeError`` is raised.
+  ``__match_args__`` (as obtained using ``len()``), ``TypeError`` is raised.
 - Otherwise, positional pattern ``i`` is converted to a keyword pattern
   using ``__match_args__[i]`` as the keyword,
   provided it the latter is a string;


### PR DESCRIPTION
This was discussed on python-dev in the thread
https://mail.python.org/archives/list/python-dev@python.org/thread/YYIT3QXMLPNLXQAQ5BCXE4LLJ57EE7JV/#YYIT3QXMLPNLXQAQ5BCXE4LLJ57EE7JV

I don't think anyone disagrees that it's better if `__match_args__` is required to be a tuple.

- This helps static type checkers keep track of the values more easily
- It allows an optimization in the implementation where the pattern only needs to be recompiled when the value is changed.