### PR TITLE
Fix function signatures in PEP 677 

### DIFF
--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -36,7 +36,7 @@ like tab completion, static analysis tooling, and code review.
 
 Consider the following untyped code::
 
-    def flat_map(l, func):
+    def flat_map(func, l):
         out = []
         for element in l:
             out.extend(func(element))

--- a/pep-0677.rst
+++ b/pep-0677.rst
@@ -58,8 +58,8 @@ We can add types to this example to detect the runtime error::
     from typing import Callable
 
     def flat_map(
-        l: list[int],
-        func: Callable[[int], list[int]]
+        func: Callable[[int], list[int]],
+        l: list[int]
     ) -> list[int]:
         ....
 
@@ -91,8 +91,8 @@ the benefits of static typing. For example, they might write this::
     from typing import Callable
 
     def flat_map(
-        l: list[int],
-        func: Callable[..., Any]
+        func: Callable[..., Any],
+        l: list[int]
     ) -> list[int]:
         ....
 
@@ -108,8 +108,8 @@ type checkers to find the bug.
 With our proposal, the example looks like this::
 
     def flat_map(
-        l: list[int],
         func: (int) -> list[int],
+        l: list[int]
     ) -> list[int]:
         out = []
         for element in l:


### PR DESCRIPTION
The `flat_map` function is passing the function first in its calls, so the definition should reflect the same.