### PR TITLE
PEP 677: Readability and organizational edits

### DIFF
--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -333,7 +333,7 @@ a simple add function looks like this::
 
 Scala and Kotlin use essentially the same ``:`` syntax for return
 annotations.  The ``:`` makes sense in these languages because they
-all use all of these languages use ``:`` for type annotations of
+all use ``:`` for type annotations of
 parameters and variables, and the use for function return types is
 similar.
 

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -28,10 +28,10 @@ Motivation
 ==========
 
 One way to make code safer and easier to analyze is by making sure
-that functions and classes are well-typed. In Python we have type
-annotations defined by PEP 484 to provide type hints that can find
-bugs as well as helping with editor tooling like tab completion,
-static analysis tooling, and code review.
+that functions and classes are well-typed.  In Python we have type
+annotations, the framework for which is defined in PEP 484, to provide
+type hints that can find bugs as well as helping with editor tooling
+like tab completion, static analysis tooling, and code review.
 
 Empirically `we have found
 <https://github.com/pradeep90/annotation_collector#typed-projects---callable-type>`_

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -636,21 +636,33 @@ An idea we looked at very early on was to `allow using functions as types
 <https://docs.google.com/document/d/1rv6CCDnmLIeDrYlXe-QcyT0xNPSYAuO1EBYjU3imU5s/edit?usp=sharing>`_.
 The idea is allowing a function to stand in for its own call
 signature, with roughly the same semantics as the ``__call__`` method
-of callback protocols. Think this may be a great idea and worth its
-own PEP, but that it is not a good alternative to improving the
-usability of callable types:
+of callback protocols::
+```
+def CallableType(
+    positional_only: int,
+    /,
+    named: str,
+    *args: float,
+    keyword_only: int = ...,
+    **kwargs: str)`
+) -> bool: ...
 
-- Using functions as types would not give us a new way of describing
-  function types as first class values. Instead, they would require a
-  function definition statement that effectively defines a type alias
-  (much as a Callable Protocol class statement does).
-- Functions-as-types would support almost exactly the same features
-  that Callable protocols do today: named, optional, and variadic args
-  as well as the ability to define overloads.
 
-Another reason we don't view functions-as-types as a good alternative
-is that it would be difficult to handle ``ParamSpec``, which we
-consider a critical feature to support.
+f: CallableType = ...
+f(5, 6.6, 6.7, named=6, x="hello", y="world")  # typechecks as bool
+````
+
+This may be a good idea, but we do not consider it a viable
+replacement for callable types:
+
+- It would be difficult to handle ``ParamSpec``, which we consider a
+  critical feature to support.
+- When using functions as types, the callable types are not first-class
+  values.  Instead, they require a separate, out-of-line function
+  definition to define a type alias
+- It would not support more features than callback protocols, and seems
+  more like a shorter way to write them than a replacement for
+  ``Callable``.
 
 Parenthesis-Free Syntax
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -33,14 +33,12 @@ annotations, the framework for which is defined in PEP 484, to provide
 type hints that can find bugs as well as helping with editor tooling
 like tab completion, static analysis tooling, and code review.
 
-Empirically `we have found
-<https://github.com/pradeep90/annotation_collector#typed-projects---callable-type>`_
-that it is common for library authors to make use of untyped or
-partially-typed callables (e.g. ``Callable[..., Any]`` or a bare
-``Callable``) which we believe is partially a result of the existing
-types being hard to use. But using this kind of partially-typed
-callable can negate the benefits of static typing.
-
+Possibly as a result, `programmers often fail to write complete
+Callable types
+<https://github.com/pradeep90/annotation_collector#typed-projects---callable-type>`_.
+Such untyped or partially-typed callable types do not check the
+parameter types or return types of the given callable and thus negate
+the benefits of static typing.
 
 For example, consider the following::
 

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -253,6 +253,80 @@ concise and the type representations are visually descriptive::
     ) -> (bool, **P) -> R:
         ...
 
