### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,74 +3,74 @@
 # active core developers.
 
 # The PEP editors are the fallback "owners" for everything in this repository.
-*             @python/pep-editors
+*             @JelleZijlstra
 
-pep-0001.txt  @warsaw @ncoghlan
-pep-0001-process_flow.png  @warsaw @ncoghlan
-pep-0001/     @warsaw @ncoghlan
+# pep-0001.txt  @warsaw @ncoghlan
+# pep-0001-process_flow.png  @warsaw @ncoghlan
+# pep-0001/     @warsaw @ncoghlan
 # pep-0002.txt
-pep-0003.txt  @jeremyhylton
+# pep-0003.txt  @jeremyhylton
 pep-0004.txt  @brettcannon
 # pep-0005.txt
 # pep-0006.txt
-pep-0007.txt  @gvanrossum @warsaw
-pep-0008.txt  @gvanrossum @warsaw @ncoghlan
-pep-0009.txt  @warsaw
-pep-0010.txt  @warsaw
-pep-0011.txt  @brettcannon
-pep-0012.rst  @brettcannon @warsaw
+# pep-0007.txt  @gvanrossum @warsaw
+# pep-0008.txt  @gvanrossum @warsaw @ncoghlan
+# pep-0009.txt  @warsaw
+# pep-0010.txt  @warsaw
+# pep-0011.txt  @brettcannon
+# pep-0012.rst  @brettcannon @warsaw
 # pep-0013.rst is owned by the entire core team.
 # ...
-pep-0020.txt  @tim-one
+# pep-0020.txt  @tim-one
 # ...
-pep-0042.txt  @jeremyhylton
+# pep-0042.txt  @jeremyhylton
 # ...
-pep-0100.txt  @malemburg
-pep-0101.txt  @warsaw @gvanrossum
-pep-0102.txt  @warsaw @gvanrossum
+# pep-0100.txt  @malemburg
+# pep-0101.txt  @warsaw @gvanrossum
+# pep-0102.txt  @warsaw @gvanrossum
 # pep-0103.txt
 # ...
-pep-0160.txt  @freddrake
+# pep-0160.txt  @freddrake
 # ...
-pep-0200.txt  @jeremyhylton
-pep-0201.txt  @warsaw
-pep-0202.txt  @warsaw
-pep-0203.txt  @Yhg1s
-pep-0204.txt  @Yhg1s
-pep-0205.txt  @freddrake
+# pep-0200.txt  @jeremyhylton
+# pep-0201.txt  @warsaw
+# pep-0202.txt  @warsaw
+# pep-0203.txt  @Yhg1s
+# pep-0204.txt  @Yhg1s
+# pep-0205.txt  @freddrake
 # pep-0206.txt
-pep-0207.txt  @gvanrossum
-pep-0208.txt  @nascheme @malemburg
+# pep-0207.txt  @gvanrossum
+# pep-0208.txt  @nascheme @malemburg
 # pep-0209.txt
 # pep-0210.txt
 # pep-0211.txt
 # pep-0212.txt
 # pep-0213.txt
-pep-0214.txt  @warsaw
+# pep-0214.txt  @warsaw
 # pep-0215.txt
 # pep-0216.txt
 # pep-0217.txt
-pep-0218.txt  @rhettinger
+# pep-0218.txt  @rhettinger
 # pep-0219.txt
 # pep-0220.txt
-pep-0221.txt  @Yhg1s
+# pep-0221.txt  @Yhg1s
 # pep-0222.txt
-pep-0223.txt  @tim-one
-pep-0224.txt  @malemburg
+# pep-0223.txt  @tim-one
+# pep-0224.txt  @malemburg
 # pep-0225.txt
-pep-0226.txt  @jeremyhylton
-pep-0227.txt  @jeremyhylton
-pep-0228.txt  @gvanrossum
+# pep-0226.txt  @jeremyhylton
+# pep-0227.txt  @jeremyhylton
+# pep-0228.txt  @gvanrossum
 # pep-0229.txt
-pep-0230.txt  @gvanrossum
-pep-0231.txt  @warsaw
-pep-0232.txt  @warsaw
+# pep-0230.txt  @gvanrossum
+# pep-0231.txt  @warsaw
+# pep-0232.txt  @warsaw
 # pep-0233.txt
-pep-0234.txt  @gvanrossum
-pep-0235.txt  @tim-one
-pep-0236.txt  @tim-one
-pep-0237.txt  @gvanrossum
-pep-0238.txt  @gvanrossum
+# pep-0234.txt  @gvanrossum
+# pep-0235.txt  @tim-one
+# pep-0236.txt  @tim-one
+# pep-0237.txt  @gvanrossum
+# pep-0238.txt  @gvanrossum
 # pep-0239.txt
 # pep-0240.txt
 # pep-0241.txt
@@ -78,492 +78,492 @@ pep-0238.txt  @gvanrossum
 # pep-0243.txt
 # pep-0244.txt
 # pep-0245.txt
-pep-0246.txt  @aleaxit
+# pep-0246.txt  @aleaxit
 # pep-0247.txt
-pep-0248.txt  @malemburg
-pep-0249.txt  @malemburg
-pep-0250.txt  @pfmoore
-pep-0251.txt  @warsaw @gvanrossum
-pep-0252.txt  @gvanrossum
-pep-0253.txt  @gvanrossum
-pep-0254.txt  @gvanrossum
-pep-0255.txt  @nascheme @tim-one
+# pep-0248.txt  @malemburg
+# pep-0249.txt  @malemburg
+# pep-0250.txt  @pfmoore
+# pep-0251.txt  @warsaw @gvanrossum
+# pep-0252.txt  @gvanrossum
+# pep-0253.txt  @gvanrossum
+# pep-0254.txt  @gvanrossum
+# pep-0255.txt  @nascheme @tim-one
 # pep-0256.txt
-pep-0257.txt  @gvanrossum
+# pep-0257.txt  @gvanrossum
 # pep-0258.txt
-pep-0259.txt  @gvanrossum
-pep-0260.txt  @gvanrossum
+# pep-0259.txt  @gvanrossum
+# pep-0260.txt  @gvanrossum
 # pep-0261.txt
 # pep-0262.txt
-pep-0263.txt  @malemburg
+# pep-0263.txt  @malemburg
 # pep-0264.txt
 # pep-0265.txt
 # pep-0266.txt
-pep-0267.txt  @jeremyhylton
+# pep-0267.txt  @jeremyhylton
 # pep-0268.txt
 # pep-0269.txt
 # pep-0270.txt
 # pep-0271.txt
 # pep-0272.txt
 # pep-0273.txt
-pep-0274.txt  @warsaw
-pep-0275.txt  @malemburg
+# pep-0274.txt  @warsaw
+# pep-0275.txt  @malemburg
 # pep-0276.txt
 # pep-0277.txt
-pep-0278.txt  @jackjansen
-pep-0279.txt  @rhettinger
-pep-0280.txt  @gvanrossum
+# pep-0278.txt  @jackjansen
+# pep-0279.txt  @rhettinger
+# pep-0280.txt  @gvanrossum
 # pep-0281.txt
-pep-0282.txt  @vsajip
-pep-0283.txt  @gvanrossum
+# pep-0282.txt  @vsajip
+# pep-0283.txt  @gvanrossum
 # pep-0284.txt
-pep-0285.txt  @gvanrossum
+# pep-0285.txt  @gvanrossum
 # pep-0286.txt
 # pep-0287.txt
-pep-0288.txt  @rhettinger
-pep-0289.txt  @rhettinger
-pep-0290.txt  @rhettinger
+# pep-0288.txt  @rhettinger
+# pep-0289.txt  @rhettinger
+# pep-0290.txt  @rhettinger
 # pep-0291.txt
-pep-0292.txt  @warsaw
-pep-0293.txt  @doerwalter
+# pep-0292.txt  @warsaw
+# pep-0293.txt  @doerwalter
 # pep-0294.txt
 # pep-0295.txt
 # pep-0296.txt
-pep-0297.txt  @malemburg
-pep-0298.txt  @theller
+# pep-0297.txt  @malemburg
+# pep-0298.txt  @theller
 # pep-0299.txt
 # pep-0301.txt
-pep-0302.txt  @pfmoore
+# pep-0302.txt  @pfmoore
 # pep-0303.txt
 # pep-0304.txt
 # pep-0305.txt
-pep-0306.txt  @jackdied @ncoghlan @benjaminp
-pep-0307.txt  @gvanrossum @tim-one
-pep-0308.txt  @gvanrossum @rhettinger
+# pep-0306.txt  @jackdied @ncoghlan @benjaminp
+# pep-0307.txt  @gvanrossum @tim-one
+# pep-0308.txt  @gvanrossum @rhettinger
 # pep-0309.txt
-pep-0310.txt  @pfmoore
-pep-0311.txt  @mhammond
-pep-0312.txt  @aleaxit
+# pep-0310.txt  @pfmoore
+# pep-0311.txt  @mhammond
+# pep-0312.txt  @aleaxit
 # pep-0313.txt
 # pep-0314.txt
-pep-0315.txt  @rhettinger
+# pep-0315.txt  @rhettinger
 # pep-0316.txt
 # pep-0317.txt
 # pep-0318.txt
 # pep-0319.txt
-pep-0320.txt  @warsaw @rhettinger
+# pep-0320.txt  @warsaw @rhettinger
 # pep-0321.txt
-pep-0322.txt  @rhettinger
-pep-0323.txt  @aleaxit
+# pep-0322.txt  @rhettinger
+# pep-0323.txt  @aleaxit
 # pep-0324.txt
 # pep-0325.txt
-pep-0326.txt  @terryjreedy
-pep-0327.txt  @facundobatista
+# pep-0326.txt  @terryjreedy
+# pep-0327.txt  @facundobatista
 # pep-0328.txt
-pep-0329.txt  @rhettinger
+# pep-0329.txt  @rhettinger
 # pep-0330.txt
 # pep-0331.txt
 # pep-0332.txt
-pep-0333.txt  @pjeby
+# pep-0333.txt  @pjeby
 # pep-0334.txt
 # pep-0335.txt
 # pep-0336.txt
 # pep-0337.txt
-pep-0338.txt  @ncoghlan
-pep-0339.txt  @brettcannon
-pep-0340.txt  @gvanrossum
-pep-0341.txt  @birkenfeld
-pep-0342.txt  @gvanrossum @pjeby
-pep-0343.txt  @gvanrossum @ncoghlan
+# pep-0338.txt  @ncoghlan
+# pep-0339.txt  @brettcannon
+# pep-0340.txt  @gvanrossum
+# pep-0341.txt  @birkenfeld
+# pep-0342.txt  @gvanrossum @pjeby
+# pep-0343.txt  @gvanrossum @ncoghlan
 # pep-0344.txt
 # pep-0345.txt
-pep-0346.txt  @ncoghlan
+# pep-0346.txt  @ncoghlan
 # pep-0347.txt
-pep-0348.txt  @brettcannon
-pep-0349.txt  @nascheme
+# pep-0348.txt  @brettcannon
+# pep-0349.txt  @nascheme
 # pep-0350.txt
-pep-0351.txt  @warsaw
-pep-0352.txt  @brettcannon @gvanrossum
+# pep-0351.txt  @warsaw
+# pep-0352.txt  @brettcannon @gvanrossum
 # pep-0353.txt
 # pep-0354.txt
 # pep-0355.txt
-pep-0356.txt  @gvanrossum
+# pep-0356.txt  @gvanrossum
 # pep-0357.txt
-pep-0358.txt  @nascheme @gvanrossum
+# pep-0358.txt  @nascheme @gvanrossum
 # pep-0359.txt
-pep-0360.txt  @brettcannon
-pep-0361.txt  @warsaw
-pep-0362.txt  @brettcannon @1st1 @larryhastings
+# pep-0360.txt  @brettcannon
+# pep-0361.txt  @warsaw
+# pep-0362.txt  @brettcannon @1st1 @larryhastings
 # pep-0363.txt
-pep-0364.txt  @warsaw
-pep-0365.txt  @pjeby
-pep-0366.txt  @ncoghlan
+# pep-0364.txt  @warsaw
+# pep-0365.txt  @pjeby
+# pep-0366.txt  @ncoghlan
 # pep-0367.txt
 # pep-0368.txt
-pep-0369.txt  @tiran
-pep-0370.txt  @tiran
+# pep-0369.txt  @tiran
+# pep-0370.txt  @tiran
 # pep-0371.txt
-pep-0372.txt  @mitsuhiko @rhettinger
-pep-0373.txt  @benjaminp
-pep-0374.txt  @brettcannon @avassalotti @warsaw
-pep-0375.txt  @benjaminp
+# pep-0372.txt  @mitsuhiko @rhettinger
+# pep-0373.txt  @benjaminp
+# pep-0374.txt  @brettcannon @avassalotti @warsaw
+# pep-0375.txt  @benjaminp
 # pep-0376.txt
-pep-0377.txt  @ncoghlan
-pep-0378.txt  @rhettinger
+# pep-0377.txt  @ncoghlan
+# pep-0378.txt  @rhettinger
 # pep-0379.txt
 # pep-0380.txt
 # pep-0381.txt
 # pep-0382.txt
 # pep-0383.txt
 # pep-0384.txt
-pep-0385.txt  @pitrou @birkenfeld
+# pep-0385.txt  @pitrou @birkenfeld
 # pep-0386.txt
-pep-0387.txt  @benjaminp
+# pep-0387.txt  @benjaminp
 # pep-0389.txt
 # pep-0390.txt
-pep-0391.txt  @vsajip
-pep-0392.txt  @birkenfeld
+# pep-0391.txt  @vsajip
+# pep-0392.txt  @birkenfeld
 # pep-0393.txt
-pep-0394.txt  @ncoghlan @warsaw @encukou @willingc
-pep-0395.txt  @ncoghlan
-pep-0396.txt  @warsaw
-pep-0397.txt  @mhammond
-pep-0398.txt  @birkenfeld
-pep-0399.txt  @brettcannon
-pep-0400.txt  @vstinner
-pep-0401.txt  @warsaw @brettcannon
-pep-0402.txt  @pjeby
-pep-0403.txt  @ncoghlan
-pep-0404.txt  @warsaw
+# pep-0394.txt  @ncoghlan @warsaw @encukou @willingc
+# pep-0395.txt  @ncoghlan
+# pep-0396.txt  @warsaw
+# pep-0397.txt  @mhammond
+# pep-0398.txt  @birkenfeld
+# pep-0399.txt  @brettcannon
+# pep-0400.txt  @vstinner
+# pep-0401.txt  @warsaw @brettcannon
+# pep-0402.txt  @pjeby
+# pep-0403.txt  @ncoghlan
+# pep-0404.txt  @warsaw
 # pep-0405.txt
-pep-0406.txt  @ncoghlan
-pep-0407.txt  @pitrou @birkenfeld @warsaw
-pep-0408.txt  @ncoghlan @eliben
-pep-0409.txt  @ethanfurman
-pep-0410.txt  @vstinner
-pep-0411.txt  @ncoghlan @eliben
-pep-0412.txt  @markshannon
-pep-0413.txt  @ncoghlan
-pep-0414.txt  @mitsuhiko @ncoghlan
-pep-0415.txt  @benjaminp
-pep-0416.txt  @vstinner
-pep-0417.txt  @voidspace
-pep-0418.txt  @vstinner
-pep-0418/     @vstinner
+# pep-0406.txt  @ncoghlan
+# pep-0407.txt  @pitrou @birkenfeld @warsaw
+# pep-0408.txt  @ncoghlan @eliben
+# pep-0409.txt  @ethanfurman
+# pep-0410.txt  @vstinner
+# pep-0411.txt  @ncoghlan @eliben
+# pep-0412.txt  @markshannon
+# pep-0413.txt  @ncoghlan
+# pep-0414.txt  @mitsuhiko @ncoghlan
+# pep-0415.txt  @benjaminp
+# pep-0416.txt  @vstinner
+# pep-0417.txt  @voidspace
+# pep-0418.txt  @vstinner
+# pep-0418/     @vstinner
 # pep-0419.txt
-pep-0420.txt  @ericvsmith
-pep-0421.txt  @ericsnowcurrently
-pep-0422.txt  @ncoghlan
+# pep-0420.txt  @ericvsmith
+# pep-0421.txt  @ericsnowcurrently
+# pep-0422.txt  @ncoghlan
 # pep-0423.txt
-pep-0424.txt  @alex
+# pep-0424.txt  @alex
 # pep-0425.txt
-pep-0426.txt  @ncoghlan @dstufft
-pep-0426/     @ncoghlan @dstufft
+# pep-0426.txt  @ncoghlan @dstufft
+# pep-0426/     @ncoghlan @dstufft
 # pep-0427.txt
-pep-0428.txt  @pitrou
-pep-0429.txt  @larryhastings
-pep-0430.txt  @ncoghlan
+# pep-0428.txt  @pitrou
+# pep-0429.txt  @larryhastings
+# pep-0430.txt  @ncoghlan
 # pep-0431.txt
