### PR TITLE
PEP 646: Be more precise about type *parameters* vs type *arguments*

### DIFF
--- a/pep-0646.rst
+++ b/pep-0646.rst
@@ -307,19 +307,55 @@ length, and the type parameters themselves must be identical):
   pointwise_multiply(x, y)  # Error
   pointwise_multiply(x, z)  # Error
 
-Multiple Type Variable Tuples: Not Allowed
-''''''''''''''''''''''''''''''''''''''''''
+Multiple Type Variable Tuples Can Cause Ambiguity
+'''''''''''''''''''''''''''''''''''''''''''''''''
 
-As of this PEP, only a single type variable tuple may appear in a type parameter list:
+In some situations, use of multiple type variable tuples may lead to ambiguity.
+For example:
 
 ::
 
-    class Array(Generic[*Ts1, *Ts2]): ...  # Error
+    class Array(Generic[*Ts1, *Ts2]): ...
+    x: Array[int, str, bool]
 
-The reason is that multiple type variable tuples make it ambiguous
-which parameters get bound to which type variable tuple: ::
+Here, there is no unique assignment of types to type variables. Should we
+assign ``int`` and ``str`` to ``Ts1`` and ``bool`` to ``Ts2``, or should we
+assign ``int`` to ``Ts1`` and ``str`` and ``bool`` to ``Ts2``?
 
-    x: Array[int, str, bool]  # Ts1 = ???, Ts2 = ???
+As a general rule, this PEP disallows uses of type variable tuples that lead
+to such ambiguity.
+
+In particular, we disallow multiple type variable tuples being used in the
+same list of type arguments. This is likely the most common construction
+in which ambiguity may occur:
+
+::
+
+    # Error: multiple uses in type arguments to Generic
+    class Foo(Generic[*Ts1, *Ts2]): ...
+
+    # Error: multiple uses in type arguments to Tuple
+    def bar(x: Tuple[*Ts1, *Ts2]): ...
+
+    # Error: ditto
+    # (Note that in this example, type assignment is unambiguous, but we
+    # still disallow it to keep the rule simple.)
+    def baz(a: Tuple[*Ts1], b: Tuple[*Ts2]) -> Tuple[*Ts1, *Ts2]: ...
+
+    # Fine: multiple instances, but in *different* type argument lists
+    def qux(x: Tuple[*Ts1], y: Tuple[*Ts2]): ...
+
+However, ambiguity may also appear in other constructions:
+
+::
+
+    # Error: multiple instances in different type argument lists,
+    #        but still ambiguous
+    class Child(Parent1[*Ts1], Parent2[*Ts2]): ...
+
+For the sake of brevity, we refrain from enumerating all possible constructions
+which can lead to ambiguity, so remember the general rule: if it leads to
+ambiguity, it's not allowed.
 
 Type Concatenation
 ------------------
@@ -446,8 +482,8 @@ hinder them when migrating a legacy code base to use ``TypeVarTuple``.
 Multiple Unpackings in a Tuple: Not Allowed
 '''''''''''''''''''''''''''''''''''''''''''
 
-As with ``TypeVarTuples``, `only one <Multiple Type Variable Tuples:
-Not Allowed_>`_ unpacking may appear in a tuple:
+As with ``TypeVarTuples``, `only one <Multiple Type Variable Tuples Can Cause
+Ambiguity_>`_ unpacking may appear in a tuple:
 
 
 ::
@@ -673,7 +709,7 @@ or datatype:
     # E.g. Array1D[np.uint8]
     Array1D = Array[DType, Any]
 
-If an explicitly empty type parameter list is given, the type variable
+If an explicitly empty type argument list is given, the type variable
 tuple in the alias is set empty:
 
 ::
@@ -681,7 +717,7 @@ tuple in the alias is set empty:
     IntTuple[()]    # Equivalent to Tuple[int]
     NamedArray[()]  # Equivalent to Tuple[str, Array[()]]
 
-If the type parameter list is omitted entirely, the unspecified type
+If the type argument list is omitted entirely, the unspecified type
 variable tuples are treated as ``Tuple[Any, ...]`` (similar to
 `Behaviour when Type Parameters are not Specified`_):
 
@@ -959,9 +995,17 @@ Second, more than one instance of a star-unpack can occur within an index:
 
     array[*idxs_to_select, *idxs_to_select]  # Equivalent to array[1, 2, 1, 2]
 
-Note that this PEP disallows multiple unpacked TypeVarTuples within a single
-type parameter list. This requirement would therefore need to be implemented
-in type checking tools themselves rather than at the syntax level.
+Note that this PEP disallows multiple unpackings (see `here <Multiple Type
+Variable Tuples Can Cause Ambiguity_>`_ and `here <Multiple Unpackings in a
+Tuple: Not Allowed_>`_ ) within a single type argument list:
+
+::
+
+    Tuple[*Ts1, *Ts2]  # Error
+    Tuple[*Tuple[int, ...], *Tuple[str, ...]]  # Error
+
+This requirement would therefore need to be implemented in type checking tools
+themselves rather than at the syntax level.
 
 Third, slices may co-occur with starred expressions:
 


### PR DESCRIPTION
Based on Kevin's feedback here: https://mail.python.org/archives/list/python-dev@python.org/message/GIPAPKZJUXCEP5U3RILYAEVPJDQUSAGI/

This also touches the section on grammar, which we'll also have to tweak based on the feedback from Petr in the same thread (at https://mail.python.org/archives/list/python-dev@python.org/message/5YLXBCYX4VAGXWFVYLLL5RMTBXCKWPVU/), but I'll do that in a different PR.

@gvanrossum @pradeep90 @kmillikin