### PR TITLE
PEP 508: Fix grammar for 'not in' operator

### DIFF
--- a/pep-0508.txt
+++ b/pep-0508.txt
@@ -491,6 +491,8 @@ A test program - if the grammar is in a string ``grammar``::
         "name; os_name=='a' or os_name=='b' and os_name=='c'",
         # Overriding precedence -> (a or b) and c
         "name; (os_name=='a' or os_name=='b') and os_name=='c'",
+        # Check 'not in' marker_op 
+        "name; os_name not in 'a'",
         ]
 
     def format_full_version(info):

--- a/pep-0508.txt
+++ b/pep-0508.txt
@@ -362,7 +362,7 @@ The complete parsley grammar::
     version_many  = version_one:v1 (wsp* ',' version_one)*:v2 -> [v1] + v2
     versionspec   = ('(' version_many:v ')' ->v) | version_many
     urlspec       = '@' wsp* <URI_reference>
-    marker_op     = version_cmp | (wsp* 'in') | (wsp* 'not' wsp+ 'in')
+    marker_op     = version_cmp | (wsp* 'in') | (wsp* 'not' wsp+ 'in') -> 'not in'
     python_str_c  = (wsp | letter | digit | '(' | ')' | '.' | '{' | '}' |
                      '-' | '_' | '*' | '#' | ':' | ';' | ',' | '/' | '?' |
                      '[' | ']' | '!' | '~' | '`' | '@' | '$' | '%' | '^' |


### PR DESCRIPTION
Fix bug in grammar where the 'not in' operator for 'marker_op' was not properly being parsed. Add test to confirm behavior. 
