### PR TITLE
PEP-563: Fixed the comments for a few examples

### DIFF
--- a/pep-0563.rst
+++ b/pep-0563.rst
@@ -261,14 +261,16 @@ valid.  They can use local names or the fully qualified name.  Example::
 
             def method(self) -> D.field2:  # this FAILS, class D is local to C 
                 ...                        # and is therefore only available 
-                                           # as C.D.
+                                           # as C.D. This was already true
+                                           # before the PEP.
 
             def method(self) -> field2:  # this is OK
                 ...
 
-            def method(self) -> field:  # this FAILS, class D doesn't
-                ...                     # see C's attributes.  This was
-                                        # already true before this PEP.
+            def method(self) -> field:  # this FAILS, field is local to C and
+                                        # is therefore not visible to D unless
+                                        # accessed as C.field. This was already 
+                                        # true before the PEP.
 
 In the presence of an annotation that isn't a syntactically valid
 expression, SyntaxError is raised at compile time.  However, since names


### PR DESCRIPTION
This PR fixes the wording in the comments for failing examples in the  "Backwads Compatibility" section as suggested by Guido in #2007.