### PR TITLE
PEP 658: Fix attribute description in abstract

### DIFF
--- a/pep-0658.rst
+++ b/pep-0658.rst
@@ -17,7 +17,7 @@ Abstract
 
 This PEP proposes adding an anchor tag to expose the ``METADATA`` file
 from distributions in the :pep:`503` "simple" repository API. A
-``data-dist-info-metadata`` attribute is introduced to indicate where
+``data-dist-info-metadata`` attribute is introduced to indicate that
 the file from a given distribution can be independently fetched.
 
 


### PR DESCRIPTION
During the PEP's evoltion, the data-dist-info-metadata attribute was changed from indicating the metadata's location to merely indicating the file's existence. The exact location should be inferred elsewhere. But we forgot to update the description in the abstract to reflect this.

This was mentioned by @dstufft in the [resolution message](https://discuss.python.org/t/8651/48):

> I will mention there’s one bit of wording that you might want to clean up. It doesn’t really affect the contents of the PEP, but the Abstract still references `data-dist-info-metadata` as the pointer for the location of the metadata file.