### PR TITLE
PEP 13: Update 2022 Steering Council per PEP 8103 results

### DIFF
--- a/pep-0013.rst
+++ b/pep-0013.rst
@@ -21,13 +21,13 @@ Current steering council
 
 The current steering council consists of:
 
-* Barry Warsaw
 * Brett Cannon
-* Carol Willing
-* Thomas Wouters
+* Gregory P. Smith
 * Pablo Galindo Salgado
+* Petr Viktorin
+* Thomas Wouters
 
-Per the results of the vote tracked in :pep:`8102`.
+Per the results of the vote tracked in :pep:`8103`.
 
 The core team consists of those listed in the private
 https://github.com/python/voters/ repository which is publicly


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fixes https://github.com/python/peps/issues/2268.

Add results from https://python.github.io/peps/pep-8103/#results in simple alphabetical order (as it was before 991815f9367170c0c3bbb3122231cc5c448d38ac).