-pep-0432.txt  @ncoghlan @vstinner @ericsnowcurrently
-pep-0433.txt  @vstinner
-pep-0433/     @vstinner
-pep-0434.txt  @terryjreedy
-pep-0435.txt  @warsaw @eliben @ethanfurman
-pep-0436.txt  @larryhastings
+# pep-0432.txt  @ncoghlan @vstinner @ericsnowcurrently
+# pep-0433.txt  @vstinner
+# pep-0433/     @vstinner
+# pep-0434.txt  @terryjreedy
+# pep-0435.txt  @warsaw @eliben @ethanfurman
+# pep-0436.txt  @larryhastings
 # pep-0437.txt
 # pep-0438.txt
 # pep-0439.txt
-pep-0440.txt  @ncoghlan @dstufft
-pep-0441.txt  @pfmoore
-pep-0442.txt  @pitrou
-pep-0443.txt  @ambv
-pep-0444.txt  @mitsuhiko
-pep-0445.txt  @vstinner
-pep-0446.txt  @vstinner
-pep-0446/     @vstinner
-pep-0447.txt  @ronaldoussoren
+# pep-0440.txt  @ncoghlan @dstufft
+# pep-0441.txt  @pfmoore
+# pep-0442.txt  @pitrou
+# pep-0443.txt  @ambv
+# pep-0444.txt  @mitsuhiko
+# pep-0445.txt  @vstinner
+# pep-0446.txt  @vstinner
+# pep-0446/     @vstinner
+# pep-0447.txt  @ronaldoussoren
 # pep-0448.txt
-pep-0449.txt  @dstufft
-pep-0450.txt  @stevendaprano
-pep-0451.txt  @ericsnowcurrently
-pep-0452.txt  @tiran
-pep-0453.txt  @dstufft @ncoghlan
-pep-0454.txt  @vstinner
-pep-0455.txt  @pitrou
-pep-0456.txt  @tiran
-pep-0457.txt  @larryhastings
+# pep-0449.txt  @dstufft
+# pep-0450.txt  @stevendaprano
+# pep-0451.txt  @ericsnowcurrently
+# pep-0452.txt  @tiran
+# pep-0453.txt  @dstufft @ncoghlan
+# pep-0454.txt  @vstinner
+# pep-0455.txt  @pitrou
+# pep-0456.txt  @tiran
+# pep-0457.txt  @larryhastings
 # pep-0458.txt, pep-0458-1.png
-pep-0459.txt  @ncoghlan
-pep-0460.txt  @pitrou
-pep-0461.txt  @ethanfurman
-pep-0462.txt  @ncoghlan
+# pep-0459.txt  @ncoghlan
+# pep-0460.txt  @pitrou
+# pep-0461.txt  @ethanfurman
+# pep-0462.txt  @ncoghlan
 # pep-0463.txt
-pep-0464.txt  @dstufft
-pep-0465.txt  @njsmith
-pep-0466.txt  @ncoghlan
-pep-0467.txt  @ncoghlan @ethanfurman
-pep-0468.txt  @ericsnowcurrently
-pep-0469.txt  @ncoghlan
-pep-0470.txt  @dstufft
+# pep-0464.txt  @dstufft
+# pep-0465.txt  @njsmith
+# pep-0466.txt  @ncoghlan
+# pep-0467.txt  @ncoghlan @ethanfurman
+# pep-0468.txt  @ericsnowcurrently
+# pep-0469.txt  @ncoghlan
+# pep-0470.txt  @dstufft
 # pep-0471.txt
 # pep-0472.txt
 # pep-0473.txt
-pep-0474.txt  @ncoghlan
-pep-0475.txt  @vstinner
-pep-0476.txt  @alex
-pep-0477.txt  @dstufft @ncoghlan
-pep-0478.txt  @larryhastings
-pep-0479.txt  @gvanrossum
+# pep-0474.txt  @ncoghlan
+# pep-0475.txt  @vstinner
+# pep-0476.txt  @alex
+# pep-0477.txt  @dstufft @ncoghlan
+# pep-0478.txt  @larryhastings
+# pep-0479.txt  @gvanrossum
 # pep-0480.txt, pep-0480-1.png
-pep-0481.txt  @dstufft
-pep-0482.txt  @ambv
-pep-0483.txt  @gvanrossum @ilevkivskyi
-pep-0484.txt  @gvanrossum @ambv
+# pep-0481.txt  @dstufft
+# pep-0482.txt  @ambv
+# pep-0483.txt  @gvanrossum @ilevkivskyi
+# pep-0484.txt  @gvanrossum @ambv
 # pep-0485.txt
-pep-0486.txt  @pfmoore
+# pep-0486.txt  @pfmoore
 # pep-0487.txt
-pep-0488.txt  @brettcannon
-pep-0489.txt  @encukou @scoder @ncoghlan
-pep-0490.txt  @vstinner
+# pep-0488.txt  @brettcannon
+# pep-0489.txt  @encukou @scoder @ncoghlan
+# pep-0490.txt  @vstinner
 # pep-0491.txt
-pep-0492.txt  @1st1
-pep-0493.txt  @ncoghlan @malemburg
-pep-0494.txt  @ned-deily
-pep-0495.txt  @abalkin @tim-one
-pep-0495-gap.png  @abalkin @tim-one
-pep-0495-gap.svg  @abalkin @tim-one
-pep-0495-fold.svg  @abalkin @tim-one
-pep-0495-fold-2.png  @abalkin @tim-one
-pep-0495-daylightsavings.png  @abalkin @tim-one
+# pep-0492.txt  @1st1
+# pep-0493.txt  @ncoghlan @malemburg
+# pep-0494.txt  @ned-deily
+# pep-0495.txt  @abalkin @tim-one
+# pep-0495-gap.png  @abalkin @tim-one
+# pep-0495-gap.svg  @abalkin @tim-one
+# pep-0495-fold.svg  @abalkin @tim-one
+# pep-0495-fold-2.png  @abalkin @tim-one
+# pep-0495-daylightsavings.png  @abalkin @tim-one
 # pep-0496.txt
 # pep-0497.txt
-pep-0498.txt  @ericvsmith
+# pep-0498.txt  @ericvsmith
 # pep-0499.txt
-pep-0500.txt  @abalkin @tim-one
-pep-0501.txt  @ncoghlan
+# pep-0500.txt  @abalkin @tim-one
+# pep-0501.txt  @ncoghlan
 # pep-0502.txt
-pep-0503.txt  @dstufft
-pep-0504.txt  @ncoghlan
-pep-0505.rst  @zooba
-pep-0505/     @zooba
-pep-0506.txt  @stevendaprano
-pep-0507.txt  @warsaw
-pep-0508.txt  @rbtcollins
-pep-0509.txt  @vstinner
-pep-0510.txt  @vstinner
-pep-0511.txt  @vstinner
-pep-0512.txt  @brettcannon
-pep-0513.txt  @njsmith
-pep-0514.txt  @zooba
-pep-0515.txt  @birkenfeld @serhiy-storchaka
-pep-0516.txt  @rbtcollins @njsmith
-pep-0517.txt  @njsmith
-pep-0518.txt  @brettcannon @njsmith @dstufft
-pep-0519.txt  @brettcannon
-pep-0520.txt  @ericsnowcurrently
-pep-0521.txt  @njsmith
-pep-0522.txt  @ncoghlan @njsmith
-pep-0523.txt  @brettcannon @DinoV
-pep-0524.txt  @vstinner
-pep-0525.txt  @1st1
-pep-0525-1.png  @1st1
-pep-0526.txt  @ilevkivskyi @lisroach @gvanrossum
-pep-0527.txt  @dstufft
-pep-0528.txt  @zooba
-pep-0529.txt  @zooba
-pep-0530.txt  @1st1
-pep-0531.txt  @ncoghlan
-pep-0532.txt  @ncoghlan
-pep-0532/     @ncoghlan
-pep-0533.txt  @njsmith
-pep-0534.txt  @encukou @ncoghlan
-pep-0535.txt  @ncoghlan
+# pep-0503.txt  @dstufft
+# pep-0504.txt  @ncoghlan
+# pep-0505.rst  @zooba
+# pep-0505/     @zooba
+# pep-0506.txt  @stevendaprano
+# pep-0507.txt  @warsaw
+# pep-0508.txt  @rbtcollins
+# pep-0509.txt  @vstinner
+# pep-0510.txt  @vstinner
+# pep-0511.txt  @vstinner
+# pep-0512.txt  @brettcannon
+# pep-0513.txt  @njsmith
+# pep-0514.txt  @zooba
+# pep-0515.txt  @birkenfeld @serhiy-storchaka
+# pep-0516.txt  @rbtcollins @njsmith
+# pep-0517.txt  @njsmith
+# pep-0518.txt  @brettcannon @njsmith @dstufft
+# pep-0519.txt  @brettcannon
+# pep-0520.txt  @ericsnowcurrently
+# pep-0521.txt  @njsmith
+# pep-0522.txt  @ncoghlan @njsmith
+# pep-0523.txt  @brettcannon @DinoV
+# pep-0524.txt  @vstinner
+# pep-0525.txt  @1st1
+# pep-0525-1.png  @1st1
+# pep-0526.txt  @ilevkivskyi @lisroach @gvanrossum
+# pep-0527.txt  @dstufft
+# pep-0528.txt  @zooba
+# pep-0529.txt  @zooba
+# pep-0530.txt  @1st1
+# pep-0531.txt  @ncoghlan
+# pep-0532.txt  @ncoghlan
+# pep-0532/     @ncoghlan
+# pep-0533.txt  @njsmith
+# pep-0534.txt  @encukou @ncoghlan
+# pep-0535.txt  @ncoghlan
 # pep-0536.txt
-pep-0537.txt  @ned-deily
-pep-0538.txt  @ncoghlan
+# pep-0537.txt  @ned-deily
+# pep-0538.txt  @ncoghlan
 # pep-0539.txt
-pep-0540.txt  @vstinner
-pep-0541.txt  @ambv
+# pep-0540.txt  @vstinner
+# pep-0541.txt  @ambv
 # pep-0542.txt
-pep-0543.rst  @tiran
-pep-0544.txt  @ilevkivskyi @ambv
-pep-0545.txt  @JulienPalard @methane @vstinner
-pep-0546.txt  @vstinner
-pep-0547.rst  @encukou
-pep-0548.rst  @bitdancer
-pep-0549.rst  @larryhastings
-pep-0550.rst  @1st1
-pep-0550-lookup_hamt.png  @1st1
-pep-0550-hamt_vs_dict.png  @1st1
-pep-0550-hamt_vs_dict-v2.png  @1st1
-pep-0551.rst  @zooba
-pep-0552.rst  @benjaminp
-pep-0553.rst  @warsaw
-pep-0554.rst  @ericsnowcurrently
+# pep-0543.rst  @tiran
+# pep-0544.txt  @ilevkivskyi @ambv
+# pep-0545.txt  @JulienPalard @methane @vstinner
+# pep-0546.txt  @vstinner
+# pep-0547.rst  @encukou
+# pep-0548.rst  @bitdancer
+# pep-0549.rst  @larryhastings
+# pep-0550.rst  @1st1
+# pep-0550-lookup_hamt.png  @1st1
+# pep-0550-hamt_vs_dict.png  @1st1
+# pep-0550-hamt_vs_dict-v2.png  @1st1
+# pep-0551.rst  @zooba
+# pep-0552.rst  @benjaminp
+# pep-0553.rst  @warsaw
+# pep-0554.rst  @ericsnowcurrently
 # pep-0555.rst
-pep-0556.rst  @pitrou
-pep-0557.rst  @ericvsmith
-pep-0558.rst  @ncoghlan
-pep-0559.rst  @warsaw
-pep-0560.rst  @ilevkivskyi
+# pep-0556.rst  @pitrou
+# pep-0557.rst  @ericvsmith
+# pep-0558.rst  @ncoghlan
+# pep-0559.rst  @warsaw
+# pep-0560.rst  @ilevkivskyi
 # pep-0561.rst
-pep-0562.rst  @ilevkivskyi
-pep-0563.rst  @ambv
-pep-0564.rst  @vstinner
-pep-0565.rst  @ncoghlan
+# pep-0562.rst  @ilevkivskyi
+# pep-0563.rst  @ambv
+# pep-0564.rst  @vstinner
+# pep-0565.rst  @ncoghlan
 # pep-0566.rst
-pep-0567.rst  @1st1
-pep-0568.rst  @njsmith
-pep-0569.rst  @ambv
-pep-0570.rst  @larryhastings @pablogsal
+# pep-0567.rst  @1st1
+# pep-0568.rst  @njsmith
+# pep-0569.rst  @ambv
+# pep-0570.rst  @larryhastings @pablogsal
 # pep-0571.rst
-pep-0572.rst  @tim-one @gvanrossum
-pep-0573.rst  @encukou @ncoghlan @ericsnowcurrently
-pep-0574.rst  @pitrou
+# pep-0572.rst  @tim-one @gvanrossum
+# pep-0573.rst  @encukou @ncoghlan @ericsnowcurrently
+# pep-0574.rst  @pitrou
 # pep-0575.rst
-pep-0576.rst  @markshannon
-pep-0577.rst  @ncoghlan
-pep-0578.rst  @zooba
+# pep-0576.rst  @markshannon
+# pep-0577.rst  @ncoghlan
+# pep-0578.rst  @zooba
 # pep-0579.rst
 # pep-0580.rst
-pep-0581.rst  @Mariatta
-pep-0582.rst  @kushaldas @zooba @dstufft @ncoghlan
+# pep-0581.rst  @Mariatta
+# pep-0582.rst  @kushaldas @zooba @dstufft @ncoghlan
 # pep-0583.rst
-pep-0584.rst  @stevendaprano @brandtbucher
-pep-0585.rst  @ambv
-pep-0586.rst  @ilevkivskyi
-pep-0587.rst  @vstinner @ncoghlan
-pep-0588.rst  @Mariatta
-pep-0589.rst  @gvanrossum
-pep-0590.rst  @markshannon
-pep-0591.rst  @ilevkivskyi
-pep-0592.rst  @dstufft
-pep-0593.rst  @ilevkivskyi
-pep-0594.rst  @tiran
-pep-0595.rst  @ezio-melotti @berkerpeksag
-pep-0596.rst  @ambv
-pep-0597.rst  @methane
-pep-0598.rst  @ncoghlan
-pep-0599.rst  @pfmoore
-pep-0600.rst  @njsmith
-pep-0601.txt  @isidentical
-pep-0602.rst  @ambv
-pep-0602-example-release-calendar.png  @ambv
-pep-0602-example-release-calendar.pptx  @ambv
-pep-0602-overlapping-support-matrix.png  @ambv
-pep-0602-overlapping-support-matrix.pptx  @ambv
-pep-0603.rst  @1st1
-pep-0603-lookup_hamt.png  @1st1
-pep-0603-hamt_vs_dict.png  @1st1
+# pep-0584.rst  @stevendaprano @brandtbucher
+# pep-0585.rst  @ambv
+# pep-0586.rst  @ilevkivskyi
+# pep-0587.rst  @vstinner @ncoghlan
+# pep-0588.rst  @Mariatta
+# pep-0589.rst  @gvanrossum
+# pep-0590.rst  @markshannon
+# pep-0591.rst  @ilevkivskyi
+# pep-0592.rst  @dstufft
+# pep-0593.rst  @ilevkivskyi
+# pep-0594.rst  @tiran
+# pep-0595.rst  @ezio-melotti @berkerpeksag
+# pep-0596.rst  @ambv
+# pep-0597.rst  @methane
+# pep-0598.rst  @ncoghlan
+# pep-0599.rst  @pfmoore
+# pep-0600.rst  @njsmith
+# pep-0601.txt  @isidentical
+# pep-0602.rst  @ambv
+# pep-0602-example-release-calendar.png  @ambv
+# pep-0602-example-release-calendar.pptx  @ambv
+# pep-0602-overlapping-support-matrix.png  @ambv
+# pep-0602-overlapping-support-matrix.pptx  @ambv
+# pep-0603.rst  @1st1
+# pep-0603-lookup_hamt.png  @1st1
+# pep-0603-hamt_vs_dict.png  @1st1
 # pep-0604.rst
