### PR TITLE
PEP 101: #python-dev channel is now on Libera Chat

### DIFF
--- a/pep-0101.txt
+++ b/pep-0101.txt
@@ -158,7 +158,7 @@ maintenance branches is ``X.Y``.
 This helps by performing several automatic editing steps, and guides you
 to perform some manual editing steps.
 
-- Log into irc.freenode.net and join the #python-dev channel.
+- Log into irc.libera.chat and join the #python-dev channel.
 
   You probably need to coordinate with other people around the world.
   This IRC channel is where we've arranged to meet.


### PR DESCRIPTION
Per the announcement on the python-dev mailing list:
https://mail.python.org/archives/list/python-dev@python.org/thread/FQW44V4DZFX4GAGOAMAZAN5KDQXCASDU/
