### PR TITLE
Fix missing quotes around python-dev in overrides causing display bug

### DIFF
--- a/AUTHOR_OVERRIDES.csv
+++ b/AUTHOR_OVERRIDES.csv
@@ -1,5 +1,5 @@
 Overridden Name,Surname First,Name Reference
-The Python core team and community,The Python core team and community,python-dev
+The Python core team and community,"The Python core team and community",python-dev
 Ernest W. Durbin III,"Durbin, Ernest W., III",Durbin
 Greg Ewing,"Ewing, Gregory",Ewing
 Guido van Rossum,"van Rossum, Guido (GvR)",GvR


### PR DESCRIPTION
While all the other rows had them, the line for `python-dev` in `AUTHOR-OVERRIDES.csv` was missing quotes around `Surname First`, which resulted in the author for the relevant PEPs being displayed as `and Community` instead of `python-dev`, as intended. This PR fixes that, which (confirmed by testing) solves the bug.