### PR TITLE
PEP 0000: Fix LGTM.com warning: Unnecessary 'else' clause in loop

### DIFF
--- a/pep0/pep.py
+++ b/pep0/pep.py
@@ -196,14 +196,13 @@ class PEP(object):
                                    pep_file.name)
         except StopIteration:
             raise PEPError("headers missing or out of order",
-                                pep_file.name)
+                           pep_file.name)
         required = False
         try:
             while not required:
                 current_header, required = next(header_order)
-            else:
-                raise PEPError("PEP is missing its %r" % (current_header,),
-                               pep_file.name)
+            raise PEPError("PEP is missing its %r" % (current_header,),
+                           pep_file.name)
         except StopIteration:
             pass
         # 'PEP'.
@@ -272,11 +271,10 @@ class PEP(object):
                 else:
                     email = match_dict['email']
                 author_list.append((author, email))
-            else:
-                # If authors were found then stop searching as only expect one
-                # style of author citation.
-                if author_list:
-                    break
+            # If authors were found then stop searching as only expect one
+            # style of author citation.
+            if author_list:
+                break
         return author_list
 
     @property


### PR DESCRIPTION
This '`while`' statement has a redundant '`else`' as no '`break`' is present in the body.
This '`for`' statement has a redundant '`else`' as no '`break`' is present in the body.

Fixes two of these LGTM.com warnings:
https://lgtm.com/projects/g/python/peps/?severity=warning

While the existing code is correct and runs without errors, I did find the `else:` doesn't help understand the logic of the code. But then this is mainly a question of tastes and habits, so feel free to disregard this issue.