### PR TITLE
Fix LGTM.com warning: Incomplete ordering

### DIFF
--- a/pep_sphinx_extensions/pep_zero_generator/parser.py
+++ b/pep_sphinx_extensions/pep_zero_generator/parser.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import re
 import textwrap
 from typing import TYPE_CHECKING
+from functools import total_ordering
 
 from pep_sphinx_extensions.pep_zero_generator.author import parse_author_email
 from pep_sphinx_extensions.pep_zero_generator.constants import ACTIVE_ALLOWED
@@ -23,6 +24,7 @@ if TYPE_CHECKING:
     from pep_sphinx_extensions.pep_zero_generator.author import Author
 
 
+@total_ordering
 class PEP:
     """Representation of PEPs.
 


### PR DESCRIPTION
Class `PEP` implements `__lt__`, but does not implement `__le__` or `__gt__` or `__ge__`.

See [rich comparisons](https://docs.python.org/2/reference/datamodel.html#object.__lt__) and [functools.total_ordering](https://docs.python.org/2/library/functools.html#functools.total_ordering).

Fixes one of the warnings raised by LGTM.com:
https://lgtm.com/projects/g/python/peps/?severity=warning