### PR TITLE
PEP 677: fix typo in example

### DIFF
--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -39,7 +39,7 @@ Consider the following untyped code::
     def flat_map(l, func):
         out = []
         for element in l:
-            out.extend(f(element))
+            out.extend(func(element))
         return out
 
 


### PR DESCRIPTION
Thanks to Eric Niewland for catching this!
