### PR TITLE
PEP 0554: drop wording about daemon threads in isolated subinterpreters

### DIFF
--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -973,7 +973,7 @@ following:
 
 * importing an extension module fails if it does not implement the
   PEP 489 API
-* new threads are not allowed (including daemon threads)
+* new threads are not allowed
 * ``os.fork()`` is not allowed (so no ``multiprocessing``)
 * ``os.exec*()``, AKA "fork+exec", is not allowed (so no ``subprocess``)
 

--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -973,7 +973,7 @@ following:
 
 * importing an extension module fails if it does not implement the
   PEP 489 API
-* new threads are not allowed
+* new threads of any kind are not allowed
 * ``os.fork()`` is not allowed (so no ``multiprocessing``)
 * ``os.exec*()``, AKA "fork+exec", is not allowed (so no ``subprocess``)
 


### PR DESCRIPTION
new threads are not allowed (including daemon threads) implies that the opposite
is true in isolated=False subinterpreters: that new threads are allowed (*excluding* daemon threads)

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
