### PR TITLE
PEP 626: typo: should be f_lineno, not f_lineo.

### DIFF
--- a/pep-0626.rst
+++ b/pep-0626.rst
@@ -15,7 +15,7 @@ Abstract
 Python should guarantee that when tracing is turned on, "line" tracing events are generated for *all* lines of code executed and *only* for lines of
 code that are executed.
 
-The ``f_lineo`` attribute of frame objects should always contain the expected line number.
+The ``f_lineno`` attribute of frame objects should always contain the expected line number.
 During frame execution, the expected line number is the line number of source code currently being executed.
 After a frame has completed, either by returning or by raising an exception,
 the expected line number is the line number of the last line of source that was executed.


### PR DESCRIPTION
I noticed this because the typo even found its way to the [What's new listing in CPython](https://github.com/python/cpython/blame/master/Doc/whatsnew/3.10.rst#L176)
