### PR TITLE
PEP 677: Format the flat_map example consistently

### DIFF
--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -107,7 +107,10 @@ type checkers to find the bug.
 
 With our proposal, the example looks like this::
 
-    def flat_map(l: list[int], func: (int) -> list[int]) -> list[int]:
+    def flat_map(
+        l: list[int],
+        func: (int) -> list[int],
+    ) -> list[int]:
         out = []
         for element in l:
             out.extend(f(element))


### PR DESCRIPTION
When Pradeep reread the PEP yesterday he noticed that all of `Callable[...]` based versions of `flat_map` are spread across several lines, whereas our demonstration of the new syntax is a one-liner.

Keeping the formatting consistent helps make comparisons apples-to-apples.