### PR TITLE
PEP 646: Add explicit section on endorsements

### DIFF
--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -1183,18 +1183,18 @@ From **Stephan Hoyer**, member of the NumPy Steering Council:
     I just wanted to thank Matthew & Pradeep for writing this PEP and for
 clarifications to the broader context of PEP 646 for array typing in
 https://github.com/python/peps/pull/1904.
-    
+
     As someone who is heavily involved in the Python numerical computing
 community (e.g., NumPy, JAX, Xarray), but who is not so familiar with the
 details of Python's type system, it is reassuring to see that a broad range
 of use-cases related to type checking of named axes & shapes have been
 considered, and could build upon the infrastructure in this PEP.
-    
+
     Type checking for shapes is something the NumPy community is very
 interested in -- there are more thumbs up on the relevant issue on NumPy's
 GitHub than any others (https://github.com/numpy/numpy/issues/7370) and we
 recently added a "typing" module that is under active development.
-    
+
     It will certainly require experimentation to figure out the best ways to
 use type checking for ndarrays, but this PEP looks like an excellent
 foundation for such work.

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -1181,34 +1181,34 @@ From **Stephan Hoyer**, member of the NumPy Steering Council:
 [#stephan-endorsement]_
 
     I just wanted to thank Matthew & Pradeep for writing this PEP and for
-clarifications to the broader context of PEP 646 for array typing in
-https://github.com/python/peps/pull/1904.
+    clarifications to the broader context of PEP 646 for array typing in
+    https://github.com/python/peps/pull/1904.
 
     As someone who is heavily involved in the Python numerical computing
-community (e.g., NumPy, JAX, Xarray), but who is not so familiar with the
-details of Python's type system, it is reassuring to see that a broad range
-of use-cases related to type checking of named axes & shapes have been
-considered, and could build upon the infrastructure in this PEP.
+    community (e.g., NumPy, JAX, Xarray), but who is not so familiar with the
+    details of Python's type system, it is reassuring to see that a broad range
+    of use-cases related to type checking of named axes & shapes have been
+    considered, and could build upon the infrastructure in this PEP.
 
     Type checking for shapes is something the NumPy community is very
-interested in -- there are more thumbs up on the relevant issue on NumPy's
-GitHub than any others (https://github.com/numpy/numpy/issues/7370) and we
-recently added a "typing" module that is under active development.
+    interested in -- there are more thumbs up on the relevant issue on NumPy's
+    GitHub than any others (https://github.com/numpy/numpy/issues/7370) and we
+    recently added a "typing" module that is under active development.
 
     It will certainly require experimentation to figure out the best ways to
-use type checking for ndarrays, but this PEP looks like an excellent
-foundation for such work.
+    use type checking for ndarrays, but this PEP looks like an excellent
+    foundation for such work.
 
 From **Dan Moldovan**, a Senior Software Engineer on the TensorFlow Dev Team
 and author of the TensorFlow RFC, `TensorFlow Canonical Type System`_: [#dan-endorsement]_
 
     I'd be interested in using this the mechanisms defined in this PEP to define
-rank-generic Tensor types in TensorFlow, which are important in specifying
-``tf.function`` signatures in a Pythonic way, using type annotations (rather
-than the custom ``input_signature`` mechanism we have today - see this issue:
-https://github.com/tensorflow/tensorflow/issues/31579). Variadic generics are
-among the last few missing pieces to create an elegant set of type definitions
-for tensors and shapes.
+    rank-generic Tensor types in TensorFlow, which are important in specifying
+    ``tf.function`` signatures in a Pythonic way, using type annotations (rather
+    than the custom ``input_signature`` mechanism we have today - see this
+    issue: https://github.com/tensorflow/tensorflow/issues/31579). Variadic
+    generics are among the last few missing pieces to create an elegant set of
+    type definitions for tensors and shapes.
 
 (For the sake of transparency - we also reached out to folks from a third popular
 numerical computing library, PyTorch, but did *not* receive a statement of

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -1167,6 +1167,54 @@ Footnotes
    shape begins with 'time × batch', then ``videos_batch[1][0]`` would select the
    same frame.
 
+Endorsements
+============
+
+This purpose of this PEP is to make life easier for the numerical computing
+community. How likely is it that numerical computing libraries will actually
+make use of the features proposed in this PEP?
+
+We reached out to a number of people with this question, and received the
+following endorsements.
+
+From **Stephan Hoyer**, member of the NumPy Steering Council:
+[#stephan-endorsement]_
+
+    I just wanted to thank Matthew & Pradeep for writing this PEP and for
+clarifications to the broader context of PEP 646 for array typing in
+https://github.com/python/peps/pull/1904.
+    
+    As someone who is heavily involved in the Python numerical computing
+community (e.g., NumPy, JAX, Xarray), but who is not so familiar with the
+details of Python's type system, it is reassuring to see that a broad range
+of use-cases related to type checking of named axes & shapes have been
+considered, and could build upon the infrastructure in this PEP.
+    
+    Type checking for shapes is something the NumPy community is very
+interested in -- there are more thumbs up on the relevant issue on NumPy's
+GitHub than any others (https://github.com/numpy/numpy/issues/7370) and we
+recently added a "typing" module that is under active development.
+    
+    It will certainly require experimentation to figure out the best ways to
+use type checking for ndarrays, but this PEP looks like an excellent
+foundation for such work.
+
+From **Dan Moldovan**, a Senior Software Engineer on the TensorFlow Dev Team
+and author of the TensorFlow RFC, `TensorFlow Canonical Type System`_: [#dan-endorsement]_
+
+    I'd be interested in using this the mechanisms defined in this PEP to define
+rank-generic Tensor types in TensorFlow, which are important in specifying
+`tf.function` signatures in a Pythonic way, using type annotations (rather than
+the custom `input_signature` mechanism we have today - see this issue:
+https://github.com/tensorflow/tensorflow/issues/31579). Variadic generics are
+among the last few missing pieces to create an elegant set of type definitions
+for tensors and shapes.
+
+(For the sake of transparency - we also reached out to folks from a third popular
+numerical computing library, PyTorch, but did *not* receive a statement of
+endorsement from them. Our understanding is that although they are interested
+in some of the same issues - e.g. static shape inference - they are currently
+focusing on enabling this through a DSL rather than the Python type system.)
 
 Acknowledgements
 ================
@@ -1176,7 +1224,7 @@ Thank you to **Alfonso Castaño**, **Antoine Pitrou**, **Bas v.B.**, **David Fos
 **Sergei Lebedev**, and **Vladimir Mikulik** for helpful feedback and suggestions on
 drafts of this PEP.
 
-Thank you especially to **Lucio** for suggesting the star syntax (which has made multiple aspects of this proposal much more concise and intuitive), and to **Stephan Hoyer** for his kind `endorsement`_ of the PEP on the python-dev mailing list.
+Thank you especially to **Lucio** for suggesting the star syntax (which has made multiple aspects of this proposal much more concise and intuitive), and to **Stephan Hoyer** and **Dan Moldovan** for their endorsements.
 
 Resources
 =========
@@ -1229,7 +1277,11 @@ References
 
 .. _this exercise: https://spinningup.openai.com/en/latest/spinningup/exercise2_2_soln.html
 
-.. _endorsement: https://mail.python.org/archives/list/python-dev@python.org/message/UDM7Y6HLHQBKXQEBIBD5ZLB5XNPDZDXV/
+.. _TensorFlow Canonical Type System: https://github.com/tensorflow/community/pull/208
+
+.. [#stephan-endorsement] https://mail.python.org/archives/list/python-dev@python.org/message/UDM7Y6HLHQBKXQEBIBD5ZLB5XNPDZDXV/
+
+.. [#dan-endorsement] https://mail.python.org/archives/list/python-dev@python.org/message/HTCARTYYCHETAMHB6OVRNR5EW5T2CP4J/
 
 Copyright
 =========

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -1170,9 +1170,9 @@ Footnotes
 Endorsements
 ============
 
-This purpose of this PEP is to make life easier for the numerical computing
-community. How likely is it that numerical computing libraries will actually
-make use of the features proposed in this PEP?
+Variadic generics have a wide range of uses. For the fraction of that range
+involving numerical computing, how likely is it that relevant libraries will
+actually make use of the features proposed in this PEP?
 
 We reached out to a number of people with this question, and received the
 following endorsements.

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -1204,8 +1204,8 @@ and author of the TensorFlow RFC, `TensorFlow Canonical Type System`_: [#dan-end
 
     I'd be interested in using this the mechanisms defined in this PEP to define
 rank-generic Tensor types in TensorFlow, which are important in specifying
-`tf.function` signatures in a Pythonic way, using type annotations (rather than
-the custom `input_signature` mechanism we have today - see this issue:
+``tf.function`` signatures in a Pythonic way, using type annotations (rather
+than the custom ``input_signature`` mechanism we have today - see this issue:
 https://github.com/tensorflow/tensorflow/issues/31579). Variadic generics are
 among the last few missing pieces to create an elegant set of type definitions
 for tensors and shapes.

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -1199,6 +1199,20 @@ From **Stephan Hoyer**, member of the NumPy Steering Council:
     use type checking for ndarrays, but this PEP looks like an excellent
     foundation for such work.
 
+From **Bas van Beek**, who has worked on preliminary support for
+shape-generics in NumPy:
+
+    I very much share Stephan's opinion here and look forward to integrating the
+    new PEP 646 variadics into numpy.
+
+    In the context of numpy (and tensor typing general): the typing of array
+    shapes is a fairly complicated subject and the introduction of variadics
+    will likely play in big role in laying its foundation, as it allows for the
+    expression of both dimensioability as well as basic shape manipulation.
+
+    All in all, I'm very interested in where both PEP 646 and future PEPs will
+    take us and look forward to further developments.
+
 From **Dan Moldovan**, a Senior Software Engineer on the TensorFlow Dev Team
 and author of the TensorFlow RFC, `TensorFlow Canonical Type System`_: [#dan-endorsement]_
 


### PR DESCRIPTION
As suggested by @gvanrossum.

@fylux Anything else to add here - should we ask the JAX folks you talked to whether they want to contribute a statement for the PEP? And any word from Bas?

@pradeep90 too.