### PR TITLE
PEP 634: Reword sequence and mapping patterns sections to be more robust.

### DIFF
--- a/pep-0634.rst
+++ b/pep-0634.rst
@@ -359,9 +359,28 @@ subpattern may occur in any position.  If no star subpattern is
 present, the sequence pattern is a fixed-length sequence pattern;
 otherwise it is a variable-length sequence pattern.
 
-A sequence pattern fails if the subject value is not an instance of
-``collections.abc.Sequence``.  It also fails if the subject value is
-an instance of ``str``, ``bytes`` or ``bytearray``.
+For a sequence pattern to succeed the subject must be a sequence,
+where being a sequence is defined as its class being one of the following:
+
+- a class that inherits from ``collections.abc.Sequence``
+- a Python class that has been registered as a ``collections.abc.Sequence``
+- a builtin class that has its ``Py_TPFLAGS_SEQUENCE`` bit set
+- a class that inherits from any of the above.
+
+The following standard library classes will have their ``Py_TPFLAGS_SEQUENCE``
+bit set:
+
+- ``deque``
+- ``list``
+- ``memoryview``
+- ``range``
+- ``tuple``
+
+Note::
+
+  Although, ``str``, ``bytes`` and ``bytearray`` are usually considered sequences,
+  they are not included in the above list and not considered to be sequences
+  when matching a sequence pattern.
 
 A fixed-length sequence pattern fails if the length of the subject
 sequence is not equal to the number of subpatterns.
@@ -414,8 +433,16 @@ A mapping pattern may not contain duplicate key values.
 syntax error; otherwise this is a runtime error and will
 raise ``ValueError``.)
 
-A mapping pattern fails if the subject value is not an instance of
-``collections.abc.Mapping``.
+For a mapping pattern to succeed the subject must be a mapping,
+where being a mapping is defined as its class being one of the following:
+
+- a class that inherits from ``collections.abc.Mapping``, or
+- a Python class that has been registered as a ``collections.abc.Mapping``, or
+- a builtin class that has its ``Py_TPFLAGS_MAPPING`` bit set, or
+- a class that inherits from any of the above.
+
+The standard library classes ``dict`` and ``mappingroxy`` will have their ``Py_TPFLAGS_MAPPING``
+bit set.
 
 A mapping pattern succeeds if every key given in the mapping pattern
 is present in the subject mapping, and the pattern for

--- a/pep-0634.rst
+++ b/pep-0634.rst
@@ -370,7 +370,8 @@ where being a sequence is defined as its class being one of the following:
 The following standard library classes will have their ``Py_TPFLAGS_SEQUENCE``
 bit set:
 
-- ``deque``
+- ``array.array``
+- ``collections.deque``
 - ``list``
 - ``memoryview``
 - ``range``
@@ -436,9 +437,9 @@ raise ``ValueError``.)
 For a mapping pattern to succeed the subject must be a mapping,
 where being a mapping is defined as its class being one of the following:
 
-- a class that inherits from ``collections.abc.Mapping``, or
-- a Python class that has been registered as a ``collections.abc.Mapping``, or
-- a builtin class that has its ``Py_TPFLAGS_MAPPING`` bit set, or
+- a class that inherits from ``collections.abc.Mapping``
+- a Python class that has been registered as a ``collections.abc.Mapping``
+- a builtin class that has its ``Py_TPFLAGS_MAPPING`` bit set
 - a class that inherits from any of the above.
 
 The standard library classes ``dict`` and ``mappingroxy`` will have their ``Py_TPFLAGS_MAPPING``


### PR DESCRIPTION
This PR makes the behavior of matching sequences and mappings more robust in unusual circumstances.

For example:
* Pattern matching can be used before `collections.abc` is imported. This might be important for coverage and profiling tools
* Registering `dict` as a `collections.abc.Sequence` will not make `{}` match `[]`.
* Pattern matching cannot fail as a result of `collections.abc` failing to import.

This change keeps the door open for PEP 653, but is a worthwhile improvement even if PEP 653 is withdrawn or rejected.

