### PR TITLE
PEP 0316: Modernize code: `== None` -> `is None`

### DIFF
--- a/pep-0316.txt
+++ b/pep-0316.txt
@@ -298,7 +298,7 @@ A somewhat contrived example::
            Returns None if no message is available.
 
            pre: self.is_open() # we must have an open connection
-           post: __return__ == None or isinstance(__return__, Message)
+           post: __return__ is None or isinstance(__return__, Message)
            """
 
     class ComplexMailClient(SimpleMailClient):


### PR DESCRIPTION
Change inspired by [PEP 0290](https://github.com/python/peps/blob/master/pep-0290.txt) (_Code Migration and Modernization_):
> Since there is only one None object, equality can be tested with identity. Identity tests are slightly faster than equality tests. Also, some object types may overload comparison, so equality testing may be much slower.
> 
> Pattern::
> ```
> if v == None  -->  if v is None:
> if v != None  -->  if v is not None:
> ```

The existing code runs without errors, there is no need to fix this other than "modernization" of the code.