### PR TITLE
PEP 563: Correct references to 3.10 default adoption

### DIFF
--- a/pep-0563.rst
+++ b/pep-0563.rst
@@ -85,7 +85,7 @@ aforementioned PEPs should be considered deprecated.
 Implementation
 ==============
 
-In Python 3.10, function and variable annotations will no longer be
+With this PEP, function and variable annotations will no longer be
 evaluated at definition time.  Instead, a string form will be preserved
 in the respective ``__annotations__`` dictionary.  Static type checkers
 will see no difference in behavior, whereas tools using annotations at
@@ -283,8 +283,8 @@ Deprecation policy
 Starting with Python 3.7, a ``__future__`` import is required to use the
 described functionality.  No warnings are raised.
 
-In Python 3.10 this will become the default behavior.  Use of annotations
-incompatible with this PEP is no longer supported.
+This is projected to become the default behavior starting in Python 3.11 or
+later. Use of annotations incompatible with this PEP is no longer supported.
 
 
 Forward References

--- a/pep-0563.rst
+++ b/pep-0563.rst
@@ -25,13 +25,12 @@ This PEP proposes changing function annotations and variable annotations
 so that they are no longer evaluated at function definition time.
 Instead, they are preserved in ``__annotations__`` in string form.
 
-This change is going to be introduced gradually, starting with a new
+This change is being introduced gradually, starting with a
 ``__future__`` import in Python 3.7.
 
 
 Rationale and Goals
 ===================
-
 PEP 3107 added support for arbitrary annotations on parts of a function
 definition.  Just like default values, annotations are evaluated at
 function definition time.  This creates a number of issues for the type
@@ -45,6 +44,8 @@ hinting use case:
   computationally free.
 
 Postponing the evaluation of annotations solves both problems.
+NOTE: PEP 649 proposes an alternative solution to the above issues,
+putting this PEP in danger of being superceded.
 
 Non-goals
 ---------
@@ -283,9 +284,10 @@ Deprecation policy
 Starting with Python 3.7, a ``__future__`` import is required to use the
 described functionality.  No warnings are raised.
 
-This is projected to become the default behavior starting in Python 3.11 or
-later. Use of annotations incompatible with this PEP is no longer supported.
-
+NOTE: Whether this will eventually become the default behavior is currently unclear
+pending decision on PEP 649.  In any case, use of annotations that depend upon
+their eager evaluation is incompatible with both proposals and is no longer
+supported.
 
 Forward References
 ==================

--- a/pep-0563.rst
+++ b/pep-0563.rst
@@ -31,6 +31,7 @@ This change is being introduced gradually, starting with a
 
 Rationale and Goals
 ===================
+
 PEP 3107 added support for arbitrary annotations on parts of a function
 definition.  Just like default values, annotations are evaluated at
 function definition time.  This creates a number of issues for the type


### PR DESCRIPTION
Edited two sentences to reflect that PEP 563 won't be default until at least 3.11 if ever.

Resolves python/peps#2084