### PR TITLE
PEP 0008: Replaced outdated usages of `print` as a statement

### DIFF
--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -470,7 +470,7 @@ Avoid extraneous whitespace in the following situations:
   ::
 
       # Wrong:
-      if x == 4 : print( x , y ); x , y = y , x
+      if x == 4 : print(x , y) ; x , y = y , x
 
 - However, in a slice the colon acts like a binary operator, and
   should have equal amounts on either side (treating it as the

--- a/pep-0008.txt
+++ b/pep-0008.txt
@@ -465,12 +465,12 @@ Avoid extraneous whitespace in the following situations:
 - Immediately before a comma, semicolon, or colon::
 
       # Correct:
-      if x == 4: print x, y; x, y = y, x
+      if x == 4: print(x, y); x, y = y, x
 
   ::
 
       # Wrong:
-      if x == 4 : print x , y ; x , y = y , x
+      if x == 4 : print( x , y ); x , y = y , x
 
 - However, in a slice the colon acts like a binary operator, and
   should have equal amounts on either side (treating it as the


### PR DESCRIPTION
The document contained two occurrences of `print` used as a statement.
I changed those to functions so that the examples work in modern Python environments.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