-pep-0605.rst  @zooba @ncoghlan
-pep-0605-example-release-calendar.png  @zooba @ncoghlan
-pep-0605-overlapping-support-matrix.png  @zooba @ncoghlan
-/pep-0605/    @zooba @ncoghlan
-pep-0606.rst  @vstinner
-pep-0607.rst  @ambv @zooba @ncoghlan
-pep-0608.rst  @vstinner
-pep-0609.rst  @pganssle
-pep-0610.rst  @cjerdonek
-pep-0611.rst  @markshannon
-pep-0612.rst  @gvanrossum
-pep-0613.rst  @gvanrossum
-pep-0614.rst  @brandtbucher
-pep-0615.rst  @pganssle
-pep-0616.rst  @ericvsmith
-pep-0617.rst  @gvanrossum @pablogsal @lysnikolaou
-pep-0618.rst  @brandtbucher
-pep-0619.rst  @pablogsal
-pep-0620.rst  @vstinner
-pep-0621.rst  @brettcannon  @pganssle
-pep-0622.rst  @brandtbucher @ilevkivskyi @gvanrossum
-pep-0623.rst  @methane
-pep-0624.rst  @methane
-pep-0625.rst  @pfmoore
-pep-0626.rst  @markshannon
-pep-0627.rst  @encukou
-pep-0628.txt  @ncoghlan
-pep-0629.rst  @dstufft
-pep-0630.rst  @encukou
-pep-0631.rst  @pganssle
-pep-0632.rst  @zooba
-pep-0633.rst  @brettcannon
-pep-0634.rst  @brandtbucher @gvanrossum
-pep-0635.rst  @gvanrossum
-pep-0636.rst  @gvanrossum
-pep-0637.rst  @stevendaprano
-pep-0638.rst  @markshannon
-pep-0639.rst  @pfmoore
-pep-0640.rst  @Yhg1s
-pep-0641.rst  @zooba @warsaw @brettcannon
-pep-0642.rst  @ncoghlan
-pep-0643.rst  @pfmoore
-pep-0644.rst  @tiran
-pep-0645.rst  @gvanrossum
-pep-0646.rst  @gvanrossum
-pep-0647.rst  @gvanrossum
-pep-0648.rst  @pablogsal
-pep-0649.rst  @larryhastings
-pep-0650.rst  @brettcannon
-pep-0651.rst  @markshannon
-pep-0652.rst  @encukou
-pep-0653.rst  @markshannon
-pep-0654.rst  @1st1 @gvanrossum
-pep-0655.rst  @gvanrossum
-pep-0656.rst  @brettcannon
+# pep-0605.rst  @zooba @ncoghlan
+# pep-0605-example-release-calendar.png  @zooba @ncoghlan
+# pep-0605-overlapping-support-matrix.png  @zooba @ncoghlan
+# /pep-0605/    @zooba @ncoghlan
+# pep-0606.rst  @vstinner
+# pep-0607.rst  @ambv @zooba @ncoghlan
+# pep-0608.rst  @vstinner
+# pep-0609.rst  @pganssle
+# pep-0610.rst  @cjerdonek
+# pep-0611.rst  @markshannon
+# pep-0612.rst  @gvanrossum
+# pep-0613.rst  @gvanrossum
+# pep-0614.rst  @brandtbucher
+# pep-0615.rst  @pganssle
+# pep-0616.rst  @ericvsmith
+# pep-0617.rst  @gvanrossum @pablogsal @lysnikolaou
+# pep-0618.rst  @brandtbucher
+# pep-0619.rst  @pablogsal
+# pep-0620.rst  @vstinner
+# pep-0621.rst  @brettcannon  @pganssle
+# pep-0622.rst  @brandtbucher @ilevkivskyi @gvanrossum
+# pep-0623.rst  @methane
+# pep-0624.rst  @methane
+# pep-0625.rst  @pfmoore
+# pep-0626.rst  @markshannon
+# pep-0627.rst  @encukou
+# pep-0628.txt  @ncoghlan
+# pep-0629.rst  @dstufft
+# pep-0630.rst  @encukou
+# pep-0631.rst  @pganssle
+# pep-0632.rst  @zooba
+# pep-0633.rst  @brettcannon
+# pep-0634.rst  @brandtbucher @gvanrossum
+# pep-0635.rst  @gvanrossum
+# pep-0636.rst  @gvanrossum
+# pep-0637.rst  @stevendaprano
+# pep-0638.rst  @markshannon
+# pep-0639.rst  @pfmoore
+# pep-0640.rst  @Yhg1s
+# pep-0641.rst  @zooba @warsaw @brettcannon
+# pep-0642.rst  @ncoghlan
+# pep-0643.rst  @pfmoore
+# pep-0644.rst  @tiran
+# pep-0645.rst  @gvanrossum
+# pep-0646.rst  @gvanrossum
+# pep-0647.rst  @gvanrossum
+# pep-0648.rst  @pablogsal
+# pep-0649.rst  @larryhastings
+# pep-0650.rst  @brettcannon
+# pep-0651.rst  @markshannon
+# pep-0652.rst  @encukou
+# pep-0653.rst  @markshannon
+# pep-0654.rst  @1st1 @gvanrossum
+# pep-0655.rst  @gvanrossum
+# pep-0656.rst  @brettcannon
 # ...
 # pep-0666.txt
 # ...
 # pep-0754.txt
 # ...
-pep-0801.rst  @warsaw
+# pep-0801.rst  @warsaw
 # ...
-pep-3000.txt  @gvanrossum
-pep-3001.txt  @birkenfeld
+# pep-3000.txt  @gvanrossum
+# pep-3001.txt  @birkenfeld
 # pep-3002.txt
-pep-3003.txt  @brettcannon  @gvanrossum
+# pep-3003.txt  @brettcannon  @gvanrossum
 # ...
-pep-3099.txt  @birkenfeld
-pep-3100.txt  @brettcannon
+# pep-3099.txt  @birkenfeld
+# pep-3100.txt  @brettcannon
 # pep-3101.txt
 # pep-3102.txt
-pep-3103.txt  @gvanrossum
+# pep-3103.txt  @gvanrossum
 # pep-3104.txt
-pep-3105.txt  @birkenfeld
-pep-3106.txt  @gvanrossum
+# pep-3105.txt  @birkenfeld
+# pep-3106.txt  @gvanrossum
 # pep-3107.txt
-pep-3108.txt  @brettcannon
+# pep-3108.txt  @brettcannon
 # pep-3109.txt
 # pep-3110.txt
 # pep-3111.txt
 # pep-3112.txt
-pep-3113.txt  @brettcannon
+# pep-3113.txt  @brettcannon
 # pep-3114.txt
 # pep-3115.txt
-pep-3116.txt  @gvanrossum
-pep-3117.txt  @birkenfeld
+# pep-3116.txt  @gvanrossum
+# pep-3117.txt  @birkenfeld
 # pep-3118.txt
-pep-3119.txt  @gvanrossum
+# pep-3119.txt  @gvanrossum
 # pep-3120.txt
 # pep-3121.txt
-pep-3122.txt  @brettcannon
+# pep-3122.txt  @brettcannon
 # pep-3123.txt
-pep-3124.txt  @pjeby
+# pep-3124.txt  @pjeby
 # pep-3125.txt
-pep-3126.txt  @rhettinger
+# pep-3126.txt  @rhettinger
 # pep-3127.txt
 # pep-3128.txt
 # pep-3129.txt
 # pep-3130.txt
 # pep-3131.txt
-pep-3132.txt  @birkenfeld
+# pep-3132.txt  @birkenfeld
 # pep-3133.txt
 # pep-3134.txt
 # pep-3135.txt
 # pep-3136.txt
-pep-3137.txt  @gvanrossum
+# pep-3137.txt  @gvanrossum
 # pep-3138.txt
-pep-3139.txt  @benjaminp
+# pep-3139.txt  @benjaminp
 # pep-3140.txt
 # pep-3141.txt
 # pep-3142.txt
@@ -571,32 +571,32 @@ pep-3139.txt  @benjaminp
 # pep-3144.txt
 # pep-3145.txt
 # pep-3146.txt
-pep-3147.txt  @warsaw
-pep-3147-1.dia  @warsaw
-pep-3147-1.png  @warsaw
-pep-3148.txt  @brianquinlan
-pep-3149.txt  @warsaw
-pep-3150.txt  @ncoghlan
-pep-3151.txt  @pitrou
+# pep-3147.txt  @warsaw
+# pep-3147-1.dia  @warsaw
+# pep-3147-1.png  @warsaw
+# pep-3148.txt  @brianquinlan
+# pep-3149.txt  @warsaw
+# pep-3150.txt  @ncoghlan
+# pep-3151.txt  @pitrou
 # pep-3152.txt
 # pep-3153.txt
-pep-3154.txt  @pitrou
-pep-3155.txt  @pitrou
-pep-3156.txt  @gvanrossum
+# pep-3154.txt  @pitrou
+# pep-3155.txt  @pitrou
+# pep-3156.txt  @gvanrossum
 # ...
-pep-3333.txt  @pjeby
+# pep-3333.txt  @pjeby
 # ...
-pep-8000.rst  @warsaw
-pep-8001.rst  @brettcannon @tiran @dstufft @ericsnowcurrently @gpshead @ambv @Mariatta @njsmith @pablogsal @rhettinger @taleinat @tim-one @zware
-pep-8002.rst  @warsaw @ambv @pitrou @dhellmann @willingc
-pep-8010.rst  @warsaw
-pep-8011.rst  @Mariatta @warsaw
-pep-8012.rst  @ambv
-pep-8013.rst  @zooba
-pep-8014.rst  @jackjansen
-pep-8015.rst  @vstinner
-pep-8016.rst  @njsmith @dstufft
+# pep-8000.rst  @warsaw
+# pep-8001.rst  @brettcannon @tiran @dstufft @ericsnowcurrently @gpshead @ambv @Mariatta @njsmith @pablogsal @rhettinger @taleinat @tim-one @zware
+# pep-8002.rst  @warsaw @ambv @pitrou @dhellmann @willingc
+# pep-8010.rst  @warsaw
+# pep-8011.rst  @Mariatta @warsaw
+# pep-8012.rst  @ambv
+# pep-8013.rst  @zooba
+# pep-8014.rst  @jackjansen
+# pep-8015.rst  @vstinner
+# pep-8016.rst  @njsmith @dstufft
 # ...
-pep-8100.rst  @njsmith
+# pep-8100.rst  @njsmith
 # pep-8101.rst
 # pep-8102.rst

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -249,7 +249,7 @@ pep-0415.txt  @benjaminp
 pep-0416.txt  @vstinner
 pep-0417.txt  @voidspace
 pep-0418.txt  @vstinner
-pep0418/      @vstinner
+pep-0418/     @vstinner
 # pep-0419.txt
 pep-0420.txt  @ericvsmith
 pep-0421.txt  @ericsnowcurrently

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,600 +3,600 @@
 # active core developers.
 
 # The PEP editors are the fallback "owners" for everything in this repository.
-# *             @python/pep-editors
+*             @python/pep-editors
 
