### PR TITLE
Set low priority for rm-ing refs section so refs still resolve correctly

### DIFF
--- a/pep2html.py
+++ b/pep2html.py
@@ -438,8 +438,8 @@ class PEPHeaders(Transform):
 class PEPFooter(Transform):
     """Remove the References section if it is empty when rendered."""
 
-    # Uses same priority as docutils.transforms.TargetNotes
-    default_priority = 520
+    # Set low priority so ref targets aren't removed before they are needed
+    default_priority = 999
 
     def apply(self):
         pep_source_path = Path(self.document['source'])


### PR DESCRIPTION
As a followup to #2155 (and thus related to #2130 ), this sets a low priority to removing the references section, to fix link references not resolving for some cases on the legacy build system (`pep2html.py`) where the references section gets removed if it would render empty, as apparently otherwise it is removed before it is needed to resolve the refs. Not sure how I didn't catch those cases in testing, but this simple tweak fixes it. Since this breaks proper link resolution on certain PEPs (at least those using multi-layer reference indirection, like [PEP 639](https://www.python.org/dev/peps/pep-0639/)) and fixes a regression, it would be appreciated to merge this promptly. Sorry for not spotting this earlier!

CC: @AA-Turner 