### PR TITLE
PEP 0007: C++ style // one-line comments

### DIFF
--- a/pep-0007.txt
+++ b/pep-0007.txt
@@ -56,8 +56,6 @@ C dialect
 * All function declarations and definitions must use full prototypes
   (i.e. specify the types of all arguments).
 
-* Only use C++ style // one-line comments in Python 3.6 or later.
-
 * No compiler warnings with major compilers (gcc, VC++, a few others).
 
 


### PR DESCRIPTION
The removed sentence is sort of a repetition of this previous text:
> * Python versions greater than or equal to 3.6 use C89 with several select C99 features:
>   [...]
>    * C++-style line comments

Versions of Python earlier than 3.6 are EOL'd. Therefore this piece of information has lost its importance, and doesn't warrant repetition.

I explain why I find this sentence is ambiguous in https://github.com/python/peps/pull/2072#issuecomment-921197784.