-# pep-0001.txt  @warsaw @ncoghlan
-# pep-0001-process_flow.png  @warsaw @ncoghlan
-# pep-0001/     @warsaw @ncoghlan
-# # pep-0002.txt
-# pep-0003.txt  @jeremyhylton
-# pep-0004.txt  @brettcannon
-# # pep-0005.txt
-# # pep-0006.txt
-# pep-0007.txt  @gvanrossum @warsaw
-# pep-0008.txt  @gvanrossum @warsaw @ncoghlan
-# pep-0009.txt  @warsaw
-# pep-0010.txt  @warsaw
-# pep-0011.txt  @brettcannon
-# pep-0012.rst  @brettcannon @warsaw
-# # pep-0013.rst is owned by the entire core team.
-# # ...
-# pep-0020.txt  @tim-one
-# # ...
-# pep-0042.txt  @jeremyhylton
-# # ...
-# pep-0100.txt  @malemburg
-# pep-0101.txt  @warsaw @gvanrossum
-# pep-0102.txt  @warsaw @gvanrossum
-# # pep-0103.txt
-# # ...
-# pep-0160.txt  @freddrake
-# # ...
-# pep-0200.txt  @jeremyhylton
-# pep-0201.txt  @warsaw
-# pep-0202.txt  @warsaw
-# pep-0203.txt  @Yhg1s
-# pep-0204.txt  @Yhg1s
-# pep-0205.txt  @freddrake
-# # pep-0206.txt
-# pep-0207.txt  @gvanrossum
-# pep-0208.txt  @nascheme @malemburg
-# # pep-0209.txt
-# # pep-0210.txt
-# # pep-0211.txt
-# # pep-0212.txt
-# # pep-0213.txt
-# pep-0214.txt  @warsaw
-# # pep-0215.txt
-# # pep-0216.txt
-# # pep-0217.txt
-# pep-0218.txt  @rhettinger
-# # pep-0219.txt
-# # pep-0220.txt
-# pep-0221.txt  @Yhg1s
-# # pep-0222.txt
-# pep-0223.txt  @tim-one
-# pep-0224.txt  @malemburg
-# # pep-0225.txt
-# pep-0226.txt  @jeremyhylton
-# pep-0227.txt  @jeremyhylton
-# pep-0228.txt  @gvanrossum
-# # pep-0229.txt
-# pep-0230.txt  @gvanrossum
-# pep-0231.txt  @warsaw
-# pep-0232.txt  @warsaw
-# # pep-0233.txt
-# pep-0234.txt  @gvanrossum
-# pep-0235.txt  @tim-one
-# pep-0236.txt  @tim-one
-# pep-0237.txt  @gvanrossum
-# pep-0238.txt  @gvanrossum
-# # pep-0239.txt
-# # pep-0240.txt
-# # pep-0241.txt
-# # pep-0242.txt
-# # pep-0243.txt
-# # pep-0244.txt
-# # pep-0245.txt
-# pep-0246.txt  @aleaxit
-# # pep-0247.txt
-# pep-0248.txt  @malemburg
-# pep-0249.txt  @malemburg
-# pep-0250.txt  @pfmoore
-# pep-0251.txt  @warsaw @gvanrossum
-# pep-0252.txt  @gvanrossum
-# pep-0253.txt  @gvanrossum
-# pep-0254.txt  @gvanrossum
-# pep-0255.txt  @nascheme @tim-one
-# # pep-0256.txt
-# pep-0257.txt  @gvanrossum
-# # pep-0258.txt
-# pep-0259.txt  @gvanrossum
-# pep-0260.txt  @gvanrossum
-# # pep-0261.txt
-# # pep-0262.txt
-# pep-0263.txt  @malemburg
-# # pep-0264.txt
-# # pep-0265.txt
-# # pep-0266.txt
-# pep-0267.txt  @jeremyhylton
-# # pep-0268.txt
-# # pep-0269.txt
-# # pep-0270.txt
-# # pep-0271.txt
-# # pep-0272.txt
-# # pep-0273.txt
-# pep-0274.txt  @warsaw
-# pep-0275.txt  @malemburg
-# # pep-0276.txt
-# # pep-0277.txt
-# pep-0278.txt  @jackjansen
-# pep-0279.txt  @rhettinger
-# pep-0280.txt  @gvanrossum
-# # pep-0281.txt
-# pep-0282.txt  @vsajip
-# pep-0283.txt  @gvanrossum
-# # pep-0284.txt
-# pep-0285.txt  @gvanrossum
-# # pep-0286.txt
-# # pep-0287.txt
-# pep-0288.txt  @rhettinger
-# pep-0289.txt  @rhettinger
-# pep-0290.txt  @rhettinger
-# # pep-0291.txt
-# pep-0292.txt  @warsaw
-# pep-0293.txt  @doerwalter
-# # pep-0294.txt
-# # pep-0295.txt
-# # pep-0296.txt
-# pep-0297.txt  @malemburg
-# pep-0298.txt  @theller
-# # pep-0299.txt
-# # pep-0301.txt
-# pep-0302.txt  @pfmoore
-# # pep-0303.txt
-# # pep-0304.txt
-# # pep-0305.txt
-# pep-0306.txt  @jackdied @ncoghlan @benjaminp
-# pep-0307.txt  @gvanrossum @tim-one
-# pep-0308.txt  @gvanrossum @rhettinger
-# # pep-0309.txt
-# pep-0310.txt  @pfmoore
-# pep-0311.txt  @mhammond
-# pep-0312.txt  @aleaxit
-# # pep-0313.txt
-# # pep-0314.txt
-# pep-0315.txt  @rhettinger
-# # pep-0316.txt
-# # pep-0317.txt
-# # pep-0318.txt
-# # pep-0319.txt
-# pep-0320.txt  @warsaw @rhettinger
-# # pep-0321.txt
-# pep-0322.txt  @rhettinger
-# pep-0323.txt  @aleaxit
-# # pep-0324.txt
-# # pep-0325.txt
-# pep-0326.txt  @terryjreedy
-# pep-0327.txt  @facundobatista
-# # pep-0328.txt
-# pep-0329.txt  @rhettinger
-# # pep-0330.txt
-# # pep-0331.txt
-# # pep-0332.txt
-# pep-0333.txt  @pjeby
-# # pep-0334.txt
-# # pep-0335.txt
-# # pep-0336.txt
-# # pep-0337.txt
-# pep-0338.txt  @ncoghlan
-# pep-0339.txt  @brettcannon
-# pep-0340.txt  @gvanrossum
-# pep-0341.txt  @birkenfeld
-# pep-0342.txt  @gvanrossum @pjeby
-# pep-0343.txt  @gvanrossum @ncoghlan
-# # pep-0344.txt
-# # pep-0345.txt
-# pep-0346.txt  @ncoghlan
-# # pep-0347.txt
-# pep-0348.txt  @brettcannon
-# pep-0349.txt  @nascheme
-# # pep-0350.txt
-# pep-0351.txt  @warsaw
-# pep-0352.txt  @brettcannon @gvanrossum
-# # pep-0353.txt
-# # pep-0354.txt
-# # pep-0355.txt
-# pep-0356.txt  @gvanrossum
-# # pep-0357.txt
-# pep-0358.txt  @nascheme @gvanrossum
-# # pep-0359.txt
-# pep-0360.txt  @brettcannon
-# pep-0361.txt  @warsaw
-# pep-0362.txt  @brettcannon @1st1 @larryhastings
-# # pep-0363.txt
-# pep-0364.txt  @warsaw
-# pep-0365.txt  @pjeby
-# pep-0366.txt  @ncoghlan
-# # pep-0367.txt
-# # pep-0368.txt
-# pep-0369.txt  @tiran
-# pep-0370.txt  @tiran
-# # pep-0371.txt
-# pep-0372.txt  @mitsuhiko @rhettinger
-# pep-0373.txt  @benjaminp
-# pep-0374.txt  @brettcannon @avassalotti @warsaw
-# pep-0375.txt  @benjaminp
-# # pep-0376.txt
-# pep-0377.txt  @ncoghlan
-# pep-0378.txt  @rhettinger
-# # pep-0379.txt
-# # pep-0380.txt
-# # pep-0381.txt
-# # pep-0382.txt
-# # pep-0383.txt
-# # pep-0384.txt
-# pep-0385.txt  @pitrou @birkenfeld
-# # pep-0386.txt
-# pep-0387.txt  @benjaminp
-# # pep-0389.txt
-# # pep-0390.txt
-# pep-0391.txt  @vsajip
-# pep-0392.txt  @birkenfeld
-# # pep-0393.txt
-# pep-0394.txt  @ncoghlan @warsaw @encukou @willingc
-# pep-0395.txt  @ncoghlan
-# pep-0396.txt  @warsaw
-# pep-0397.txt  @mhammond
-# pep-0398.txt  @birkenfeld
-# pep-0399.txt  @brettcannon
-# pep-0400.txt  @vstinner
-# pep-0401.txt  @warsaw @brettcannon
-# pep-0402.txt  @pjeby
-# pep-0403.txt  @ncoghlan
-# pep-0404.txt  @warsaw
-# # pep-0405.txt
-# pep-0406.txt  @ncoghlan
-# pep-0407.txt  @pitrou @birkenfeld @warsaw
-# pep-0408.txt  @ncoghlan @eliben
-# pep-0409.txt  @ethanfurman
-# pep-0410.txt  @vstinner
-# pep-0411.txt  @ncoghlan @eliben
-# pep-0412.txt  @markshannon
-# pep-0413.txt  @ncoghlan
-# pep-0414.txt  @mitsuhiko @ncoghlan
-# pep-0415.txt  @benjaminp
-# pep-0416.txt  @vstinner
-# pep-0417.txt  @voidspace
-# pep-0418.txt  @vstinner
-# pep0418/      @vstinner
-# # pep-0419.txt
-# pep-0420.txt  @ericvsmith
-# pep-0421.txt  @ericsnowcurrently
-# pep-0422.txt  @ncoghlan Daniel Urban
-# # pep-0423.txt
-# pep-0424.txt  @alex
-# # pep-0425.txt
-# pep-0426.txt  @ncoghlan @dstufft
-# pep-0426/     @ncoghlan @dstufft
-# # pep-0427.txt
-# pep-0428.txt  @pitrou
-# pep-0429.txt  @larryhastings
-# pep-0430.txt  @ncoghlan
-# # pep-0431.txt
-# pep-0432.txt  @ncoghlan @vstinner @ericsnowcurrently
-# pep-0433.txt  @vstinner
-# pep-0433/     @vstinner
-# pep-0434.txt  @terryjreedy
-# pep-0435.txt  @warsaw @eliben @ethanfurman
-# pep-0436.txt  @larryhastings
-# # pep-0437.txt
-# # pep-0438.txt
-# # pep-0439.txt
-# pep-0440.txt  @ncoghlan @dstufft
-# pep-0441.txt  @pfmoore
-# pep-0442.txt  @pitrou
-# pep-0443.txt  @ambv
-# pep-0444.txt  @mitsuhiko
-# pep-0445.txt  @vstinner
-# pep-0446.txt  @vstinner
-# pep-0446/     @vstinner
-# pep-0447.txt  @ronaldoussoren
-# # pep-0448.txt
-# pep-0449.txt  @dstufft
-# pep-0450.txt  @stevendaprano
-# pep-0451.txt  @ericsnowcurrently
-# pep-0452.txt  @tiran
-# pep-0453.txt  @dstufft @ncoghlan
-# pep-0454.txt  @vstinner
-# pep-0455.txt  @pitrou
-# pep-0456.txt  @tiran
-# pep-0457.txt  @larryhastings
-# # pep-0458.txt, pep-0458-1.png
-# pep-0459.txt  @ncoghlan
-# pep-0460.txt  @pitrou
-# pep-0461.txt  @ethanfurman
-# pep-0462.txt  @ncoghlan
-# # pep-0463.txt
-# pep-0464.txt  @dstufft
-# pep-0465.txt  @njsmith
-# pep-0466.txt  @ncoghlan
-# pep-0467.txt  @ncoghlan @ethanfurman
-# pep-0468.txt  @ericsnowcurrently
-# pep-0469.txt  @ncoghlan
-# pep-0470.txt  @dstufft
-# # pep-0471.txt
-# # pep-0472.txt
-# # pep-0473.txt
-# pep-0474.txt  @ncoghlan
-# pep-0475.txt  @vstinner
-# pep-0476.txt  @alex
-# pep-0477.txt  @dstufft @ncoghlan
-# pep-0478.txt  @larryhastings
-# pep-0479.txt  @gvanrossum
-# # pep-0480.txt, pep-0480-1.png
-# pep-0481.txt  @dstufft
-# pep-0482.txt  @ambv
-# pep-0483.txt  @gvanrossum @ilevkivskyi
-# pep-0484.txt  @gvanrossum @ambv
-# # pep-0485.txt
-# pep-0486.txt  @pfmoore
-# # pep-0487.txt
-# pep-0488.txt  @brettcannon
-# pep-0489.txt  @encukou @scoder @ncoghlan
-# pep-0490.txt  @vstinner
-# # pep-0491.txt
-# pep-0492.txt  @1st1
-# pep-0493.txt  @ncoghlan @malemburg
-# pep-0494.txt  @ned-deily
-# pep-0495.txt  @abalkin @tim-one
-# pep-0495-gap.png  @abalkin @tim-one
-# pep-0495-gap.svg  @abalkin @tim-one
-# pep-0495-fold.svg  @abalkin @tim-one
-# pep-0495-fold-2.png  @abalkin @tim-one
-# pep-0495-daylightsavings.png  @abalkin @tim-one
-# # pep-0496.txt
-# # pep-0497.txt
-# pep-0498.txt  @ericvsmith
-# # pep-0499.txt
-# pep-0500.txt  @abalkin @tim-one
-# pep-0501.txt  @ncoghlan
-# # pep-0502.txt
-# pep-0503.txt  @dstufft
-# pep-0504.txt  @ncoghlan
-# pep-0505.rst  @zooba
-# pep-0505/     @zooba
-# pep-0506.txt  @stevendaprano
-# pep-0507.txt  @warsaw
-# pep-0508.txt  @rbtcollins
-# pep-0509.txt  @vstinner
-# pep-0510.txt  @vstinner
-# pep-0511.txt  @vstinner
-# pep-0512.txt  @brettcannon
-# pep-0513.txt  @njsmith
-# pep-0514.txt  @zooba
-# pep-0515.txt  @birkenfeld @serhiy-storchaka
-# pep-0516.txt  @rbtcollins @njsmith
-# pep-0517.txt  @njsmith
-# pep-0518.txt  @brettcannon @njsmith @dstufft
-# pep-0519.txt  @brettcannon
-# pep-0520.txt  @ericsnowcurrently
-# pep-0521.txt  @njsmith
-# pep-0522.txt  @ncoghlan @njsmith
-# pep-0523.txt  @brettcannon @DinoV
-# pep-0524.txt  @vstinner
-# pep-0525.txt  @1st1
-# pep-0525-1.png  @1st1
-# pep-0526.txt  @ilevkivskyi @lisroach @gvanrossum
-# pep-0527.txt  @dstufft
-# pep-0528.txt  @zooba
-# pep-0529.txt  @zooba
-# pep-0530.txt  @1st1
-# pep-0531.txt  @ncoghlan
-# pep-0532.txt  @ncoghlan
-# pep-0532/     @ncoghlan
-# pep-0533.txt  @njsmith
-# pep-0534.txt  @encukou @ncoghlan
-# pep-0535.txt  @ncoghlan
-# # pep-0536.txt
-# pep-0537.txt  @ned-deily
-# pep-0538.txt  @ncoghlan
-# # pep-0539.txt
-# pep-0540.txt  @vstinner
-# pep-0541.txt  @ambv
-# # pep-0542.txt
-# pep-0543.rst  @tiran
-# pep-0544.txt  @ilevkivskyi @ambv
-# pep-0545.txt  @JulienPalard @methane @vstinner
-# pep-0546.txt  @vstinner
-# pep-0547.rst  @encukou
-# pep-0548.rst  @bitdancer
-# pep-0549.rst  @larryhastings
-# pep-0550.rst  @1st1
-# pep-0550-lookup_hamt.png  @1st1
-# pep-0550-hamt_vs_dict.png  @1st1
-# pep-0550-hamt_vs_dict-v2.png  @1st1
-# pep-0551.rst  @zooba
-# pep-0552.rst  @benjaminp
-# pep-0553.rst  @warsaw
-# pep-0554.rst  @ericsnowcurrently
-# # pep-0555.rst
-# pep-0556.rst  @pitrou
-# pep-0557.rst  @ericvsmith
-# pep-0558.rst  @ncoghlan
-# pep-0559.rst  @warsaw
-# pep-0560.rst  @ilevkivskyi
-# # pep-0561.rst
-# pep-0562.rst  @ilevkivskyi
-# pep-0563.rst  @ambv
-# pep-0564.rst  @vstinner
-# pep-0565.rst  @ncoghlan
-# # pep-0566.rst
-# pep-0567.rst  @1st1
-# pep-0568.rst  @njsmith
-# pep-0569.rst  @ambv
-# pep-0570.rst  @larryhastings @pablogsal
-# # pep-0571.rst
-# pep-0572.rst  @tim-one @gvanrossum
-# pep-0573.rst  @encukou @ncoghlan @ericsnowcurrently
-# pep-0574.rst  @pitrou
-# # pep-0575.rst
-# pep-0576.rst  @markshannon
-# pep-0577.rst  @ncoghlan
-# pep-0578.rst  @zooba
-# # pep-0579.rst
-# # pep-0580.rst
-# pep-0581.rst  @Mariatta
-# pep-0582.rst  @kushaldas @zooba @dstufft @ncoghlan
-# # pep-0583.rst
-# pep-0584.rst  @stevendaprano @brandtbucher
-# pep-0585.rst  @ambv
-# pep-0586.rst  @ilevkivskyi
-# pep-0587.rst  @vstinner @ncoghlan
-# pep-0588.rst  @Mariatta
-# pep-0589.rst  @gvanrossum
-# pep-0590.rst  @markshannon
-# pep-0591.rst  @ilevkivskyi
-# pep-0592.rst  @dstufft
-# pep-0593.rst  @ilevkivskyi
-# pep-0594.rst  @tiran
-# pep-0595.rst  @ezio-melotti @berkerpeksag
-# pep-0596.rst  @ambv
-# pep-0597.rst  @methane
-# pep-0598.rst  @ncoghlan
-# pep-0599.rst  @pfmoore
-/pep-0600.rst  @njsmith
-/pep-0601.txt  @isidentical
-/pep-0602.rst  @ambv
-/pep-0602-example-release-calendar.png  @ambv
-/pep-0602-example-release-calendar.pptx  @ambv
-/pep-0602-overlapping-support-matrix.png  @ambv
-/pep-0602-overlapping-support-matrix.pptx  @ambv
-/pep-0603.rst  @1st1
-/pep-0603-lookup_hamt.png  @1st1
-/pep-0603-hamt_vs_dict.png  @1st1
-# /pep-0604.rst
-/pep-0605.rst  @zooba @ncoghlan
-/pep-0605-example-release-calendar.png  @zooba @ncoghlan
-/pep-0605-overlapping-support-matrix.png  @zooba @ncoghlan
-/pep-0605/     @zooba @ncoghlan
-/pep-0606.rst  @vstinner
-/pep-0607.rst  @ambv @zooba @ncoghlan
-/pep-0608.rst  @vstinner
-/pep-0609.rst  @pganssle
-/pep-0610.rst  @cjerdonek
-/pep-0611.rst  @markshannon
-/pep-0612.rst  @gvanrossum
-/pep-0613.rst  @gvanrossum
-/pep-0614.rst  @brandtbucher
-/pep-0615.rst  @pganssle
-/pep-0616.rst  @ericvsmith
-/pep-0617.rst  @gvanrossum @pablogsal @lysnikolaou
-/pep-0618.rst  @brandtbucher
-/pep-0619.rst  @pablogsal
-/pep-0620.rst  @vstinner
-/pep-0621.rst  @brettcannon  @pganssle
-/pep-0622.rst  @brandtbucher @ilevkivskyi @gvanrossum
-/pep-0623.rst  @methane
-/pep-0624.rst  @methane
-/pep-0625.rst  @pfmoore
-/pep-0626.rst  @markshannon
-/pep-0627.rst  @encukou
-/pep-0628.txt  @ncoghlan
-/pep-0629.rst  @dstufft
-/pep-0630.rst  @encukou
-/pep-0631.rst  @pganssle
-/pep-0632.rst  @zooba
-/pep-0633.rst  @brettcannon
-/pep-0634.rst  @brandtbucher @gvanrossum
-/pep-0635.rst  @gvanrossum
-/pep-0636.rst  @gvanrossum
-/pep-0637.rst  @stevendaprano
-/pep-0638.rst  @markshannon
-/pep-0639.rst  @pfmoore
-/pep-0640.rst  @Yhg1s
-/pep-0641.rst  @zooba @warsaw @brettcannon
-/pep-0642.rst  @ncoghlan
-/pep-0643.rst  @pfmoore
-/pep-0644.rst  @tiran
-/pep-0645.rst  @gvanrossum
-/pep-0646.rst  @gvanrossum
-/pep-0647.rst  @gvanrossum
-/pep-0648.rst  @pablogsal
-/pep-0649.rst  @larryhastings
-/pep-0650.rst  @brettcannon
-/pep-0651.rst  @markshannon
-/pep-0652.rst  @encukou
-/pep-0653.rst  @markshannon
-/pep-0654.rst  @1st1 @gvanrossum
-/pep-0655.rst  @gvanrossum
-/pep-0656.rst  @brettcannon
+pep-0001.txt  @warsaw @ncoghlan
+pep-0001-process_flow.png  @warsaw @ncoghlan
+pep-0001/     @warsaw @ncoghlan
+# pep-0002.txt
+pep-0003.txt  @jeremyhylton
+pep-0004.txt  @brettcannon
+# pep-0005.txt
+# pep-0006.txt
+pep-0007.txt  @gvanrossum @warsaw
+pep-0008.txt  @gvanrossum @warsaw @ncoghlan
+pep-0009.txt  @warsaw
+pep-0010.txt  @warsaw
+pep-0011.txt  @brettcannon
+pep-0012.rst  @brettcannon @warsaw
+# pep-0013.rst is owned by the entire core team.
+# ...
+pep-0020.txt  @tim-one
+# ...
+pep-0042.txt  @jeremyhylton
+# ...
+pep-0100.txt  @malemburg
+pep-0101.txt  @warsaw @gvanrossum
+pep-0102.txt  @warsaw @gvanrossum
+# pep-0103.txt
+# ...
+pep-0160.txt  @freddrake
+# ...
+pep-0200.txt  @jeremyhylton
+pep-0201.txt  @warsaw
+pep-0202.txt  @warsaw
+pep-0203.txt  @Yhg1s
+pep-0204.txt  @Yhg1s
+pep-0205.txt  @freddrake
+# pep-0206.txt
+pep-0207.txt  @gvanrossum
+pep-0208.txt  @nascheme @malemburg
+# pep-0209.txt
+# pep-0210.txt
+# pep-0211.txt
+# pep-0212.txt
+# pep-0213.txt
+pep-0214.txt  @warsaw
+# pep-0215.txt
+# pep-0216.txt
+# pep-0217.txt
+pep-0218.txt  @rhettinger
+# pep-0219.txt
+# pep-0220.txt
+pep-0221.txt  @Yhg1s
+# pep-0222.txt
+pep-0223.txt  @tim-one
+pep-0224.txt  @malemburg
+# pep-0225.txt
+pep-0226.txt  @jeremyhylton
+pep-0227.txt  @jeremyhylton
+pep-0228.txt  @gvanrossum
+# pep-0229.txt
+pep-0230.txt  @gvanrossum
+pep-0231.txt  @warsaw
+pep-0232.txt  @warsaw
+# pep-0233.txt
+pep-0234.txt  @gvanrossum
+pep-0235.txt  @tim-one
+pep-0236.txt  @tim-one
+pep-0237.txt  @gvanrossum
+pep-0238.txt  @gvanrossum
+# pep-0239.txt
+# pep-0240.txt
+# pep-0241.txt
+# pep-0242.txt
+# pep-0243.txt
+# pep-0244.txt
+# pep-0245.txt
+pep-0246.txt  @aleaxit
+# pep-0247.txt
+pep-0248.txt  @malemburg
+pep-0249.txt  @malemburg
+pep-0250.txt  @pfmoore
+pep-0251.txt  @warsaw @gvanrossum
+pep-0252.txt  @gvanrossum
+pep-0253.txt  @gvanrossum
+pep-0254.txt  @gvanrossum
+pep-0255.txt  @nascheme @tim-one
+# pep-0256.txt
+pep-0257.txt  @gvanrossum
+# pep-0258.txt
+pep-0259.txt  @gvanrossum
+pep-0260.txt  @gvanrossum
+# pep-0261.txt
+# pep-0262.txt
+pep-0263.txt  @malemburg
+# pep-0264.txt
+# pep-0265.txt
+# pep-0266.txt
+pep-0267.txt  @jeremyhylton
+# pep-0268.txt
+# pep-0269.txt
+# pep-0270.txt
+# pep-0271.txt
+# pep-0272.txt
+# pep-0273.txt
+pep-0274.txt  @warsaw
+pep-0275.txt  @malemburg
+# pep-0276.txt
+# pep-0277.txt
+pep-0278.txt  @jackjansen
+pep-0279.txt  @rhettinger
+pep-0280.txt  @gvanrossum
+# pep-0281.txt
+pep-0282.txt  @vsajip
+pep-0283.txt  @gvanrossum
+# pep-0284.txt
+pep-0285.txt  @gvanrossum
+# pep-0286.txt
+# pep-0287.txt
+pep-0288.txt  @rhettinger
+pep-0289.txt  @rhettinger
+pep-0290.txt  @rhettinger
+# pep-0291.txt
+pep-0292.txt  @warsaw
+pep-0293.txt  @doerwalter
+# pep-0294.txt
+# pep-0295.txt
+# pep-0296.txt
+pep-0297.txt  @malemburg
+pep-0298.txt  @theller
+# pep-0299.txt
+# pep-0301.txt
+pep-0302.txt  @pfmoore
+# pep-0303.txt
+# pep-0304.txt
+# pep-0305.txt
+pep-0306.txt  @jackdied @ncoghlan @benjaminp
+pep-0307.txt  @gvanrossum @tim-one
+pep-0308.txt  @gvanrossum @rhettinger
+# pep-0309.txt
+pep-0310.txt  @pfmoore
+pep-0311.txt  @mhammond
+pep-0312.txt  @aleaxit
+# pep-0313.txt
+# pep-0314.txt
+pep-0315.txt  @rhettinger
+# pep-0316.txt
+# pep-0317.txt
+# pep-0318.txt
+# pep-0319.txt
+pep-0320.txt  @warsaw @rhettinger
+# pep-0321.txt
+pep-0322.txt  @rhettinger
+pep-0323.txt  @aleaxit
+# pep-0324.txt
+# pep-0325.txt
+pep-0326.txt  @terryjreedy
+pep-0327.txt  @facundobatista
+# pep-0328.txt
+pep-0329.txt  @rhettinger
+# pep-0330.txt
+# pep-0331.txt
+# pep-0332.txt
+pep-0333.txt  @pjeby
+# pep-0334.txt
+# pep-0335.txt
+# pep-0336.txt
+# pep-0337.txt
+pep-0338.txt  @ncoghlan
+pep-0339.txt  @brettcannon
+pep-0340.txt  @gvanrossum
+pep-0341.txt  @birkenfeld
+pep-0342.txt  @gvanrossum @pjeby
+pep-0343.txt  @gvanrossum @ncoghlan
+# pep-0344.txt
+# pep-0345.txt
+pep-0346.txt  @ncoghlan
+# pep-0347.txt
+pep-0348.txt  @brettcannon
+pep-0349.txt  @nascheme
+# pep-0350.txt
+pep-0351.txt  @warsaw
+pep-0352.txt  @brettcannon @gvanrossum
+# pep-0353.txt
+# pep-0354.txt
+# pep-0355.txt
+pep-0356.txt  @gvanrossum
+# pep-0357.txt
+pep-0358.txt  @nascheme @gvanrossum
+# pep-0359.txt
+pep-0360.txt  @brettcannon
+pep-0361.txt  @warsaw
+pep-0362.txt  @brettcannon @1st1 @larryhastings
+# pep-0363.txt
+pep-0364.txt  @warsaw
+pep-0365.txt  @pjeby
+pep-0366.txt  @ncoghlan
+# pep-0367.txt
+# pep-0368.txt
+pep-0369.txt  @tiran
+pep-0370.txt  @tiran
+# pep-0371.txt
+pep-0372.txt  @mitsuhiko @rhettinger
+pep-0373.txt  @benjaminp
+pep-0374.txt  @brettcannon @avassalotti @warsaw
+pep-0375.txt  @benjaminp
+# pep-0376.txt
+pep-0377.txt  @ncoghlan
+pep-0378.txt  @rhettinger
+# pep-0379.txt
+# pep-0380.txt
+# pep-0381.txt
+# pep-0382.txt
+# pep-0383.txt
+# pep-0384.txt
+pep-0385.txt  @pitrou @birkenfeld
+# pep-0386.txt
+pep-0387.txt  @benjaminp
+# pep-0389.txt
+# pep-0390.txt
+pep-0391.txt  @vsajip
+pep-0392.txt  @birkenfeld
+# pep-0393.txt
+pep-0394.txt  @ncoghlan @warsaw @encukou @willingc
+pep-0395.txt  @ncoghlan
+pep-0396.txt  @warsaw
+pep-0397.txt  @mhammond
+pep-0398.txt  @birkenfeld
+pep-0399.txt  @brettcannon
+pep-0400.txt  @vstinner
+pep-0401.txt  @warsaw @brettcannon
+pep-0402.txt  @pjeby
+pep-0403.txt  @ncoghlan
+pep-0404.txt  @warsaw
+# pep-0405.txt
+pep-0406.txt  @ncoghlan
+pep-0407.txt  @pitrou @birkenfeld @warsaw
+pep-0408.txt  @ncoghlan @eliben
+pep-0409.txt  @ethanfurman
+pep-0410.txt  @vstinner
+pep-0411.txt  @ncoghlan @eliben
+pep-0412.txt  @markshannon
+pep-0413.txt  @ncoghlan
+pep-0414.txt  @mitsuhiko @ncoghlan
+pep-0415.txt  @benjaminp
+pep-0416.txt  @vstinner
+pep-0417.txt  @voidspace
+pep-0418.txt  @vstinner
+pep0418/      @vstinner
+# pep-0419.txt
+pep-0420.txt  @ericvsmith
+pep-0421.txt  @ericsnowcurrently
+pep-0422.txt  @ncoghlan Daniel Urban
+# pep-0423.txt
+pep-0424.txt  @alex
+# pep-0425.txt
+pep-0426.txt  @ncoghlan @dstufft
+pep-0426/     @ncoghlan @dstufft
+# pep-0427.txt
+pep-0428.txt  @pitrou
+pep-0429.txt  @larryhastings
+pep-0430.txt  @ncoghlan
+# pep-0431.txt
+pep-0432.txt  @ncoghlan @vstinner @ericsnowcurrently
+pep-0433.txt  @vstinner
+pep-0433/     @vstinner
+pep-0434.txt  @terryjreedy
+pep-0435.txt  @warsaw @eliben @ethanfurman
+pep-0436.txt  @larryhastings
+# pep-0437.txt
+# pep-0438.txt
+# pep-0439.txt
+pep-0440.txt  @ncoghlan @dstufft
+pep-0441.txt  @pfmoore
+pep-0442.txt  @pitrou
+pep-0443.txt  @ambv
+pep-0444.txt  @mitsuhiko
+pep-0445.txt  @vstinner
+pep-0446.txt  @vstinner
+pep-0446/     @vstinner
+pep-0447.txt  @ronaldoussoren
+# pep-0448.txt
+pep-0449.txt  @dstufft
+pep-0450.txt  @stevendaprano
+pep-0451.txt  @ericsnowcurrently
+pep-0452.txt  @tiran
+pep-0453.txt  @dstufft @ncoghlan
+pep-0454.txt  @vstinner
+pep-0455.txt  @pitrou
+pep-0456.txt  @tiran
+pep-0457.txt  @larryhastings
+# pep-0458.txt, pep-0458-1.png
+pep-0459.txt  @ncoghlan
+pep-0460.txt  @pitrou
+pep-0461.txt  @ethanfurman
+pep-0462.txt  @ncoghlan
+# pep-0463.txt
+pep-0464.txt  @dstufft
+pep-0465.txt  @njsmith
+pep-0466.txt  @ncoghlan
+pep-0467.txt  @ncoghlan @ethanfurman
+pep-0468.txt  @ericsnowcurrently
+pep-0469.txt  @ncoghlan
+pep-0470.txt  @dstufft
+# pep-0471.txt
+# pep-0472.txt
+# pep-0473.txt
+pep-0474.txt  @ncoghlan
+pep-0475.txt  @vstinner
+pep-0476.txt  @alex
+pep-0477.txt  @dstufft @ncoghlan
+pep-0478.txt  @larryhastings
+pep-0479.txt  @gvanrossum
+# pep-0480.txt, pep-0480-1.png
+pep-0481.txt  @dstufft
+pep-0482.txt  @ambv
+pep-0483.txt  @gvanrossum @ilevkivskyi
+pep-0484.txt  @gvanrossum @ambv
+# pep-0485.txt
+pep-0486.txt  @pfmoore
+# pep-0487.txt
+pep-0488.txt  @brettcannon
+pep-0489.txt  @encukou @scoder @ncoghlan
+pep-0490.txt  @vstinner
+# pep-0491.txt
+pep-0492.txt  @1st1
+pep-0493.txt  @ncoghlan @malemburg
+pep-0494.txt  @ned-deily
+pep-0495.txt  @abalkin @tim-one
+pep-0495-gap.png  @abalkin @tim-one
+pep-0495-gap.svg  @abalkin @tim-one
+pep-0495-fold.svg  @abalkin @tim-one
+pep-0495-fold-2.png  @abalkin @tim-one
+pep-0495-daylightsavings.png  @abalkin @tim-one
+# pep-0496.txt
+# pep-0497.txt
+pep-0498.txt  @ericvsmith
+# pep-0499.txt
+pep-0500.txt  @abalkin @tim-one
+pep-0501.txt  @ncoghlan
+# pep-0502.txt
+pep-0503.txt  @dstufft
+pep-0504.txt  @ncoghlan
+pep-0505.rst  @zooba
+pep-0505/     @zooba
+pep-0506.txt  @stevendaprano
+pep-0507.txt  @warsaw
+pep-0508.txt  @rbtcollins
+pep-0509.txt  @vstinner
+pep-0510.txt  @vstinner
+pep-0511.txt  @vstinner
+pep-0512.txt  @brettcannon
+pep-0513.txt  @njsmith
+pep-0514.txt  @zooba
+pep-0515.txt  @birkenfeld @serhiy-storchaka
+pep-0516.txt  @rbtcollins @njsmith
+pep-0517.txt  @njsmith
+pep-0518.txt  @brettcannon @njsmith @dstufft
+pep-0519.txt  @brettcannon
+pep-0520.txt  @ericsnowcurrently
+pep-0521.txt  @njsmith
+pep-0522.txt  @ncoghlan @njsmith
+pep-0523.txt  @brettcannon @DinoV
+pep-0524.txt  @vstinner
+pep-0525.txt  @1st1
+pep-0525-1.png  @1st1
+pep-0526.txt  @ilevkivskyi @lisroach @gvanrossum
+pep-0527.txt  @dstufft
+pep-0528.txt  @zooba
+pep-0529.txt  @zooba
+pep-0530.txt  @1st1
+pep-0531.txt  @ncoghlan
+pep-0532.txt  @ncoghlan
+pep-0532/     @ncoghlan
+pep-0533.txt  @njsmith
+pep-0534.txt  @encukou @ncoghlan
+pep-0535.txt  @ncoghlan
+# pep-0536.txt
+pep-0537.txt  @ned-deily
+pep-0538.txt  @ncoghlan
+# pep-0539.txt
+pep-0540.txt  @vstinner
+pep-0541.txt  @ambv
+# pep-0542.txt
+pep-0543.rst  @tiran
+pep-0544.txt  @ilevkivskyi @ambv
+pep-0545.txt  @JulienPalard @methane @vstinner
+pep-0546.txt  @vstinner
+pep-0547.rst  @encukou
+pep-0548.rst  @bitdancer
+pep-0549.rst  @larryhastings
+pep-0550.rst  @1st1
+pep-0550-lookup_hamt.png  @1st1
+pep-0550-hamt_vs_dict.png  @1st1
+pep-0550-hamt_vs_dict-v2.png  @1st1
+pep-0551.rst  @zooba
+pep-0552.rst  @benjaminp
+pep-0553.rst  @warsaw
+pep-0554.rst  @ericsnowcurrently
+# pep-0555.rst
+pep-0556.rst  @pitrou
+pep-0557.rst  @ericvsmith
+pep-0558.rst  @ncoghlan
+pep-0559.rst  @warsaw
+pep-0560.rst  @ilevkivskyi
+# pep-0561.rst
+pep-0562.rst  @ilevkivskyi
+pep-0563.rst  @ambv
+pep-0564.rst  @vstinner
+pep-0565.rst  @ncoghlan
+# pep-0566.rst
+pep-0567.rst  @1st1
+pep-0568.rst  @njsmith
+pep-0569.rst  @ambv
+pep-0570.rst  @larryhastings @pablogsal
+# pep-0571.rst
+pep-0572.rst  @tim-one @gvanrossum
+pep-0573.rst  @encukou @ncoghlan @ericsnowcurrently
+pep-0574.rst  @pitrou
+# pep-0575.rst
+pep-0576.rst  @markshannon
+pep-0577.rst  @ncoghlan
+pep-0578.rst  @zooba
+# pep-0579.rst
+# pep-0580.rst
+pep-0581.rst  @Mariatta
+pep-0582.rst  @kushaldas @zooba @dstufft @ncoghlan
+# pep-0583.rst
+pep-0584.rst  @stevendaprano @brandtbucher
+pep-0585.rst  @ambv
+pep-0586.rst  @ilevkivskyi
+pep-0587.rst  @vstinner @ncoghlan
+pep-0588.rst  @Mariatta
+pep-0589.rst  @gvanrossum
+pep-0590.rst  @markshannon
+pep-0591.rst  @ilevkivskyi
+pep-0592.rst  @dstufft
+pep-0593.rst  @ilevkivskyi
+pep-0594.rst  @tiran
+pep-0595.rst  @ezio-melotti @berkerpeksag
+pep-0596.rst  @ambv
+pep-0597.rst  @methane
+pep-0598.rst  @ncoghlan
+pep-0599.rst  @pfmoore
+pep-0600.rst  @njsmith
+pep-0601.txt  @isidentical
+pep-0602.rst  @ambv
+pep-0602-example-release-calendar.png  @ambv
+pep-0602-example-release-calendar.pptx  @ambv
+pep-0602-overlapping-support-matrix.png  @ambv
+pep-0602-overlapping-support-matrix.pptx  @ambv
+pep-0603.rst  @1st1
+pep-0603-lookup_hamt.png  @1st1
+pep-0603-hamt_vs_dict.png  @1st1
+# pep-0604.rst
+pep-0605.rst  @zooba @ncoghlan
+pep-0605-example-release-calendar.png  @zooba @ncoghlan
+pep-0605-overlapping-support-matrix.png  @zooba @ncoghlan
+/pep-0605/    @zooba @ncoghlan
+pep-0606.rst  @vstinner
+pep-0607.rst  @ambv @zooba @ncoghlan
+pep-0608.rst  @vstinner
+pep-0609.rst  @pganssle
+pep-0610.rst  @cjerdonek
+pep-0611.rst  @markshannon
+pep-0612.rst  @gvanrossum
+pep-0613.rst  @gvanrossum
+pep-0614.rst  @brandtbucher
+pep-0615.rst  @pganssle
+pep-0616.rst  @ericvsmith
+pep-0617.rst  @gvanrossum @pablogsal @lysnikolaou
+pep-0618.rst  @brandtbucher
+pep-0619.rst  @pablogsal
+pep-0620.rst  @vstinner
+pep-0621.rst  @brettcannon  @pganssle
+pep-0622.rst  @brandtbucher @ilevkivskyi @gvanrossum
+pep-0623.rst  @methane
+pep-0624.rst  @methane
+pep-0625.rst  @pfmoore
+pep-0626.rst  @markshannon
+pep-0627.rst  @encukou
+pep-0628.txt  @ncoghlan
+pep-0629.rst  @dstufft
+pep-0630.rst  @encukou
+pep-0631.rst  @pganssle
+pep-0632.rst  @zooba
+pep-0633.rst  @brettcannon
+pep-0634.rst  @brandtbucher @gvanrossum
+pep-0635.rst  @gvanrossum
+pep-0636.rst  @gvanrossum
+pep-0637.rst  @stevendaprano
+pep-0638.rst  @markshannon
+pep-0639.rst  @pfmoore
+pep-0640.rst  @Yhg1s
+pep-0641.rst  @zooba @warsaw @brettcannon
+pep-0642.rst  @ncoghlan
+pep-0643.rst  @pfmoore
+pep-0644.rst  @tiran
+pep-0645.rst  @gvanrossum
+pep-0646.rst  @gvanrossum
+pep-0647.rst  @gvanrossum
+pep-0648.rst  @pablogsal
+pep-0649.rst  @larryhastings
+pep-0650.rst  @brettcannon
+pep-0651.rst  @markshannon
+pep-0652.rst  @encukou
+pep-0653.rst  @markshannon
+pep-0654.rst  @1st1 @gvanrossum
+pep-0655.rst  @gvanrossum
+pep-0656.rst  @brettcannon
 # ...
 # pep-0666.txt
 # ...
