### PR TITLE
Exclude `.codespell` from Sphinx

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -41,6 +41,8 @@ exclude_patterns = [
     "README.rst",
     "CONTRIBUTING.rst",
     "pep_sphinx_extensions/LICENCE.rst",
+    # Miscellaneous
+    ".codespell",
 ]
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
RE #2151; fixes Sphinx build.

A