### PR TITLE
PEP 517: Fix odd url markup

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -866,7 +866,7 @@ could be added incrementally. Much experience suggests that large successful
 projects often originate as quick hacks (e.g., Linux -- "just a hobby,
 won't be big and professional"; `IPython/Jupyter
 <https://en.wikipedia.org/wiki/IPython#Grants_and_awards>`_ -- `a grad
-student's ` ``$PYTHONSTARTUP`` file
+student's $PYTHONSTARTUP file
 <http://blog.fperez.org/2012/01/ipython-notebook-historical.html>`_),
 so if our goal is to encourage the growth of a vibrant ecosystem of
 good build tools, it's important to minimize the barrier to entry.


### PR DESCRIPTION
It currently looks kinda odd. 

![Screen Shot 2021-06-17 at 11 32 29 AM](https://user-images.githubusercontent.com/5844587/122454016-baeeff80-cf5f-11eb-99d0-779983943ae5.png)

Though I'm not sure of the original intention. Which part does the author want to be linked?
