### PR TITLE
PEP 636: clarify __match_args__ naming

### DIFF
--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -359,7 +359,9 @@ this alternative definition::
 
     class Click:
         __match_args__ = ("position", "button")
-        def __init__(self, position, button):
+        def __init__(self, position_arg, button_arg):
+            self.position = position_arg
+            self.button = button_arg
             ...
 
 The ``__match_args__`` special attribute defines an explicit order for your attributes

--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -360,8 +360,8 @@ this alternative definition::
     class Click:
         __match_args__ = ("position", "button")
         def __init__(self, pos, btn):
-            self.position = position_arg
-            self.button = button_arg
+            self.position = pos
+            self.button = btn
             ...
 
 The ``__match_args__`` special attribute defines an explicit order for your attributes

--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -359,7 +359,7 @@ this alternative definition::
 
     class Click:
         __match_args__ = ("position", "button")
-        def __init__(self, position_arg, button_arg):
+        def __init__(self, pos, btn):
             self.position = position_arg
             self.button = button_arg
             ...


### PR DESCRIPTION
The current example allows the reader to wonder whether the __match_args__ names must match the __init__ args or the class members.  This change explicitly shows that class member names are searched for the __match_args__ items (admittedly at the cost of some clutter).

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