-# # pep-0754.txt
-# # ...
-# pep-0801.rst  @warsaw
-# # ...
-# pep-3000.txt  @gvanrossum
-# pep-3001.txt  @birkenfeld
-# # pep-3002.txt
-# pep-3003.txt  @brettcannon  @gvanrossum
-# # ...
-# pep-3099.txt  @birkenfeld
-# pep-3100.txt  @brettcannon
-# # pep-3101.txt
-# # pep-3102.txt
-# pep-3103.txt  @gvanrossum
-# # pep-3104.txt
-# pep-3105.txt  @birkenfeld
-# pep-3106.txt  @gvanrossum
-# # pep-3107.txt
-# pep-3108.txt  @brettcannon
-# # pep-3109.txt
-# # pep-3110.txt
-# # pep-3111.txt
-# # pep-3112.txt
-# pep-3113.txt  @brettcannon
-# # pep-3114.txt
-# # pep-3115.txt
-# pep-3116.txt  @gvanrossum
-# pep-3117.txt  @birkenfeld
-# # pep-3118.txt
-# pep-3119.txt  @gvanrossum
-# # pep-3120.txt
-# # pep-3121.txt
-# pep-3122.txt  @brettcannon
-# # pep-3123.txt
-# pep-3124.txt  @pjeby
-# # pep-3125.txt
-# pep-3126.txt  @rhettinger
-# # pep-3127.txt
-# # pep-3128.txt
-# # pep-3129.txt
-# # pep-3130.txt
-# # pep-3131.txt
-# pep-3132.txt  @birkenfeld
-# # pep-3133.txt
-# # pep-3134.txt
-# # pep-3135.txt
-# # pep-3136.txt
-# pep-3137.txt  @gvanrossum
-# # pep-3138.txt
-# pep-3139.txt  @benjaminp
-# # pep-3140.txt
-# # pep-3141.txt
-# # pep-3142.txt
-# # pep-3143.txt
-# # pep-3144.txt
-# # pep-3145.txt
-# # pep-3146.txt
-# pep-3147.txt  @warsaw
-# pep-3147-1.dia  @warsaw
-# pep-3147-1.png  @warsaw
-# pep-3148.txt  @brianquinlan
-# pep-3149.txt  @warsaw
-# pep-3150.txt  @ncoghlan
-# pep-3151.txt  @pitrou
-# # pep-3152.txt
-# # pep-3153.txt
-# pep-3154.txt  @pitrou
-# pep-3155.txt  @pitrou
-# pep-3156.txt  @gvanrossum
-# # ...
-# pep-3333.txt  @pjeby
-# # ...
-# pep-8000.rst  @warsaw
-# pep-8001.rst  @brettcannon @tiran @dstufft @ericsnowcurrently @gpshead @ambv @Mariatta @njsmith @pablogsal @rhettinger @taleinat @tim-one @zware
-# pep-8002.rst  @warsaw @ambv @pitrou @dhellmann @willingc
-# pep-8010.rst  @warsaw
-# pep-8011.rst  @Mariatta @warsaw
-# pep-8012.rst  @ambv
-# pep-8013.rst  @zooba
-# pep-8014.rst  @jackjansen
-# pep-8015.rst  @vstinner
-# pep-8016.rst  @njsmith @dstufft
-# # ...
-# pep-8100.rst  @njsmith
-# # pep-8101.rst
-# # pep-8102.rst
+# pep-0754.txt
+# ...
+pep-0801.rst  @warsaw
+# ...
+pep-3000.txt  @gvanrossum
+pep-3001.txt  @birkenfeld
+# pep-3002.txt
+pep-3003.txt  @brettcannon  @gvanrossum
+# ...
+pep-3099.txt  @birkenfeld
+pep-3100.txt  @brettcannon
+# pep-3101.txt
+# pep-3102.txt
+pep-3103.txt  @gvanrossum
+# pep-3104.txt
+pep-3105.txt  @birkenfeld
+pep-3106.txt  @gvanrossum
+# pep-3107.txt
+pep-3108.txt  @brettcannon
+# pep-3109.txt
+# pep-3110.txt
+# pep-3111.txt
+# pep-3112.txt
+pep-3113.txt  @brettcannon
+# pep-3114.txt
+# pep-3115.txt
+pep-3116.txt  @gvanrossum
+pep-3117.txt  @birkenfeld
+# pep-3118.txt
+pep-3119.txt  @gvanrossum
+# pep-3120.txt
+# pep-3121.txt
+pep-3122.txt  @brettcannon
+# pep-3123.txt
+pep-3124.txt  @pjeby
+# pep-3125.txt
+pep-3126.txt  @rhettinger
+# pep-3127.txt
+# pep-3128.txt
+# pep-3129.txt
+# pep-3130.txt
+# pep-3131.txt
+pep-3132.txt  @birkenfeld
+# pep-3133.txt
+# pep-3134.txt
+# pep-3135.txt
+# pep-3136.txt
+pep-3137.txt  @gvanrossum
+# pep-3138.txt
+pep-3139.txt  @benjaminp
+# pep-3140.txt
+# pep-3141.txt
+# pep-3142.txt
+# pep-3143.txt
+# pep-3144.txt
+# pep-3145.txt
+# pep-3146.txt
+pep-3147.txt  @warsaw
+pep-3147-1.dia  @warsaw
+pep-3147-1.png  @warsaw
+pep-3148.txt  @brianquinlan
+pep-3149.txt  @warsaw
+pep-3150.txt  @ncoghlan
+pep-3151.txt  @pitrou
+# pep-3152.txt
+# pep-3153.txt
+pep-3154.txt  @pitrou
+pep-3155.txt  @pitrou
+pep-3156.txt  @gvanrossum
+# ...
+pep-3333.txt  @pjeby
+# ...
+pep-8000.rst  @warsaw
+pep-8001.rst  @brettcannon @tiran @dstufft @ericsnowcurrently @gpshead @ambv @Mariatta @njsmith @pablogsal @rhettinger @taleinat @tim-one @zware
+pep-8002.rst  @warsaw @ambv @pitrou @dhellmann @willingc
+pep-8010.rst  @warsaw
+pep-8011.rst  @Mariatta @warsaw
+pep-8012.rst  @ambv
+pep-8013.rst  @zooba
+pep-8014.rst  @jackjansen
+pep-8015.rst  @vstinner
+pep-8016.rst  @njsmith @dstufft
+# ...
+pep-8100.rst  @njsmith
+# pep-8101.rst
+# pep-8102.rst

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,74 +3,74 @@
 # active core developers.
 
 # The PEP editors are the fallback "owners" for everything in this repository.
