### PR TITLE
A couple pep2html.py issues

### DIFF
--- a/pep2html.py
+++ b/pep2html.py
@@ -52,7 +52,7 @@ except ImportError:
 
 from docutils import core, nodes, utils
 from docutils.readers import standalone
-from docutils.transforms import peps, references, misc, frontmatter, Transform
+from docutils.transforms import peps, frontmatter, Transform
 from docutils.parsers import rst
 
 class DataError(Exception):

--- a/pep2html.py
+++ b/pep2html.py
@@ -538,7 +538,7 @@ def make_html(inpath, verbose=0):
                               % (inpath, pep_type)), file=sys.stderr)
         sys.stdout.flush()
         return None
-    elif PEP_TYPE_DISPATCH[pep_type] == None:
+    elif PEP_TYPE_DISPATCH[pep_type] is None:
         pep_type_error(inpath, pep_type)
         return None
     outpath = os.path.splitext(inpath)[0] + ".html"


### PR DESCRIPTION
Fixes a couple LGTM.com recommendations:
https://lgtm.com/projects/g/python/peps/?severity=recommendation

The "Testing equality to None" commit relates to [PEP 0290](https://github.com/python/peps/blob/master/pep-0290.txt) (_Code Migration and Modernization_):
> Since there is only one None object, equality can be tested with identity. Identity tests are slightly faster than equality tests. Also, some object types may overload comparison, so equality testing may be much slower.
> 
> Pattern::
> ```
> if v == None  -->  if v is None:
> if v != None  -->  if v is not None:
> ```

Anyway, the existing code runs without errors, there is no need to fix this other than "modernization" of the code.
