### PR TITLE
PEP 677: Use PEP 646 syntax when discussing unpack

### DIFF
--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -468,8 +468,8 @@ evaluate the AST form::
         Name("bool")
     )
 
-and be treated by type checkers as equivalent to
-``Callable[[int, Unpack[Ts]], bool]``.
+and be treated by type checkers as equivalent to or ``Callable[[int,
+*Ts], bool]`` or ``Callable[[int, Unpack[Ts]], bool]``.
 
 
 Implications of the Grammar


### PR DESCRIPTION
I'd intended to make this update everywhere in an earlier PR, but missed this line.
