### PR TITLE
Typos found by codespell

### DIFF
--- a/pep-0563.rst
+++ b/pep-0563.rst
@@ -46,7 +46,7 @@ hinting use case:
 
 Postponing the evaluation of annotations solves both problems.
 NOTE: PEP 649 proposes an alternative solution to the above issues,
-putting this PEP in danger of being superceded.
+putting this PEP in danger of being superseded.
 
 Non-goals
 ---------

--- a/pep-0665.rst
+++ b/pep-0665.rst
@@ -291,7 +291,7 @@ native timestamp type). It MUST be recorded using the UTC time zone to
 avoid ambiguity.
 
 If the SOURCE_DATE_EPOCH_ environment variable is set, it MUST be used
-as the timestamp by the locker. This faciliates reproducibility of the
+as the timestamp by the locker. This facilitates reproducibility of the
 lock file itself.
 
 
@@ -538,11 +538,11 @@ The expected algorithm for resolving what to install is:
 #. Install the best-fitting wheel file for each package which
    remains.
 
-What constitues the "best-fitting wheel file" is an open issue.
+What constitutes the "best-fitting wheel file" is an open issue.
 
 Installers MUST support installing into an empty environment.
 Installers MAY support installing into an environment that already
-conatins installed packages (and whatever that would entail).
+contains installed packages (and whatever that would entail).
 
 
 ========================

--- a/pep-0670.rst
+++ b/pep-0670.rst
@@ -155,7 +155,7 @@ slowdown, there should be a good reason to do the conversion. One reason
 can be hiding implementation details.
 
 Using static inline functions in the internal C API is fine: the
-internal C API exposes implemenation details by design and should not be
+internal C API exposes implementation details by design and should not be
 used outside Python.
 
 Cast to PyObject*

--- a/pep-0672.rst
+++ b/pep-0672.rst
@@ -145,7 +145,7 @@ This allows identifiers that look the same to humans, but not to Python.
 For example, all of the following are distinct identifiers:
 
 * ``scope`` (Latin, ASCII-only)
-* ``scоpe`` (wih a Cyrillic ``о``)
+* ``scоpe`` (with a Cyrillic ``о``)
 * ``scοpe`` (with a Greek ``ο``)
 * ``ѕсоре`` (all Cyrillic letters)
 


### PR DESCRIPTION
Fixes a handful typos detected by [codespell](https://github.com/codespell-project/codespell) in a handful PEPs.

See #2073, #1144, #1113, #294 for similar previous PRs.