### PR TITLE
[PEP 646] Allow cleanly substituting any tuple type for a TypeVarTuple

### DIFF
--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -272,40 +272,6 @@ To keep this PEP minimal, ``TypeVarTuple`` does not yet support specification of
 We leave the decision of how these arguments should behave to a future PEP, when variadic generics have been tested in the field. As of this PEP, type variable tuples are
 invariant.
 
-Behaviour when Type Parameters are not Specified
-''''''''''''''''''''''''''''''''''''''''''''''''
-
-When a generic class parameterised by a type variable tuple is used without
-any type parameters, it behaves as if its type parameters are '``Any, ...``'
-(an arbitrary number of ``Any``):
-
-::
-
-    def takes_any_array(arr: Array): ...
-
-    x: Array[Height, Width]
-    takes_any_array(x)  # Valid
-    y: Array[Time, Height, Width]
-    takes_any_array(y)  # Also valid
-
-This enables gradual typing: existing functions accepting, for example,
-a plain TensorFlow ``Tensor`` will still be valid even if ``Tensor`` is made
-generic and calling code passes a ``Tensor[Height, Width]``.
-
-This also works in the opposite direction:
-
-::
-
-    def takes_specific_array(arr: Array[Height, Width]): ...
-
-    z: Array
-    takes_specific_array(z)
-
-This way, even if libraries are updated to use types like ``Array[Height, Width]``,
-users of those libraries won't be forced to also apply type annotations to
-all of their code; users still have a choice about what parts of their code
-to type and which parts to not.
-
 Type Variable Tuple Equality
 ''''''''''''''''''''''''''''
 
@@ -597,6 +563,47 @@ to the type variable tuple:
 
     def foo(f: Callable[[int, *Ts, T], Tuple[T, *Ts]]): ...
 
+Behaviour when Type Parameters are not Specified
+''''''''''''''''''''''''''''''''''''''''''''''''
+
+When a generic class parameterised by a type variable tuple is used without
+any type parameters, it behaves as if the type variable tuple was
+substituted with ``Tuple[Any, ...]``:
+
+::
+
+    def takes_any_array(arr: Array): ...
+
+    # equivalent to:
+    def takes_any_array(arr: Array[*Tuple[Any, ...]]): ...
+
+    x: Array[Height, Width]
+    takes_any_array(x)  # Valid
+    y: Array[Time, Height, Width]
+    takes_any_array(y)  # Also valid
+
+This enables gradual typing: existing functions accepting, for example,
+a plain TensorFlow ``Tensor`` will still be valid even if ``Tensor`` is made
+generic and calling code passes a ``Tensor[Height, Width]``.
+
+This also works in the opposite direction:
+
+::
+
+    def takes_specific_array(arr: Array[Height, Width]): ...
+
+    z: Array
+    # equivalent to Array[*Tuple[Any, ...]]
+
+    takes_specific_array(z)
+
+(For details, see the section on `Unpacking an Unbounded Tuple Type`_.)
+
+This way, even if libraries are updated to use types like ``Array[Height, Width]``,
+users of those libraries won't be forced to also apply type annotations to
+all of their code; users still have a choice about what parts of their code
+to type and which parts to not.
+
 Aliases
 -------
 
@@ -638,8 +645,9 @@ tuple in the alias is set empty:
     IntTuple[()]    # Equivalent to Tuple[int]
     NamedArray[()]  # Equivalent to Tuple[str, Array[()]]
 
-If the type parameter list is omitted entirely, the alias is
-compatible with arbitrary type parameters:
+If the type parameter list is omitted entirely, the unspecified type
+variable tuples are treated as ``Tuple[Any, ...]`` (similar to
+`Behaviour when Type Parameters are not Specified`_):
 
 ::
 

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -146,18 +146,20 @@ data type.)
 Specification
 =============
 
-In order to support the above use cases, we introduce ``TypeVarTuple``. This serves as a placeholder not for a single type but for an *arbitrary* number of types, and behaving like a number of ``TypeVar`` instances packed in a ``Tuple``.
+In order to support the above use cases, we introduce
+``TypeVarTuple``. This serves as a placeholder not for a single type
+but for a *tuple* of types.
 
 In addition, we introduce a new use for the star operator: to 'unpack'
-``TypeVarTuple`` instances, in order to access the type variables
-contained in the tuple.
+``TypeVarTuple`` instances and tuple types. Unpacking a
+``TypeVarTuple`` or tuple type is the typing equivalent of unpacking a
+variable or a tuple of values.
 
 Type Variable Tuples
 --------------------
 
 In the same way that a normal type variable is a stand-in for a single type,
-a type variable *tuple* is a stand-in for an arbitrary number of types (zero or
-more) in a flat ordered list.
+a type variable *tuple* is a stand-in for a *tuple* type.
 
 Type variable tuples are created with:
 
@@ -166,6 +168,9 @@ Type variable tuples are created with:
     from typing import TypeVarTuple
 
     Ts = TypeVarTuple('Ts')
+
+Using a Type Variable Tuple in Generic Classes
+''''''''''''''''''''''''''''''''''''''''''''''
 
 Type variable tuples behave like a number of individual type variables packed in a
 ``Tuple``. To understand this, consider the following example:
