### PR TITLE
PEP 636: Fix typo: being --> been

### DIFF
--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -187,7 +187,7 @@ Composing patterns
 
 This is a good moment to step back from the examples and understand how the patterns
 that you have been using are built. Patterns can be nested within each other, and we
-have being doing that implicitly in the examples above.
+have been doing that implicitly in the examples above.
 
 There are some "simple" patterns ("simple" here meaning that they do not contain other
 patterns) that we've seen:


### PR DESCRIPTION
Seen originally at (https://bugs.python.org/issue45370).

Fixing typo `have being doing` to `have been doing`. 

Fixes https://github.com/python/peps/issues/2100