### PR TITLE
Don't auto-add inline links to ref section & rm if empty, per #2130

### DIFF
--- a/pep_sphinx_extensions/pep_processor/transforms/pep_footer.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_footer.py
@@ -5,7 +5,6 @@ import subprocess
 from docutils import nodes
 from docutils import transforms
 from docutils.transforms import misc
-from docutils.transforms import references
 
 from pep_sphinx_extensions import config
 
@@ -13,13 +12,8 @@ from pep_sphinx_extensions import config
 class PEPFooter(transforms.Transform):
     """Footer transforms for PEPs.
 
-     - Appends external links to footnotes.
+     - Removes the References section if it is empty when rendered.
      - Creates a link to the (GitHub) source text.
-
-    TargetNotes:
-        Locate the `References` section, insert a placeholder at the end
-        for an external target footnote insertion transform, and schedule
-        the transform to run immediately.
 
     Source Link:
         Create the link to the source file from the document source path,
@@ -36,10 +30,9 @@ class PEPFooter(transforms.Transform):
             return  # not a PEP file, exit early
 
         doc = self.document[0]
-        reference_section = copyright_section = None
+        reference_section = None
 
         # Iterate through sections from the end of the document
-        num_sections = len(doc)
         for i, section in enumerate(reversed(doc)):
             if not isinstance(section, nodes.section):
                 continue
@@ -47,31 +40,12 @@ class PEPFooter(transforms.Transform):
             if "references" in title_words:
                 reference_section = section
                 break
-            elif "copyright" in title_words:
-                copyright_section = num_sections - i - 1
 
-        # Add a references section if we didn't find one
-        if not reference_section:
-            reference_section = nodes.section()
-            reference_section += nodes.title("", "References")
-            self.document.set_id(reference_section)
-            if copyright_section:
-                # Put the new "References" section before "Copyright":
-                doc.insert(copyright_section, reference_section)
-            else:
-                # Put the new "References" section at end of doc:
-                doc.append(reference_section)
-
-        # Add and schedule execution of the TargetNotes transform
-        pending = nodes.pending(references.TargetNotes)
-        reference_section.append(pending)
-        self.document.note_pending(pending, priority=0)
-
-        # If there are no references after TargetNotes has finished, remove the
-        # references section
-        pending = nodes.pending(misc.CallBack, details={"callback": _cleanup_callback})
-        reference_section.append(pending)
-        self.document.note_pending(pending, priority=1)
+        # Remove references section if there are no displayed footnotes
+        if reference_section:
+            pending = nodes.pending(misc.CallBack, details={"callback": _cleanup_callback})
+            reference_section.append(pending)
+            self.document.note_pending(pending, priority=1)
 
         # Add link to source text and last modified date
         if pep_source_path.stem != "pep-0000":
@@ -80,13 +54,13 @@ class PEPFooter(transforms.Transform):
 
 
 def _cleanup_callback(pending: nodes.pending) -> None:
-    """Remove an empty "References" section.
-
-    Called after the `references.TargetNotes` transform is complete.
-
-    """
-    if len(pending.parent) == 2:  # <title> and <pending>
-        pending.parent.parent.remove(pending.parent)
+    """Remove an empty "References" section."""
+    for ref_node in pending.parent:
+        # Don't remove section if has more than title, link targets and pending
+        if not isinstance(
+                ref_node, (nodes.title, nodes.target, nodes.pending)):
+            return
+    pending.parent.parent.remove(pending.parent)
 
 
 def _add_source_link(pep_source_path: Path) -> nodes.paragraph:


### PR DESCRIPTION
First step to implementing #2130 , as agreed with @gvanrossum and the PEP editor team.

When building, don't add redundant footnotes and references entries for URLs that are already directly linked inline. This avoids an unnecessary, potentially confusing footnote for each link, and taking up additional space in the references section for no real benefit, plus simplifies the build code and should improve build time, especially for Sphinx. Furthermore, if the references section is empty (not including now-invisible link targets), remove it, as we did before (but in a more robust manner). This allows past and future PEPs to still use inline references with targets stored in the references section, while avoiding showing a now-empty references section.

These are both implemented for Sphinx and the legacy builder, and I visually inspected a variety of PEPs with various cases with both builders to ensure the desired results were achieved, and there were no obvious side effects from this change.

Following merging this PR, following the plan outlined in #2130 , I'll proceed with one updating the meta-PEP docs in PEP 0, PEP 1 and PEP 12 to reflect the revised policy of using standard reST links (inline or with separate targets) rather than the references section, and follow that with a PR updating the relative handful of references in the other active meta-PEPs, for consistency.