### PR TITLE
PEP 673: forbid Self in type aliases.

### DIFF
--- a/pep-0673.rst
+++ b/pep-0673.rst
@@ -605,11 +605,6 @@ The following uses of ``Self`` are accepted:
         # Accepted (treated as an @property returning the Callable type)
         bar: Callable[[Self], int] = foo
 
-    TupleSelf = Tuple[Self, Self]
-    class Alias:
-        def return_tuple(self) -> TupleSelf:
-            return (self, self)
-
     class HasNestedFunction:
         x: int = 42
 
@@ -659,6 +654,20 @@ The following uses of ``Self`` are rejected.
         def bar(self) -> T: ...
 
     class Baz(Foo[Self]): ...  # Rejected
+
+We reject type aliases containing ``Self``. Supporting ``Self``
+outside class definitions can require a lot of special-handling in
+type checkers. Given that it also goes against the rest of the PEP to
+use ``Self`` outside a class definition, we believe the added
+convenience of aliases is not worth it:
+
+::
+
+    TupleSelf = Tuple[Self, Self]  # Rejected
+
+    class Alias:
+        def return_tuple(self) -> TupleSelf:  # Rejected
+            return (self, self)
 
 Note that we reject ``Self`` in staticmethods. ``Self`` does not add much
 value since there is no ``self`` or ``cls`` to return. The only possible use
@@ -781,8 +790,8 @@ Other languages have similar ways to express the type of the enclosing class:
 
 Thanks to the following people for their feedback on the PEP:
 
-Jia Chen, Rebecca Chen, Sergei Lebedev, Kaylynn Morgan, Tuomas Suutari, Alex
-Waygood, Shannon Zhu, and Никита Соболев
+Jia Chen, Rebecca Chen, Sergei Lebedev, Kaylynn Morgan, Tuomas
+Suutari, Eric Traut, Alex Waygood, Shannon Zhu, and Никита Соболев
 
 Copyright
 =========


### PR DESCRIPTION
Thanks to Eric Traut who tested all the code examples in Pyright and
raised implementation concerns about ``Self`` type in aliases.

I ran into implementation issues in Pyre too. This is because Pyre
preprocesses things like ``Self`` in an early phase and does alias
resolution in a later phase. Mixing the two would lead to a lot of
hacks.

@JelleZijlstra I believe you had some concerns about using `Tuple` this way at runtime. Do we need to include them too?

@gobot1234 What do you think? Do you have any workarounds or strong objections? 

Here is our [prior discussion](https://docs.google.com/document/d/1ujuSMXDmSIOJpiZyV7mvBEC8P-y55AgSzXcvhrZciuI/edit?disco=AAAARP_cNZ4) about aliases on the Google Doc. A user had brought up a concern there too that `Self` outside a class would be confusing. Given that Eric pushed back too, I feel we can drop this.

Copy-pasting the discussion for easy reference:

```
Sergei Lebedev
12:44 PM Oct 25
Is it valid to use Self in a type alias?

Gobot1234
1:12 PM Oct 25
Like `alias: TypeAlias = list[Self]` at a top level?

Sergei Lebedev
1:22 PM Oct 25
Yep, or even alias = Self or alias = list[Self] without the TypeAlias annotation.

Gobot1234
1:32 PM Oct 25
Yeah I think both of those should be fine

Sergei Lebedev
1:40 PM Oct 25
I can see how a type checker could support both, but I'm not sure if the PEP should allow that, though, unless we could find a convincing use-case. Wdyt?

Gobot1234
3:07 PM Oct 25
I somewhat agree but I don't really see why allowing apart from Self being sort of unbound and being potentially difficult to implement it would be so bad, some people come up with monstrous types so it might be helpful there and for that use case I'd probably consider it worthwhile.

Sergei Lebedev
8:24 AM Oct 26
Sure, my point was that seeing Self outside of a class body could look confusing, since there is no enclosing class. On a slightly unrelated note, how would a "local" type alias like

class A:
T = Self
x: T

work?

Gobot1234
9:08 AM Oct 26
reveal_type(A().x) revealed type would be Self@__main__.A I would imagine.

Pradeep Kumar Srinivasan
1:09 PM Oct 26
@Sergei Both should be fine, but as you said this can be hard to understand. I've added a simple example.

If there's any pushback from the rest of the community or the other type checkers, we'll drop it since it isn't crucial.
```


