### PR TITLE
Fix refs section removal breaking external links on Sphinx build too

### DIFF
--- a/pep_sphinx_extensions/pep_processor/transforms/pep_footer.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_footer.py
@@ -18,8 +18,8 @@ class PEPFooter(transforms.Transform):
 
     """
 
-    # Uses same priority as docutils.transforms.TargetNotes
-    default_priority = 520
+    # Set low priority so ref targets aren't removed before they are needed
+    default_priority = 999
 
     def apply(self) -> None:
         pep_source_path = Path(self.document["source"])


### PR DESCRIPTION
Followup to #2227 to fix #2155 for the new Sphinx build; I'd previously attempted to reproduce the issue locally on the same PEP and it apparently didn't occur, but I didn't realize I was looking at a stale built file, and it turns out that in fact the same fix is needed. Sorry for the double PR!