### PR TITLE
PEP 659: fix a typo

### DIFF
--- a/pep-0659.rst
+++ b/pep-0659.rst
@@ -225,7 +225,7 @@ See [4]_ for a full implementation.
 Compatibility
 =============
 
-There will no change to the language, library or API.
+There will be no change to the language, library or API.
 
 The only way that users will be able to detect the presence of the new interpreter is through timing execution, the use of debugging tools,
 or measuring memory use.


### PR DESCRIPTION
Fix a minor typo in the compatibility section.
