### PR TITLE
Fixed typo: 'distunction -> distinction'

### DIFF
--- a/pep-0654.rst
+++ b/pep-0654.rst
@@ -154,7 +154,7 @@ The difference between them is that ``ExceptionGroup`` can only wrap
 exceptions and selects between ``ExceptionGroup`` and ``BaseExceptionGroup``
 makes the choice automatic. In the rest of the document, when we refer to
 an exception group, we mean either an ``ExceptionGroup`` or a
-``BaseExceptionGroup``. When it is necessary to make the distunction, we
+``BaseExceptionGroup``. When it is necessary to make the distinction, we
 use the class name. For brevity, we will use ``ExceptionGroup`` in code
 examples that are relevant to both.
 
@@ -1148,7 +1148,7 @@ the help of the reference implementation [11]_.
 It has the builtin ``ExceptionGroup`` along with the changes to the traceback
 formatting code, in addition to the grammar, compiler and interpreter changes
 required to support ``except*``. ``BaseExceptionGroup`` will be added
-soon. 
+soon.
 
 Two opcodes were added: one implements the exception type match check via
 ``ExceptionGroup.split()``, and the other is used at the end of a ``try-except``
@@ -1280,7 +1280,7 @@ Applying an ``except*`` Clause on One Exception at a Time
 
 We explained above that it is unsafe to execute an ``except`` clause in
 existing code more than once, because the code may not be idempotent.
-We considered doing this in the new ``except*`` clauses, 
+We considered doing this in the new ``except*`` clauses,
 where the backwards compatibility considerations do not exist.
 The idea is to always execute an ``except*`` clause on a single exception,
 possibly executing the same clause multiple times when it matches multiple


### PR DESCRIPTION
<!--

PEP 654: Fixed typo: 'distunction -> distinction'

-->

Fixed a small error on line 157; 'distunction' to 'distinction'.
