### PR TITLE
PEP 8: update example of backslash usage for with statements

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -227,8 +227,8 @@ parentheses. These should be used in preference to using a backslash
 for line continuation.
 
 Backslashes may still be appropriate at times.  For example, long,
-multiple ``with``-statements cannot use implicit continuation, so
-backslashes are acceptable::
+multiple ``with``-statements could not use implicit continuation
+before Python 3.10, so backslashes were acceptable for that case::
 
     with open('/path/to/some/file/you/want/to/read') as file_1, \
          open('/path/to/some/file/being/written', 'w') as file_2:


### PR DESCRIPTION
Parentheses are allowed in 3.10, so I did the minimal change to be accurate.
