### PR TITLE
PEP 639: Update PEP delegate, post history and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -493,7 +493,7 @@ pep-0635.rst  @brandtbucher @gvanrossum
 pep-0636.rst  @brandtbucher @gvanrossum
 pep-0637.rst  @stevendaprano
 pep-0638.rst  @markshannon
-pep-0639.rst  @pfmoore
+pep-0639.rst  @pfmoore @CAM-Gerlach
 pep-0640.rst  @Yhg1s
 pep-0641.rst  @zooba @warsaw @brettcannon
 pep-0642.rst  @ncoghlan

--- a/pep-0639.rst
+++ b/pep-0639.rst
@@ -5,13 +5,13 @@ Last-Modified: $Date$
 Author: Philippe Ombredanne <pombredanne at nexb.com>,
         C.A.M. Gerlach <CAM.Gerlach at Gerlach.CAM>
 Sponsor: Paul Moore <p.f.moore at gmail.com>
-PEP-Delegate: Paul Moore <p.f.moore at gmail.com>
+PEP-Delegate: Brett Cannon <brett at python.org>
 Discussions-To: https://discuss.python.org/t/12622
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 15-Aug-2019
-Post-History:
+Post-History: 15-Aug-2019, 17-Dec-2021
 Resolution:
 
 

--- a/pep-0639.rst
+++ b/pep-0639.rst
@@ -1396,7 +1396,7 @@ but re-using the ``license`` key for the license expression, either by
 defining it as the (previously reserved) string value for the ``license``
 key, retaining the ``expression`` subkey in the ``license`` table, or
 allowing both. Indeed, this would seem to have been envisioned by PEP 621
-itself with this PEP in mind, in particular the first approach::
+itself with this PEP in mind, in particular the first approach:
 
     A practical string value for the license key has been purposefully left
     out to allow for a future PEP to specify support for SPDX expressions


### PR DESCRIPTION
Update the PEP delegate for PEP 639, pending an approving outcome of [the relevant PyPA committers discussion](https://mail.python.org/archives/list/pypa-committers@python.org/thread/TJXEXQHP7XXYC33I5EXCD3KTHWHX2VVO/). Also updates the post history.