### PR TITLE
PEP 634: Fix markup for sequence pattern note

### DIFF
--- a/pep-0634.rst
+++ b/pep-0634.rst
@@ -377,11 +377,11 @@ bit set:
 - ``range``
 - ``tuple``
 
-Note::
+.. note::
 
-  Although, ``str``, ``bytes`` and ``bytearray`` are usually considered sequences,
-  they are not included in the above list and not considered to be sequences
-  when matching a sequence pattern.
+  Although ``str``, ``bytes``, and ``bytearray`` are usually
+  considered sequences, they are not included in the above list and do
+  not match sequence patterns.
 
 A fixed-length sequence pattern fails if the length of the subject
 sequence is not equal to the number of subpatterns.
@@ -442,7 +442,7 @@ where being a mapping is defined as its class being one of the following:
 - a builtin class that has its ``Py_TPFLAGS_MAPPING`` bit set
 - a class that inherits from any of the above.
 
-The standard library classes ``dict`` and ``mappingroxy`` will have their ``Py_TPFLAGS_MAPPING``
+The standard library classes ``dict`` and ``mappingproxy`` will have their ``Py_TPFLAGS_MAPPING``
 bit set.
 
 A mapping pattern succeeds if every key given in the mapping pattern


### PR DESCRIPTION
Also, slightly rework the note to be less wordy.