### PR TITLE
PEP 558: Update PEP for implementation changes and PEP 667

### DIFF
--- a/pep-0558.rst
+++ b/pep-0558.rst
@@ -399,8 +399,8 @@ Fast locals proxy objects and the internal frame value cache returned by
   slots in the frame's fast locals array
 * changes made by executing code in the frame will be visible to newly created
   fast locals proxy objects, when directly accessing specific keys on existing
-  fast locals proxy objects, when performing intrinsically O(n) operations on
-  existing fast locals proxy objects. Visibility in the internal frame value
+  fast locals proxy objects, and when performing intrinsically O(n) operations
+  on existing fast locals proxy objects. Visibility in the internal frame value
   cache (and in fast locals proxy operations that rely on the frame) cache is
   subject to the cache update guidelines discussed in the next section
 
@@ -408,7 +408,9 @@ Due to the last point, the frame API documentation will recommend that a new
 ``frame.f_locals`` reference be retrieved whenever an optimised frame (or
 a related frame) might have been running code that binds or unbinds local
 variable or cell references, and the code iterates over the proxy, checks
-its length, or calls ``popitem()``.
+its length, or calls ``popitem()``. This will be the most natural style of use
+in tracing function implementations, as those are passed references to frames
+rather than directly to ``frames.f_locals``.
 
 
 Fast locals proxy implementation details
@@ -421,7 +423,7 @@ exposed as part of the Python runtime API:
 * *frame_cache_updated*: whether this proxy has already updated the frame's
   internal value cache at least once
 
-In addition, proxy instances use and update the follow attributes stored on the
+In addition, proxy instances use and update the following attributes stored on the
 underlying frame:
 
 * *fast_refs*: a hidden mapping from variable names to either fast local storage
@@ -441,10 +443,10 @@ frame but not currently bound raise ``KeyError`` (just as they're omitted from
 the result of ``locals()``).
 
 As the frame storage is always accessed directly, the proxy will automatically
-pick up name binding operations that take place as the function executes. The
-internal value cache is implicitly updated when individual variables are read
-from the frame state (including for containment checks, which need to check if
-the name is currently bound or unbound).
+pick up name binding and unbinding operations that take place as the function
+executes. The internal value cache is implicitly updated when individual
+variables are read from the frame state (including for containment checks,
+which need to check if the name is currently bound or unbound).
 
 Similarly, ``__setitem__`` and ``__delitem__`` operations on the proxy will
 directly affect the corresponding fast local or cell reference on the underlying
@@ -511,7 +513,9 @@ calling ``frame.clear()``, as that only drop's the frame's references to cell
 variables, it doesn't clear the cells themselves. This PEP could be a potential
 opportunity to narrow the scope of attempts to clear the frame variables
 directly by leaving cells belonging to outer frames alone, and only clearing
-local variables and cells belonging directly to the frame underlying the proxy.
+local variables and cells belonging directly to the frame underlying the proxy
+(this issue affects PEP 667 as well, as the question relates to the handling of
+cell variables, and is entirely independent of the internal frame value cache).
 
 
 Changes to the stable C API/ABI
@@ -822,7 +826,6 @@ whenever a new fast locals proxy instance was created for that frame. They also
 proposed storing a separate copy of the ``fast_refs`` lookup mapping on each
 
 
-
 What happens with the default args for ``eval()`` and ``exec()``?
 -----------------------------------------------------------------
 
@@ -1068,7 +1071,7 @@ PEP 558 prints the same result as PEP 667 does::
     ('x',)
 
 That said, it's certainly possible to desynchronise the cache quite easily when
-keeping proxy references around while letting the code run in the frame.
+keeping proxy references around while letting code run in the frame.
 This isn't a new problem, as it's similar to the way that
 ``sys._getframe().f_locals`` behaves in existing versions when no trace hooks
 are installed. The following example::
@@ -1109,13 +1112,13 @@ The output once again becomes the same as it would be under PEP 667::
     ('x',)
 
 Tracing function implementations, which are expected to be the main consumer of
-that fast locals proxy API, generally won't run into the above problem, since
-they get passed a reference to the frame object and retrieve a fresh fast
-locals proxy instance from that and the frame itself isn't running code while
-the trace function is running. If the trace function *does* allow code to be
-run on the frame (e.g. it's a debugger), then it should also follow the coding
-guideline and retrieve a new proxy instance each time it allows code to run in
-the frame.
+the fast locals proxy API, generally won't run into the above problem, since
+they get passed a reference to the frame object (and retrieve a fresh fast
+locals proxy instance from that), while the frame itself isn't running code
+while the trace function is running. If the trace function *does* allow code to
+be run on the frame (e.g. it's a debugger), then it should also follow the
+coding guideline and retrieve a new proxy instance each time it allows code
+to run in the frame.
 
 Most trace functions are going to be reading or writing individual keys, or
 running intrinsically O(n) operations like iterating over all currently bound


### PR DESCRIPTION
* address remaining review comments from the July threads
* Rationale section renamed to Motivation
* Design Discussion section renamed to Rationale and Design Discussion
* kind enum is guaranteed to be at least 32 bits
* fast refs mapping is stored on the underlying frame
* delay initial cache refresh for each proxy instance to the
  first operation that needs it
* be specific about which operations always update the cache, and which
  update it if it hasn't been updated by this proxy instance
* eliminate more mentions of the old "dynamic snapshot" terminology
* add new rationale/discussion section covering PEP 667 (including
  how the PEP 558 implementation could be turned into a PEP 667
  implementation if desired)
* make it clearer that proxy instances are ephemeral (lots of
  stale phrasing with "the" dating from when they stored on the frame)