@@ -198,6 +203,9 @@ and so on:
   Batch = NewType('Batch', int)
   y: Array[Batch, Height, Width] = Array()
   z: Array[Time, Batch, Height, Width] = Array()
+
+Using a Type Variable Tuple in Functions
+''''''''''''''''''''''''''''''''''''''''
 
 Type variable tuples can be used anywhere a normal ``TypeVar`` can.
 This includes class definitions, as shown above, as well as function

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -151,15 +151,16 @@ In order to support the above use cases, we introduce
 but for a *tuple* of types.
 
 In addition, we introduce a new use for the star operator: to 'unpack'
-``TypeVarTuple`` instances and tuple types. Unpacking a
-``TypeVarTuple`` or tuple type is the typing equivalent of unpacking a
-variable or a tuple of values.
+``TypeVarTuple`` instances and tuple types such as ``Tuple[int,
+str]``. Unpacking a ``TypeVarTuple`` or tuple type is the typing
+equivalent of unpacking a variable or a tuple of values.
 
 Type Variable Tuples
 --------------------
 
-In the same way that a normal type variable is a stand-in for a single type,
-a type variable *tuple* is a stand-in for a *tuple* type.
+In the same way that a normal type variable is a stand-in for a single
+type such as ``int``, a type variable *tuple* is a stand-in for a *tuple* type such as
+``Tuple[int, str]``.
 
 Type variable tuples are created with:
 
@@ -169,8 +170,8 @@ Type variable tuples are created with:
 
     Ts = TypeVarTuple('Ts')
 
-Using a Type Variable Tuple in Generic Classes
-''''''''''''''''''''''''''''''''''''''''''''''
+Using Type Variable Tuples in Generic Classes
+'''''''''''''''''''''''''''''''''''''''''''''
 
 Type variable tuples behave like a number of individual type variables packed in a
 ``Tuple``. To understand this, consider the following example:
@@ -204,8 +205,8 @@ and so on:
   y: Array[Batch, Height, Width] = Array()
   z: Array[Time, Batch, Height, Width] = Array()
 
-Using a Type Variable Tuple in Functions
-''''''''''''''''''''''''''''''''''''''''
+Using Type Variable Tuples in Functions
+'''''''''''''''''''''''''''''''''''''''
 
 Type variable tuples can be used anywhere a normal ``TypeVar`` can.
 This includes class definitions, as shown above, as well as function
@@ -315,12 +316,10 @@ As of this PEP, only a single type variable tuple may appear in a type parameter
 
     class Array(Generic[*Ts1, *Ts2]): ...  # Error
 
-Only one unpacking may appear in a tuple:
+The reason is that multiple type variable tuples make it ambiguous
+which parameters get bound to which type variable tuple: ::
 
-::
-
-    x: Tuple[int, *Ts, str, *Ts2]  # Error
-    y: Tuple[int, *Tuple[int, ...], str, *Tuple[str, ...]]  # Error
+    x: Array[int, str, bool]  # Ts1 = ???, Ts2 = ???
 
 Type Concatenation
 ------------------
@@ -361,71 +360,36 @@ Normal ``TypeVar`` instances can also be prefixed and/or suffixed:
     z = prefix_tuple(x=0, y=(True, 'a'))
     # Inferred type of z is Tuple[int, bool, str]
 
-Unpacking a Tuple Type
-----------------------
+Unpacking Tuple Types
+---------------------
 
-We mentioned that a ``TypeVarTuple`` simply stands for a tuple of
-types. Thus, we can cleanly replace any use of a ``TypeVarTuple`` in a
-function signature with a tuple type.
+We mentioned that a ``TypeVarTuple`` stands for a tuple of types.
+Since we can unpack a ``TypeVarTuple``, for consistency, we also
+allow unpacking a tuple type. As we shall see, this also enables a
+number of interesting features.
 
-Unpacking a Concrete Tuple Type
-'''''''''''''''''''''''''''''''
+
+Unpacking Concrete Tuple Types
+''''''''''''''''''''''''''''''
 
 Unpacking a concrete tuple type is analogous to unpacking a tuple of
 values at runtime. ``Tuple[int, *Tuple[bool, bool], str]`` is
-equivalent to ``Tuple[int, bool, bool, str]``. While this is unlikely
-to be useful by itself, we mention it to cleanly specify how we unpack
-a ``TypeVarTuple`` that is substituted by a concrete tuple type:
+equivalent to ``Tuple[int, bool, bool, str]``.
 
-::
-
-    def strip_and_add_float(x: Tuple[int, *Ts, str]) -> Tuple[float, *Ts, float]: ...
-
-When ``strip_and_add_float`` is called with a value that has a concrete
-tuple type, say, ``Tuple[int, bool, bool, str]``, ``Ts`` is bound to
-the concrete tuple ``Tuple[bool, bool]``.
-
-::
-
-    x: Tuple[int, bool, bool, str] = (1, True, False, "hello")
-
-    y = strip_and_add_float(x)
-    # Inferred type of y: Tuple[float, bool, bool, float]
-
-The inferred type is ``Tuple[float, bool, bool, float]`` because
-unpacking ``Tuple[bool, bool]`` in the return type ``Tuple[float, *Ts,
-float]`` gives back ``Tuple[float, bool, bool, float]``.
-
-Unpacking an Unbounded Tuple Type
-'''''''''''''''''''''''''''''''''
+Unpacking Unbounded Tuple Types
+'''''''''''''''''''''''''''''''
 
 Unpacking an unbounded tuple preserves the unbounded tuple as it is.
