### PR TITLE
PEP-563: Fixed a nested class example in 

### DIFF
--- a/pep-0563.rst
+++ b/pep-0563.rst
@@ -259,14 +259,15 @@ valid.  They can use local names or the fully qualified name.  Example::
             def method(self) -> C.D.field2:  # this is OK
                 ...
 
-            def method(self) -> D.field2:  # this is OK
-                ...
+            def method(self) -> D.field2:  # this FAILS, class D is local to C 
+                ...                        # and is therefore only available 
+                                           # as C.D.
 
             def method(self) -> field2:  # this is OK
                 ...
 
             def method(self) -> field:  # this FAILS, class D doesn't
-                ...                     # see C's attributes,  This was
+                ...                     # see C's attributes.  This was
                                         # already true before this PEP.
 
 In the presence of an annotation that isn't a syntactically valid


### PR DESCRIPTION
The "Backward Compatibility" section in PEP-563 contains an example which
violates Python scoping rules. This PR updates the PEP to say that the example
is not OK and should fail.

See discussion in typing-sig for details [*].

[*]: https://mail.python.org/archives/list/typing-sig@python.org/thread/F2ERQCGB6W6VADR7G6NN4TLMFJECD6EW/