### PR TITLE
PEP 636: repeated patterns as enums

### DIFF
--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -262,6 +262,24 @@ the same time does a capture. We can do so with an **as pattern**::
 The as-pattern matches whatever pattern is on its left-hand side, but also binds the
 value to a name.
 
+Common patterns as enums
+------------------------
+
+The most compact way to define a pattern that is used several times is as an enum::
+
+   from enum import Enum
+   class Direction(Enum):
+       north = 1
+       east = 2
+       south = 3
+       west = 4
+
+or equivalently, ``Direction = Enum('Direction', 'north east south west')``, and then::
+
+   match phrase.split():
+       case ['go', Direction() as direction]:
+           ...
+
 Adding conditions to patterns
 -----------------------------
 

--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -276,7 +276,17 @@ The most compact way to define a pattern that is used several times is as an enu
 
 or equivalently, ``Direction = Enum('Direction', 'north east south west')``, and then::
 
-   match phrase.split():
+   directions = {e.name: e for e in Direction}
+   
+   def tokenize(phrase):
+       def classify(word):
+           if word in directions:
+               return directions[word]
+           else:
+               return word
+       return [classify(word) for word in phrase.split()]
+
+   match tokenize(phrase):
        case ['go', Direction() as direction]:
            ...
 


### PR DESCRIPTION
In the previous section we are omitting a repeated pattern for brevity, so here is the perfect place to point out that commonly used patterns may be expressed most compactly as enums.  This is a technique that is not obvious from any other part of the tutorial.

I don't see any natural place to add it to the appendix, and would suggest leaving that unmodified.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
