### PR TITLE
Sphinx - fix last modified dates for PEPs

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # fetch all history so that last modified date-times are accurate
 
       - name: 🐍 Set up Python 3.9
         uses: actions/setup-python@v2


### PR DESCRIPTION
Fixes last-modified dates in PEP footers by fetching the entire repo when cloning

See for example https://python.github.io/peps/pep-0801/ (2021-07-04) vs https://aa-turner.github.io/peps/pep-0801/ (2018-06-21)

A

cc: @pablogsal 
