### PR TITLE
PEP 634: Clarify late-registration edge-case

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -489,8 +489,8 @@ pep-0631.rst  @pganssle
 pep-0632.rst  @zooba
 pep-0633.rst  @brettcannon
 pep-0634.rst  @brandtbucher @gvanrossum
-pep-0635.rst  @gvanrossum
-pep-0636.rst  @gvanrossum
+pep-0635.rst  @brandtbucher @gvanrossum
+pep-0636.rst  @brandtbucher @gvanrossum
 pep-0637.rst  @stevendaprano
 pep-0638.rst  @markshannon
 pep-0639.rst  @pfmoore

--- a/pep-0634.rst
+++ b/pep-0634.rst
@@ -365,7 +365,8 @@ where being a sequence is defined as its class being one of the following:
 - a class that inherits from ``collections.abc.Sequence``
 - a Python class that has been registered as a ``collections.abc.Sequence``
 - a builtin class that has its ``Py_TPFLAGS_SEQUENCE`` bit set
-- a class that inherits from any of the above.
+- a class that inherits from any of the above (including classes defined *before* a
+  parent's ``Sequence`` registration)
 
 The following standard library classes will have their ``Py_TPFLAGS_SEQUENCE``
 bit set:
@@ -440,7 +441,8 @@ where being a mapping is defined as its class being one of the following:
 - a class that inherits from ``collections.abc.Mapping``
 - a Python class that has been registered as a ``collections.abc.Mapping``
 - a builtin class that has its ``Py_TPFLAGS_MAPPING`` bit set
-- a class that inherits from any of the above.
+- a class that inherits from any of the above  (including classes defined *before* a
+  parent's ``Mapping`` registration)
 
 The standard library classes ``dict`` and ``mappingproxy`` will have their ``Py_TPFLAGS_MAPPING``
 bit set.


### PR DESCRIPTION
...as requested by @markshannon in https://github.com/python/cpython/pull/26864.

Also, add myself as a CODEOWNER of PEPs 635 and 636.
