### PR TITLE
PEP 3104: Add footnote to give example

### DIFF
--- a/pep-3104.txt
+++ b/pep-3104.txt
@@ -251,9 +251,10 @@ in an outer scope when using the variable in an expression.  One
 syntax that has been suggested for this is ``.x`` [7]_, which would
 refer to ``x`` without creating a local binding for it.  A concern
 with this proposal is that in many contexts ``x`` and ``.x`` could
-be used interchangeably, which would confuse the reader.  A closely
-related idea is to use multiple dots to specify the number of scope
-levels to ascend [8]_, but most consider this too error-prone [17]_.
+be used interchangeably, which would confuse the reader [31]_. A
+closely related idea is to use multiple dots to specify the number
+of scope levels to ascend [8]_, but most consider this too error-prone
+[17]_.
 
 Rebinding Operator
 ''''''''''''''''''
@@ -528,6 +529,9 @@ References
 
 .. [30] Whatever happened to 'nonlocal x = y'? (Guido van Rossum)
    https://mail.python.org/pipermail/python-dev/2018-January/151627.html
+   
+.. [31] Using and binding relative names (Almann T. Goo)
+   https://mail.python.org/pipermail/python-dev/2006-February/061761.html
 
 
 Acknowledgements


### PR DESCRIPTION
While reading PEP 3104 to understand the ``nonlocal`` keyword, I found the explanation for why an alternative was not chosen to be vague. Further digging revealed an example for why there was a concern that ``.x`` and ``x`` could be used interchangeably. I linked this example as a footnote to save future readers time from digging to find an example. I hope this will increase comprehension of the PEP for future learners.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
