### PR TITLE
PEP 676: Mention additional enhacements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -550,7 +550,7 @@ pep-0672.rst  @encukou
 pep-0673.rst  @jellezijlstra
 pep-0674.rst  @vstinner
 pep-0675.rst  @jellezijlstra
-pep-0676.rst  @Mariatta
+pep-0676.rst  @AA-Turner @Mariatta
 pep-0677.rst  @gvanrossum
 pep-0678.rst  @iritkatriel
 pep-0679.rst  @pablogsal

--- a/pep-0676.rst
+++ b/pep-0676.rst
@@ -79,6 +79,7 @@ There are several requests for additional features in reading PEPs, such as:
 * typographic quotation marks [4]_
 * additional footer information [5]_
 * intersphinx functionality [6]_
+* dark mode theme [7]_
 
 These are "easy wins" from this proposal, and would serve to improve the
 quality-of-life for consumers of PEPs (including reviewers and writers).
@@ -88,7 +89,7 @@ schedule. This means that updates to PEPs cannot be circulated immediately,
 reducing productivity. The reference implementation renders and publishes all
 PEPs on every commit to the repository, solving the issue by design.
 
-The reference implementation fixes several issues [7]_. For example:
+The reference implementation fixes several issues [8]_. For example:
 
 * list styles are currently not respected by `python.org`_'s stylesheets
 * support for updating images in PEPs is challenging in `python.org`_
@@ -168,8 +169,8 @@ Reference Implementation
 ========================
 
 The proposed implementation has been merged into the `python/peps`_ repository
-in a series of pull requests [8]_. It uses the `Sphinx`_ documentation system
-with a custom theme and extensions.
+in a series of pull requests [9]_. It uses the `Sphinx`_ documentation system
+with a custom theme (supporting normal and dark colour schemes) and extensions.
 
 This already automatically renders all PEPs on every commit, and publishes them
 to `python.github.io/peps`_.
@@ -233,11 +234,12 @@ Footnotes
 .. [4] Requested: `peps#165 <https://github.com/python/peps/issues/165>`__
 .. [5] Requested: `pythondotorg#1564 <https://github.com/python/pythondotorg/issues/1564>`__
 .. [6] Requested: `comment in peps#2 <https://github.com/python/peps/issues/2#issuecomment-339195595>`__
-.. [7] As of November 2021, see
+.. [7] Requested: `in python-dev <https://mail.python.org/archives/list/python-dev@python.org/message/E7PK6TLVDJIYXVGFA6ZYPB24KLJASPUI/>`__
+.. [8] As of November 2021, see
        `peps#1387 <https://github.com/python/peps/issues/1387>`__,
        `pythondotorg#824 <https://github.com/python/pythondotorg/issues/824>`__,
        `pythondotorg#1556 <https://github.com/python/pythondotorg/pull/1556>`__,
-.. [8] Implementation PRs:
+.. [9] Implementation PRs:
        `peps#1930 <https://github.com/python/peps/pull/1930>`__,
        `peps#1931 <https://github.com/python/peps/pull/1931>`__,
        `peps#1932 <https://github.com/python/peps/pull/1932>`__,

--- a/pep-0676.rst
+++ b/pep-0676.rst
@@ -170,7 +170,7 @@ Reference Implementation
 
 The proposed implementation has been merged into the `python/peps`_ repository
 in a series of pull requests [9]_. It uses the `Sphinx`_ documentation system
-with a custom theme (supporting normal and dark colour schemes) and extensions.
+with a custom theme (supporting light and dark colour schemes) and extensions.
 
 This already automatically renders all PEPs on every commit, and publishes them
 to `python.github.io/peps`_. The high level documentation for the system covers

--- a/pep-0676.rst
+++ b/pep-0676.rst
@@ -173,7 +173,9 @@ in a series of pull requests [9]_. It uses the `Sphinx`_ documentation system
 with a custom theme (supporting normal and dark colour schemes) and extensions.
 
 This already automatically renders all PEPs on every commit, and publishes them
-to `python.github.io/peps`_.
+to `python.github.io/peps`_. The high level documentation for the system covers
+:doc:`how to render PEPs locally <docs/build>` and
+:doc:`the implementation of the system <docs/rendering_system>`
 
 
 Rejected Ideas

--- a/pep-0676.rst
+++ b/pep-0676.rst
@@ -174,8 +174,8 @@ with a custom theme (supporting normal and dark colour schemes) and extensions.
 
 This already automatically renders all PEPs on every commit, and publishes them
 to `python.github.io/peps`_. The high level documentation for the system covers
-:doc:`how to render PEPs locally <docs/build>` and
-:doc:`the implementation of the system <docs/rendering_system>`
+`how to render PEPs locally <https://python.github.io/peps/docs/build>`__ and
+`the implementation of the system <https://python.github.io/peps/docs/rendering_system>`__.
 
 
 Rejected Ideas


### PR DESCRIPTION
From discourse. Minor update.

The build might fail due to the `:doc:` role. I wait with bated breath.

A