### PR TITLE
PEP 1: Further refine phrasing and organization of PEP-Delegate description

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -280,16 +280,14 @@ for review yet), the Steering Council may also initiate a PEP review, first
 notifying the PEP author(s) and giving them a chance to make revisions.
 
 The final authority for PEP approval is the Steering Council. However, whenever
-a new PEP is put forward, any core developer that believes they are suitably
+a new PEP is put forward, any core developer who believes they are suitably
 experienced to make the final decision on that PEP may offer to serve as
 the PEP-Delegate for it. If the Steering Council assents to their offer, the
 PEP-Delegate will then have the authority to approve or reject that PEP.
 
 The term "PEP-Delegate" is used under the Steering Council governance model
 for the PEP's designated decision maker,
-and recorded in the "PEP-Delegate" field in the PEP's header.
-For PEPs written prior to the Steering Council governance model, the field name
-"BDFL-Delegate" will still be kept.
+who is recorded in the "PEP-Delegate" field in the PEP's header.
 The term "BDFL-Delegate" is a deprecated alias for PEP-Delegate, a legacy of
 the time when when Python was led by `a BDFL <Python's BDFL_>`_.
 Any legacy references to "BDFL-Delegate" should be treated as equivalent to

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -271,7 +271,7 @@ PEP Review & Resolution
 Once the authors have completed a PEP, they may request a review for
 style and consistency from the PEP editors.
 
-However, content review and final acceptance of the PEP must be requested of the
+However, content review of the PEP must be requested of the
 core developers, usually via an email to the python-dev mailing list.
 
 To expedite the process in selected cases (e.g. when a change is clearly
@@ -282,22 +282,22 @@ notifying the PEP author(s) and giving them a chance to make revisions.
 The final authority for PEP approval is the Steering Council. However, whenever
 a new PEP is put forward, any core developer that believes they are suitably
 experienced to make the final decision on that PEP may offer to serve as
-the PEP-Delegate for that PEP, and they will then have the
-authority to approve (or reject) that PEP.
+the PEP-Delegate for that PEP, and not declined by the Steering Council,
+they will then have the authority to approve or reject that PEP.
 
-The term "PEP-Delegate" is used under the Steering
-Council governance model. The PEP's designated decision maker,
-the "PEP-Delegate" with the Steering Council's support, is
-recorded in the "PEP-Delegate" field in the PEP's header. For
-PEPs written prior to the Steering Council's governance model, the field name
+The term "PEP-Delegate" is used under the Steering Council governance model
+for the PEP's designated decision maker,
+and recorded in the "PEP-Delegate" field in the PEP's header.
+For PEPs written prior to the Steering Council governance model, the field name
 "BDFL-Delegate" will still be kept.
-The terms PEP-Delegate and BDFL-Delegate may be used interchangeably in
-discussion. PEP-Delegate is the preferred term under the Steering Council
-governance model.
+The term "BDFL-Delegate" is a deprecated alias for PEP-Delegate, a legacy of
+the time when when Python was led by `a BDFL <Python's BDFL_>`_.
+Any legacy references to "BDFL-Delegate" should be treated as equivalent to
+"PEP-Delegate".
 
 Individuals offering to serve as PEP-Delegate should notify the Steering
 Council, PEP authors and PEP sponsor of their intent to self-nominate.
-Individuals taking on this responsibility are free to seek
+Those taking on this responsibility are free to seek
 additional guidance from the Steering Council at any time, and are also expected
 to take the advice and perspectives of other core developers into account.
 

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -282,8 +282,8 @@ notifying the PEP author(s) and giving them a chance to make revisions.
 The final authority for PEP approval is the Steering Council. However, whenever
 a new PEP is put forward, any core developer that believes they are suitably
 experienced to make the final decision on that PEP may offer to serve as
-the PEP-Delegate for that PEP, and not declined by the Steering Council,
-they will then have the authority to approve or reject that PEP.
+the PEP-Delegate for it. If the Steering Council assents to their offer, the
+PEP-Delegate will then have the authority to approve or reject that PEP.
 
 The term "PEP-Delegate" is used under the Steering Council governance model
 for the PEP's designated decision maker,


### PR DESCRIPTION
Further refine the PEP 1 phrasing around PEP-delegates, as originally opened as #1445 and further reviewed and merged in #2256 . See my review on #2256 for the rationale behind the specific copyedits (which I've further refined since then).

Also, fixes a related instance where `python-dev` instead of the Steering Council was specified as the final approve of PEPs (I plan to open another issue to discuss also mentioning/linking the PEPs category of the Python Discourse, as well as a few related changes). 