### PR TITLE
PEP 3119: re: sets, "subclass/superclass" should be "subset/superset"

### DIFF
--- a/pep-3119.txt
+++ b/pep-3119.txt
@@ -542,13 +542,13 @@ type ``frozenset`` derives from ``Set`` and ``Hashable``.
     those three classes is a set though!  Sets have the additional
     invariant that each element occurs only once (as can be determined
     by iteration), and in addition sets define concrete operators that
-    implement the inequality operations as subclass/superclass tests.
+    implement the inequality operations as subset/superset tests.
     In general, the invariants for finite sets in mathematics
     hold. [11]_
 
     Sets with different implementations can be compared safely,
     (usually) efficiently and correctly using the mathematical
-    definitions of the subclass/superclass operations for finite sets.
+    definitions of the subset/supeset operations for finite sets.
     The ordering operations have concrete implementations; subclasses
     may override these for speed but should maintain the semantics.
     Because ``Set`` derives from ``Sized``, ``__eq__`` may take a


### PR DESCRIPTION
re: sets, "subclass/superclass" should be "subset/superset" when referring to the inequality operations on sets.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
