### PR TITLE
Infra: rename master to main

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   deploy-to-pages:

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Python Enhancement Proposals
 ============================
 
-.. image:: https://travis-ci.org/python/peps.svg?branch=master
-    :target: https://travis-ci.org/python/peps
+.. image:: https://github.com/python/peps/actions/workflows/build.yml/badge.svg
+    :target: https://github.com/python/peps/actions
 
 The PEPs in this repo are published automatically on the web at
 https://www.python.org/dev/peps/.  To learn more about the purpose of
@@ -58,7 +58,7 @@ Generating HTML for python.org
 python.org includes its own helper modules to render PEPs as HTML, with
 suitable links back to the source pages in the version control repository.
 
-These can be found at https://github.com/python/pythondotorg/tree/master/peps
+These can be found at https://github.com/python/pythondotorg/tree/main/peps
 
 When making changes to the PEP management process that may impact python.org's
 rendering pipeline:
@@ -76,7 +76,7 @@ Rendering PEPs with Sphinx
 ==========================
 
 There is a Sphinx-rendered version of the PEPs at https://python.github.io/peps/
-(updated on every push to ``master``)
+(updated on every push to ``main``).
 
 **Warning:** This version is not, and should not be taken to be, a canonical
 source for PEPs whilst it remains in preview (`please report any rendering bugs

--- a/pep_sphinx_extensions/config.py
+++ b/pep_sphinx_extensions/config.py
@@ -2,5 +2,5 @@
 
 pep_stem = "pep-{:0>4}"
 pep_url = f"{pep_stem}.html"
-pep_vcs_url = "https://github.com/python/peps/blob/master/"
-pep_commits_url = "https://github.com/python/peps/commits/master/"
+pep_vcs_url = "https://github.com/python/peps/blob/main/"
+pep_commits_url = "https://github.com/python/peps/commits/main/"

--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -29,7 +29,7 @@
             <h2>Contents</h2>
             {{ toc }}
             <br />
-            <strong><a href="https://github.com/python/peps/blob/master/{{sourcename}}">Page Source (GitHub)</a></strong>
+            <strong><a href="https://github.com/python/peps/blob/main/{{sourcename}}">Page Source (GitHub)</a></strong>
         </nav>
     </section>
     <script src="{{ pathto('_static/doctools.js', resource=True) }}"></script>


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->


Follow on for https://github.com/python/peps/issues/1956.

Renames to fix CI and PEP generation, but not in actual PEPs.

Also replace the defunct Travis CI badge with a GitHub Actions one.
