### PR TITLE
PEP 0426: Fix LGTM.com recommendation: Unused local variable

### DIFF
--- a/pep-0426/pepsort.py
+++ b/pep-0426/pepsort.py
@@ -146,7 +146,6 @@ class Analysis:
         ]
 
         sort_key = SORT_KEYS[pepno]
-        sort_failures = 0
         for i, (pname, versions) in enumerate(projects.items()):
             if i % 100 == 0:
                 sys.stderr.write('%s / %s\r' % (i, num_projects))


### PR DESCRIPTION
The value assigned to local variable `sort_failures` is never used.

Fixes one of these LGTM.com recommendations:
https://lgtm.com/projects/g/python/peps/?severity=recommendation