### PR TITLE
PEP 515: fix links

### DIFF
--- a/pep-0515.txt
+++ b/pep-0515.txt
@@ -175,13 +175,13 @@ References
 
 .. [1] http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3499.html
 
-.. [2] http://dlang.org/spec/lex.html#integerliteral
+.. [2] https://dlang.org/spec/lex.html#integerliteral
 
-.. [3] http://perldoc.perl.org/perldata.html#Scalar-value-constructors
+.. [3] https://perldoc.perl.org/perldata#Scalar-value-constructors
 
 .. [4] https://web.archive.org/web/20160304121349/http://doc.rust-lang.org/reference.html#integer-literals
 
-.. [5] https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html
+.. [5] https://docs.swift.org/swift-book/ReferenceManual/LexicalStructure.html
 
 .. [6] https://github.com/dotnet/roslyn/issues/216
 
@@ -191,7 +191,7 @@ References
 
 .. [9] https://web.archive.org/web/20160223175334/http://docs.julialang.org/en/release-0.4/manual/integers-and-floating-point-numbers/
 
-.. [10] http://ruby-doc.org/core-2.3.0/doc/syntax/literals_rdoc.html#label-Numbers
+.. [10] https://ruby-doc.org/core-2.3.0/doc/syntax/literals_rdoc.html#label-Numbers
 
 .. [11] https://mail.python.org/pipermail/python-dev/2016-February/143283.html
 

--- a/pep-0515.txt
+++ b/pep-0515.txt
@@ -179,7 +179,7 @@ References
 
 .. [3] http://perldoc.perl.org/perldata.html#Scalar-value-constructors
 
-.. [4] http://doc.rust-lang.org/reference.html#number-literals
+.. [4] https://web.archive.org/web/20160304121349/http://doc.rust-lang.org/reference.html#integer-literals
 
 .. [5] https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html
 
@@ -189,7 +189,7 @@ References
 
 .. [8] http://archive.adaic.com/standards/83lrm/html/lrm-02-04.html#2.4
 
-.. [9] http://docs.julialang.org/en/release-0.4/manual/integers-and-floating-point-numbers/
+.. [9] https://web.archive.org/web/20160223175334/http://docs.julialang.org/en/release-0.4/manual/integers-and-floating-point-numbers/
 
 .. [10] http://ruby-doc.org/core-2.3.0/doc/syntax/literals_rdoc.html#label-Numbers
 


### PR DESCRIPTION
While working on https://bugs.python.org/issue44267 I've noticed some broken links (first commit).  The second one fix links with redirects.

BTW, the stdlib implementation doesn't follow PEP.  Is it ok?