### PR TITLE
Add build process notes to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,8 +89,8 @@ Build PEPs with Sphinx locally:
    not impact the build process.
 4. Navigate to the ``build`` directory of your PEPs repo to find the HTML pages.
 
-Arguments to the build file:
-----------------------------
+Arguments to ``build.py``:
+--------------------------
 
 Renderers:
 

--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,7 @@ Build PEPs with Sphinx locally:
    unreferenced citations or labels -- whilst these are valid warnings they do
    not impact the build process.
 4. Navigate to the ``build`` directory of your PEPs repo to find the HTML pages.
+   PEP 0 provides a formatted index, and may be a useful reference.
 
 Arguments to ``build.py``:
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -70,3 +70,51 @@ rendering pipeline:
   local clone of the PEP repository
 * Run ``./manage.py generate_pep_pages`` as described in
   https://pythondotorg.readthedocs.io/pep_generation.html
+
+
+Rendering PEPs with Sphinx
+==========================
+
+Build PEPs with Sphinx locally:
+-------------------------------
+
+1. Ensure you have Python 3.9 and Sphinx installed
+2. If you have access to ``make``, follow (i), otherwise (ii)
+
+   i.  Run ``make sphinx-local``
+   ii. Run ``python build.py -j 8 --build-files``. Note that the jobs argument
+       only takes effect on unix (non-mac) systems.
+3. Wait for Sphinx to render the PEPs. There may be a series of warnings about
+   unreferenced citations or labels -- whilst these are valid warnings they do
+   not impact the build process.
+4. Navigate to the ``build`` directory of your PEPs repo to find the HTML pages.
+
+Arguments to the build file:
+----------------------------
+
+Renderers:
+
+``-f`` or ``--build-files``
+    Renders PEPs to ``pep-XXXX.html`` files
+
+``-d`` or ``--build-dirs``
+    Renders PEPs to ``index.html`` files within ``pep-XXXX`` directories
+
+Options:
+
+``-i`` or ``--index-file``
+    Copies PEP 0 to a base index file
+
+``-j`` or ``--jobs``
+    How many parallel jobs to run (if supported). Integer, default 1
+
+``-n`` or ``--nitpicky``
+    Runs Sphinx in `nitpicky` mode
+
+``-w`` or ``--fail-on-warning``
+    Fails Sphinx on warnings
+
+Tools:
+
+``-l`` or ``--check-links``
+    Checks validity of links within PEP sources

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Rendering PEPs with Sphinx
 Build PEPs with Sphinx locally:
 -------------------------------
 
-1. Ensure you have Python 3.9 and Sphinx installed
+1. Ensure you have Python >=3.9 and Sphinx installed
 2. If you have access to ``make``, follow (i), otherwise (ii)
 
    i.  Run ``make sphinx-local``

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,14 @@ rendering pipeline:
 Rendering PEPs with Sphinx
 ==========================
 
+There is a Sphinx-rendered version of the PEPs at https://python.github.io/peps/
+(updated on every push to ``master``)
+
+**Warning:** This version is not, and should not be taken to be, a canonical
+source for PEPs whilst it remains in preview (`please report any rendering bugs
+<https://github.com/python/peps/issues/new>`_). The canonical source for PEPs remains
+https://www.python.org/dev/peps/
+
 Build PEPs with Sphinx locally:
 -------------------------------
 


### PR DESCRIPTION
Closes #2014 

Didn't add any notes on the process of how Sphinx & `pep_sphinx_extensions` actually works but added brief instructions on how to build locally and a reference to `build.py`

cc: @pablogsal 
