### PR TITLE
Add config option in `build.py` for Sphinx builders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ pages: rss
 sphinx:
 	$(SPHINX_BUILD)
 
+# for building Sphinx without a web-server
+sphinx-local:
+	$(SPHINX_BUILD) --build-files
+
 fail_on_warning:
 	$(SPHINX_BUILD) --fail-on-warning
 

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ sphinx:
 sphinx-local:
 	$(SPHINX_BUILD) --build-files
 
-fail_on_warning:
+fail-warning:
 	$(SPHINX_BUILD) --fail-on-warning
 
-check_links:
+check-links:
 	$(SPHINX_BUILD) --check-links

--- a/build.py
+++ b/build.py
@@ -10,9 +10,11 @@ def create_parser():
     parser = argparse.ArgumentParser(description="Build PEP documents")
     # alternative builders:
     parser.add_argument("-l", "--check-links", action="store_true")
+    parser.add_argument("-f", "--build-files", action="store_true")
+    parser.add_argument("-d", "--build-dirs", action="store_true")
 
     # flags / options
-    parser.add_argument("-f", "--fail-on-warning", action="store_true")
+    parser.add_argument("-w", "--fail-on-warning", action="store_true")
     parser.add_argument("-n", "--nitpicky", action="store_true")
     parser.add_argument("-j", "--jobs", type=int, default=1)
 
@@ -31,9 +33,15 @@ if __name__ == "__main__":
     doctree_directory = build_directory / ".doctrees"
 
     # builder configuration
-    sphinx_builder = "dirhtml"
-    if args.check_links:
+    if args.build_files:
+        sphinx_builder = "html"
+    elif args.build_dirs:
+        sphinx_builder = "dirhtml"
+    elif args.check_links:
         sphinx_builder = "linkcheck"
+    else:
+        # default builder
+        sphinx_builder = "dirhtml"
 
     # other configuration
     config_overrides = {}


### PR DESCRIPTION
xref discussion in #1931, https://github.com/python/peps/pull/1931#issuecomment-857283694

Two questions left - what to put as the default (directories or files), and whether to add a make target (I don't know if make passes args through? If so this Q is irrelevant)