-*             @JelleZijlstra
+*             @python/pep-editors
 
-# pep-0001.txt  @warsaw @ncoghlan
-# pep-0001-process_flow.png  @warsaw @ncoghlan
-# pep-0001/     @warsaw @ncoghlan
+pep-0001.txt  @warsaw @ncoghlan
+pep-0001-process_flow.png  @warsaw @ncoghlan
+pep-0001/     @warsaw @ncoghlan
 # pep-0002.txt
-# pep-0003.txt  @jeremyhylton
+pep-0003.txt  @jeremyhylton
 pep-0004.txt  @brettcannon
 # pep-0005.txt
 # pep-0006.txt
-# pep-0007.txt  @gvanrossum @warsaw
-# pep-0008.txt  @gvanrossum @warsaw @ncoghlan
-# pep-0009.txt  @warsaw
-# pep-0010.txt  @warsaw
-# pep-0011.txt  @brettcannon
-# pep-0012.rst  @brettcannon @warsaw
+pep-0007.txt  @gvanrossum @warsaw
+pep-0008.txt  @gvanrossum @warsaw @ncoghlan
+pep-0009.txt  @warsaw
+pep-0010.txt  @warsaw
+pep-0011.txt  @brettcannon
+pep-0012.rst  @brettcannon @warsaw
 # pep-0013.rst is owned by the entire core team.
 # ...
-# pep-0020.txt  @tim-one
+pep-0020.txt  @tim-one
 # ...
-# pep-0042.txt  @jeremyhylton
+pep-0042.txt  @jeremyhylton
 # ...
-# pep-0100.txt  @malemburg
-# pep-0101.txt  @warsaw @gvanrossum
-# pep-0102.txt  @warsaw @gvanrossum
+pep-0100.txt  @malemburg
+pep-0101.txt  @warsaw @gvanrossum
+pep-0102.txt  @warsaw @gvanrossum
 # pep-0103.txt
 # ...
-# pep-0160.txt  @freddrake
+pep-0160.txt  @freddrake
 # ...
-# pep-0200.txt  @jeremyhylton
-# pep-0201.txt  @warsaw
-# pep-0202.txt  @warsaw
-# pep-0203.txt  @Yhg1s
-# pep-0204.txt  @Yhg1s
-# pep-0205.txt  @freddrake
+pep-0200.txt  @jeremyhylton
+pep-0201.txt  @warsaw
+pep-0202.txt  @warsaw
+pep-0203.txt  @Yhg1s
+pep-0204.txt  @Yhg1s
+pep-0205.txt  @freddrake
 # pep-0206.txt
-# pep-0207.txt  @gvanrossum
-# pep-0208.txt  @nascheme @malemburg
+pep-0207.txt  @gvanrossum
+pep-0208.txt  @nascheme @malemburg
 # pep-0209.txt
 # pep-0210.txt
 # pep-0211.txt
 # pep-0212.txt
 # pep-0213.txt
-# pep-0214.txt  @warsaw
+pep-0214.txt  @warsaw
 # pep-0215.txt
 # pep-0216.txt
 # pep-0217.txt
-# pep-0218.txt  @rhettinger
+pep-0218.txt  @rhettinger
 # pep-0219.txt
 # pep-0220.txt
-# pep-0221.txt  @Yhg1s
+pep-0221.txt  @Yhg1s
 # pep-0222.txt
-# pep-0223.txt  @tim-one
-# pep-0224.txt  @malemburg
+pep-0223.txt  @tim-one
+pep-0224.txt  @malemburg
 # pep-0225.txt
-# pep-0226.txt  @jeremyhylton
-# pep-0227.txt  @jeremyhylton
-# pep-0228.txt  @gvanrossum
+pep-0226.txt  @jeremyhylton
+pep-0227.txt  @jeremyhylton
+pep-0228.txt  @gvanrossum
 # pep-0229.txt
-# pep-0230.txt  @gvanrossum
-# pep-0231.txt  @warsaw
-# pep-0232.txt  @warsaw
+pep-0230.txt  @gvanrossum
+pep-0231.txt  @warsaw
+pep-0232.txt  @warsaw
 # pep-0233.txt
-# pep-0234.txt  @gvanrossum
-# pep-0235.txt  @tim-one
-# pep-0236.txt  @tim-one
-# pep-0237.txt  @gvanrossum
-# pep-0238.txt  @gvanrossum
+pep-0234.txt  @gvanrossum
+pep-0235.txt  @tim-one
+pep-0236.txt  @tim-one
+pep-0237.txt  @gvanrossum
+pep-0238.txt  @gvanrossum
 # pep-0239.txt
 # pep-0240.txt
 # pep-0241.txt
@@ -78,492 +78,492 @@ pep-0004.txt  @brettcannon
 # pep-0243.txt
 # pep-0244.txt
 # pep-0245.txt
-# pep-0246.txt  @aleaxit
+pep-0246.txt  @aleaxit
 # pep-0247.txt
-# pep-0248.txt  @malemburg
-# pep-0249.txt  @malemburg
-# pep-0250.txt  @pfmoore
-# pep-0251.txt  @warsaw @gvanrossum
-# pep-0252.txt  @gvanrossum
-# pep-0253.txt  @gvanrossum
-# pep-0254.txt  @gvanrossum
-# pep-0255.txt  @nascheme @tim-one
+pep-0248.txt  @malemburg
+pep-0249.txt  @malemburg
+pep-0250.txt  @pfmoore
+pep-0251.txt  @warsaw @gvanrossum
+pep-0252.txt  @gvanrossum
+pep-0253.txt  @gvanrossum
+pep-0254.txt  @gvanrossum
+pep-0255.txt  @nascheme @tim-one
 # pep-0256.txt
-# pep-0257.txt  @gvanrossum
+pep-0257.txt  @gvanrossum
 # pep-0258.txt
-# pep-0259.txt  @gvanrossum
-# pep-0260.txt  @gvanrossum
+pep-0259.txt  @gvanrossum
+pep-0260.txt  @gvanrossum
 # pep-0261.txt
 # pep-0262.txt
-# pep-0263.txt  @malemburg
+pep-0263.txt  @malemburg
 # pep-0264.txt
 # pep-0265.txt
 # pep-0266.txt
-# pep-0267.txt  @jeremyhylton
+pep-0267.txt  @jeremyhylton
 # pep-0268.txt
 # pep-0269.txt
 # pep-0270.txt
 # pep-0271.txt
 # pep-0272.txt
 # pep-0273.txt
-# pep-0274.txt  @warsaw
-# pep-0275.txt  @malemburg
+pep-0274.txt  @warsaw
+pep-0275.txt  @malemburg
 # pep-0276.txt
 # pep-0277.txt
-# pep-0278.txt  @jackjansen
-# pep-0279.txt  @rhettinger
-# pep-0280.txt  @gvanrossum
+pep-0278.txt  @jackjansen
+pep-0279.txt  @rhettinger
+pep-0280.txt  @gvanrossum
 # pep-0281.txt
-# pep-0282.txt  @vsajip
-# pep-0283.txt  @gvanrossum
+pep-0282.txt  @vsajip
+pep-0283.txt  @gvanrossum
 # pep-0284.txt
-# pep-0285.txt  @gvanrossum
+pep-0285.txt  @gvanrossum
 # pep-0286.txt
 # pep-0287.txt
-# pep-0288.txt  @rhettinger
-# pep-0289.txt  @rhettinger
-# pep-0290.txt  @rhettinger
+pep-0288.txt  @rhettinger
+pep-0289.txt  @rhettinger
+pep-0290.txt  @rhettinger
 # pep-0291.txt
-# pep-0292.txt  @warsaw
-# pep-0293.txt  @doerwalter
+pep-0292.txt  @warsaw
+pep-0293.txt  @doerwalter
 # pep-0294.txt
 # pep-0295.txt
 # pep-0296.txt
-# pep-0297.txt  @malemburg
-# pep-0298.txt  @theller
+pep-0297.txt  @malemburg
+pep-0298.txt  @theller
 # pep-0299.txt
 # pep-0301.txt
-# pep-0302.txt  @pfmoore
+pep-0302.txt  @pfmoore
 # pep-0303.txt
 # pep-0304.txt
 # pep-0305.txt
-# pep-0306.txt  @jackdied @ncoghlan @benjaminp
-# pep-0307.txt  @gvanrossum @tim-one
-# pep-0308.txt  @gvanrossum @rhettinger
+pep-0306.txt  @jackdied @ncoghlan @benjaminp
+pep-0307.txt  @gvanrossum @tim-one
+pep-0308.txt  @gvanrossum @rhettinger
 # pep-0309.txt
-# pep-0310.txt  @pfmoore
-# pep-0311.txt  @mhammond
-# pep-0312.txt  @aleaxit
+pep-0310.txt  @pfmoore
+pep-0311.txt  @mhammond
+pep-0312.txt  @aleaxit
 # pep-0313.txt
 # pep-0314.txt
-# pep-0315.txt  @rhettinger
+pep-0315.txt  @rhettinger
 # pep-0316.txt
 # pep-0317.txt
 # pep-0318.txt
 # pep-0319.txt
-# pep-0320.txt  @warsaw @rhettinger
+pep-0320.txt  @warsaw @rhettinger
 # pep-0321.txt
-# pep-0322.txt  @rhettinger
-# pep-0323.txt  @aleaxit
+pep-0322.txt  @rhettinger
+pep-0323.txt  @aleaxit
 # pep-0324.txt
 # pep-0325.txt
-# pep-0326.txt  @terryjreedy
-# pep-0327.txt  @facundobatista
+pep-0326.txt  @terryjreedy
+pep-0327.txt  @facundobatista
 # pep-0328.txt
-# pep-0329.txt  @rhettinger
+pep-0329.txt  @rhettinger
 # pep-0330.txt
 # pep-0331.txt
 # pep-0332.txt
-# pep-0333.txt  @pjeby
+pep-0333.txt  @pjeby
 # pep-0334.txt
 # pep-0335.txt
 # pep-0336.txt
 # pep-0337.txt
