### PR TITLE
PEP 613: Loosen class scope restriction of explicit TypeAlias

### DIFF
--- a/pep-0613.rst
+++ b/pep-0613.rst
@@ -97,13 +97,24 @@ Scope Restrictions:
 
 ::
 
+  class Foo:
+    x = ClassName
+    y: TypeAlias = ClassName
+    z: Type[ClassName] = ClassName
+
+Type aliases are valid within class scope, both implicitly (``x``) and
+explicitly (``y``). If the line should be interpreted as a class
+variable, it must be explicitly annotated as (``z``)
+
+::
+
   x = ClassName
   def foo() -> None:
     x = ClassName
 
 The outer ``x`` is a valid type alias, but type checkers must error if the
 inner ``x`` is ever used as a type because type aliases cannot be defined
-inside a nested scope.
+inside of a function.
 This is confusing because the alias declaration rule is not explicit, and because
 a type error will not be thrown on the location of the inner type alias declaration
 but rather on every one of its subsequent use cases.
@@ -116,10 +127,10 @@ but rather on every one of its subsequent use cases.
   def bar() -> None:
     x: TypeAlias = ClassName
 
-With explicit aliases, the outer assignment is still a valid type variable,
-and the inner assignment can either be a valid local variable or a clear error,
-communicating to the author that type aliases cannot be defined inside a nested
-scope.
+With explicit aliases, the outer assignment is still a valid type variable.
+Inside ``foo``, the inner assignment should be interpreted as ``x: Type[ClassName]``.
+Inside ``bar``, the the type checker should a clear error, communicating to the
+author that type aliases cannot be defined inside a function.
 
 
 Specification
@@ -198,6 +209,14 @@ what the runtime value of ``MyType`` is.
 In comparison, the chosen syntax option ``MyType: TypeAlias = int`` is
 appealing because it still sticks with the ``MyType = int`` assignment
 syntax, and adds some information for the type checker purely as an annotation.
+
+
+Version History
+===============
+
+* 2021-11-16
+
+    * Allow TypeAlias inside class scope
 
 
 Copyright

--- a/pep-0613.rst
+++ b/pep-0613.rst
@@ -104,7 +104,7 @@ Scope Restrictions:
 
 Type aliases are valid within class scope, both implicitly (``x``) and
 explicitly (``y``). If the line should be interpreted as a class
-variable, it must be explicitly annotated as (``z``)
+variable, it must be explicitly annotated (``z``).
 
 ::
 
@@ -129,8 +129,8 @@ but rather on every one of its subsequent use cases.
 
 With explicit aliases, the outer assignment is still a valid type variable.
 Inside ``foo``, the inner assignment should be interpreted as ``x: Type[ClassName]``.
-Inside ``bar``, the the type checker should a clear error, communicating to the
-author that type aliases cannot be defined inside a function.
+Inside ``bar``, the type checker should raise a clear error, communicating
+to the author that type aliases cannot be defined inside a function.
 
 
 Specification


### PR DESCRIPTION
Per discussion on typing-sig
https://mail.python.org/archives/list/typing-sig@python.org/thread/CGOO7GPPECGMLFDUDXSSXTRADI4BXYCS/