+Comparing to Other Languages
+----------------------------
+
+Many popular programming languages use an arrow syntax similar
+to the one we are proposing here.
+
+TypeScript
+~~~~~~~~~~
+
+In `TypeScript
+<https://basarat.gitbook.io/typescript/type-system/callable#arrow-syntax>`_,
+function types are expressed in a syntax almost the same as the one we
+are proposing, but the arrow token is ``=>`` and arguments have names::
+
+    (x: int, y: str) => bool
+
+The names of the arguments are not actually relevant to the type. So,
+for example, this is the same callable type::
+
+    (a: int, b: str) => bool
+
+Kotlin
+~~~~~~
+
+Function types in `Kotlin <https://kotlinlang.org/docs/lambdas.html>`_ permit
+an identical syntax to the one we are proposing, for example::
+
+    (Int, String) -> Bool
+
+It also optionally allows adding names to the arguments, for example::
+
+    (x: Int, y: String) -> Bool
+
+As in TypeScript, the argument names if provided are just there for documentation
+and are not part of the type itself.
+
+Scala
+~~~~~
+
+`Scala <https://docs.scala-lang.org/tour/higher-order-functions.html>`_
+uses the ``=>`` arrow for function types. Other than that, their syntax is
+the same as the one we are proposing, for example::
+
+    (Int, String) => Bool
+
+Scala, like Python, has the ability to provide function arguments by name.
+Function types can optionally include names, for example::
+
+    (x: Int, y: String) => Bool
+
+Unlike in TypeScript and Kotlin, these names are part of the type if
+provided - any function implementing the type must use the same names.
+This is similar to the extended syntax proposal we described in our
+`Rejected Alternatives`_ section.
+
+The ML Language Family
+~~~~~~~~~~~~~~~~~~~~~~
+
+Languages in the ML family, including `F#
+<https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/fsharp-types#syntax-for-types>`_,
+`OCaml
+<https://www2.ocaml.org/learn/tutorials/basics.html#Defining-a-function>`_,
+and `Haskell <https://wiki.haskell.org/Type_signature>`_, all use
+``->`` to represent function types. All of them use a parentheses-free
+syntax with multiple arrows, for example in Haskell::
+
+    Integer -> String -> Bool
+
+The use of multiple arrows, which differs from our proposal, makes
+sense for languages in this family because they use automatic
+`currying <https://en.wikipedia.org/wiki/Currying>`_ of function arguments,
+which means that a multi-argument function behaves like a single-argument
+function returning a function.
+
 
 Specification
 =============
@@ -826,83 +900,6 @@ led us to the current proposal.
 **Pradeep** `brought this proposal to python-dev
 <https://mail.python.org/archives/list/python-dev@python.org/thread/VBHJOS3LOXGVU6I4FABM6DKHH65GGCUB>`_
 for feedback.
-
-Other Languages
----------------
-
-Many popular programming languages use an arrow syntax similar
-to the one we are proposing here
-
-the same ``->`` arrow token we are proposing here.
-almost identical to the ones we are proposing here
-
-TypeScript
-~~~~~~~~~~
-
-In `TypeScript
-<https://basarat.gitbook.io/typescript/type-system/callable#arrow-syntax>`_,
-function types are expressed in a syntax almost the same as the one we
-are proposing, but the arrow token is ``=>`` and arguments have names::
-
-    (x: int, y: str) => bool
-
-The names of the arguments are not actually relevant to the type. So,
-for example, this is the same callable type::
-
-    (a: int, b: str) => bool
-
-Kotlin
-~~~~~~
-
-Function types in `Kotlin <https://kotlinlang.org/docs/lambdas.html>`_ permit
-an identical syntax to the one we are proposing, for example::
-
-    (Int, String) -> Bool
-
-It also optionally allows adding names to the arguments, for example::
-
-    (x: Int, y: String) -> Bool
-
-As in TypeScript, the argument names if provided are just there for documentation
-and are not part of the type itself.
-
-Scala
-~~~~~
-
-`Scala <https://docs.scala-lang.org/tour/higher-order-functions.html>`_
-uses the ``=>`` arrow for function types. Other than that, their syntax is
-the same as the one we are proposing, for example::
-
-    (Int, String) => Bool
-
-Scala, like Python, has the ability to provide function arguments by name.
-Function types can optionally include names, for example::
-
-    (x: Int, y: String) => Bool
-
-Unlike in TypeScript and Kotlin, these names are part of the type if
-provided - any function implementing the type must use the same names.
-This is similar to the extended syntax proposal we described in our
-`Rejected Alternatives`_ section.
-
-The ML Language Family
-~~~~~~~~~~~~~~~~~~~~~~
-
-Languages in the ML family, including `F#
-<https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/fsharp-types#syntax-for-types>`_,
-`OCaml
-<https://www2.ocaml.org/learn/tutorials/basics.html#Defining-a-function>`_,
-and `Haskell <https://wiki.haskell.org/Type_signature>`_, all use
-``->`` to represent function types. All of them use a parentheses-free
-syntax with multiple arrows, for example in Haskell::
-
-    Integer -> String -> Bool
-
-The use of multiple arrows, which differs from our proposal, makes
-sense for languages in this family because they use automatic
-`currying <https://en.wikipedia.org/wiki/Currying>`_ of function arguments,
-which means that a multi-argument function behaves like a single-argument
-function returning a function.
 
 Acknowledgments
 ---------------

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -164,7 +164,7 @@ using the existing ``typing.Callable``::
     from app_logic import Response, UserSetting
 
 
