### PR TITLE
PEP 440: Extend example to clarify 1.dev0 < 1.0.15

### DIFF
--- a/pep-0440.txt
+++ b/pep-0440.txt
@@ -676,6 +676,7 @@ shared prefix, ordering MUST be by the value of the numeric component.
 
 The following example covers many of the possible combinations::
 
+    1.dev0
     1.0.dev456
     1.0a1
     1.0a2.dev456
@@ -693,6 +694,7 @@ The following example covers many of the possible combinations::
     1.0+5
     1.0.post456.dev34
     1.0.post456
+    1.0.15
     1.1.dev1
 
 


### PR DESCRIPTION
    >>> from packaging.version import Version
    >>> Version("1.dev0") > Version("1.0.15")
    False

The way to do version check is suggested by @hugovk.