### PR TITLE
Remove references to pyo files from PEP-657

### DIFF
--- a/pep-0657.rst
+++ b/pep-0657.rst
@@ -167,8 +167,8 @@ the program.
 
 We understand that the extra cost of this information may not be acceptable for
 some users, so we propose an opt-out mechanism when Python is executed in
-optimized mode (``python -O``), which will cause pyo files to not include the
-extra information.
+optimized mode (``python -O``), which will cause ``opt-*.pyc`` files to not
+include the extra information.
 
 
 Specification
@@ -300,7 +300,7 @@ Opt-out mechanism
 To offer an opt-out mechanism for those users that care about the storage and
 memory overhead, the functionality will be deactivated along with the extra
 information when Python is executed in optimized mode (``python -O``) resulting
-in ``pyo`` files not having the overhead associated with the extra required
+in ``pyc`` files not having the overhead associated with the extra required
 data.
 
 To allow third party tools and other programs that are currently parsing


### PR DESCRIPTION
As Brett mentioned in https://mail.python.org/archives/list/python-dev@python.org/message/2NKLQFEVHQ53QSTV4ZKQ3EYPCLTZXMFF/ actual `pyo` files haven't existed for a while and have been replaced with files that look like `cpython-35.opt-2.pyc` so let's update the terms in the PEP.