### PR TITLE
PEPs 1, 426, 512, 545, 8001, 8002, 8016: rename master to main

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -221,7 +221,7 @@ The standard PEP workflow is:
 
 Once the review process is complete, and the PEP editors approve it (note that
 this is *not* the same as accepting your PEP!), they will squash commit your
-pull request onto master.
+pull request onto main.
 
 The PEP editors will not unreasonably deny publication of a PEP.  Reasons for
 denying PEP status include duplication of effort, being technically unsound,
@@ -791,7 +791,7 @@ References and Footnotes
 
 .. [6] More details on the PEP rendering and publication process can be found
    in the PEPs repo README at
-   https://github.com/python/peps/blob/master/README.rst
+   https://github.com/python/peps/blob/main/README.rst
 
 .. [7] `CODEOWNERS` documentation
    (https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners)

--- a/pep-0426.txt
+++ b/pep-0426.txt
@@ -658,7 +658,7 @@ A string containing a full URL where the source for this specific version of
 the distribution can be downloaded.
 
 Source URLs MUST be unique within each project. This means that the URL
-can't be something like ``"https://github.com/pypa/pip/archive/master.zip"``,
+can't be something like ``"https://github.com/pypa/pip/archive/main.zip"``,
 but instead must be ``"https://github.com/pypa/pip/archive/1.3.1.zip"``.
 
 The source URL MUST reference either a source archive or a tag or specific

--- a/pep-0512.txt
+++ b/pep-0512.txt
@@ -739,7 +739,7 @@ Required:
   - Message #python-dev for each commit (PR or direct)
     (https://github.com/python/cpython/settings/hooks/new?service=irc)
   - Get docs built from git
-    (https://github.com/python/docsbuild-scripts/blob/master/build_docs.py already
+    (https://github.com/python/docsbuild-scripts/blob/main/build_docs.py already
     updated; https://github.com/python/psf-salt/pull/91 to switch)
   - Migrate buildbots to be triggered and pull from GitHub
 

--- a/pep-0545.txt
+++ b/pep-0545.txt
@@ -115,7 +115,7 @@ The three currently stable branches that will be translated are [12]_:
 branches needs to be modified to support translation [12]_, whereas
 these branches now only accept security-only fixes.
 
-The development branch (master) should have a lower translation priority
+The development branch (main) should have a lower translation priority
 than stable branches.  But docsbuild-scripts should build it anyway so
 it is possible for a team to work on it to be ready for the next
 release.

--- a/pep-8001.rst
+++ b/pep-8001.rst
@@ -156,13 +156,13 @@ Description of the poll::
 
 Candidates (note: linebreaks are significant here)::
 
-    <a href="https://www.python.org/dev/peps/pep-8010/">PEP 8010: The Technical Leader Governance Model</a> (Warsaw) (<a href="https://github.com/python/peps/commits/master/pep-8010.rst">changelog</a>)
-    <a href="https://www.python.org/dev/peps/pep-8011/">PEP 8011: Python Governance Model Lead by Trio of Pythonistas</a> (Mariatta, Warsaw) (<a href="https://github.com/python/peps/commits/master/pep-8011.rst">changelog</a>)
-    <a href="https://www.python.org/dev/peps/pep-8012/">PEP 8012: The Community Governance Model</a> (Langa) (<a href="https://github.com/python/peps/commits/master/pep-8012.rst">changelog</a>)
-    <a href="https://www.python.org/dev/peps/pep-8013/">PEP 8013: The External Council Governance Model</a> (Dower) (<a href="https://github.com/python/peps/commits/master/pep-8013.rst">changelog</a>)
-    <a href="https://www.python.org/dev/peps/pep-8014/">PEP 8014: The Commons Governance Model</a> (Jansen) (<a href="https://github.com/python/peps/commits/master/pep-8014.rst">changelog</a>)
-    <a href="https://www.python.org/dev/peps/pep-8015/">PEP 8015: Organization of the Python community</a> (Stinner) (<a href="https://github.com/python/peps/commits/master/pep-8015.rst">changelog</a>)
-    <a href="https://www.python.org/dev/peps/pep-8016/">PEP 8016: The Steering Council Model</a> (Smith, Stufft) (<a href="https://github.com/python/peps/commits/master/pep-8016.rst">changelog</a>)
+    <a href="https://www.python.org/dev/peps/pep-8010/">PEP 8010: The Technical Leader Governance Model</a> (Warsaw) (<a href="https://github.com/python/peps/commits/main/pep-8010.rst">changelog</a>)
+    <a href="https://www.python.org/dev/peps/pep-8011/">PEP 8011: Python Governance Model Lead by Trio of Pythonistas</a> (Mariatta, Warsaw) (<a href="https://github.com/python/peps/commits/main/pep-8011.rst">changelog</a>)
+    <a href="https://www.python.org/dev/peps/pep-8012/">PEP 8012: The Community Governance Model</a> (Langa) (<a href="https://github.com/python/peps/commits/main/pep-8012.rst">changelog</a>)
+    <a href="https://www.python.org/dev/peps/pep-8013/">PEP 8013: The External Council Governance Model</a> (Dower) (<a href="https://github.com/python/peps/commits/main/pep-8013.rst">changelog</a>)
+    <a href="https://www.python.org/dev/peps/pep-8014/">PEP 8014: The Commons Governance Model</a> (Jansen) (<a href="https://github.com/python/peps/commits/main/pep-8014.rst">changelog</a>)
+    <a href="https://www.python.org/dev/peps/pep-8015/">PEP 8015: Organization of the Python community</a> (Stinner) (<a href="https://github.com/python/peps/commits/main/pep-8015.rst">changelog</a>)
+    <a href="https://www.python.org/dev/peps/pep-8016/">PEP 8016: The Steering Council Model</a> (Smith, Stufft) (<a href="https://github.com/python/peps/commits/main/pep-8016.rst">changelog</a>)
     Further discussion
 
 Options::

--- a/pep-8002.rst
+++ b/pep-8002.rst
@@ -532,7 +532,7 @@ Controversial decision process
 The Technical Board occasionally approves Django
 Enhancement Proposals (DEPs) but those are rare.  The DEP process is
 roughly modeled after PEPs and documented in `DEP 1
-<https://github.com/django/deps/blob/master/final/0001-dep-process.rst>`_.
+<https://github.com/django/deps/blob/main/final/0001-dep-process.rst>`_.
 DEPs are mostly used to design major new features, but also for
 information on general guidelines and process.
 
@@ -594,7 +594,7 @@ TypeScript
 
 The governance structure is not externally documented besides the
 `CONTRIBUTING.md
-<https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md>`_
+<https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md>`_
 document in the main TypeScript repository.
 
 Key people and their functions

--- a/pep-8016.rst
+++ b/pep-8016.rst
@@ -359,7 +359,7 @@ Copyright
 =========
 
 Text copied from Django used under `their license
-<https://github.com/django/django/blob/master/LICENSE>`__. The rest of
+<https://github.com/django/django/blob/main/LICENSE>`__. The rest of
 this document has been placed in the public domain.
 
 


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->


Follow on for https://github.com/python/peps/issues/1956, similar to #2178.

Renames `master` to `main` in some PEPs, for this repo and some references. I've not attempted to rename all, and skipped older ones especially rejected or withdrawn.
