### PR TITLE
PEP 656: Accepted

### DIFF
--- a/pep-0656.rst
+++ b/pep-0656.rst
@@ -2,12 +2,14 @@ PEP: 656
 Title: Platform Tag for Linux Distributions Using Musl
 Author: Tzu-ping Chung <uranusjr@gmail.com>
 Sponsor: Brett Cannon <brett@python.org>
-PEP-Delegate: TBD
+PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/7165
-Status: Draft
+Status: Accepted
 Type: Informational
 Content-Type: text/x-rst
 Created: 17-Mar-2021
+Post-History: 17-Mar-2021 18-Apr-2021
+Resolution: https://discuss.python.org/t/7165/32
 
 
 Abstract


### PR DESCRIPTION
https://discuss.python.org/t/pep-656-platform-tag-for-linux-distributions-using-musl/7165/32