-``Tuple[int, *Tuple[str, ...], str]`` signifies a tuple
-type where the first element is guaranteed to be of type ``int``, the
-last element is guaranteed to be of type ``str``, and there may be
-zero or more elements of type ``str`` in between. Note that
-``Tuple[*Tuple[int, ...]]`` is equivalent to ``Tuple[int, ...]``.
+That is, ``*Tuple[int, ...]`` remains ``*Tuple[int, ...]``; there's no
+simpler form. This enables us to specify types such as ``Tuple[int,
+*Tuple[str, ...], str]`` - a tuple type where the first element is
+guaranteed to be of type ``int``, the last element is guaranteed to be
+of type ``str``, and the elements in the middle are zero or more
+elements of type ``str``. Note that ``Tuple[*Tuple[int, ...]]`` is
+equivalent to ``Tuple[int, ...]``.
 
-Consider the following functions:
-
-::
-
-    def add_first_last(x: Tuple[*Ts]) -> Tuple[int, *Ts, str]: ...
-
-When ``add_first_last`` is called with a value that has an *unbounded*
-tuple type, say, ``Tuple[str, ...]``, ``Ts`` is bound to the concrete
-tuple ``Tuple[str, ...]`` and substituted in the return type.
-
-::
-
-    x: Tuple[str, ...]
-
-    y = add_first_last(x)
-    # Inferred type of y: Tuple[int, *Tuple[str, ...], str]
-
-
-Unpacking unbounded tuples is useful in function signatures where we
-don't care about the exact elements and do not want to define an
+Unpacking unbounded tuples is also useful in function signatures where
+we don't care about the exact elements and don't want to define an
 unnecessary ``TypeVarTuple``:
 
 ::
@@ -444,25 +408,26 @@ unnecessary ``TypeVarTuple``:
     process_batch_channels(z)  # Error: Expected Channels.
 
 
-We can also pass a ``Tuple[int, ...]`` wherever a ``Tuple[*Ts]`` is
+We can also pass a ``*Tuple[int, ...]`` wherever a ``*Ts`` is
 expected. This is useful when we have particularly dynamic code and
-cannot infer the precise number of dimensions or the precise types for
+cannot state the precise number of dimensions or the precise types for
 each of the dimensions. In those cases, we can smoothly fall back to
 an unbounded tuple:
 
 ::
 
+    y: Array[*Tuple[Any, ...]] = read_from_file()
+
     def expect_variadic_array(
         x: Array[Batch, *Shape]
     ) -> None: ...
+
+    expect_variadic_array(y)  # OK
 
     def expect_precise_array(
         x: Array[Batch, Height, Width, Channels]
     ) -> None: ...
 
-    y: Array[*Tuple[Any, ...]] = read_from_file()
-
-    expect_variadic_array(y)  # OK
     expect_precise_array(y)  # OK
 
 ``Array[*Tuple[Any, ...]]`` stands for an array with an arbitrary
