### PR TITLE
PEP-662: Add prepare_metadata_for_build_editable

### DIFF
--- a/pep-0662.rst
+++ b/pep-0662.rst
@@ -163,6 +163,33 @@ called.
 
 If not defined, the default implementation is equivalent to returning ``[]``.
 
+``prepare_metadata_for_build_editable``
+---------------------------------------
+
+::
+
+  def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
+      ...
+
+Must create a ``.dist-info`` directory containing wheel metadata
+inside the specified ``metadata_directory`` (i.e., creates a directory
+like ``{metadata_directory}/{package}-{version}.dist-info/``). This
+directory MUST be a valid ``.dist-info`` directory as defined in the
+wheel specification, except that it need not contain ``RECORD`` or
+signatures. The hook MAY also create other files inside this
+directory, and a build frontend MUST preserve, but otherwise ignore, such files;
+the intention here is that in cases where the metadata depends on build-time
+decisions, the build backend may need to record these decisions in
+some convenient format for re-use by the actual wheel-building step.
+
+This must return the basename (not the full path) of the ``.dist-info``
+directory it creates, as a unicode string.
+
+If a build frontend needs this information and the method is
+not defined, it should call ``build_editable`` and look at the resulting
+metadata directly.
+
+
 ``build_editable``
 ------------------
 
@@ -177,16 +204,16 @@ must return the basename (not the full path) of the ``.whl`` file it creates,
 as a unicode string. The wheel file must be of type virtual wheel as defined
 under the terminology section.
 
-If the build frontend has previously called ``prepare_metadata_for_build_wheel``
+If the build frontend has previously called ``prepare_metadata_for_build_editable``
 and depends on the wheel resulting from this call to have metadata
 matching this earlier call, then it should provide the path to the created
 ``.dist-info`` directory as the ``metadata_directory`` argument. If this
 argument is provided, then ``build_editable`` MUST produce a wheel with identical
 metadata. The directory passed in by the build frontend MUST be
-identical to the directory created by ``prepare_metadata_for_build_wheel``,
+identical to the directory created by ``prepare_metadata_for_build_editable``,
 including any unrecognized files it created.
 
-Backends which do not provide the ``prepare_metadata_for_build_wheel`` hook may
+Backends which do not provide the ``prepare_metadata_for_build_editable`` hook may
 either silently ignore the ``metadata_directory`` parameter to ``build_editable``,
 or else raise an exception when it is set to anything other than ``None``.
 
@@ -245,7 +272,7 @@ value must be a ``file://`` URL pointing to the project directory (i.e., the
 directory containing ``pyproject.toml``), and the ``dir_info`` value must be
 ``{'editable': true}``.
 
-The frontend can rely on the ``prepare_metadata_for_build_wheel`` hook when
+The frontend can rely on the ``prepare_metadata_for_build_editable`` hook when
 installing in editable mode.
 
 If the frontend concludes it cannot achieve an editable installation with the


### PR DESCRIPTION
This provides full symetry with build_wheel and allows
a fast path for the frontend to validate the backend metadata,
without needing to build the wheel.

Signed-off-by: Bernát Gábor <gaborjbernat@gmail.com>
