### PR TITLE
PEP 655: Punt to Python 3.11

### DIFF
--- a/pep-0655.rst
+++ b/pep-0655.rst
@@ -8,7 +8,7 @@ Type: Standards Track
 Content-Type: text/x-rst
 Requires: 604
 Created: 30-Jan-2021
-Python-Version: 3.10
+Python-Version: 3.11
 Post-History: 31-Jan-2021, 11-Feb-2021, 20-Feb-2021, 26-Feb-2021
 
 


### PR DESCRIPTION
PEP 655 hasn't made it into Python 3.10. Tentatively update it to Python 3.11 to avoid confusion.
