### PR TITLE
PEP 600: add manylinux2014 compatibility

### DIFF
--- a/pep-0600.rst
+++ b/pep-0600.rst
@@ -68,11 +68,11 @@ wheels, and the manylinux approach has achieved substantial uptake
 among both package maintainers and end-users. But any manylinux PEP
 needs some way to address these complexities.
 
-In previous manylinux PEPs (:pep:`513`, :pep:`571`), we've done this
-by attempting to write down in the PEP the exact set of libraries,
-symbol versions, Python configuration, etc. that we believed would
-lead to wheels that work on all mainstream glibc-based Linux systems.
-But this created several problems:
+In previous manylinux PEPs (:pep:`513`, :pep:`571`, :pep:`599`), we've
+done this by attempting to write down in the PEP the exact set of
+libraries, symbol versions, Python configuration, etc. that we
+believed would lead to wheels that work on all mainstream glibc-based
+Linux systems. But this created several problems:
 
 First, PEPs are generally supposed to be normative references: if
 software doesn't match the PEP, then we fix the software. But in this
@@ -248,6 +248,13 @@ tags:
 - ``manylinux1_i686`` is now an alias for ``manylinux_2_5_i686``
 - ``manylinux2010_x86_64`` is now an alias for ``manylinux_2_12_x86_64``
 - ``manylinux2010_i686`` is now an alias for ``manylinux_2_12_i686``
+- ``manylinux2014_x86_64`` is now an alias for ``manylinux_2_17_x86_64``
+- ``manylinux2014_i686`` is now an alias for ``manylinux_2_17_i686``
+- ``manylinux2014_aarch64`` is now an alias for ``manylinux_2_17_aarch64``
+- ``manylinux2014_armv7l`` is now an alias for ``manylinux_2_17_armv7l``
+- ``manylinux2014_ppc64`` is now an alias for ``manylinux_2_17_ppc64``
+- ``manylinux2014_ppc64le`` is now an alias for ``manylinux_2_17_ppc64le``
+- ``manylinux2014_s390x`` is now an alias for ``manylinux_2_17_s390x``
 
 This redefinition is largely a no-op, but does affect a few things:
 
@@ -299,11 +306,14 @@ the default logic should be used.
 
 For compatibility with previous specifications, if the tag is
 ``manylinux1`` or ``manylinux_2_5`` exactly, then we also check the
-module for a boolean attribute ``manylinux1_compatible``, and if the
+module for a boolean attribute ``manylinux1_compatible``, if the
 tag version is ``manylinux2010`` or ``manylinux_2_12`` exactly, then
 we also check the module for a boolean attribute
-``manylinux2010_compatible``. If both the new and old attributes are
-defined, then ``manylinux_compatible`` takes precedence.
+``manylinux2010_compatible``, and if the tag version is
+``manylinux2014`` or ``manylinux_2_17`` exactly, then we also check
+the module for a boolean attribute ``manylinux2014_compatible``. If
+both the new and old attributes are defined, then
+``manylinux_compatible`` takes precedence.
 
 Here's some example code. You don't have to actually use this code,
 but you can use it for reference if you have questions about the exact
@@ -314,6 +324,13 @@ semantics::
       "manylinux1_i686": "manylinux_2_5_i686",
       "manylinux2010_x86_64": "manylinux_2_12_x86_64",
       "manylinux2010_i686": "manylinux_2_12_i686",
+      "manylinux2014_x86_64": "manylinux_2_17_x86_64",
+      "manylinux2014_i686": "manylinux_2_17_i686",
+      "manylinux2014_aarch64": "manylinux_2_17_aarch64",
+      "manylinux2014_armv7l": "manylinux_2_17_armv7l",
+      "manylinux2014_ppc64": "manylinux_2_17_ppc64",
+      "manylinux2014_ppc64le": "manylinux_2_17_ppc64le",
+      "manylinux2014_s390x": "manylinux_2_17_s390x",
   }
 
   def manylinux_tag_is_compatible_with_this_system(tag):
@@ -368,6 +385,7 @@ matches the following regexes:
 
 - ``manylinux1_(x86_64|i686)``
 - ``manylinux2010_(x86_64|i686)``
+- ``manylinux2014_(x86_64|i686|aarch64|armv7l|ppc64|ppc64le|s390x)``
 - ``manylinux_[0-9]+_[0-9]+_(.*)``
 
 Package indexes may impose additional requirements; for example, they


### PR DESCRIPTION
- Add a link to PEP 599
- Add a mention to manylinux2014 aliases

c.f. [discussion](https://discuss.python.org/t/pep-600-future-manylinux-platform-tags-for-portable-linux-built-distributions/2414/34) for more details