### PR TITLE
PEP 8: Fix indentation of two paragraphs in list

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -1357,15 +1357,15 @@ Programming Recommendations
       # Wrong:
       if type(obj) is type(1):
 
-When checking if an object is a string, keep in mind that it might
-be a unicode string too!  In Python 2, str and unicode have a
-common base class, basestring, so you can do::
+  When checking if an object is a string, keep in mind that it might
+  be a unicode string too!  In Python 2, str and unicode have a
+  common base class, basestring, so you can do::
 
       if isinstance(obj, basestring):
 
-Note that in Python 3, ``unicode`` and ``basestring`` no longer exist
-(there is only ``str``) and a bytes object is no longer a kind of
-string (it is a sequence of integers instead).
+  Note that in Python 3, ``unicode`` and ``basestring`` no longer exist
+  (there is only ``str``) and a bytes object is no longer a kind of
+  string (it is a sequence of integers instead).
 
 - For sequences, (strings, lists, tuples), use the fact that empty
   sequences are false::


### PR DESCRIPTION
Two paragraphs in the [Programming Recommendations](https://www.python.org/dev/peps/pep-0008/) section of PEP 8 seem to have the wrong indentation. It is the bullet point regarding usage of `isinstance()`, and it seems to me they are supposed to be a part of that bullet point.