### PR TITLE
Fixed typo: 'to reraised -> to reraise'

### DIFF
--- a/pep-0654.rst
+++ b/pep-0654.rst
@@ -58,7 +58,7 @@ together as the stack unwinds. Several real world use cases are listed below.
 * **Multiple user callbacks fail.** Python's ``atexit.register()`` function
   allows users to register functions that are called on system exit. If any of
   them raise exceptions, only the last one is reraised, but it would be better
-  to reraised all of them together (see ``atexit`` documentation [5]_.)
+  to reraise all of them together (see ``atexit`` documentation [5]_.)
   Similarly, the pytest library allows users to register finalizers which
   are executed at teardown. If more than one of these finalizers raises an
   exception, only the first is reported to the user. This can be improved with
@@ -1148,7 +1148,7 @@ the help of the reference implementation [11]_.
 It has the builtin ``ExceptionGroup`` along with the changes to the traceback
 formatting code, in addition to the grammar, compiler and interpreter changes
 required to support ``except*``. ``BaseExceptionGroup`` will be added
-soon. 
+soon.
 
 Two opcodes were added: one implements the exception type match check via
 ``ExceptionGroup.split()``, and the other is used at the end of a ``try-except``
@@ -1280,7 +1280,7 @@ Applying an ``except*`` Clause on One Exception at a Time
 
 We explained above that it is unsafe to execute an ``except`` clause in
 existing code more than once, because the code may not be idempotent.
-We considered doing this in the new ``except*`` clauses, 
+We considered doing this in the new ``except*`` clauses,
 where the backwards compatibility considerations do not exist.
 The idea is to always execute an ``except*`` clause on a single exception,
 possibly executing the same clause multiple times when it matches multiple


### PR DESCRIPTION
<!--

PEP 654: Fixed typo—'to reraised -> to reraise'
-->

This fixes a small typo on line 61; it changes 'to reraised' to 'to reraise'.