### PR TITLE
PEP 1: Use plain text formatting and fix links

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -739,7 +739,7 @@ Once the PEP is ready for the repository, a PEP editor will:
   ("Standards Track", "Informational", or "Process"), and marked its
   status as "Draft".
 
-* Add the PEP to a local fork of the PEP repository.  For workflow
+* Add the PEP to a local fork of the `PEP repository`_.  For workflow
   instructions, follow `The Python Developers Guide <https://devguide.python.org/>`_
 
   The git repo for the peps is::

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -740,7 +740,7 @@ Once the PEP is ready for the repository, a PEP editor will:
   status as "Draft".
 
 * Add the PEP to a local fork of the PEP repository.  For workflow
-  instructions, follow `The Python Developers Guide <http://docs.python.org/devguide>`_
+  instructions, follow `The Python Developers Guide <https://devguide.python.org/>`_
 
   The git repo for the peps is::
 
@@ -772,15 +772,12 @@ administrative & editorial part (which is generally a low volume task).
 
 Resources:
 
-* `Index of Python Enhancement Proposals <http://www.python.org/dev/peps/>`_
+* `Index of Python Enhancement Proposals <https://www.python.org/dev/peps/>`_
 
 * `Following Python's Development
-  <http://docs.python.org/devguide/communication.html>`_
+  <https://devguide.python.org/communication/>`_
 
-* `Python Developer's Guide <http://docs.python.org/devguide/>`_
-
-* `Frequently Asked Questions for Developers
-  <http://docs.python.org/devguide/faq.html>`_
+* `Python Developer's Guide <https://devguide.python.org/>`_
 
 
 References and Footnotes
@@ -795,16 +792,16 @@ References and Footnotes
    https://github.com/python/peps/blob/main/README.rst
 
 .. [3] `CODEOWNERS` documentation
-   (https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners)
+   (https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
 
 .. _issue tracker:
-   http://bugs.python.org/
+   https://bugs.python.org/
 
 .. _CC0-1.0-Universal: https://choosealicense.com/licenses/cc0-1.0/
 
-.. _reStructuredText: http://docutils.sourceforge.net/rst.html
+.. _reStructuredText: https://docutils.sourceforge.io/rst.html
 
-.. _Docutils: http://docutils.sourceforge.net/
+.. _Docutils: https://docutils.sourceforge.io/
 
 .. _PEP repository: https://github.com/python/peps
 

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -188,7 +188,7 @@ The standard PEP workflow is:
   "Informational", or "Process" as appropriate, and for the "Status:"
   field enter "Draft".  For full details, see `PEP Header Preamble`_.
 
-* Update `.github/CODEOWNERS` [3]_ such that any co-author(s) or sponsors
+* Update `.github/CODEOWNERS`_ such that any co-author(s) or sponsors
   with write access to the `PEP repository`_ are listed for your new file.
   This ensures any future pull requests changing the file will be assigned
   to them.
@@ -710,7 +710,7 @@ For each new PEP that comes in an editor does the following:
 * The file name extension is correct (i.e. ``.rst``).
 
 * Ensure that everyone listed as a sponsor or co-author of the PEP who has write
-  access to the `PEP repository`_ is added to `.github/CODEOWNERS` [3]_.
+  access to the `PEP repository`_ is added to `.github/CODEOWNERS`_.
 
 * Skim the PEP for obvious defects in language (spelling, grammar,
   sentence structure, etc.), and code style (examples should conform to
@@ -791,8 +791,8 @@ References and Footnotes
    in the PEPs repo README at
    https://github.com/python/peps/blob/main/README.rst
 
-.. [3] `CODEOWNERS` documentation
-   (https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
+.. _.github/CODEOWNERS:
+   https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 .. _issue tracker:
    https://bugs.python.org/

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -530,7 +530,9 @@ PEP Header Preamble
 
 Each PEP must begin with an :rfc:`2822` style header preamble.  The headers
 must appear in the following order.  Headers marked with "*" are
-optional and are described below.  All other headers are required. ::
+optional and are described below.  All other headers are required.
+
+.. code-block:: text
 
     PEP: <pep number>
     Title: <pep title>

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -742,10 +742,6 @@ Once the PEP is ready for the repository, a PEP editor will:
 * Add the PEP to a local fork of the `PEP repository`_.  For workflow
   instructions, follow `The Python Developers Guide <https://devguide.python.org/>`_
 
-  The git repo for the peps is::
-
-   https://github.com/python/peps
-
 * Run ``./genpepindex.py`` and ``./pep2html.py <PEP Number>`` to ensure they
   are generated without errors. If either triggers errors, then the web site
   will not be updated to reflect the PEP changes.


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Prep for [PEP 676](https://python.github.io/peps/pep-0676/), which will give syntax highlighting. By default Python formatting is used:

![image](https://user-images.githubusercontent.com/1324225/150679600-d45de74c-fb66-4334-9540-a6d32095d587.png)

https://python.github.io/peps/pep-0001/#pep-header-preamble

But we want plain text formatting here.

---

Also update some links to their newly redirected location.

And delete this one:

```
* `Frequently Asked Questions for Developers
  <http://docs.python.org/devguide/faq.html>`_
```

Because it redirects to 404 https://devguide.python.org/faq/

Checking the Internet Archive (https://web.archive.org/web/20120301112706/http://docs.python.org/devguide/faq.html#how-do-i-tell-who-is-and-isn-t-a-core-developer) I don't see a matching page on the new devguide?