-# pep-0338.txt  @ncoghlan
-# pep-0339.txt  @brettcannon
-# pep-0340.txt  @gvanrossum
-# pep-0341.txt  @birkenfeld
-# pep-0342.txt  @gvanrossum @pjeby
-# pep-0343.txt  @gvanrossum @ncoghlan
+pep-0338.txt  @ncoghlan
+pep-0339.txt  @brettcannon
+pep-0340.txt  @gvanrossum
+pep-0341.txt  @birkenfeld
+pep-0342.txt  @gvanrossum @pjeby
+pep-0343.txt  @gvanrossum @ncoghlan
 # pep-0344.txt
 # pep-0345.txt
-# pep-0346.txt  @ncoghlan
+pep-0346.txt  @ncoghlan
 # pep-0347.txt
-# pep-0348.txt  @brettcannon
-# pep-0349.txt  @nascheme
+pep-0348.txt  @brettcannon
+pep-0349.txt  @nascheme
 # pep-0350.txt
-# pep-0351.txt  @warsaw
-# pep-0352.txt  @brettcannon @gvanrossum
+pep-0351.txt  @warsaw
+pep-0352.txt  @brettcannon @gvanrossum
 # pep-0353.txt
 # pep-0354.txt
 # pep-0355.txt
-# pep-0356.txt  @gvanrossum
+pep-0356.txt  @gvanrossum
 # pep-0357.txt
-# pep-0358.txt  @nascheme @gvanrossum
+pep-0358.txt  @nascheme @gvanrossum
 # pep-0359.txt
-# pep-0360.txt  @brettcannon
-# pep-0361.txt  @warsaw
-# pep-0362.txt  @brettcannon @1st1 @larryhastings
+pep-0360.txt  @brettcannon
+pep-0361.txt  @warsaw
+pep-0362.txt  @brettcannon @1st1 @larryhastings
 # pep-0363.txt
-# pep-0364.txt  @warsaw
-# pep-0365.txt  @pjeby
-# pep-0366.txt  @ncoghlan
+pep-0364.txt  @warsaw
+pep-0365.txt  @pjeby
+pep-0366.txt  @ncoghlan
 # pep-0367.txt
 # pep-0368.txt
-# pep-0369.txt  @tiran
-# pep-0370.txt  @tiran
+pep-0369.txt  @tiran
+pep-0370.txt  @tiran
 # pep-0371.txt
-# pep-0372.txt  @mitsuhiko @rhettinger
-# pep-0373.txt  @benjaminp
-# pep-0374.txt  @brettcannon @avassalotti @warsaw
-# pep-0375.txt  @benjaminp
+pep-0372.txt  @mitsuhiko @rhettinger
+pep-0373.txt  @benjaminp
+pep-0374.txt  @brettcannon @avassalotti @warsaw
+pep-0375.txt  @benjaminp
 # pep-0376.txt
-# pep-0377.txt  @ncoghlan
-# pep-0378.txt  @rhettinger
+pep-0377.txt  @ncoghlan
+pep-0378.txt  @rhettinger
 # pep-0379.txt
 # pep-0380.txt
 # pep-0381.txt
 # pep-0382.txt
 # pep-0383.txt
 # pep-0384.txt
-# pep-0385.txt  @pitrou @birkenfeld
+pep-0385.txt  @pitrou @birkenfeld
 # pep-0386.txt
-# pep-0387.txt  @benjaminp
+pep-0387.txt  @benjaminp
 # pep-0389.txt
 # pep-0390.txt
-# pep-0391.txt  @vsajip
-# pep-0392.txt  @birkenfeld
+pep-0391.txt  @vsajip
+pep-0392.txt  @birkenfeld
 # pep-0393.txt
-# pep-0394.txt  @ncoghlan @warsaw @encukou @willingc
-# pep-0395.txt  @ncoghlan
-# pep-0396.txt  @warsaw
-# pep-0397.txt  @mhammond
-# pep-0398.txt  @birkenfeld
-# pep-0399.txt  @brettcannon
-# pep-0400.txt  @vstinner
-# pep-0401.txt  @warsaw @brettcannon
-# pep-0402.txt  @pjeby
-# pep-0403.txt  @ncoghlan
-# pep-0404.txt  @warsaw
+pep-0394.txt  @ncoghlan @warsaw @encukou @willingc
+pep-0395.txt  @ncoghlan
+pep-0396.txt  @warsaw
+pep-0397.txt  @mhammond
+pep-0398.txt  @birkenfeld
+pep-0399.txt  @brettcannon
+pep-0400.txt  @vstinner
+pep-0401.txt  @warsaw @brettcannon
+pep-0402.txt  @pjeby
+pep-0403.txt  @ncoghlan
+pep-0404.txt  @warsaw
 # pep-0405.txt
-# pep-0406.txt  @ncoghlan
-# pep-0407.txt  @pitrou @birkenfeld @warsaw
-# pep-0408.txt  @ncoghlan @eliben
-# pep-0409.txt  @ethanfurman
-# pep-0410.txt  @vstinner
-# pep-0411.txt  @ncoghlan @eliben
-# pep-0412.txt  @markshannon
-# pep-0413.txt  @ncoghlan
-# pep-0414.txt  @mitsuhiko @ncoghlan
-# pep-0415.txt  @benjaminp
-# pep-0416.txt  @vstinner
-# pep-0417.txt  @voidspace
-# pep-0418.txt  @vstinner
-# pep-0418/     @vstinner
+pep-0406.txt  @ncoghlan
+pep-0407.txt  @pitrou @birkenfeld @warsaw
+pep-0408.txt  @ncoghlan @eliben
+pep-0409.txt  @ethanfurman
+pep-0410.txt  @vstinner
+pep-0411.txt  @ncoghlan @eliben
+pep-0412.txt  @markshannon
+pep-0413.txt  @ncoghlan
+pep-0414.txt  @mitsuhiko @ncoghlan
+pep-0415.txt  @benjaminp
+pep-0416.txt  @vstinner
+pep-0417.txt  @voidspace
+pep-0418.txt  @vstinner
+pep-0418/     @vstinner
 # pep-0419.txt
-# pep-0420.txt  @ericvsmith
-# pep-0421.txt  @ericsnowcurrently
-# pep-0422.txt  @ncoghlan
+pep-0420.txt  @ericvsmith
+pep-0421.txt  @ericsnowcurrently
+pep-0422.txt  @ncoghlan
 # pep-0423.txt
-# pep-0424.txt  @alex
+pep-0424.txt  @alex
 # pep-0425.txt
-# pep-0426.txt  @ncoghlan @dstufft
-# pep-0426/     @ncoghlan @dstufft
+pep-0426.txt  @ncoghlan @dstufft
+pep-0426/     @ncoghlan @dstufft
 # pep-0427.txt
-# pep-0428.txt  @pitrou
-# pep-0429.txt  @larryhastings
-# pep-0430.txt  @ncoghlan
+pep-0428.txt  @pitrou
+pep-0429.txt  @larryhastings
+pep-0430.txt  @ncoghlan
 # pep-0431.txt
-# pep-0432.txt  @ncoghlan @vstinner @ericsnowcurrently
-# pep-0433.txt  @vstinner
-# pep-0433/     @vstinner
-# pep-0434.txt  @terryjreedy
-# pep-0435.txt  @warsaw @eliben @ethanfurman
-# pep-0436.txt  @larryhastings
+pep-0432.txt  @ncoghlan @vstinner @ericsnowcurrently
+pep-0433.txt  @vstinner
+pep-0433/     @vstinner
+pep-0434.txt  @terryjreedy
+pep-0435.txt  @warsaw @eliben @ethanfurman
+pep-0436.txt  @larryhastings
 # pep-0437.txt
 # pep-0438.txt
 # pep-0439.txt
-# pep-0440.txt  @ncoghlan @dstufft
-# pep-0441.txt  @pfmoore
-# pep-0442.txt  @pitrou
-# pep-0443.txt  @ambv
-# pep-0444.txt  @mitsuhiko
-# pep-0445.txt  @vstinner
-# pep-0446.txt  @vstinner
-# pep-0446/     @vstinner
-# pep-0447.txt  @ronaldoussoren
+pep-0440.txt  @ncoghlan @dstufft
+pep-0441.txt  @pfmoore
+pep-0442.txt  @pitrou
+pep-0443.txt  @ambv
+pep-0444.txt  @mitsuhiko
+pep-0445.txt  @vstinner
+pep-0446.txt  @vstinner
+pep-0446/     @vstinner
+pep-0447.txt  @ronaldoussoren
 # pep-0448.txt
-# pep-0449.txt  @dstufft
-# pep-0450.txt  @stevendaprano
-# pep-0451.txt  @ericsnowcurrently
-# pep-0452.txt  @tiran
-# pep-0453.txt  @dstufft @ncoghlan
-# pep-0454.txt  @vstinner
-# pep-0455.txt  @pitrou
-# pep-0456.txt  @tiran
-# pep-0457.txt  @larryhastings
+pep-0449.txt  @dstufft
+pep-0450.txt  @stevendaprano
+pep-0451.txt  @ericsnowcurrently
+pep-0452.txt  @tiran
+pep-0453.txt  @dstufft @ncoghlan
+pep-0454.txt  @vstinner
+pep-0455.txt  @pitrou
+pep-0456.txt  @tiran
+pep-0457.txt  @larryhastings
 # pep-0458.txt, pep-0458-1.png
-# pep-0459.txt  @ncoghlan
-# pep-0460.txt  @pitrou
-# pep-0461.txt  @ethanfurman
-# pep-0462.txt  @ncoghlan
+pep-0459.txt  @ncoghlan
+pep-0460.txt  @pitrou
+pep-0461.txt  @ethanfurman
+pep-0462.txt  @ncoghlan
 # pep-0463.txt
-# pep-0464.txt  @dstufft
-# pep-0465.txt  @njsmith
-# pep-0466.txt  @ncoghlan
-# pep-0467.txt  @ncoghlan @ethanfurman
-# pep-0468.txt  @ericsnowcurrently
-# pep-0469.txt  @ncoghlan
-# pep-0470.txt  @dstufft
+pep-0464.txt  @dstufft
+pep-0465.txt  @njsmith
+pep-0466.txt  @ncoghlan
+pep-0467.txt  @ncoghlan @ethanfurman
+pep-0468.txt  @ericsnowcurrently
+pep-0469.txt  @ncoghlan
+pep-0470.txt  @dstufft
 # pep-0471.txt
 # pep-0472.txt
 # pep-0473.txt
-# pep-0474.txt  @ncoghlan
-# pep-0475.txt  @vstinner
-# pep-0476.txt  @alex
-# pep-0477.txt  @dstufft @ncoghlan
-# pep-0478.txt  @larryhastings
-# pep-0479.txt  @gvanrossum
+pep-0474.txt  @ncoghlan
+pep-0475.txt  @vstinner
+pep-0476.txt  @alex
+pep-0477.txt  @dstufft @ncoghlan
+pep-0478.txt  @larryhastings
+pep-0479.txt  @gvanrossum
 # pep-0480.txt, pep-0480-1.png
-# pep-0481.txt  @dstufft
-# pep-0482.txt  @ambv
-# pep-0483.txt  @gvanrossum @ilevkivskyi
-# pep-0484.txt  @gvanrossum @ambv
+pep-0481.txt  @dstufft
+pep-0482.txt  @ambv
+pep-0483.txt  @gvanrossum @ilevkivskyi
+pep-0484.txt  @gvanrossum @ambv
 # pep-0485.txt
-# pep-0486.txt  @pfmoore
+pep-0486.txt  @pfmoore
 # pep-0487.txt
-# pep-0488.txt  @brettcannon
-# pep-0489.txt  @encukou @scoder @ncoghlan
-# pep-0490.txt  @vstinner
+pep-0488.txt  @brettcannon
+pep-0489.txt  @encukou @scoder @ncoghlan
+pep-0490.txt  @vstinner
 # pep-0491.txt
-# pep-0492.txt  @1st1
-# pep-0493.txt  @ncoghlan @malemburg
-# pep-0494.txt  @ned-deily
-# pep-0495.txt  @abalkin @tim-one
-# pep-0495-gap.png  @abalkin @tim-one
-# pep-0495-gap.svg  @abalkin @tim-one
-# pep-0495-fold.svg  @abalkin @tim-one
-# pep-0495-fold-2.png  @abalkin @tim-one
-# pep-0495-daylightsavings.png  @abalkin @tim-one
+pep-0492.txt  @1st1
+pep-0493.txt  @ncoghlan @malemburg
+pep-0494.txt  @ned-deily
+pep-0495.txt  @abalkin @tim-one
+pep-0495-gap.png  @abalkin @tim-one
+pep-0495-gap.svg  @abalkin @tim-one
+pep-0495-fold.svg  @abalkin @tim-one
+pep-0495-fold-2.png  @abalkin @tim-one
+pep-0495-daylightsavings.png  @abalkin @tim-one
 # pep-0496.txt
 # pep-0497.txt
-# pep-0498.txt  @ericvsmith
+pep-0498.txt  @ericvsmith
 # pep-0499.txt
-# pep-0500.txt  @abalkin @tim-one
-# pep-0501.txt  @ncoghlan
+pep-0500.txt  @abalkin @tim-one
+pep-0501.txt  @ncoghlan
 # pep-0502.txt
-# pep-0503.txt  @dstufft
-# pep-0504.txt  @ncoghlan
-# pep-0505.rst  @zooba
-# pep-0505/     @zooba
-# pep-0506.txt  @stevendaprano
-# pep-0507.txt  @warsaw
-# pep-0508.txt  @rbtcollins
-# pep-0509.txt  @vstinner
-# pep-0510.txt  @vstinner
-# pep-0511.txt  @vstinner
-# pep-0512.txt  @brettcannon
-# pep-0513.txt  @njsmith
-# pep-0514.txt  @zooba
-# pep-0515.txt  @birkenfeld @serhiy-storchaka
-# pep-0516.txt  @rbtcollins @njsmith
-# pep-0517.txt  @njsmith
-# pep-0518.txt  @brettcannon @njsmith @dstufft
-# pep-0519.txt  @brettcannon
-# pep-0520.txt  @ericsnowcurrently
-# pep-0521.txt  @njsmith
-# pep-0522.txt  @ncoghlan @njsmith
-# pep-0523.txt  @brettcannon @DinoV
-# pep-0524.txt  @vstinner
-# pep-0525.txt  @1st1
-# pep-0525-1.png  @1st1
-# pep-0526.txt  @ilevkivskyi @lisroach @gvanrossum
-# pep-0527.txt  @dstufft
-# pep-0528.txt  @zooba
-# pep-0529.txt  @zooba
-# pep-0530.txt  @1st1
-# pep-0531.txt  @ncoghlan
-# pep-0532.txt  @ncoghlan
-# pep-0532/     @ncoghlan
-# pep-0533.txt  @njsmith
-# pep-0534.txt  @encukou @ncoghlan
-# pep-0535.txt  @ncoghlan
+pep-0503.txt  @dstufft
+pep-0504.txt  @ncoghlan
+pep-0505.rst  @zooba
+pep-0505/     @zooba
+pep-0506.txt  @stevendaprano
+pep-0507.txt  @warsaw
+pep-0508.txt  @rbtcollins
+pep-0509.txt  @vstinner
+pep-0510.txt  @vstinner
+pep-0511.txt  @vstinner
+pep-0512.txt  @brettcannon
+pep-0513.txt  @njsmith
+pep-0514.txt  @zooba
+pep-0515.txt  @birkenfeld @serhiy-storchaka
+pep-0516.txt  @rbtcollins @njsmith
+pep-0517.txt  @njsmith
+pep-0518.txt  @brettcannon @njsmith @dstufft
+pep-0519.txt  @brettcannon
+pep-0520.txt  @ericsnowcurrently
+pep-0521.txt  @njsmith
+pep-0522.txt  @ncoghlan @njsmith
+pep-0523.txt  @brettcannon @DinoV
+pep-0524.txt  @vstinner
+pep-0525.txt  @1st1
+pep-0525-1.png  @1st1
+pep-0526.txt  @ilevkivskyi @lisroach @gvanrossum
+pep-0527.txt  @dstufft
+pep-0528.txt  @zooba
+pep-0529.txt  @zooba
+pep-0530.txt  @1st1
+pep-0531.txt  @ncoghlan
+pep-0532.txt  @ncoghlan
+pep-0532/     @ncoghlan
+pep-0533.txt  @njsmith
+pep-0534.txt  @encukou @ncoghlan
+pep-0535.txt  @ncoghlan
 # pep-0536.txt
-# pep-0537.txt  @ned-deily
-# pep-0538.txt  @ncoghlan
+pep-0537.txt  @ned-deily
+pep-0538.txt  @ncoghlan
 # pep-0539.txt
-# pep-0540.txt  @vstinner
-# pep-0541.txt  @ambv
+pep-0540.txt  @vstinner
+pep-0541.txt  @ambv
 # pep-0542.txt
