### PR TITLE
PEP 621: Remove mentions of core metadata from `Entry points`

### DIFF
--- a/pep-0621.rst
+++ b/pep-0621.rst
@@ -363,11 +363,11 @@ Entry points
 
 There are three tables related to entry points. The
 ``[project.scripts]`` table corresponds to the ``console_scripts``
-group in the `core metadata`_. The key of the table is the name of the
+group. The key of the table is the name of the
 entry point and the value is the object reference.
 
 The ``[project.gui-scripts]`` table corresponds to the ``gui_scripts``
-group in the `core metadata`_. Its format is the same as
+group. Its format is the same as
 ``[project.scripts]``.
 
 The ``[project.entry-points]`` table is a collection of tables. Each

--- a/pep-0621.rst
+++ b/pep-0621.rst
@@ -350,7 +350,7 @@ Entry points
 - Format: Table (``[project.scripts]``, ``[project.gui-scripts]``, and
   ``[project.entry-points]``)
 - `Core metadata`_: N/A;
-  `Entry point specification <https://packaging.python.org/specifications/entry-points/>`_
+  `Entry points specification`_
 - Synonyms
 
   - Flit_: ``[tool.flit.scripts]`` table for console scripts,
@@ -363,11 +363,11 @@ Entry points
 
 There are three tables related to entry points. The
 ``[project.scripts]`` table corresponds to the ``console_scripts``
-group. The key of the table is the name of the
+group in the `entry points specification`_. The key of the table is the name of the
 entry point and the value is the object reference.
 
 The ``[project.gui-scripts]`` table corresponds to the ``gui_scripts``
-group. Its format is the same as
+group in the `entry points specification`_. Its format is the same as
 ``[project.scripts]``.
 
 The ``[project.entry-points]`` table is a collection of tables. Each
@@ -720,6 +720,7 @@ CC0-1.0-Universal license, whichever is more permissive.
 .. _trove classifiers: https://pypi.org/classifiers/
 .. _SPDX: https://spdx.dev/
 .. _RFC #822: https://tools.ietf.org/html/rfc822
+.. _entry points specification: https://packaging.python.org/specifications/entry-points/
 
 ..
    Local Variables:


### PR DESCRIPTION
Under `Entry points` it says:

> The [project.scripts] table corresponds to the console_scripts group in the core metadata.

But the entry points aren't part of the core metadata; they're a separate spec.

I have removed the "in the core metadata" passage, as I can't see a clear way of adding a link to the entry points specification in its place.
There's already a link on line 353, so the user should be able to find the spec.