### PR TITLE
PEP 612: Update CPython implementation link

### DIFF
--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -576,9 +576,9 @@ Reference Implementation
 
 The `Pyre <https://pyre-check.org/>`_ type checker supports all of the behavior
 described above.  A reference implementation of the runtime components needed
-for those uses is provided in the ``pyre_extensions`` module.  A reference
-implementation for CPython can be found 
-`here <https://github.com/python/cpython/pull/23702>`_.
+for those uses is provided in the ``pyre_extensions`` module.  An
+implementation for CPython can be found in the
+`typing module <https://github.com/python/cpython/blob/3.10/Lib/typing.py>`_.
 
 Rejected Alternatives
 ---------------------


### PR DESCRIPTION
Updated the link to point to Python 3.10's ``typing`` module instead my old PR.

I think that PR is pretty outdated by now, and it has some not-so-nice parts that we had to patch up later on. Calling it a reference implementation is somewhat misleading.