### PR TITLE
Update instructions to use pep-9999.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,8 @@ Checking PEP formatting and rendering
 
 Do not commit changes with bad formatting.  To check the formatting of
 a PEP, use the Makefile.  In particular, to generate HTML for PEP 999,
-your source code should be in ``pep-0999.rst`` and the HTML will be
-generated to ``pep-0999.html`` by the command ``make pep-0999.html``.
+your source code should be in ``pep-9999.rst`` and the HTML will be
+generated to ``pep-9999.html`` by the command ``make pep-9999.html``.
 The default Make target generates HTML for all PEPs.
 
 If you don't have Make, use the ``pep2html.py`` script directly.


### PR DESCRIPTION
Seems the instructions are old (?) in this README and deviates from [PEP-0012](https://www.python.org/dev/peps/pep-0012).

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
