### PR TITLE
PEP648: add __file__ global support to __sitecustomize__ exec

### DIFF
--- a/pep-0648.rst
+++ b/pep-0648.rst
@@ -143,8 +143,10 @@ When a ``__sitecustomize__`` directory is discovered, all of the files that
 have a ``.py`` extension within it will be read with ``io.open_code`` and
 executed by using ``exec`` [#exec]_.
 
-An empty dictionary will be passed as ``globals`` to the ``exec`` function
-to prevent unexpected interactions between different files.
+A new dictionary instance will be passed as ``globals`` to each invocation of
+``exec`` to minimize unexpected interactions between different files. The
+``__file__`` global will be set to the currently executing file's path to
+accommodate path-aware customizations.
 
 Failure handling
 ----------------


### PR DESCRIPTION
Propose exposing `__file__` global to `__sitecustomize__` script executions to allow context-aware path hackery (see also [related comment on PoC impl](https://github.com/mariocj89/cpython/commit/3469604d271a659272359f271ac8a7d66008071a#r63781538))

cc @mariocj89 
