### PR TITLE
PEP561: Clarify stub-only namespace package behavior

### DIFF
--- a/pep-0561.rst
+++ b/pep-0561.rst
@@ -156,6 +156,28 @@ in pip 9.0, if you update ``flyingcircus-stubs``, it will update
 ``--upgrade-strategy=only-if-needed`` flag. In pip 10.0 this is the default
 behavior.
 
+For namespace packages (see PEP 420), stub-only packages should
+use the ``-stubs`` suffix on only the root namespace package.
+All stub-only namespace packages should omit ``__init__.pyi`` files. ``py.typed``
+marker files are not necessary for stub-only packages, but similarly
+to inline packages, if used, they should be in submodules of the namespace to
+avoid conflicts and for clarity.
+
+For example, if the ``pentagon`` and ``hexagon`` are separate distributions
+installing within the namespace package ``shapes.polygon``
+The corresponding types-only distributions should produce packages
+laid out as follows::
+
+    shapes-stubs
+    └── polygons
+        └── pentagon
+            └── __init__.pyi
+
+    shapes-stubs
+    └── polygons
+        └── hexagon
+            └── __init__.pyi
+
 
 Type Checker Module Resolution Order
 ------------------------------------
@@ -179,6 +201,11 @@ resolve modules containing type information:
 
 5. Typeshed (if used) - Provides the stdlib types and several third party
    libraries.
+
+If typecheckers identify a stub-only namespace package without the desired module
+in step 3, they should continue to step 4/5. Typecheckers should identify namespace packages
+by the absence of ``__init__.pyi``.  This allows different subpackages to
+independently opt for inline vs stub-only.
 
 Type checkers that check a different Python version than the version they run
 on MUST find the type information in the ``site-packages``/``dist-packages``
@@ -235,6 +262,10 @@ Vlasovskikh, Nathaniel Smith, and Guido van Rossum.
 
 Version History
 ===============
+
+* 2021-09-20
+
+    * Clarify expectations and typechecker behavior for stub-only namespace packages
 
 * 2018-07-09
 


### PR DESCRIPTION
Clarify requirements on authors of stub-only packages within namespace packages, as well as requirements for type checkers handling such packages.