### PR TITLE
PEP 657: use 0-indexed offsets

### DIFF
--- a/pep-0657.rst
+++ b/pep-0657.rst
@@ -218,12 +218,10 @@ and ``-1`` for the ``PyCode_Addr2Location`` API. The availability of the informa
 on whether the offsets fall under the range, as well as the runtime flags for the interpreter
 configuration.
 
-Although the AST nodes use ``int`` types to store these values, ``uint8_t`` types will be used
-for storage in the new map to minimize storage impact. This decision allows offsets to go from
-0 to 255, while offsets bigger than these values will be treated as missing (value of 0).
-We believe this is an acceptable compromise as line lengths in Python tend to
-be much lower than this limit (a query of the top 100 packages in PyPI shows
-that less than 0.01% of lines were longer than 255 characters).
+The AST nodes use ``int`` types to store these values. The current implementation, however,
+utilizes ``uint8_t`` types as an implementation detail to minimize storage impact. This decision
+allows offsets to go from 0 to 255, while offsets bigger than these values will be treated as
+missing (value of 0).
 
 As specified previously, the underlying storage of the offsets should be
 considered an implementation detail, as the public APIs to obtain this values

--- a/pep-0657.rst
+++ b/pep-0657.rst
@@ -221,7 +221,7 @@ configuration.
 The AST nodes use ``int`` types to store these values. The current implementation, however,
 utilizes ``uint8_t`` types as an implementation detail to minimize storage impact. This decision
 allows offsets to go from 0 to 255, while offsets bigger than these values will be treated as
-missing (value of 0).
+missing (returning ``-1`` on the ``PyCode_Addr2Location`` and ``None`` API in the ``co_positions()`` API).
 
 As specified previously, the underlying storage of the offsets should be
 considered an implementation detail, as the public APIs to obtain this values

--- a/pep-0657.rst
+++ b/pep-0657.rst
@@ -210,11 +210,17 @@ Offset semantics
 ^^^^^^^^^^^^^^^^
 
 These offsets are propagated by the compiler from the ones stored currently in
-all AST nodes. They are 1-indexed and a value of 0 will mean that the
-information is not available. Although the AST nodes use ``int`` types to store
-these values, ``uint8_t`` types will be used for storage in the new map to
-minimize storage impact. This decision allows offsets to go from 0 to 255,
-while offsets bigger than these values will be treated as missing (value of 0).
+all AST nodes. The output of the public APIs (``co_positions`` and ``PyCode_Addr2Location``)
+that deal with these attributes use 0-indexed offsets (just like the AST nodes), but the underlying
+implementation is free to represent the actual data in whatever form they choose to be most efficient.
+The error code regarding information not available is ``None`` for the ``co_positions()`` API,
+and ``-1`` for the ``PyCode_Addr2Location`` API. The availability of the information highly depends
+on whether the offsets fall under the range, as well as the runtime flags for the interpreter
+configuration.
+
+Although the AST nodes use ``int`` types to store these values, ``uint8_t`` types will be used
+for storage in the new map to minimize storage impact. This decision allows offsets to go from
+0 to 255, while offsets bigger than these values will be treated as missing (value of 0).
 We believe this is an acceptable compromise as line lengths in Python tend to
 be much lower than this limit (a query of the top 100 packages in PyPI shows
 that less than 0.01% of lines were longer than 255 characters).


### PR DESCRIPTION
For the background of this change, see the discussion on: https://github.com/python/cpython/pull/26958#issuecomment-873480427