### PR TITLE
PEP 0526 clarify comment

### DIFF
--- a/pep-0526.txt
+++ b/pep-0526.txt
@@ -223,7 +223,7 @@ allows one to annotate instance variables that should be initialized
 in ``__init__`` or ``__new__``. The proposed syntax is as follows::
 
   class BasicStarship:
-      captain: str = 'Picard'               # instance variable with default
+      captain: str = 'Picard'               # "instance" variable, but because it has a default appears at class level
       damage: int                           # instance variable without default
       stats: ClassVar[Dict[str, int]] = {}  # class variable
 


### PR DESCRIPTION
The existing comment reads as if a variable with a default is not a class variable, and so contradicts the [python tutorial](https://docs.python.org/3/tutorial/classes.html#class-and-instance-variables)  

This addition hopefully clarifies the comment.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
