### PR TITLE
PEP 0007: Only use C++ style // one-line comments

### DIFF
--- a/pep-0007.txt
+++ b/pep-0007.txt
@@ -84,7 +84,7 @@ Code lay-out
           int t_size = PyType_BASICSIZE(type);
           int b_size = PyType_BASICSIZE(base);
 
-          assert(t_size >= b_size); /* type smaller than base! */
+          assert(t_size >= b_size); // type smaller than base!
           ...
           return 1;
       }
@@ -104,8 +104,8 @@ Code lay-out
 
 * The return statement should *not* get redundant parentheses::
 
-      return albatross; /* correct */
-      return(albatross); /* incorrect */
+      return albatross; // correct
+      return(albatross); // incorrect
 
 * Function and macro call style: ``foo(a, b, c)`` -- no space before
   the open paren, no spaces inside the parens, no spaces before
@@ -131,7 +131,7 @@ Code lay-out
           type->tp_dictoffset == b_size &&
           (size_t)t_size == b_size + sizeof(PyObject *))
       {
-          return 0; /* "Forgive" adding a __dict__ only */
+          return 0; // "Forgive" adding a __dict__ only
       }
 
 * Put blank lines around functions, structure definitions, and major
@@ -209,7 +209,7 @@ Documentation Strings
 
   Though some C compilers accept string literals without either::
 
-      /* BAD -- don't do this! */
+      // BAD -- don't do this!
       PyDoc_STRVAR(myfunction__doc__,
       "myfunction(name, value) -> bool\n\n
       Determine whether name and value make a valid pair.");


### PR DESCRIPTION
PEP 0007 itself states:
> Only use C++ style // one-line comments in Python 3.6 or later.

Therefore switch to C++ style // one-line comments.