### PR TITLE
PEP 619: Python 3.10.1 was released on 2021-12-06

### DIFF
--- a/pep-0619.rst
+++ b/pep-0619.rst
@@ -64,9 +64,10 @@ Bugfix releases
 
 Actual:
 
+- 3.10.1: Monday, 2021-12-06
+
 Expected:
 
-- 3.10.1: Monday, 2021-12-06
 - 3.10.2: Monday, 2022-02-07
 - 3.10.3: Monday, 2022-04-04
 - 3.10.4: Monday, 2022-06-06


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