-    async def customize_response_for_settings(
+    def customize_response(
         response: Response,
         customizer: Callable[[Response, list[UserSetting]], Awaitable[Response]]
     ) -> Response:
@@ -174,7 +174,7 @@ With our proposal, this code can be abbreviated to::
 
     from app_logic import Response, UserSetting
 
-    def make_endpoint(
+    def customize_response(
         response: Response,
         customizer: async (Response, list[UserSetting]) -> Response,
     ) -> Response:
@@ -408,8 +408,9 @@ error::
     (int, ...) -> bool
 
 We decided that there were compelling reasons to do this:
-- The semantics of ``(...) -> bool`` are different from ``(T) ->
-  bool`` for any valid type T: ``(...)`` is a special form indicating
+
+- The semantics of ``(...) -> bool`` are different from ``(T) -> bool``
+  for any valid type T: ``(...)`` is a special form indicating
   ``AnyArguments`` whereas ``T`` is a type parameter in the arguments
   list.
 - ``...`` is used as a placeholder default value to indicate an
@@ -637,20 +638,18 @@ An idea we looked at very early on was to `allow using functions as types
 The idea is allowing a function to stand in for its own call
 signature, with roughly the same semantics as the ``__call__`` method
 of callback protocols::
-```
-def CallableType(
-    positional_only: int,
-    /,
-    named: str,
-    *args: float,
-    keyword_only: int = ...,
-    **kwargs: str)`
-) -> bool: ...
 
+    def CallableType(
+        positional_only: int,
+        /,
+        named: str,
+        *args: float,
+        keyword_only: int = ...,
+        **kwargs: str)`
+    ) -> bool: ...
 
-f: CallableType = ...
-f(5, 6.6, 6.7, named=6, x="hello", y="world")  # typechecks as bool
-````
+    f: CallableType = ...
+    f(5, 6.6, 6.7, named=6, x="hello", y="world")  # typechecks as bool
 
 This may be a good idea, but we do not consider it a viable
 replacement for callable types:

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -67,7 +67,7 @@ If ``flat_map`` were part of a library, this would mean all of the
 users of that library would be forced to find bugs at runtime that
 should have been easy to catch with types.
 
-To get type safety, we can properly type the
+We can properly type the function argument to get type safety::
 
     from typing import Callable
 
@@ -86,6 +86,7 @@ To get type safety, we can properly type the
 
 Now type checkers can catch the problem, but the code is not as easy
 to read as we would like because of a few challenges using ``Callable``:
+
 - It is verbose, particularly for more complex function signatures.
 - It relies on two levels of nested brackets, unlike any other generic
   type. This can be expecially hard to read when some of the type

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -314,6 +314,35 @@ provided - any function implementing the type must use the same names.
 This is similar to the extended syntax proposal we described in our
 `Rejected Alternatives`_ section.
 
+Function Definition vs Callable Type Annotations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In all of the languages listed above, type annotations for function
+definitions use a ``:`` rather than a ``->``. For example, in TypeScript
+a simple add function looks like this::
+
+    function greeter(fn: (a: string) => void) {
+      fn("Hello, World");
+    }
+
+Scala and Kotlin use essentially the same syntax for return annotations.
+
+The ``:`` makes sense for all of these languages because, like Python,
+they all use all of these languages use ``:`` for type annotations of
+parameters and variables, and the use for function return types is
+similar.
+
+In Python, because ``:`` denotes the start of a function body we use a
+different token ``->`` for return annotations, which means that the context
+for our proposal differs from the other languages in that there's potential
+for more confusion when reading function definitions that include callable
+types.
+
+This is a key concern for which we are seeking feedback with our draft
+PEP; one idea we have floated is to use ``=>`` instead to make it easier
+to differentiate.
+
+
 The ML Language Family
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -332,7 +361,6 @@ sense for languages in this family because they use automatic
 `currying <https://en.wikipedia.org/wiki/Currying>`_ of function arguments,
 which means that a multi-argument function behaves like a single-argument
 function returning a function.
-
 
 Specification
 =============

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -27,38 +27,11 @@ work as a drop-in replacement.
 Motivation
 ==========
 
-Describing Callable Signatures with ``typing.Callable``
--------------------------------------------------------
-
 One way to make code safer and easier to analyze is by making sure
 that functions and classes are well-typed. In Python we have type
 annotations defined by PEP 484 to provide type hints that can find
 bugs as well as helping with editor tooling like tab completion,
 static analysis tooling, and code review.
-
-One of the types `defined by PEP 484
-<https://www.python.org/dev/peps/pep-0484/#callable>`_ is
-``typing.Callable``, which describes a callable value such as a
-function or a method. It takes two parameters as inputs but with the
-first parameter being either a placeholder like ``...`` or a list of
-types. For example:
-
-- ``Callable[..., int]`` indicates a function with arbitrary
-  parameters returning an integer.
-- ``Callable[[str, int], bool]`` indicates a function taking two
-  positional parameters of types ``str`` and ``int`` and returning a
-  ``bool``.
-
-Of the types defined by PEP 484, ``typing.Callable`` is the most
-complex because it is the only one that requires two levels of
-brackets in the same type. PEP 612 added ``typing.ParamSpec`` and
-``typing.Concatenate`` to help describe functions that pass ``*args``
-and ``**kwargs`` to callbacks, which is very common with
-decorators. This made ``typing.Callable`` more powerful but also more
-complicated.
-
-Problems with ``typing.Callable``
----------------------------------
 
 Empirically `we have found
 <https://github.com/pradeep90/annotation_collector#typed-projects---callable-type>`_
@@ -66,77 +39,109 @@ that it is common for library authors to make use of untyped or
 partially-typed callables (e.g. ``Callable[..., Any]`` or a bare
 ``Callable``) which we believe is partially a result of the existing
 types being hard to use. But using this kind of partially-typed
-callable can negate the benefits of static typing. For example,
-consider the following code::
+callable can negate the benefits of static typing.
+
+
+For example, consider the following::
 
     from typing import Any, Callable
 
-    def with_retries(
-        f: Callable[..., Any]
-    ) -> Callable[..., Any]:
-        def wrapper(retry_once, *args, **kwargs):
-            if retry_once:
-                try: return f(*args, **kwargs)
-                except Exception: pass
-            return f(*args, **kwargs)
-        return wrapper
 
-    @with_retries
-    def f(x: int) -> int:
-        return x
+    def flat_map(f: Callable[..., Any], l: list[int]) -> list[int]:
+        out = []
+        for element in l:
+            out.extend(f(element))
+        return out
+
+    def f(x: int, y: int) -> int:
+        return y + z
+
+    flat_map(f, [1, 2, 3])  # oops, no type error:
+
+It is clear from the code that the funciton ``flat_map`` is intended
+to accept a single argument as input. But because it uses ``...``
+in place of the arguments list, a typechecker cannot detect that it
+is an error to pass ``f`` to ``flat_map``.
+
+If ``flat_map`` were part of a library, this would mean all of the
+users of that library would be forced to find bugs at runtime that
+should have been easy to catch with types.
+
+To get type safety, we can properly type the
+
+    from typing import Callable
 
 
-    f(True, z=15)
+    def flat_map(f: Callable[[int], list[int]], l: list[int]) -> list[int]:
+        out = []
+        for element in l:
+            out.extend(f(element))
+        return out
 
-The decorator above is clearly not intended to modify the type of the
-function it wraps, but because it uses ``Callable[..., Any]`` it
-accidentally eliminates the annotations on ``f``, and type checkers
-will accept the code above even though it is sure to crash at
-runtime. A correct version of this code would look like this::
+    def f(x: int, y: int) -> int:
+        return y + z
 
-    from typing import Any, Callable, Concatenate, ParamSpec, TypeVar
+    flat_map(f, [1, 2, 3])  # type-checking error!
 
-    R = TypeVar("R")
-    P = ParamSpec("P")
 
-    def with_retries(
-        f: Callable[P, R]
-    ) -> Callable[Concatenate[bool, P] R]:
-        def wrapper(retry_once: bool, *args: P.args, **kwargs: P.kwargs):
-            ...
-        return wrapper
+Now type checkers can catch the problem, but the code is not as easy
+to read as we would like because of a few challenges using ``Callable``:
+- It is verbose, particularly for more complex function signatures.
+- It relies on two levels of nested brackets, unlike any other generic
+  type. This can be expecially hard to read when some of the type
+  parameters are themselves generic types.
+- The bracket structure is not visually similar to how function signatures
+  are written.
+- It requires an explicit import, unlike many of the other most common
+  types like `list`.
+
+With our proposal, the example looks like this::
+
+    def flat_map(f: (int) -> list[int], l: list[int]) -> list[int]:
+        out = []
+        for element in l:
+            out.extend(f(element))
+        return out
 
     ...
 
-With these changes, the incorrect attempt to pass ``z`` to ``f``
-produces a typecheck error as we would like.
+The type ``(int) -> list[int]`` is more concise, uses an arrow similar
+to the one indicating a return type in a function header, avoids
+nested brackets, and does not require an import.
 
-Four usability problems with the way ``typing.Callable`` is
-represented may explain why library authors often do not use its full
-power:
 
-- It is verbose, particularly for more complex function signatures.
-- It does not visually represent the way function headers are written,
-  which can make it harder to learn and use.
-- It requires an explicit import, something we no longer require for
-  most of the other very common types after PEP 604 (``|`` for
-  ``Union`` types) and PEP 585 (generic collections)
-- It relies on two levels of nested square brackets. This can be quite
-  hard to read, especially when the function arguments themselves have
-  square brackets.
+Rationale
+=========
 
-With our proposed syntax, the properly-typed decorator example becomes
-concise and the type representations are visually descriptive::
+The ``Callable`` type is widely used. For example, `as of October 2021
+it was
+<https://github.com/pradeep90/annotation_collector#overall-stats-in-typeshed>`_
+the fifth most common complex type in typeshed, after ``Optional``,
+``Tuple``, ``Union``, and ``List``.
 
-    from typing import Any, ParamSpec, TypeVar
+The others have had their syntax improved and the need for imports
+eliminated by either PEP 604 or PEP 585:
 
-    R = TypeVar("R")
-    P = ParamSpec("P")
+- ``typing.Optional[int]`` is written ``int | None``
+- ``typing.Union[int, str]`` is written ``int | str``
+- ``typing.List[int]`` is written ``list[int]``
+- ``typing.Tuple[int, str]`` is written ``tuple[int, str]``
 
-    def with_retries(
-        f: (**P) -> R
-    ) -> (bool, **P) -> R:
-        ...
+The ``typing.Callable`` type is used almost as often as these other
+types, is more complicated to read and write, and still requires an
+import and bracket-based syntax.
+
+In this proposal, we chose to support all the existing semantics of
+``typing.Callable``, without adding support for new features. We took
+this decision after examining how frequently each feature might be
+used in existing typed and untyped open-source code. We determined
+that the vast majority of use cases are covered.
+
+We considered adding support for named, optional, and variadic
+arguments. However, we decided against including these features, as
+our analysis showed they are infrequently used. When they are really
+needed, it is possible to type these using `callback protocols
+<https://mypy.readthedocs.io/en/stable/protocols.html#callback-protocols>`_.
 
 An Arrow Syntax for Callable Types
 ----------------------------------
@@ -184,33 +189,70 @@ This is shorter and requires fewer imports. It also has far less
 nesting of square brackets - only one level, as opposed to three in
 the original code.
 
-Rationale
-=========
+Compact Syntax for ``ParamSpec``
+--------------------------------
 
-The ``Callable`` type is widely used. For example, `as of October 2021
-it was
-<https://github.com/pradeep90/annotation_collector#overall-stats-in-typeshed>`_
-the fifth most common complex type in typeshed, after ``Optional``,
-``Tuple``, ``Union``, and ``List``.
+A particularly common case where library authors leave off type information
+for callables is when defining decorators. Consider the following::
 
-Most of the other commonly used types have had their syntax improved
-via either PEP 604 or PEP 585. ``Callable`` is used heavily enough to
-similarly justify a more usable syntax.
 
-In this proposal, we chose to support all the existing semantics of
-``typing.Callable``, without adding support for new features. We took
-this decision after examining how frequently each feature might be
-used in existing typed and untyped open-source code. We determined
-that the vast majority of use cases are covered.
+    from typing import Any, Callable
 
-We considered adding support for named, optional, and variadic
-arguments. However, we decided against including these features, as
-our analysis showed they are infrequently used. When they are really
-needed, it is possible to type these using `callback protocols
-<https://mypy.readthedocs.io/en/stable/protocols.html#callback-protocols>`_.
+    def with_retries(
+        f: Callable[..., Any]
+    ) -> Callable[..., Any]:
+        def wrapper(retry_once, *args, **kwargs):
+            if retry_once:
+                try: return f(*args, **kwargs)
+                except Exception: pass
+            return f(*args, **kwargs)
+        return wrapper
 
-See the Rejected Alternatives section for more detailed discussion
-about omitted features.
+    @with_retries
+    def f(x: int) -> int:
+        return x
+
+
+    f(y=10)  # oops - no type error!
+
+In the code above, it is clear that the decorator should produce a
+function whose signature is like that of the argument ``f`` other
+than an additional `with_retries` argument. But the use of ``...``
+prevents a type checker from seeing this and alerting a user that
+``f(y=10)`` is invalid.
+
+
+With PEP 612 it is possible to type decorators like this correctly
+as follows::
+
+    from typing import Any, Callable, Concatenate, ParamSpec, TypeVar
+
+    R = TypeVar("R")
+    P = ParamSpec("P")
+
+    def with_retries(
+        f: Callable[P, R]
+    ) -> Callable[Concatenate[bool, P] R]:
+        def wrapper(retry_once: bool, *args: P.args, **kwargs: P.kwargs):
+            ...
+        return wrapper
+
+    ...
+
+
+With our proposed syntax, the properly-typed decorator example becomes
+concise and the type representations are visually descriptive::
+
+    from typing import Any, ParamSpec, TypeVar
+
+    R = TypeVar("R")
+    P = ParamSpec("P")
+
+    def with_retries(
+        f: (**P) -> R
+    ) -> (bool, **P) -> R:
+        ...
+
 
 Specification
 =============

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -206,7 +206,7 @@ that the vast majority of use cases are covered.
 We considered adding support for named, optional, and variadic
 arguments. However, we decided against including these features, as
 our analysis showed they are infrequently used. When they are really
-needed, it is possible to type these using `Callback Protocols
+needed, it is possible to type these using `callback protocols
 <https://mypy.readthedocs.io/en/stable/protocols.html#callback-protocols>`_.
 
 See the Rejected Alternatives section for more detailed discussion
@@ -257,7 +257,8 @@ same::
 Grammar and AST
 ---------------
 
-The proposed new syntax can be described by these AST changes ::
+The proposed new syntax can be described by these AST changes to `Parser/Python.asdl
+<https://github.com/python/cpython/blob/main/Parser/Python.asdl>`_::
 
     expr = <prexisting_expr_kinds>
          | AsyncCallableType(callable_type_arguments args, expr returns)
@@ -301,8 +302,8 @@ types by modifying the grammar for
 ``callable_type_positional_argument`` as follows::
 
     callable_type_positional_argument:
-        | expression ','
-        | expression &')'
+        | !'...' expression ','
+        | !'...' expression &')'
         | '*' expression ','
         | '*' expression &')'
 
@@ -340,8 +341,8 @@ Because operators bind more tightly than ``->``, parentheses are
 required whenever an arrow type is intended to be inside an argument
 to an operator like ``|``::
 
-    (int) -> bool | () -> bool    # syntax error!
-    (int) -> bool | (() -> bool)  # okay
+    (int) -> () -> int | () -> bool      # syntax error!
+    (int) -> (() -> int) | (() -> bool)  # okay
 
 
 We discussed each of these behaviors and believe they are desirable:
@@ -400,20 +401,28 @@ want a type annotation and ``...`` is a valid expression. This is
 never semantically valid and all type checkers would reject it, but
 the grammar would allow it if we did not explicitly prevent this.
 
-We decided that there were compelling reasons to prevent it: - The
-semantics of ``(...) -> bool`` are different from ``(T) -> bool`` for
-any valid type T: ``(...)`` is a special form indicating
-``AnyArguments`` whereas ``T`` is a type parameter in the arguments
-list.  - ``...`` is used as a placeholder default value to indicate an
-optional argument in stubs and Callback Protocols. Allowing it in the
-position of a type could easily lead to confusion and possibly bugs
-due to typos.
-
 Since ``...`` is meaningless as a type and there are usability
 concerns, our grammar rules it out and the following is a syntax
 error::
 
     (int, ...) -> bool
+
+We decided that there were compelling reasons to do this:
+- The semantics of ``(...) -> bool`` are different from ``(T) ->
+  bool`` for any valid type T: ``(...)`` is a special form indicating
+  ``AnyArguments`` whereas ``T`` is a type parameter in the arguments
+  list.
+- ``...`` is used as a placeholder default value to indicate an
+  optional argument in stubs and callback protocols. Allowing it in
+  the position of a type could easily lead to confusion and possibly
+  bugs due to typos.
+- In the `tuple` generic type, we special-case ``...`` to mean
+  "more of the same", e.g. a ``tuple[int, ...]`` means a tuple with
+  one or more integers. We do not use ``...`` in a a similar way
+  in callable types, so to prevent misunderstandings it makes sense
+  to prevent this.
+
+
 
 Incompatibility with other possible uses of ``*`` and ``**``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -508,7 +517,7 @@ described by the existing ``typing.Callable`` semantics:
 
 Features that other, more complicated proposals would support account
 for fewer than 2% of the use cases we found. These are already
-expressible using Callback Protocols, and since they are uncommon we
+expressible using callback protocols, and since they are uncommon we
 decided that it made more sense to move forward with a simpler syntax.
 
 Extended Syntax Supporting Named and Optional Arguments
@@ -551,16 +560,34 @@ We decided against proposing it for the following reasons:
   community decides after more experience and discussion that we want
   the additional features, they should be straightforward to propose
   in the future.
-- We realized that because of overloads, it is not possible to replace
-  all need for Callback Protocols even with an extended syntax. This
-  makes us prefer proposing a simple solution that handles most use
-  cases well.
+- Even a full extended syntax cannot replace the use of callback
+  protocols for overloads. For example, no closed form of callable type
+  could express a function that maps bools to bools and ints to floats,
+  like this callback protocol.::
+
+    from typing import overload, Protocol
+
+    class OverloadedCallback(Protocol)
+
+      @overload
+      def __call__(self, x: int) -> float: ...
+
+      @overload
+      def __call__(self, x: bool) -> bool: ...
+
+      def __call__(self, x: int | bool) -> float | bool: ...
+
+
+    f: OverloadedCallback = ...
+    f(True)  # bool
+    f(3)     # float
+
+
 
 We confirmed that the current proposal is forward-compatible with
 extended syntax by
 `implementing <https://github.com/stroxler/cpython/tree/callable-type-syntax--extended>`_
-a quick-and-dirty grammar and AST on top of the grammar and AST for
-the current proposal.
+a quick-and-dirty grammar and AST on top of this grammar and AST for.
 
 
 Syntax Closer to Function Signatures
@@ -605,12 +632,11 @@ Other Proposals Considered
 Functions-as-Types
 ~~~~~~~~~~~~~~~~~~
 
-An idea we looked at very early on was to `allow using functions as
-types
+An idea we looked at very early on was to `allow using functions as types
 <https://docs.google.com/document/d/1rv6CCDnmLIeDrYlXe-QcyT0xNPSYAuO1EBYjU3imU5s/edit?usp=sharing>`_.
 The idea is allowing a function to stand in for its own call
 signature, with roughly the same semantics as the ``__call__`` method
-of Callback Protocols. Think this may be a great idea and worth its
+of callback protocols. Think this may be a great idea and worth its
 own PEP, but that it is not a good alternative to improving the
 usability of callable types:
 
@@ -619,7 +645,7 @@ usability of callable types:
   function definition statement that effectively defines a type alias
   (much as a Callable Protocol class statement does).
 - Functions-as-types would support almost exactly the same features
-  that Callable Protocols do today: named, optional, and variadic args
+  that Callable protocols do today: named, optional, and variadic args
   as well as the ability to define overloads.
 
 Another reason we don't view functions-as-types as a good alternative
@@ -797,7 +823,7 @@ the same as the one we are proposing, for example::
     (Int, String) => Bool
 
 Scala, like Python, has the ability to provide function arguments by name.
-Funciton types can optionally include names, for example::
+Function types can optionally include names, for example::
 
     (x: Int, y: String) => Bool
 

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -44,48 +44,37 @@ callable can negate the benefits of static typing.
 
 For example, consider the following::
 
-    from typing import Any, Callable
-
-
-    def flat_map(f: Callable[..., Any], l: list[int]) -> list[int]:
+    def flat_map(l, func):
         out = []
         for element in l:
             out.extend(f(element))
         return out
 
-    def f(x: int, y: int) -> int:
+
+    def f0(x) -> int:
+        return [x]
+
+    def f1(x, y) -> int:
         return y + z
 
-    flat_map(f, [1, 2, 3])  # oops, no type error:
+    flat_map(f0, [1, 2, 3])  # no runtime error, output is [1, 2, 3]
+    flat_map(f1, [1, 2, 3])  # runtime error!
 
-It is clear from the code that the funciton ``flat_map`` is intended
-to accept a single argument as input. But because it uses ``...``
-in place of the arguments list, a typechecker cannot detect that it
-is an error to pass ``f`` to ``flat_map``.
 
-If ``flat_map`` were part of a library, this would mean all of the
-users of that library would be forced to find bugs at runtime that
-should have been easy to catch with types.
-
-We can properly type the function argument to get type safety::
+We can add types to this example to detect the runtime error::
 
     from typing import Callable
 
+    def flat_map(l: list[int], func: Callable[[int], list[int]]):
+        ....
 
-    def flat_map(f: Callable[[int], list[int]], l: list[int]) -> list[int]:
-        out = []
-        for element in l:
-            out.extend(f(element))
-        return out
-
-    def f(x: int, y: int) -> int:
-        return y + z
-
-    flat_map(f, [1, 2, 3])  # type-checking error!
+    ...
 
 
-Now type checkers can catch the problem, but the code is not as easy
-to read as we would like because of a few challenges using ``Callable``:
+    flat_map(f0, [1, 2, 3])  # type checks okay, output is [1, 2, 3]
+    flat_map(f1, [1, 2, 3])  # type check error
+
+There are a few usability challenges with ``Callable`` we can see here:
 
 - It is verbose, particularly for more complex function signatures.
 - It relies on two levels of nested brackets, unlike any other generic
@@ -96,9 +85,25 @@ to read as we would like because of a few challenges using ``Callable``:
 - It requires an explicit import, unlike many of the other most common
   types like `list`.
 
+Possibly as a result of these usability challenges, our stats show
+that it is common for library authors to use ``Callable[..., Any]``
+(or equivalently just ``Callable``), which gives only partial typing
+and hides the error::
+
+    from typing import Callable
+
+    def flat_map(l: list[int], func: Callable[..., Any]):
+        ....
+
+    ...
+
+
+    flat_map(f1, [1, 2, 3])  # no type check error!
+
+
 With our proposal, the example looks like this::
 
-    def flat_map(f: (int) -> list[int], l: list[int]) -> list[int]:
+    def flat_map(l: list[int], func: (int) -> list[int]) -> list[int]:
         out = []
         for element in l:
             out.extend(f(element))

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -51,28 +51,31 @@ For example, consider the following::
         return out
 
 
-    def f0(x) -> int:
+    def wrap(x: int) -> list[int]:
         return [x]
 
-    def f1(x, y) -> int:
-        return y + z
+    def add(x: int, y: int) -> int:
+        return x + y
 
-    flat_map(f0, [1, 2, 3])  # no runtime error, output is [1, 2, 3]
-    flat_map(f1, [1, 2, 3])  # runtime error!
+    flat_map(wrap, [1, 2, 3])  # no runtime error, output is [1, 2, 3]
+    flat_map(add, [1, 2, 3])   # runtime error: `add` expects 2 arguments, got 1
 
 
 We can add types to this example to detect the runtime error::
 
     from typing import Callable
 
-    def flat_map(l: list[int], func: Callable[[int], list[int]]):
+    def flat_map(
+        l: list[int],
+        func: Callable[[int], list[int]]
+    ) -> list[int]:
         ....
 
     ...
 
 
-    flat_map(f0, [1, 2, 3])  # type checks okay, output is [1, 2, 3]
-    flat_map(f1, [1, 2, 3])  # type check error
+    flat_map(wrap, [1, 2, 3])  # type checks okay, output is [1, 2, 3]
+    flat_map(add, [1, 2, 3])   # type check error
 
 There are a few usability challenges with ``Callable`` we can see here:
 
@@ -92,13 +95,16 @@ and hides the error::
 
     from typing import Callable
 
-    def flat_map(l: list[int], func: Callable[..., Any]):
+    def flat_map(
+        l: list[int],
+        func: Callable[..., Any]
+    ) -> list[int]:
         ....
 
     ...
 
 
-    flat_map(f1, [1, 2, 3])  # no type check error!
+    flat_map(add, [1, 2, 3])  # oops, no type check error!
 
 
 With our proposal, the example looks like this::
@@ -321,14 +327,13 @@ In all of the languages listed above, type annotations for function
 definitions use a ``:`` rather than a ``->``. For example, in TypeScript
 a simple add function looks like this::
 
-    function greeter(fn: (a: string) => void) {
-      fn("Hello, World");
+    function higher_order(fn: (a: string) => string): string {
+      return fn("Hello, World");
     }
 
-Scala and Kotlin use essentially the same syntax for return annotations.
-
-The ``:`` makes sense for all of these languages because, like Python,
-they all use all of these languages use ``:`` for type annotations of
+Scala and Kotlin use essentially the same ``:`` syntax for return
+annotations.  The ``:`` makes sense in these languages because they
+all use all of these languages use ``:`` for type annotations of
 parameters and variables, and the use for function return types is
 similar.
 

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -33,14 +33,7 @@ annotations, the framework for which is defined in PEP 484, to provide
 type hints that can find bugs as well as helping with editor tooling
 like tab completion, static analysis tooling, and code review.
 
-Possibly as a result, `programmers often fail to write complete
-Callable types
-<https://github.com/pradeep90/annotation_collector#typed-projects---callable-type>`_.
-Such untyped or partially-typed callable types do not check the
-parameter types or return types of the given callable and thus negate
-the benefits of static typing.
-
-For example, consider the following::
+Consider the following untyped code::
 
     def flat_map(l, func):
         out = []
@@ -86,10 +79,13 @@ There are a few usability challenges with ``Callable`` we can see here:
 - It requires an explicit import, unlike many of the other most common
   types like ``list``.
 
-Possibly as a result of these usability challenges, our stats show
-that it is common for library authors to use ``Callable[..., Any]``
-(or equivalently just ``Callable``), which gives only partial typing
-and hides the error::
+Possibly as a result, `programmers often fail to write complete
+Callable types
+<https://github.com/pradeep90/annotation_collector#typed-projects---callable-type>`_.
+Such untyped or partially-typed callable types do not check the
+parameter types or return types of the given callable and thus negate
+the benefits of static typing. For example, they might write this::
+
 
     from typing import Callable
 
@@ -104,6 +100,9 @@ and hides the error::
 
     flat_map(add, [1, 2, 3])  # oops, no type check error!
 
+There's some partial type information here - we at least know that ``func``
+needs to be callable. But we've dropped too much type information to catch
+the mistake.
 
 With our proposal, the example looks like this::
 

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -83,7 +83,7 @@ There are a few usability challenges with ``Callable`` we can see here:
 - The bracket structure is not visually similar to how function signatures
   are written.
 - It requires an explicit import, unlike many of the other most common
-  types like `list`.
+  types like ``list``.
 
 Possibly as a result of these usability challenges, our stats show
 that it is common for library authors to use ``Callable[..., Any]``
@@ -223,7 +223,7 @@ for callables is when defining decorators. Consider the following::
 
 In the code above, it is clear that the decorator should produce a
 function whose signature is like that of the argument ``f`` other
-than an additional `with_retries` argument. But the use of ``...``
+than an additional ``retry_once`` argument. But the use of ``...``
 prevents a type checker from seeing this and alerting a user that
 ``f(y=10)`` is invalid.
 
@@ -539,7 +539,7 @@ We decided that there were compelling reasons to do this:
   optional argument in stubs and callback protocols. Allowing it in
   the position of a type could easily lead to confusion and possibly
   bugs due to typos.
-- In the `tuple` generic type, we special-case ``...`` to mean
+- In the ``tuple`` generic type, we special-case ``...`` to mean
   "more of the same", e.g. a ``tuple[int, ...]`` means a tuple with
   one or more integers. We do not use ``...`` in a a similar way
   in callable types, so to prevent misunderstandings it makes sense

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -337,11 +337,11 @@ all use ``:`` for type annotations of
 parameters and variables, and the use for function return types is
 similar.
 
-In Python, because ``:`` denotes the start of a function body we use a
-different token ``->`` for return annotations, which means that the context
-for our proposal differs from the other languages in that there's potential
-for more confusion when reading function definitions that include callable
-types.
+In Python we use ``:`` to denote the start of a function body and
+``->`` for return annotations. As a result, even though our proposal
+is superficially the same as these other languages the context is
+different. There is potential for more confusion in Python when
+reading function definitions that include callable types.
 
 This is a key concern for which we are seeking feedback with our draft
 PEP; one idea we have floated is to use ``=>`` instead to make it easier

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -245,7 +245,7 @@ as follows::
     def with_retries(
         f: Callable[P, R]
     ) -> Callable[Concatenate[bool, P] R]:
-        def wrapper(retry_once: bool, *args: P.args, **kwargs: P.kwargs):
+        def wrapper(retry_once: bool, *args: P.args, **kwargs: P.kwargs) -> R:
             ...
         return wrapper
 


### PR DESCRIPTION
Almost nothing material to the proposal itself is changing, the only specification tweak is that we updated the grammar snippet for supporting PEP 646 to include a guard against `'...'`.

All other edits are just for readability:
- fixes for typos and markup issues
- clarifying examples and/or wording
- moving subsections between sections (mainly shrinking "Motivation" and expanding "Rationale")

This closes all open suggestions from review of the initial PR except that:
- I still have a ParamSpec example in Rationale, which may be worth removing
- There's a suggestion to add a `Statistics` subsection to the `Resources` section and I haven't gotten to that yet