### PR TITLE
PEP 533: Fix links containing inline code.

### DIFF
--- a/pep-0533.txt
+++ b/pep-0533.txt
@@ -180,9 +180,9 @@ Alternatives
 PEP 525 asyncgen hooks
 ----------------------
 
-PEP 525 proposes a `set of global thread-local hooks managed by new
-``sys.{get/set}_asyncgen_hooks()`` functions
-<https://www.python.org/dev/peps/pep-0525/#finalization>`_, which
+PEP 525 `proposes a set of global thread-local hooks
+<https://www.python.org/dev/peps/pep-0525/#finalization>`_
+managed by new ``sys.{get/set}_asyncgen_hooks()`` functions, which
 allow event loops to integrate with the garbage collector to run
 cleanup for async generators. In principle, this proposal and PEP 525
 are complementary, in the same way that ``with`` blocks and
@@ -609,12 +609,11 @@ as::
               operations.iterclose(iter(iterable))
           map_chaining_exceptions(iterclose_iterable, iterables, last_exc=e)
 
-In some cases this requires some subtlety; for example,
-```itertools.tee``
-<https://docs.python.org/3/library/itertools.html#itertools.tee>`_
+In some cases this requires some subtlety; for example, `itertools.tee`_
 should not call ``__iterclose__`` on the underlying iterator until it
 has been called on *all* of the clone iterators.
 
+.. _itertools.tee: https://docs.python.org/3/library/itertools.html#itertools.tee
 
 Example / Rationale
 -------------------


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Inline code is not permitted within links in reStructuredText, and produces malformed output:

![image](https://user-images.githubusercontent.com/8050853/125660172-cbd09fb1-73c4-4598-8db1-e51cef8a37fd.png)

