### PR TITLE
PEP 657: addr => addrq

### DIFF
--- a/pep-0657.rst
+++ b/pep-0657.rst
@@ -194,7 +194,7 @@ this PEP:
 * One new C-API function: ::
 
     int PyCode_Addr2Location(
-        PyCodeObject *co, int addr,
+        PyCodeObject *co, int addrq,
         int *startline, int *startcolumn,
         int *endline, int *endcolumn)
 

--- a/pep-0657.rst
+++ b/pep-0657.rst
@@ -195,8 +195,8 @@ this PEP:
 
     int PyCode_Addr2Location(
         PyCodeObject *co, int addrq,
-        int *startline, int *startcolumn,
-        int *endline, int *endcolumn)
+        int *start_line, int *start_column,
+        int *end_line, int *end_column)
 
   will be added so the end line, the start column offsets and the end column
   offset can be obtained given the index of a bytecode instruction. This


### PR DESCRIPTION
Consistent with the other existing APIs, e.g `int PyCode_Addr2Line(PyCodeObject *co, int addrq)`. 