### PR TITLE
Only restrict to deploying on pushes to `master` in the python/peps repo

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,9 +1,6 @@
 name: Deploy to GitHub Pages
 
-on:
-  push:
-    branches: [main]
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   deploy-to-pages:
@@ -34,6 +31,8 @@ jobs:
         run: rm -r build/.doctrees/
 
       - name: 🚀 Deploy to GitHub pages
+        # This allows CI to build branches for testing
+        if: github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@4.1.1
         with:
           branch: gh-pages # The branch to deploy to.


### PR DESCRIPTION
cc: @pablogsal 

Relaxes restriction from #1987, builds on PRs from forks.