-# pep-0543.rst  @tiran
-# pep-0544.txt  @ilevkivskyi @ambv
-# pep-0545.txt  @JulienPalard @methane @vstinner
-# pep-0546.txt  @vstinner
-# pep-0547.rst  @encukou
-# pep-0548.rst  @bitdancer
-# pep-0549.rst  @larryhastings
-# pep-0550.rst  @1st1
-# pep-0550-lookup_hamt.png  @1st1
-# pep-0550-hamt_vs_dict.png  @1st1
-# pep-0550-hamt_vs_dict-v2.png  @1st1
-# pep-0551.rst  @zooba
-# pep-0552.rst  @benjaminp
-# pep-0553.rst  @warsaw
-# pep-0554.rst  @ericsnowcurrently
+pep-0543.rst  @tiran
+pep-0544.txt  @ilevkivskyi @ambv
+pep-0545.txt  @JulienPalard @methane @vstinner
+pep-0546.txt  @vstinner
+pep-0547.rst  @encukou
+pep-0548.rst  @bitdancer
+pep-0549.rst  @larryhastings
+pep-0550.rst  @1st1
+pep-0550-lookup_hamt.png  @1st1
+pep-0550-hamt_vs_dict.png  @1st1
+pep-0550-hamt_vs_dict-v2.png  @1st1
+pep-0551.rst  @zooba
+pep-0552.rst  @benjaminp
+pep-0553.rst  @warsaw
+pep-0554.rst  @ericsnowcurrently
 # pep-0555.rst
-# pep-0556.rst  @pitrou
-# pep-0557.rst  @ericvsmith
-# pep-0558.rst  @ncoghlan
-# pep-0559.rst  @warsaw
-# pep-0560.rst  @ilevkivskyi
+pep-0556.rst  @pitrou
+pep-0557.rst  @ericvsmith
+pep-0558.rst  @ncoghlan
+pep-0559.rst  @warsaw
+pep-0560.rst  @ilevkivskyi
 # pep-0561.rst
-# pep-0562.rst  @ilevkivskyi
-# pep-0563.rst  @ambv
-# pep-0564.rst  @vstinner
-# pep-0565.rst  @ncoghlan
+pep-0562.rst  @ilevkivskyi
+pep-0563.rst  @ambv
+pep-0564.rst  @vstinner
+pep-0565.rst  @ncoghlan
 # pep-0566.rst
-# pep-0567.rst  @1st1
-# pep-0568.rst  @njsmith
-# pep-0569.rst  @ambv
-# pep-0570.rst  @larryhastings @pablogsal
+pep-0567.rst  @1st1
+pep-0568.rst  @njsmith
+pep-0569.rst  @ambv
+pep-0570.rst  @larryhastings @pablogsal
 # pep-0571.rst
-# pep-0572.rst  @tim-one @gvanrossum
-# pep-0573.rst  @encukou @ncoghlan @ericsnowcurrently
-# pep-0574.rst  @pitrou
+pep-0572.rst  @tim-one @gvanrossum
+pep-0573.rst  @encukou @ncoghlan @ericsnowcurrently
+pep-0574.rst  @pitrou
 # pep-0575.rst
-# pep-0576.rst  @markshannon
-# pep-0577.rst  @ncoghlan
-# pep-0578.rst  @zooba
+pep-0576.rst  @markshannon
+pep-0577.rst  @ncoghlan
+pep-0578.rst  @zooba
 # pep-0579.rst
 # pep-0580.rst
-# pep-0581.rst  @Mariatta
-# pep-0582.rst  @kushaldas @zooba @dstufft @ncoghlan
+pep-0581.rst  @Mariatta
+pep-0582.rst  @kushaldas @zooba @dstufft @ncoghlan
 # pep-0583.rst
-# pep-0584.rst  @stevendaprano @brandtbucher
-# pep-0585.rst  @ambv
-# pep-0586.rst  @ilevkivskyi
-# pep-0587.rst  @vstinner @ncoghlan
-# pep-0588.rst  @Mariatta
-# pep-0589.rst  @gvanrossum
-# pep-0590.rst  @markshannon
-# pep-0591.rst  @ilevkivskyi
-# pep-0592.rst  @dstufft
-# pep-0593.rst  @ilevkivskyi
-# pep-0594.rst  @tiran
-# pep-0595.rst  @ezio-melotti @berkerpeksag
-# pep-0596.rst  @ambv
-# pep-0597.rst  @methane
-# pep-0598.rst  @ncoghlan
-# pep-0599.rst  @pfmoore
-# pep-0600.rst  @njsmith
-# pep-0601.txt  @isidentical
-# pep-0602.rst  @ambv
-# pep-0602-example-release-calendar.png  @ambv
-# pep-0602-example-release-calendar.pptx  @ambv
-# pep-0602-overlapping-support-matrix.png  @ambv
-# pep-0602-overlapping-support-matrix.pptx  @ambv
-# pep-0603.rst  @1st1
-# pep-0603-lookup_hamt.png  @1st1
-# pep-0603-hamt_vs_dict.png  @1st1
+pep-0584.rst  @stevendaprano @brandtbucher
+pep-0585.rst  @ambv
+pep-0586.rst  @ilevkivskyi
+pep-0587.rst  @vstinner @ncoghlan
+pep-0588.rst  @Mariatta
+pep-0589.rst  @gvanrossum
+pep-0590.rst  @markshannon
+pep-0591.rst  @ilevkivskyi
+pep-0592.rst  @dstufft
+pep-0593.rst  @ilevkivskyi
+pep-0594.rst  @tiran
+pep-0595.rst  @ezio-melotti @berkerpeksag
+pep-0596.rst  @ambv
+pep-0597.rst  @methane
+pep-0598.rst  @ncoghlan
+pep-0599.rst  @pfmoore
+pep-0600.rst  @njsmith
+pep-0601.txt  @isidentical
+pep-0602.rst  @ambv
+pep-0602-example-release-calendar.png  @ambv
+pep-0602-example-release-calendar.pptx  @ambv
+pep-0602-overlapping-support-matrix.png  @ambv
+pep-0602-overlapping-support-matrix.pptx  @ambv
+pep-0603.rst  @1st1
+pep-0603-lookup_hamt.png  @1st1
+pep-0603-hamt_vs_dict.png  @1st1
 # pep-0604.rst
-# pep-0605.rst  @zooba @ncoghlan
-# pep-0605-example-release-calendar.png  @zooba @ncoghlan
-# pep-0605-overlapping-support-matrix.png  @zooba @ncoghlan
-# /pep-0605/    @zooba @ncoghlan
-# pep-0606.rst  @vstinner
-# pep-0607.rst  @ambv @zooba @ncoghlan
-# pep-0608.rst  @vstinner
-# pep-0609.rst  @pganssle
-# pep-0610.rst  @cjerdonek
-# pep-0611.rst  @markshannon
-# pep-0612.rst  @gvanrossum
-# pep-0613.rst  @gvanrossum
-# pep-0614.rst  @brandtbucher
-# pep-0615.rst  @pganssle
-# pep-0616.rst  @ericvsmith
-# pep-0617.rst  @gvanrossum @pablogsal @lysnikolaou
-# pep-0618.rst  @brandtbucher
-# pep-0619.rst  @pablogsal
-# pep-0620.rst  @vstinner
-# pep-0621.rst  @brettcannon  @pganssle
-# pep-0622.rst  @brandtbucher @ilevkivskyi @gvanrossum
-# pep-0623.rst  @methane
-# pep-0624.rst  @methane
-# pep-0625.rst  @pfmoore
-# pep-0626.rst  @markshannon
-# pep-0627.rst  @encukou
-# pep-0628.txt  @ncoghlan
-# pep-0629.rst  @dstufft
-# pep-0630.rst  @encukou
-# pep-0631.rst  @pganssle
-# pep-0632.rst  @zooba
-# pep-0633.rst  @brettcannon
-# pep-0634.rst  @brandtbucher @gvanrossum
-# pep-0635.rst  @gvanrossum
-# pep-0636.rst  @gvanrossum
-# pep-0637.rst  @stevendaprano
-# pep-0638.rst  @markshannon
-# pep-0639.rst  @pfmoore
-# pep-0640.rst  @Yhg1s
-# pep-0641.rst  @zooba @warsaw @brettcannon
-# pep-0642.rst  @ncoghlan
-# pep-0643.rst  @pfmoore
-# pep-0644.rst  @tiran
-# pep-0645.rst  @gvanrossum
-# pep-0646.rst  @gvanrossum
-# pep-0647.rst  @gvanrossum
-# pep-0648.rst  @pablogsal
-# pep-0649.rst  @larryhastings
-# pep-0650.rst  @brettcannon
-# pep-0651.rst  @markshannon
-# pep-0652.rst  @encukou
-# pep-0653.rst  @markshannon
-# pep-0654.rst  @1st1 @gvanrossum
-# pep-0655.rst  @gvanrossum
-# pep-0656.rst  @brettcannon
+pep-0605.rst  @zooba @ncoghlan
+pep-0605-example-release-calendar.png  @zooba @ncoghlan
+pep-0605-overlapping-support-matrix.png  @zooba @ncoghlan
+/pep-0605/    @zooba @ncoghlan
+pep-0606.rst  @vstinner
+pep-0607.rst  @ambv @zooba @ncoghlan
+pep-0608.rst  @vstinner
+pep-0609.rst  @pganssle
+pep-0610.rst  @cjerdonek
+pep-0611.rst  @markshannon
+pep-0612.rst  @gvanrossum
+pep-0613.rst  @gvanrossum
+pep-0614.rst  @brandtbucher
+pep-0615.rst  @pganssle
+pep-0616.rst  @ericvsmith
+pep-0617.rst  @gvanrossum @pablogsal @lysnikolaou
+pep-0618.rst  @brandtbucher
+pep-0619.rst  @pablogsal
+pep-0620.rst  @vstinner
+pep-0621.rst  @brettcannon  @pganssle
+pep-0622.rst  @brandtbucher @ilevkivskyi @gvanrossum
+pep-0623.rst  @methane
+pep-0624.rst  @methane
+pep-0625.rst  @pfmoore
+pep-0626.rst  @markshannon
+pep-0627.rst  @encukou
+pep-0628.txt  @ncoghlan
+pep-0629.rst  @dstufft
+pep-0630.rst  @encukou
+pep-0631.rst  @pganssle
+pep-0632.rst  @zooba
+pep-0633.rst  @brettcannon
+pep-0634.rst  @brandtbucher @gvanrossum
+pep-0635.rst  @gvanrossum
+pep-0636.rst  @gvanrossum
+pep-0637.rst  @stevendaprano
+pep-0638.rst  @markshannon
+pep-0639.rst  @pfmoore
+pep-0640.rst  @Yhg1s
+pep-0641.rst  @zooba @warsaw @brettcannon
+pep-0642.rst  @ncoghlan
+pep-0643.rst  @pfmoore
+pep-0644.rst  @tiran
+pep-0645.rst  @gvanrossum
+pep-0646.rst  @gvanrossum
+pep-0647.rst  @gvanrossum
+pep-0648.rst  @pablogsal
+pep-0649.rst  @larryhastings
+pep-0650.rst  @brettcannon
+pep-0651.rst  @markshannon
+pep-0652.rst  @encukou
+pep-0653.rst  @markshannon
+pep-0654.rst  @1st1 @gvanrossum
+pep-0655.rst  @gvanrossum
+pep-0656.rst  @brettcannon
 # ...
 # pep-0666.txt
 # ...
 # pep-0754.txt
 # ...
-# pep-0801.rst  @warsaw
+pep-0801.rst  @warsaw
 # ...
-# pep-3000.txt  @gvanrossum
-# pep-3001.txt  @birkenfeld
+pep-3000.txt  @gvanrossum
+pep-3001.txt  @birkenfeld
 # pep-3002.txt
-# pep-3003.txt  @brettcannon  @gvanrossum
+pep-3003.txt  @brettcannon  @gvanrossum
 # ...
-# pep-3099.txt  @birkenfeld
-# pep-3100.txt  @brettcannon
+pep-3099.txt  @birkenfeld
+pep-3100.txt  @brettcannon
 # pep-3101.txt
 # pep-3102.txt
-# pep-3103.txt  @gvanrossum
+pep-3103.txt  @gvanrossum
 # pep-3104.txt
-# pep-3105.txt  @birkenfeld
-# pep-3106.txt  @gvanrossum
+pep-3105.txt  @birkenfeld
+pep-3106.txt  @gvanrossum
 # pep-3107.txt
-# pep-3108.txt  @brettcannon
+pep-3108.txt  @brettcannon
 # pep-3109.txt
 # pep-3110.txt
 # pep-3111.txt
 # pep-3112.txt
-# pep-3113.txt  @brettcannon
+pep-3113.txt  @brettcannon
 # pep-3114.txt
 # pep-3115.txt
-# pep-3116.txt  @gvanrossum
-# pep-3117.txt  @birkenfeld
+pep-3116.txt  @gvanrossum
+pep-3117.txt  @birkenfeld
 # pep-3118.txt
-# pep-3119.txt  @gvanrossum
+pep-3119.txt  @gvanrossum
 # pep-3120.txt
 # pep-3121.txt
-# pep-3122.txt  @brettcannon
+pep-3122.txt  @brettcannon
 # pep-3123.txt
-# pep-3124.txt  @pjeby
+pep-3124.txt  @pjeby
 # pep-3125.txt
-# pep-3126.txt  @rhettinger
+pep-3126.txt  @rhettinger
 # pep-3127.txt
 # pep-3128.txt
 # pep-3129.txt
 # pep-3130.txt
 # pep-3131.txt
-# pep-3132.txt  @birkenfeld
+pep-3132.txt  @birkenfeld
 # pep-3133.txt
 # pep-3134.txt
 # pep-3135.txt
 # pep-3136.txt
-# pep-3137.txt  @gvanrossum
+pep-3137.txt  @gvanrossum
 # pep-3138.txt
-# pep-3139.txt  @benjaminp
+pep-3139.txt  @benjaminp
 # pep-3140.txt
 # pep-3141.txt
 # pep-3142.txt
@@ -571,32 +571,32 @@ pep-0004.txt  @brettcannon
 # pep-3144.txt
 # pep-3145.txt
 # pep-3146.txt
-# pep-3147.txt  @warsaw
-# pep-3147-1.dia  @warsaw
-# pep-3147-1.png  @warsaw
-# pep-3148.txt  @brianquinlan
-# pep-3149.txt  @warsaw
-# pep-3150.txt  @ncoghlan
-# pep-3151.txt  @pitrou
+pep-3147.txt  @warsaw
+pep-3147-1.dia  @warsaw
+pep-3147-1.png  @warsaw
+pep-3148.txt  @brianquinlan
+pep-3149.txt  @warsaw
+pep-3150.txt  @ncoghlan
+pep-3151.txt  @pitrou
 # pep-3152.txt
 # pep-3153.txt
-# pep-3154.txt  @pitrou
-# pep-3155.txt  @pitrou
-# pep-3156.txt  @gvanrossum
+pep-3154.txt  @pitrou
+pep-3155.txt  @pitrou
+pep-3156.txt  @gvanrossum
 # ...
-# pep-3333.txt  @pjeby
+pep-3333.txt  @pjeby
 # ...
-# pep-8000.rst  @warsaw
-# pep-8001.rst  @brettcannon @tiran @dstufft @ericsnowcurrently @gpshead @ambv @Mariatta @njsmith @pablogsal @rhettinger @taleinat @tim-one @zware
-# pep-8002.rst  @warsaw @ambv @pitrou @dhellmann @willingc
-# pep-8010.rst  @warsaw
-# pep-8011.rst  @Mariatta @warsaw
-# pep-8012.rst  @ambv
-# pep-8013.rst  @zooba
-# pep-8014.rst  @jackjansen
-# pep-8015.rst  @vstinner
-# pep-8016.rst  @njsmith @dstufft
+pep-8000.rst  @warsaw
+pep-8001.rst  @brettcannon @tiran @dstufft @ericsnowcurrently @gpshead @ambv @Mariatta @njsmith @pablogsal @rhettinger @taleinat @tim-one @zware
+pep-8002.rst  @warsaw @ambv @pitrou @dhellmann @willingc
+pep-8010.rst  @warsaw
+pep-8011.rst  @Mariatta @warsaw
+pep-8012.rst  @ambv
+pep-8013.rst  @zooba
+pep-8014.rst  @jackjansen
+pep-8015.rst  @vstinner
+pep-8016.rst  @njsmith @dstufft
 # ...
-# pep-8100.rst  @njsmith
+pep-8100.rst  @njsmith
 # pep-8101.rst
 # pep-8102.rst

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -253,7 +253,7 @@ pep0418/      @vstinner
 # pep-0419.txt
 pep-0420.txt  @ericvsmith
 pep-0421.txt  @ericsnowcurrently
-pep-0422.txt  @ncoghlan Daniel Urban
+pep-0422.txt  @ncoghlan
 # pep-0423.txt
 pep-0424.txt  @alex
 # pep-0425.txt


### PR DESCRIPTION
Fixes #1920

This version works, because I opened #1924 against this branch and it correctly requested review from Brett.

This makes three changes:
- revert #1921
- remove "Daniel Urban", whose name created a syntax error. I did some very brief searching and couldn't figure out what his GitHub username is.
- fix the path for the pep 418 directory