### PR TITLE
PEP 582: Add Discussions To

### DIFF
--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -9,7 +9,6 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 16-May-2018
-
 Python-Version: 3.8
 
 

--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -5,6 +5,7 @@ Last-Modified: $Date$
 Author: Kushal Das <mail@kushaldas.in>, Steve Dower <steve.dower@python.org>,
         Donald Stufft <donald@stufft.io>, Nick Coghlan <ncoghlan@gmail.com>
 Status: Draft
+Discussions-To: https://discuss.python.org/t/pep-582-python-local-packages-directory/963/109
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 16-May-2018

--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Kushal Das <mail@kushaldas.in>, Steve Dower <steve.dower@python.org>,
         Donald Stufft <donald@stufft.io>, Nick Coghlan <ncoghlan@gmail.com>
-Discussions-To: https://discuss.python.org/t/pep-582-python-local-packages-directory/963/109
+Discussions-To: https://discuss.python.org/t/pep-582-python-local-packages-directory/963/
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -5,8 +5,8 @@ Last-Modified: $Date$
 Author: Kushal Das <mail@kushaldas.in>, Steve Dower <steve.dower@python.org>,
         Donald Stufft <donald@stufft.io>, Nick Coghlan <ncoghlan@gmail.com>
 Status: Draft
-Discussions-To: https://discuss.python.org/t/pep-582-python-local-packages-directory/963/109
 Type: Standards Track
+Discussions-To: https://discuss.python.org/t/pep-582-python-local-packages-directory/963/109
 Content-Type: text/x-rst
 Created: 16-May-2018
 Python-Version: 3.8

--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -6,9 +6,9 @@ Author: Kushal Das <mail@kushaldas.in>, Steve Dower <steve.dower@python.org>,
         Donald Stufft <donald@stufft.io>, Nick Coghlan <ncoghlan@gmail.com>
 Status: Draft
 Type: Standards Track
-Discussions-To: https://discuss.python.org/t/pep-582-python-local-packages-directory/963/109
 Content-Type: text/x-rst
 Created: 16-May-2018
+Discussions-To: https://discuss.python.org/t/pep-582-python-local-packages-directory/963/109
 Python-Version: 3.8
 
 

--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -4,11 +4,12 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Kushal Das <mail@kushaldas.in>, Steve Dower <steve.dower@python.org>,
         Donald Stufft <donald@stufft.io>, Nick Coghlan <ncoghlan@gmail.com>
+Discussions-To: https://discuss.python.org/t/pep-582-python-local-packages-directory/963/109
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 16-May-2018
-Discussions-To: https://discuss.python.org/t/pep-582-python-local-packages-directory/963/109
+
 Python-Version: 3.8
 
 


### PR DESCRIPTION
According to https://github.com/python/peps/issues/1796, it looks like the desired discussion forum is Discourse.
Closes https://github.com/python/peps/issues/1796