### PR TITLE
PEP 7: Clarify that compiler extensions are prohibited in general, not just GCC

### DIFF
--- a/pep-0007.txt
+++ b/pep-0007.txt
@@ -50,8 +50,8 @@ C dialect
   Future C99 features may be added to this list in the future
   depending on compiler support (mostly significantly MSVC).
 
-* Don't use GCC extensions (e.g. don't write multi-line strings
-  without trailing backslashes).
+* Don't use compiler-specific extensions, such as those of GCC or MSVC
+  (e.g. don't write multi-line strings without trailing backslashes).
 
 * All function declarations and definitions must use full prototypes
   (i.e. specify the types of all arguments).


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Tweaks the wording of PEP 7 slightly, per @encukou 's suggestion on @erikjanss 's issue, to clarify that compiler extensions are prohibited in general, mentioning GCC and MSVC as specific offenders and retaining the existing GCC example, rather than just only GCC extensions specifically.

Fixes #758 