### PR TITLE
Release: drop 'make suspicious' from release process.

### DIFF
--- a/pep-0101.txt
+++ b/pep-0101.txt
@@ -227,11 +227,6 @@ to perform some manual editing steps.
   (e.g. ``blurb release 3.4.7rc1``).  This merges all the recent news
   blurbs into a single file marked with this release's version number.
 
-- Check the docs for markup errors.
-
-  cd to the Doc directory and run ``make suspicious``.  If any markup
-  errors are found, fix them.
-
 - Regenerate Lib/pydoc-topics.py.
 
   While still in the Doc directory, run ``make pydoc-topics``.  Then copy


### PR DESCRIPTION
As it's no longer mandatory to merge, some false positives can sneak in.

It's a burden for RMs, and it's slowly been handled in:

https://bugs.python.org/issue42238

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
