### PR TITLE
Add configuration for running `codespell` locally

### DIFF
--- a/.codespell/exclude-file.txt
+++ b/.codespell/exclude-file.txt
@@ -1,0 +1,9 @@
+    of scoped seem allright. I still think there is not enough need
+
+    da de dum, hmm, hmm, dum de dum.
+
+    output=`dmesg | grep hda`
+    p2 = Popen(["grep", "hda"], stdin=p1.stdout, stdout=PIPE)
+
+    Error-de_DE=Wenn ist das Nunstück git und Slotermeyer?
+     Ja! Beiherhund das Oder die Virtualenvironment gersput!

--- a/.codespell/ignore-words.txt
+++ b/.codespell/ignore-words.txt
@@ -1,0 +1,17 @@
+adaptee
+ans
+arithmetics
+asend
+ba
+clos
+complies
+crate
+extraversion
+fo
+iif
+nd
+ned
+recuse
+reenable
+therefor
+warmup

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,5 @@
+[codespell]
+skip = ./.git
+ignore-words = .codespell/ignore-words.txt
+exclude-file = .codespell/exclude-file.txt
+uri-ignore-words-list = daa,ist,searchin,theses

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,9 +2,9 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
-    - id: mixed-line-ending
-      name: Normalize mixed line endings
-      args: [--fix=lf]
+      - id: mixed-line-ending
+        name: Normalize mixed line endings
+        args: [--fix=lf]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.8.0
@@ -16,6 +16,13 @@ repos:
       - id: rst-directive-colons
         files: '^pep-\d+\.txt|\.rst$'
         types: [text]
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+        name: Check for common misspellings in text files
+        stages: [manual]
 
   - repo: local
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ lint:
 	pre-commit --version > /dev/null || python3 -m pip install pre-commit
 	pre-commit run --all-files
 
+spellcheck:
+	pre-commit --version > /dev/null || python3 -m pip install pre-commit
+	pre-commit run --all-files --hook-stage manual codespell
+
 # New Sphinx targets:
 
 SPHINX_JOBS=8

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ docutils >= 0.16
 
 # For RSS
 feedgen >= 0.9.0  # For RSS feed
+
+# For catching typos
+codespell

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,3 @@ docutils >= 0.16
 
 # For RSS
 feedgen >= 0.9.0  # For RSS feed
-
-# For catching typos
-codespell


### PR DESCRIPTION
Merely add codespell configuration files, following https://github.com/python/peps/pull/2075#issuecomment-968744828:
* `.codespellrc` is the root configuration file
* `.codespell/ignore-words.txt` list of words that are false positives
* `.codespell/exclude-file.txt` list of lines that contain false positives

Unlike the initial PR #2075, this PR focuses on configuration and does not attempt to add a spelling check to the CI.

A few notes:

* Codespell checks the current directory for a file named [`setup.cfg` or `.codespellrc`](https://github.com/codespell-project/codespell/blob/master/README.rst#using-a-config-file). I have opened https://github.com/codespell-project/codespell/pull/2087, but the request hasn't been accepted yet. In the meantime, in the absence of a `setup.cfg` file, I have added a new hidden configuration file `.codespellrc`

* One of the caveats is the necessity to maintain a list of false positives. There are not too many of them, but contributors might have to add a new false positive to the list from time to time.

* The location of the list of words that are false positives is:
  	`.codespell/ignore_words.txt`

* The location of the list of entire lines that are false positives is:
  	`.codespell/exclude-file.txt`

* Some false positives that appear only in URIs are listed after option `uri-ignore-words-list` in the main configuration file:
  	`.codespellrc`

* The [default dictionaries used by codespell](https://github.com/codespell-project/codespell/blob/c75f778/codespell_lib/_codespell.py#L70) are `clear` and `rare`. While `rare` might catch a few additional typos, it raises a few additional false positives, such as `complies`, `therefor` and `theses`.