### PR TITLE
PEP 657: Rename opt out command line flag

### DIFF
--- a/pep-0657.rst
+++ b/pep-0657.rst
@@ -321,7 +321,7 @@ programs that are currently parsing tracebacks to catch up the following
 methods will be provided to deactivate this feature:
 
 * A new environment variable: ``PYTHONNODEBUGRANGES``.
-* A new command line option for the dev mode: ``python -Xnodebugranges``.
+* A new command line option for the dev mode: ``python -Xno_debug_ranges``.
 
 If any of these methods are used, the Python compiler will **not** populate
 code objects with the new information (``None`` will be used instead) and any


### PR DESCRIPTION
Added underscores between the words for consistency with flags like:

* [`-X warn_default_encoding`](https://www.python.org/dev/peps/pep-0597/#abstract)
* [`-X pycache_prefix`](https://docs.python.org/3/library/sys.html#sys.pycache_prefix)