### PR TITLE
PEP 677: Add Discussions-To and Post-History headers

### DIFF
--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -3,7 +3,7 @@ Title: Callable Type Syntax
 Author: Steven Troxler <steven.troxler@gmail.com>,
         Pradeep Kumar Srinivasan <gohanpra@gmail.com>
 Sponsor: Guido van Rossum <guido at python.org>
-Discussions-To: typing-sig@python.org
+Discussions-To: python-dev@python.org
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -3,12 +3,13 @@ Title: Callable Type Syntax
 Author: Steven Troxler <steven.troxler@gmail.com>,
         Pradeep Kumar Srinivasan <gohanpra@gmail.com>
 Sponsor: Guido van Rossum <guido at python.org>
+Discussions-To: typing-sig@python.org
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 13-Dec-2021
 Python-Version: 3.11
-Post-History:
+Post-History: 16-Dec-2021
 
 Abstract
 ========


### PR DESCRIPTION
It isn't entirely clear whether Discussions-To should be typing-sig or python-dev, but PEPs 604 and 585 have a similar purpose and both say typing-sig so I went with that (especially since neither Pradeep nor I generally follow python-dev)