### PR TITLE
PEP 636: minor grammar fixes

### DIFF
--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -211,7 +211,7 @@ Or patterns
 
 Going back to the adventure game example, you may find that you'd like to have several
 patterns resulting in the same outcome. For example, you might want the commands
-``north`` and ``go north`` be equivalent. You may also desire to have aliases for
+``north`` and ``go north`` to be equivalent. You may also desire to have aliases for
 ``get X``, ``pick up X`` and ``pick X up`` for any X.
 
 The ``|`` symbol in patterns combines them as alternatives. You could for example write::
@@ -253,7 +253,7 @@ version without "go" for brevity)::
 This code is a single branch, and it verifies that the word after "go" is really a
 direction. But the code moving the player around needs to know which one was chosen and
 has no way to do so. What we need is a pattern that behaves like the or pattern but at
-the same time does a capture. We can do so with a **as pattern**::
+the same time does a capture. We can do so with an **as pattern**::
 
    match command.split():
        case ["go", ("north" | "south" | "east" | "west") as direction]:


### PR DESCRIPTION
missing word
a [vowel] -> an [vowel]