### PR TITLE
PEP 677: Remove `async` keyword from proposal

### DIFF
--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -174,13 +174,13 @@ Our goals are that:
 Consider this simplified real-world example from a web server, written
 using the existing ``typing.Callable``::
 
-    from typing import Awaitable, Callable
+    from typing import Callable
     from app_logic import Response, UserSetting
 
 
     def customize_response(
         response: Response,
-        customizer: Callable[[Response, list[UserSetting]], Awaitable[Response]]
+        customizer: Callable[[Response, list[UserSetting]], Response]
     ) -> Response:
        ...
 
@@ -190,7 +190,7 @@ With our proposal, this code can be abbreviated to::
 
     def customize_response(
         response: Response,
-        customizer: async (Response, list[UserSetting]) -> Response,
+        customizer: (Response, list[UserSetting]) -> Response,
     ) -> Response:
         ...
 
@@ -390,20 +390,17 @@ same::
     f2: (...) -> bool
     f2: Callable[..., bool]
 
-    f3: async (str) -> str
-    f3: Callable[[str], Awaitable[str]]
+    f3: (**P) -> bool
+    f3: Callable[P, bool]
 
-    f4: (**P) -> bool
-    f4: Callable[P, bool]
+    f4: (int, **P) -> bool
+    f4: Callable[Concatenate[int, P], bool]
 
-    f5: (int, **P) -> bool
-    f5: Callable[Concatenate[int, P], bool]
+    f5: (*Ts) -> bool
+    f5: Callable[[*Ts], bool]
 
-    f6: (*Ts) -> bool
-    f6: Callable[[*Ts], bool]
-
-    f7: (int, *Ts, str) -> bool
-    f7: Callable[[int, *Ts, str], bool]
+    f6: (int, *Ts, str) -> bool
+    f6: Callable[[int, *Ts, str], bool]
 
 
 Grammar and AST
@@ -413,7 +410,6 @@ The proposed new syntax can be described by these AST changes to `Parser/Python.
 <https://github.com/python/cpython/blob/main/Parser/Python.asdl>`_::
 
     expr = <prexisting_expr_kinds>
-         | AsyncCallableType(callable_type_arguments args, expr returns)
          | CallableType(callable_type_arguments args, expr returns)
 
     callable_type_arguments = AnyArguments
@@ -432,7 +428,6 @@ Here are our proposed changes to the `Python Grammar
 
     callable_type_expression:
         | callable_type_arguments '->' expression
-        | ASYNC callable_type_arguments '->' expression
 
     callable_type_arguments:
         | '(' '...' [','] ')'
@@ -521,21 +516,6 @@ We discussed each of these behaviors and believe they are desirable:
   parentheses, is consistent with other languages like TypeScript and
   respects the principle that valid expressions should normally be
   substitutable when possible.
-
-``async`` Keyword
-~~~~~~~~~~~~~~~~~
-
-All of the binding rules still work for async callable types::
-
-    (int) -> async (float) -> str | bool
-    (int) -> (async (float) -> (str | bool))
-
-    def f() -> async (int, str) -> bool: pass
-    def f() -> (async (int, str) -> bool): pass
-
-    def f() -> async (int) -> async (str) -> bool: pass
-    def f() -> (async (int) -> (async (str) -> bool)): pass
-
 
 Trailing Commas
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
After some discussion, we decided that supporting the `async`
keyword is not an essential part of this proposal. Our reasons
are that
- it adds an additional layer of concern about things like
  operator precedence.
- it creates a situation where there are two ways to write
  every callable type that returns an awaitable: by returning
  an Awatiable or by using the `async` keyword. In function
  definitions this isn't really true because `async` changes
  runtime semantics, but for types it's pure syntactic sugar.
- Awaitable-returning callables are relatively infrequently
  used, at least in typeshed examples we've looked at.


I've updated the reference implementation at https://github.com/stroxler/cpython/tree/callable-type-syntax--shorthand to reflect the updates in this PR.