### PR TITLE
PEP 619: Update date for Python3.10rc2

### DIFF
--- a/pep-0619.rst
+++ b/pep-0619.rst
@@ -56,10 +56,10 @@ Actual:
 - 3.10.0 beta 3: Thursday, 2021-06-17
 - 3.10.0 beta 4: Saturday, 2021-07-10
 - 3.10.0 candidate 1: Tuesday, 2021-08-03
+- 3.10.0 candidate 2: Tuesday, 2021-09-07
 
 Expected:
 
-- 3.10.0 candidate 2: Monday, 2021-09-06 (if necessary)
 - 3.10.0 final: Monday, 2021-10-04
 
 Subsequent bugfix releases every two months.


### PR DESCRIPTION
> Release Date: Sept. 7, 2021

https://www.python.org/downloads/release/python-3100rc2/

https://discuss.python.org/t/python-3-10-0rc2-is-now-available/10496

cc @pablogsal

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