@@ -473,10 +438,23 @@ is bound to ``Tuple[Any, ...]``. In the call to
 ``Width``, and ``Channels`` are all bound to ``Any``.
 
 This allows users to handle dynamic code gracefully while still
-explicitly marking the code as unsafe (by using ``*Tuple[Any, ...]``).
-Otherwise, users would face noisy errors from the type checker every
-time they tried to use the variable ``y``, which would hinder them
-when migrating a legacy code base to use ``TypeVarTuple``.
+explicitly marking the code as unsafe (by using ``y: Array[*Tuple[Any,
+...]]``).  Otherwise, users would face noisy errors from the type
+checker every time they tried to use the variable ``y``, which would
+hinder them when migrating a legacy code base to use ``TypeVarTuple``.
+
+Multiple Unpackings in a Tuple: Not Allowed
+'''''''''''''''''''''''''''''''''''''''''''
+
+As with ``TypeVarTuples``, `only one <Multiple Type Variable Tuples:
+Not Allowed_>`_ unpacking may appear in a tuple:
+
+
+::
+
+    x: Tuple[int, *Ts, str, *Ts2]  # Error
+    y: Tuple[int, *Tuple[int, ...], str, *Tuple[str, ...]]  # Error
+
 
 ``*args`` as a Type Variable Tuple
 ----------------------------------
@@ -508,18 +486,19 @@ or suffixes of the variadic argument list. For example:
 ::
 
     # os.execle takes arguments 'path, arg0, arg1, ..., env'
-    def execle(path: str, *args: *Tuple[*Ts, Mapping[str, str]]) -> None: ...
+    def execle(path: str, *args: *Tuple[*Ts, Env]) -> None: ...
 
-Note this this is different to
+Note that this is different to
 
 ::
 
-    def execle(path: str, *args: *Ts, env: Mapping[str, str]) -> None: ...
+    def execle(path: str, *args: *Ts, env: Env) -> None: ...
 
 as this would make ``env`` a keyword-only argument.
 
-Unpacking an unbounded tuple is equivalent to the PEP 484 behavior of
-``*args: int``, which accepts zero or more values of type ``int``:
+Using an unpacked unbounded tuple is equivalent to the PEP 484
+behavior [#pep-484-args]_ of ``*args: int``, which accepts zero or
+more values of type ``int``:
 
 ::
 
@@ -587,10 +566,10 @@ Type variable tuples can also be used in the arguments section of a
       def __init__(
         self,
         target: Callable[[*Ts], None],
-        args: Tuple[*Ts]
-      ): ...
+        args: Tuple[*Ts],
+      ) -> None: ...
 
-    def func(arg1: int, arg2: str): ...
+    def func(arg1: int, arg2: str) -> None: ...
 
     Process(target=func, args=(0, 'foo'))  # Valid
     Process(target=func, args=('foo', 0))  # Error
@@ -621,7 +600,7 @@ the function:
     def foo(*args: *Tuple[int, *Ts, T]) -> Tuple[T, *Ts]: ...
 
 Behaviour when Type Parameters are not Specified
-''''''''''''''''''''''''''''''''''''''''''''''''
+------------------------------------------------
 
 When a generic class parameterised by a type variable tuple is used without
 any type parameters, it behaves as if the type variable tuple was
@@ -654,7 +633,7 @@ This also works in the opposite direction:
 
     takes_specific_array(z)
 
-(For details, see the section on `Unpacking an Unbounded Tuple Type`_.)
+(For details, see the section on `Unpacking Unbounded Tuple Types`_.)
 
 This way, even if libraries are updated to use types like ``Array[Height, Width]``,
 users of those libraries won't be forced to also apply type annotations to
@@ -729,7 +708,7 @@ Normal ``TypeVar`` instances can also be used in such aliases:
     Foo[str, int]
     # T bound to float, Ts to Tuple[()]
     Foo[float]
-    # T bound to Any, Ts to an arbitrary number of Any
+    # T bound to Any, Ts to an Tuple[Any, ...]
     Foo
 
 Overloads for Accessing Individual Types
@@ -810,8 +789,8 @@ otherwise imply. Also, we may later wish to support arguments that should not be
 
 We therefore settled on ``TypeVarTuple``.
 
-Unspecified Type Parameters: Tuples vs TypeVarTuples
-----------------------------------------------------
+Unspecified Type Parameters: Tuple vs TypeVarTuple
+--------------------------------------------------
 
 In order to support gradual typing, this PEP states that *both*
 of the following examples should type-check correctly:
