### PR TITLE
PEP 626: Add length parameter to PyLineTable_InitAddressRange

### DIFF
--- a/pep-0626.rst
+++ b/pep-0626.rst
@@ -282,9 +282,7 @@ Note that these functions are not part of the C-API, so will be need to be linke
         int ar_start;
         int ar_end;
         int ar_line;
-        int opaque1;
-        void *opaque2;
-        void *opaque3;
+        struct _opaque opaque;
     } PyCodeAddressRange;
 
     void PyLineTable_InitAddressRange(char *linetable, Py_ssize_t length, int firstlineno, PyCodeAddressRange *range);
@@ -301,18 +299,22 @@ Note that these functions are not part of the C-API, so will be need to be linke
   The data in ``linetable`` is immutable, but its lifetime depends on its code object.
   For reliable operation, ``linetable`` should be copied into a local buffer before calling ``PyLineTable_InitAddressRange``.
 
-  Although these functions are not part of C-API, they will provided by all future versions of CPython.
-  The ``PyLineTable_`` functions do not call into the C-API, so can be safely copied into any tool that needs to use them.
-  The ``PyCodeAddressRange`` struct may acquire additional ``opaque`` fields in future versions, but the ``ar_`` fields will remain unchanged.
+Although these functions are not part of C-API, they will provided by all future versions of CPython.
+The ``PyLineTable_`` functions do not call into the C-API, so can be safely copied into any tool that needs to use them.
+The ``PyCodeAddressRange`` struct will not be changed, but the ``_opaque`` struct is not part of the specification and may change.
+
+.. note::
+  The ``PyCodeAddressRange`` struct has changed from the original version of this PEP, where the addition fields were defined, but 
+  were liable to change.
 
 For example, the following code prints out all the address ranges:
 
 ::
 
-    void print_address_ranges(char *linetable, int firstlineno)
+    void print_address_ranges(char *linetable, Py_ssize_t length, int firstlineno)
     {
         PyCodeAddressRange range;
-        PyLineTable_InitAddressRange(linetable, firstlineno, &range);
+        PyLineTable_InitAddressRange(linetable, length, firstlineno, &range);
         while (PyLineTable_NextAddressRange(&range)) {
             printf("Bytecodes from %d (inclusive) to %d (exclusive) ",
                    range.start, range.end);

--- a/pep-0626.rst
+++ b/pep-0626.rst
@@ -284,9 +284,10 @@ Note that these functions are not part of the C-API, so will be need to be linke
         int ar_line;
         int opaque1;
         void *opaque2;
+        void *opaque3;
     } PyCodeAddressRange;
 
-    void PyLineTable_InitAddressRange(char *linetable, int firstlineno, PyCodeAddressRange *range);
+    void PyLineTable_InitAddressRange(char *linetable, Py_ssize_t length, int firstlineno, PyCodeAddressRange *range);
     int PyLineTable_NextAddressRange(PyCodeAddressRange *range);
     int PyLineTable_PreviousAddressRange(PyCodeAddressRange *range);
 


### PR DESCRIPTION
Allows line tables that are not sentinel terminated and makes the extent of the line table explicit.

See https://bugs.python.org/issue42739 and https://github.com/python/cpython/pull/25657
