### PR TITLE
PEP 673: minor fixes to the code samples

### DIFF
--- a/pep-0673.rst
+++ b/pep-0673.rst
@@ -290,7 +290,7 @@ We propose using ``Self`` directly to achieve the same behavior:
     class Shape:
         def difference(self, other: Self) -> float: ...
 
-        def apply(self, f: Callable[[Self], None]) -> None: …
+        def apply(self, f: Callable[[Self], None]) -> None: ...
 
 Note that specifying ``self: Self`` is harmless, so some users may find it
 more readable to write the above as:
@@ -350,9 +350,8 @@ We propose expressing this constraint using ``next: Self | None``:
 
     @dataclass
     class LinkedList(Generic[T]):
-        next: Self | None = None
         value: T
-
+        next: Self | None = None
 
     @dataclass
     class OrdinalLinkedList(LinkedList[int]):


### PR DESCRIPTION
- Use `...` instead of a unicode ellipsis
- Fix dataclass definition with defaulted before non-defaulted field