@@ -1469,6 +1448,8 @@ References
 .. [#stephan-endorsement] https://mail.python.org/archives/list/python-dev@python.org/message/UDM7Y6HLHQBKXQEBIBD5ZLB5XNPDZDXV/
 
 .. [#dan-endorsement] https://mail.python.org/archives/list/python-dev@python.org/message/HTCARTYYCHETAMHB6OVRNR5EW5T2CP4J/
+
+.. [#pep-484-args] https://www.python.org/dev/peps/pep-0484/#arbitrary-argument-lists-and-default-argument-values
 
 Copyright
 =========

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -388,6 +388,123 @@ Normal ``TypeVar`` instances can also be prefixed and/or suffixed:
     z = prefix_tuple(x=0, y=(True, 'a'))
     # Inferred type of z is Tuple[int, bool, str]
 
+Unpacking a Tuple Type
+----------------------
+
+We mentioned that a ``TypeVarTuple`` simply stands for a tuple of
+types. Thus, we can cleanly replace any use of a ``TypeVarTuple`` in a
+function signature with a tuple type.
+
+Unpacking a Concrete Tuple Type
+'''''''''''''''''''''''''''''''
+
+Unpacking a concrete tuple type is analogous to unpacking a tuple of
+values at runtime. ``Tuple[int, *Tuple[bool, bool], str]`` is
+equivalent to ``Tuple[int, bool, bool, str]``. While this is unlikely
+to be useful by itself, we mention it to cleanly specify how we unpack
+a ``TypeVarTuple`` that is substituted by a concrete tuple type:
+
+::
+
+    def strip_and_add_float(x: Tuple[int, *Ts, str]) -> Tuple[float, *Ts, float]: ...
+
+When ``strip_and_add_float`` is called with a value that has a concrete
+tuple type, say, ``Tuple[int, bool, bool, str]``, ``Ts`` is bound to
+the concrete tuple ``Tuple[bool, bool]``.
+
+::
+
+    x: Tuple[int, bool, bool, str] = (1, True, False, "hello")
+
+    y = strip_and_add_float(x)
+    # Inferred type of y: Tuple[float, bool, bool, float]
+
+The inferred type is ``Tuple[float, bool, bool, float]`` because
+unpacking ``Tuple[bool, bool]`` in the return type ``Tuple[float, *Ts,
+float]`` gives back ``Tuple[float, bool, bool, float]``.
+
+Unpacking an Unbounded Tuple Type
+'''''''''''''''''''''''''''''''''
+
+Unpacking an unbounded tuple preserves the unbounded tuple as it is.
+``Tuple[int, *Tuple[str, ...], str]`` signifies a tuple
+type where the first element is guaranteed to be of type ``int``, the
+last element is guaranteed to be of type ``str``, and there may be
+zero or more elements of type ``str`` in between. Note that
+``Tuple[*Tuple[int, ...]]`` is equivalent to ``Tuple[int, ...]``.
+
+Consider the following functions:
+
+::
+
+    def add_first_last(x: Tuple[*Ts]) -> Tuple[int, *Ts, str]: ...
+
+When ``add_first_last`` is called with a value that has an *unbounded*
+tuple type, say, ``Tuple[str, ...]``, ``Ts`` is bound to the concrete
+tuple ``Tuple[str, ...]`` and substituted in the return type.
+
+::
+
+    x: Tuple[str, ...]
+
+    y = add_first_last(x)
+    # Inferred type of y: Tuple[int, *Tuple[str, ...], str]
+
+
+Unpacking unbounded tuples is useful in function signatures where we
+don't care about the exact elements and do not want to define an
+unnecessary ``TypeVarTuple``:
+
+::
+
+    def process_batch_channels(
+        x: Array[Batch, *Tuple[Any, ...], Channels]
+    ) -> None:
+        ...
+
+
+    x: Array[Batch, Height, Width, Channels]
+    process_batch_channels(x)  # OK
+    y: Array[Batch, Channels]
+    process_batch_channels(y)  # OK
+    z: Array[Batch]
+    process_batch_channels(z)  # Error: Expected Channels.
+
+
+We can also pass a ``Tuple[int, ...]`` wherever a ``Tuple[*Ts]`` is
+expected. This is useful when we have particularly dynamic code and
+cannot infer the precise number of dimensions or the precise types for
+each of the dimensions. In those cases, we can smoothly fall back to
+an unbounded tuple:
+
+::
+
+    def expect_variadic_array(
+        x: Array[Batch, *Shape]
+    ) -> None: ...
+
+    def expect_precise_array(
+        x: Array[Batch, Height, Width, Channels]
+    ) -> None: ...
+
+    y: Array[*Tuple[Any, ...]] = read_from_file()
+
+    expect_variadic_array(y)  # OK
+    expect_precise_array(y)  # OK
+
+``Array[*Tuple[Any, ...]]`` stands for an array with an arbitrary
+number of dimensions of type ``Any``. This means that, in the call to
+``expect_variadic_array``, ``Batch`` is bound to ``Any`` and ``Shape``
+is bound to ``Tuple[Any, ...]``. In the call to
+``expect_precise_array``, the variables ``Batch``, ``Height``,
+``Width``, and ``Channels`` are all bound to ``Any``.
+
+This allows users to handle dynamic code gracefully while still
+explicitly marking the code as unsafe (by using ``*Tuple[Any, ...]``).
+Otherwise, users would face noisy errors from the type checker every
+time they tried to use the variable ``y``, which would hinder them
+when migrating a legacy code base to use ``TypeVarTuple``.
+
 ``*args`` as a Type Variable Tuple
 ----------------------------------
 

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -397,7 +397,7 @@ prefixed and/or suffixed:
     b = add_batch_axis(a)      # Inferred type is Array[Batch, Height, Width]
     c = del_batch_axis(b)      # Array[Height, Width]
     d = add_batch_channels(a)  # Array[Batch, Height, Width, Channels]
-    
+
 
 Normal ``TypeVar`` instances can also be prefixed and/or suffixed:
 
@@ -428,7 +428,7 @@ individual arguments become the types in the type variable tuple:
 ::
 
     Ts = TypeVarTuple('Ts')
-    
+
     def args_to_tuple(*args: *Ts) -> Tuple[*Ts]: ...
 
     args_to_tuple(1, 'a')  # Inferred type is Tuple[int, str]
@@ -493,7 +493,7 @@ Type variable tuples can also be used in the arguments section of a
       ): ...
 
     def func(arg1: int, arg2: str): ...
-    
+
     Process(target=func, args=(0, 'foo'))  # Valid
     Process(target=func, args=('foo', 0))  # Error
 
@@ -575,7 +575,7 @@ Normal ``TypeVar`` instances can also be used in such aliases:
     Foo[float]
     # T bound to Any, Ts to an arbitrary number of Any
     Foo
-   
+
 Overloads for Accessing Individual Types
 ----------------------------------------
 
@@ -756,7 +756,7 @@ within square brackets), necessary to support star-unpacking of TypeVarTuples:
 Before:
 
 ::
-    
+
     slices:
         | slice !','
         | ','.slice+ [',']
@@ -764,7 +764,7 @@ Before:
 After:
 
 ::
-    
+
     slices:
         | slice !','
         | ','.(slice | starred_expression)+ [',']
@@ -792,7 +792,7 @@ implementation.
     class TypeVarTuple:
         def __init__(self, name):
             self._name = name
-            self._unpacked = UnpackedTypeVarTuple(name) 
+            self._unpacked = UnpackedTypeVarTuple(name)
         def __iter__(self):
             yield self._unpacked
         def __repr__(self):
@@ -945,7 +945,7 @@ reasons:
   the user is familiar with star-unpacking in other contexts; if the
   user is reading or writing code that uses variadic generics, this seems
   reasonable.)
-  
+
 If even change 1 is thought too significant a change, therefore, it might be
 better for us to reconsider our options before going ahead with this second
 alternative.
@@ -1000,7 +1000,7 @@ We can attach names to each parameter using normal type variables:
     b: Array[Literal[32]]
     matrix_vector_multiply(a, b)
     # Result is Array[Literal[64]]
-    
+
 Note that such names have a purely local scope. That is, the name
 ``K`` is bound to ``Literal[64]`` only within ``matrix_vector_multiply``. To put it another
 way, there's no relationship between the value of ``K`` in different
@@ -1022,7 +1022,7 @@ type operators that enable arithmetic on array shapes - for example:
 ::
 
     def repeat_each_element(x: Array[N]) -> Array[Mul[2, N]]: ...
-    
+
 Such arithmetic type operators would only make sense if names such as ``N`` refer to axis size.
 
 Use Case 2: Specifying Shape Semantics
@@ -1037,16 +1037,16 @@ For example:
 ::
 
     # lib.py
-    
+
     class Batch: pass
     class Time: pass
-    
+
     def make_array() -> Array[Batch, Time]: ...
-    
+
     # user.py
-    
+
     from lib import Batch, Time
-    
+
     # `Batch` and `Time` have the same identity as in `lib`,
     # so must take array as produced by `lib.make_array`
     def use_array(x: Array[Batch, Time]): ...
@@ -1070,17 +1070,17 @@ without knowing the type ahead of time. For example, we can still write:
     N = TypeVar('N')
 
     def matrix_vector_multiply(x: Array[K, N], Array[N]) -> Array[K]: ...
-    
+
 We can then use this with:
-    
+
     class Batch: pass
     class Values: pass
-    
+
     batch_of_values: Array[Batch, Values]
     value_weights: Array[Values]
     matrix_vector_multiply(batch_of_values, value_weights)
     # Result is Array[Batch]
-    
+
 The disadvantages are the inverse of the advantages from use case 1.
 In particular, this approach does not lend itself well to arithmetic
 on axis types: ``Mul[2, Batch]`` would be as meaningless as ``2 * int``.
@@ -1103,7 +1103,7 @@ Consider the following 'normal' code:
 ::
 
     def f(x: int): ...
-   
+
 Note that we have symbols for both the value of the thing (``x``) and the type of
 the thing (``int``). Why can't we do the same with axes? For example, with an imaginary
 syntax, we could write:
@@ -1111,7 +1111,7 @@ syntax, we could write:
 ::
 
     def f(array: Array[TimeValue: TimeType]): ...
-    
+
 This would allow us to access the axis size (say, 32) through the symbol ``TimeValue``
 *and* the type through the symbol ``TypeType``.
 
@@ -1120,7 +1120,7 @@ This might even be possible using existing syntax, through a second level of par
 ::
 
    def f(array: array[TimeValue[TimeType]]): ..
-   
+
 However, we leave exploration of this approach to the future.
 
 Appendix B: Shaped Types vs Named Axes

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -579,7 +579,7 @@ Type variable tuples can also be used in the arguments section of a
     class Process:
       def __init__(
         self,
-        target: Callable[[*Ts], Any],
+        target: Callable[[*Ts], None],
         args: Tuple[*Ts]
       ): ...
 
@@ -596,6 +596,22 @@ to the type variable tuple:
     T = TypeVar('T')
 
     def foo(f: Callable[[int, *Ts, T], Tuple[T, *Ts]]): ...
+
+The behavior of a Callable containing an unpacked item, whether the
+item is a ``TypeVarTuple`` or a tuple type, is to treat the elements
+as if they were the type for ``*args``. So, ``Callable[[*Ts], None]``
+is treated as the type of the function:
+
+::
+
+    def foo(*args: *Ts) -> None: ...
+
+``Callable[[int, *Ts, T], Tuple[T, *Ts]]`` is treated as the type of
+the function:
+
+::
+
+    def foo(*args: *Tuple[int, *Ts, T]) -> Tuple[T, *Ts]: ...
 
 Behaviour when Type Parameters are not Specified
 ''''''''''''''''''''''''''''''''''''''''''''''''

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -490,8 +490,53 @@ individual arguments become the types in the type variable tuple:
 
     args_to_tuple(1, 'a')  # Inferred type is Tuple[int, str]
 
-If no arguments are passed, the type variable tuple behaves like an
-empty tuple, ``Tuple[()]``.
+In the above example, ``Ts`` is bound to ``Tuple[int, str]``. If no
+arguments are passed, the type variable tuple behaves like an empty
+tuple, ``Tuple[()]``.
+
+As usual, we can unpack any tuple types. For example, by using a type
+variable tuple inside a tuple of other types, we can refer to prefixes
+or suffixes of the variadic argument list. For example:
+
+::
+
+    # os.execle takes arguments 'path, arg0, arg1, ..., env'
+    def execle(path: str, *args: *Tuple[*Ts, Mapping[str, str]]) -> None: ...
+
+Note this this is different to
+
+::
+
+    def execle(path: str, *args: *Ts, env: Mapping[str, str]) -> None: ...
+
+as this would make ``env`` a keyword-only argument.
+
+Unpacking an unbounded tuple is equivalent to the PEP 484 behavior of
+``*args: int``, which accepts zero or more values of type ``int``:
+
+::
+
+    def foo(*args: *Tuple[int, ...]) -> None: ...
+
+    # equivalent to:
+    def foo(*args: int) -> None: ...
+
+Unpacking tuple types also allows more precise types for heterogeneous
+``*args``. The following function expects an ``int`` at the beginning,
+zero or more ``str`` values, and a ``str`` at the end:
+
+::
+
+    def foo(*args: *Tuple[int, *Tuple[str, ...], str]) -> None: ...
+
+For completeness, we mention that unpacking a concrete tuple allows us
+to specify ``*args`` of a fixed number of heterogeneous types:
+
+::
+
+    def foo(*args: *Tuple[int, str]) -> None: ...
+
+    foo(1, "hello")  # OK
 
 Note that, in keeping with the rule that type variable tuples must always
 be used unpacked, annotating ``*args`` as being a plain type variable tuple
@@ -513,17 +558,6 @@ all arguments must be a ``Tuple`` parameterised with the same types.
     foo((0,), (1,))    # Valid
     foo((0,), (1, 2))  # Error
     foo((0,), ('1',))  # Error
-
-Following `Type Variable Tuples Must Have Known Length`_, note
-that the following should *not* type-check as valid (even though it is, of
-course, valid at runtime):
-
-::
-
-    def foo(*args: *Ts): ...
-
-    def bar(x: Tuple[int, ...]):
-      foo(*x)  # NOT valid
 
 Finally, note that a type variable tuple may *not* be used as the type of
 ``**kwargs``. (We do not yet know of a use case for this feature, so we prefer

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -306,40 +306,6 @@ users of those libraries won't be forced to also apply type annotations to
 all of their code; users still have a choice about what parts of their code
 to type and which parts to not.
 
-Type Variable Tuples Must Have Known Length
-'''''''''''''''''''''''''''''''''''''''''''
-
-Type variables tuples may not be bound to a type with unknown length.
-That is:
-
-::
-
-    def foo(x: Tuple[*Ts]): ...
-
-    x: Tuple[float, ...]
-    foo(x)  # NOT valid; Ts would be bound to ``Tuple[float, ...]``
-
-If this is confusing - didn't we say that type variable tuples are a stand-in
-for an *arbitrary* number of types? - note the difference between the
-length of the type variable tuple *itself*, and the length of the type it is
-*bound* to. Type variable tuples themselves can be of arbitrary length -
-that is, they can be bound to ``Tuple[int]``, ``Tuple[int, int]``, and
-so on - but the types they are bound to must be of known length -
-that is, ``Tuple[int, int]``, but not ``Tuple[int, ...]``.
-
-Note that, as a result of this rule, omitting the type parameter list is the
-*only* way of instantiating a generic type with an arbitrary number of
-type parameters. (We plan to introduce a more deliberate syntax for this
-case in a future PEP.) For example, an unparameterised ``Array`` may
-*behave* like ``Array[Any, ...]``, but it cannot be instantiated using
-``Array[Any, ...]``, because this would bind its type variable tuple to ``Tuple[Any, ...]``:
-
-::
-
-    x: Array            # Valid
-    y: Array[int, ...]  # Error
-    z: Array[Any, ...]  # Error
-
 Type Variable Tuple Equality
 ''''''''''''''''''''''''''''
 

--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -315,6 +315,13 @@ As of this PEP, only a single type variable tuple may appear in a type parameter
 
     class Array(Generic[*Ts1, *Ts2]): ...  # Error
 
+Only one unpacking may appear in a tuple:
+
+::
+
+    x: Tuple[int, *Ts, str, *Ts2]  # Error
+    y: Tuple[int, *Tuple[int, ...], str, *Tuple[str, ...]]  # Error
+
 Type Concatenation
 ------------------
 
@@ -803,8 +810,8 @@ otherwise imply. Also, we may later wish to support arguments that should not be
 
 We therefore settled on ``TypeVarTuple``.
 
-Behaviour when Type Parameters are not Specified
-------------------------------------------------
+Unspecified Type Parameters: Tuples vs TypeVarTuples
+----------------------------------------------------
 
 In order to support gradual typing, this PEP states that *both*
 of the following examples should type-check correctly:


### PR DESCRIPTION
Our specification implicitly treated it as legal to replace a `TypeVarTuple` with a tuple such as `Tuple[int, str]`. However, we did not mention the natural implications for `*args` or `Callable`. We also did not address the behavior of unbounded tuples.

This led to artificial restrictions (such as "type variable tuples must be of known length").

This PR specifies that, wherever a `Ts` is used, we can legally replace it with `Tuple[int, str]` or `Tuple[int, ...]` or `Tuple[int, *Ts, str]`. Concretely, the following are valid:
+ `*args: *Tuple[int, *Ts, str]`, etc.
+ `Callable[[int, *Ts, str], None]`, etc.
+ `Tuple[int, *Tuple[str, ...]]`, etc.

This replaces #2125 .

cc @mrahtz @gvanrossum 