### PR TITLE
PEP 3141: fix link for the Haskell numeric prelude

### DIFF
--- a/pep-3141.txt
+++ b/pep-3141.txt
@@ -526,7 +526,7 @@ References
 
 .. [#numericprelude] NumericPrelude: An experimental alternative hierarchy
    of numeric type classes
-   (http://darcs.haskell.org/numericprelude/docs/html/index.html)
+   (https://archives.haskell.org/code.haskell.org/numeric-prelude/docs/html/index.html)
 
 .. [#schemetower] The Scheme numerical tower
    (https://groups.csail.mit.edu/mac/ftpdir/scheme-reports/r5rs-html/r5rs_8.html#SEC50)


### PR DESCRIPTION
Was - 404 (discovered while working on https://github.com/python/cpython/pull/25552).

Not sure, perhaps it would be better add the web archive link:
https://web.archive.org/web/20161115045107/http://code.haskell.org/numeric-prelude/docs/html/index.html
or https://archives.haskell.org/code.haskell.org/numeric-prelude/docs/html/index.html
The current package version is different.