### PR TITLE
PEP 484: Mark as Final

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -5,7 +5,7 @@ Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>, Jukka Lehtosalo <jukka.lehtosalo@iki.fi>, Łukasz Langa <lukasz@python.org>
 BDFL-Delegate: Mark Shannon
 Discussions-To: Python-Dev <python-dev@python.org>
-Status: Provisional
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 29-Sep-2014


### PR DESCRIPTION
PEP 484 is still marked as "Provisional", but as @Fidget-Spinner pointed out in python/typing#805, it shouldn't be any more. python/cpython#16204 removed talk about typing's provisional status from the module docs, and enhancements to typing have been in the form of new PEPs for the last few release cycles.

Going to mark this as a draft so Guido can have a chance to comment once he's back.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
