### PR TITLE
PEP 657: Fix incorrect percentage for standard library pyc size increase

### DIFF
--- a/pep-0657.rst
+++ b/pep-0657.rst
@@ -153,7 +153,7 @@ end offset) for every bytecode instruction.
 
 As an illustrative example to gauge the impact of this change, we have
 calculated that this change will increase the size of the standard library’s
-pyc files by 22% (6MB) from 70MB to 76MB. The overhead in memory usage will be
+pyc files by 8.5% (6MB) from 70MB to 76MB. The overhead in memory usage will be
 the same (assuming the *full standard library* is loaded into the same
 program). We believe that this is a very acceptable number since the order of
 magnitude of the overhead is very small, especially considering the storage

--- a/pep-0657.rst
+++ b/pep-0657.rst
@@ -153,7 +153,7 @@ end offset) for every bytecode instruction.
 
 As an illustrative example to gauge the impact of this change, we have
 calculated that this change will increase the size of the standard library’s
-pyc files by 22% (6MB) from 28.5MB to 35MB. The overhead in memory usage will be
+pyc files by 22% (6MB) from 28.4MB to 34.7MB. The overhead in memory usage will be
 the same (assuming the *full standard library* is loaded into the same
 program). We believe that this is a very acceptable number since the order of
 magnitude of the overhead is very small, especially considering the storage

--- a/pep-0657.rst
+++ b/pep-0657.rst
@@ -153,7 +153,7 @@ end offset) for every bytecode instruction.
 
 As an illustrative example to gauge the impact of this change, we have
 calculated that this change will increase the size of the standard library’s
-pyc files by 8.5% (6MB) from 70MB to 76MB. The overhead in memory usage will be
+pyc files by 22% (6MB) from 28.5MB to 35MB. The overhead in memory usage will be
 the same (assuming the *full standard library* is loaded into the same
 program). We believe that this is a very acceptable number since the order of
 magnitude of the overhead is very small, especially considering the storage


### PR DESCRIPTION
Looks like we accidentally retained the old estimated percentage increase, let's update this to the real number.

(Point out by `/u/velit` in https://www.reddit.com/r/Python/comments/n89r40/pep_657_include_fine_grained_error_locations_in/gxhihrk/)