### PR TITLE
PEP 569: Include Python 3.8.12 in 3.8 release schedule

### DIFF
--- a/pep-0569.rst
+++ b/pep-0569.rst
@@ -91,6 +91,7 @@ Source-only security fix releases
 Provided irregularly on an "as-needed" basis until October 2024.
 
 - 3.8.11: Monday, 2021-06-28
+- 3.8.12: Monday, 2021-08-30
 
 
 Features for 3.8


### PR DESCRIPTION
@ambv 