### PR TITLE
PEP 600 supersedes PEP 513, PEP 571, PEP 599

### DIFF
--- a/pep-0513.txt
+++ b/pep-0513.txt
@@ -5,11 +5,12 @@ Last-Modified: $Date$
 Author: Robert T. McGibbon <rmcgibbo@gmail.com>, Nathaniel J. Smith <njs@pobox.com>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
 Discussions-To: Distutils SIG <distutils-sig@python.org>
-Status: Active
+Status: Superseded
 Type: Informational
 Content-Type: text/x-rst
 Created: 19-Jan-2016
 Post-History: 19-Jan-2016, 25-Jan-2016, 29-Jan-2016
+Superseded-By: 600
 Resolution: https://mail.python.org/pipermail/distutils-sig/2016-January/028211.html
 
 

--- a/pep-0571.rst
+++ b/pep-0571.rst
@@ -7,11 +7,12 @@ Author: Mark  Williams <mrw@enotuniq.org>,
         Thomas Kluyver <thomas@kluyver.me.uk>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
 Discussions-To: Distutils SIG <distutils-sig@python.org>
-Status: Active
+Status: Superseded
 Type: Informational
 Content-Type: text/x-rst
 Created: 05-Feb-2018
 Post-History:
+Superseded-By: 600
 Resolution: https://mail.python.org/pipermail/distutils-sig/2018-April/032156.html
 
 

--- a/pep-0599.rst
+++ b/pep-0599.rst
@@ -6,11 +6,12 @@ Author: Dustin Ingram <di@python.org>
 Sponsor: Paul Moore <p.f.moore@gmail.com>
 BDFL-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/the-next-manylinux-specification/
-Status: Final
+Status: Superseded
 Type: Informational
 Content-Type: text/x-rst
 Created: 29-Apr-2019
 Post-History: 29-April-2019
+Superseded-By: 600
 Resolution: https://discuss.python.org/t/the-next-manylinux-specification/1043/199
 
 

--- a/pep-0600.rst
+++ b/pep-0600.rst
@@ -12,6 +12,7 @@ Type: Informational
 Content-Type: text/x-rst
 Created: 03-May-2019
 Post-History: 3-May-2019
+Replaces: 513, 571, 599
 Resolution: https://discuss.python.org/t/pep-600-future-manylinux-platform-tags-for-portable-linux-built-distributions/2414/27
 
 Abstract


### PR DESCRIPTION
Per PEP 600:
```
When this PEP is accepted, the previous manylinux PEPs will receive a final update noting that they are no longer maintained and referring to this PEP.
```
