### PR TITLE
Clarify our intent to support PEP 646 Unpack in type checking, not just grammar

### DIFF
--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -450,16 +450,9 @@ Here are our proposed changes to the `Python Grammar
 
 
 If PEP 646 is accepted, we intend to include support for unpacked
-types in two ways.
-
-First we will allow an ``Unpack[Ts]`` operator for both ``Tuple``
-and ``TypeVarTuple`` values ``Ts``. This does not require any grammar
-or runtime changes since these are already valid expressions, but
-type checkers should support ``Unpack``.
-
-Second, to support the "star-for-unpack" syntax proposed in PEP 646,
-we will modify the grammar for ``callable_type_positional_argument``
-as follows::
+types in two ways. To support the "star-for-unpack" syntax proposed in
+PEP 646, we will modify the grammar for
+``callable_type_positional_argument`` as follows::
 
     callable_type_positional_argument:
         | !'...' expression ','
@@ -467,8 +460,16 @@ as follows::
         | '*' expression ','
         | '*' expression &')'
 
-With this change, a type of the form ``(int, *Ts) -> bool`` should be
-treated as equivalent to ``Callable[[int, Unpack[Ts]], bool]``.
+With this change, a type of the form ``(int, *Ts) -> bool`` should
+evaluate the the AST form::
+
+    CallableType(
+        ArgumentsList(Name("int"), Starred(Name("Ts")),
+        Name("bool")
+    )
+
+and be treated by type checkers as equivalent to
+``Callable[[int, Unpack[Ts]], bool]``.
 
 
 Implications of the Grammar

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -457,7 +457,7 @@ and ``TypeVarTuple`` values ``Ts``. This does not require any grammar
 or runtime changes since these are already valid expressions, but
 type checkers should support ``Unpack``.
 
-Moreover, to support the "star-for-unpack" syntax proposed in PEP 646,
+Second, to support the "star-for-unpack" syntax proposed in PEP 646,
 we will modify the grammar for ``callable_type_positional_argument``
 as follows::
 

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -450,8 +450,16 @@ Here are our proposed changes to the `Python Grammar
 
 
 If PEP 646 is accepted, we intend to include support for unpacked
-types by modifying the grammar for
-``callable_type_positional_argument`` as follows::
+types in two ways.
+
+First we will allow an ``Unpack[Ts]`` operator for both ``Tuple``
+and ``TypeVarTuple`` values ``Ts``. This does not require any grammar
+or runtime changes since these are already valid expressions, but
+type checkers should support ``Unpack``.
+
+Moreover, to support the "star-for-unpack" syntax proposed in PEP 646,
+we will modify the grammar for ``callable_type_positional_argument``
+as follows::
 
     callable_type_positional_argument:
         | !'...' expression ','
@@ -459,10 +467,12 @@ types by modifying the grammar for
         | '*' expression ','
         | '*' expression &')'
 
+With this change, a type of the form ``(int, *Ts) -> bool`` should be
+treated as equivalent to ``Callable[[int, Unpack[Ts]], bool]``.
+
 
 Implications of the Grammar
 ---------------------------
-
 
 Precedence of ->
 ~~~~~~~~~~~~~~~~

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -461,7 +461,7 @@ PEP 646, we will modify the grammar for
         | '*' expression &')'
 
 With this change, a type of the form ``(int, *Ts) -> bool`` should
-evaluate the the AST form::
+evaluate the AST form::
 
     CallableType(
         ArgumentsList(Name("int"), Starred(Name("Ts")),


### PR DESCRIPTION
Thanks to Eric Traut for pointing out that we should be clearer
about our intent here and not just give a grammar snippet.