### PR TITLE
PEP 619: Python 3.10.0 was released on schedule

### DIFF
--- a/pep-0619.rst
+++ b/pep-0619.rst
@@ -57,9 +57,6 @@ Actual:
 - 3.10.0 beta 4: Saturday, 2021-07-10
 - 3.10.0 candidate 1: Tuesday, 2021-08-03
 - 3.10.0 candidate 2: Tuesday, 2021-09-07
-
-Expected:
-
 - 3.10.0 final: Monday, 2021-10-04
 
 Subsequent bugfix releases every two months.


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3100/
https://discuss.python.org/t/python-3-10-0-is-now-available/10955

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

@pablogsal Thanks for the release and the release stream yesterday!
