### PR TITLE
PEP 1: Further clarify PEP-Delegate notification & acceptance process

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -283,7 +283,7 @@ The final authority for PEP approval is the Steering Council. However, whenever
 a new PEP is put forward, any core developer who believes they are suitably
 experienced to make the final decision on that PEP may offer to serve as its
 PEP-Delegate by `notifying the Steering Council <Steering Council issue_>`_
-of their intent. If the Steering Council accepts their offer,
+of their intent. If the Steering Council approves their offer,
 the PEP-Delegate will then have the authority to approve or reject that PEP.
 
 The term "PEP-Delegate" is used under the Steering Council governance model
@@ -294,14 +294,15 @@ the time when when Python was led by `a BDFL <Python's BDFL_>`_.
 Any legacy references to "BDFL-Delegate" should be treated as equivalent to
 "PEP-Delegate".
 
-Individuals offering to serve as PEP-Delegate should notify the PEP authors
-and PEP sponsor of their intent to self-nominate, and submit their request as
-`a new issue <Steering Council issue_>`_ on the `Steering Council repository`_.
+An individual offering to nominate themselves as a PEP-Delegate must notify
+the relevant authors and (when present) the sponsor for the PEP, and submit
+their request to the Steering Council
+(which can be done via a `new issue <Steering Council issue_>`_ ).
 Those taking on this responsibility are free to seek
 additional guidance from the Steering Council at any time, and are also expected
 to take the advice and perspectives of other core developers into account.
 
-The Steering Council will generally accept such self-nominations by default,
+The Steering Council will generally approve such self-nominations by default,
 but may choose to decline them.
 Possible reasons for the Steering Council declining a
 self-nomination as PEP-Delegate include, but are not limited to, perceptions of
@@ -807,8 +808,6 @@ References and Footnotes
 .. _`GitHub pull request`: https://github.com/python/peps/pulls
 
 .. _`GitHub issue`: https://github.com/python/peps/issues
-
-.. _Steering Council repository: https://github.com/python/steering-council
 
 .. _Steering Council issue: https://github.com/python/steering-council/issues/new/choose
 

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -281,9 +281,10 @@ notifying the PEP author(s) and giving them a chance to make revisions.
 
 The final authority for PEP approval is the Steering Council. However, whenever
 a new PEP is put forward, any core developer who believes they are suitably
-experienced to make the final decision on that PEP may offer to serve as
-the PEP-Delegate for it. If the Steering Council assents to their offer, the
-PEP-Delegate will then have the authority to approve or reject that PEP.
+experienced to make the final decision on that PEP may offer to serve as its
+PEP-Delegate by `notifying the Steering Council <Steering Council issue_>`_
+of their intent. If the Steering Council accepts their offer,
+the PEP-Delegate will then have the authority to approve or reject that PEP.
 
 The term "PEP-Delegate" is used under the Steering Council governance model
 for the PEP's designated decision maker,
@@ -293,14 +294,16 @@ the time when when Python was led by `a BDFL <Python's BDFL_>`_.
 Any legacy references to "BDFL-Delegate" should be treated as equivalent to
 "PEP-Delegate".
 
-Individuals offering to serve as PEP-Delegate should notify the Steering
-Council, PEP authors and PEP sponsor of their intent to self-nominate.
+Individuals offering to serve as PEP-Delegate should notify the PEP authors
+and PEP sponsor of their intent to self-nominate, and submit their request as
+`a new issue <Steering Council issue_>`_ on the `Steering Council repository`_.
 Those taking on this responsibility are free to seek
 additional guidance from the Steering Council at any time, and are also expected
 to take the advice and perspectives of other core developers into account.
 
-Such self-nominations are accepted by default, but may be explicitly declined by
-the Steering Council. Possible reasons for the Steering Council declining a
+The Steering Council will generally accept such self-nominations by default,
+but may choose to decline them.
+Possible reasons for the Steering Council declining a
 self-nomination as PEP-Delegate include, but are not limited to, perceptions of
 a potential conflict of interest (e.g. working for the same organisation as the
 PEP submitter), or simply considering another potential PEP-Delegate to be
@@ -804,6 +807,10 @@ References and Footnotes
 .. _`GitHub pull request`: https://github.com/python/peps/pulls
 
 .. _`GitHub issue`: https://github.com/python/peps/issues
+
+.. _Steering Council repository: https://github.com/python/steering-council
+
+.. _Steering Council issue: https://github.com/python/steering-council/issues/new/choose
 
 
 Copyright


### PR DESCRIPTION
Followup to #1430 and PRs #2256 and #2257 , and discussed on python/steering-council#97 , to ensure the description of how PEP delegates should notify and request approval of the Steering Council is clear and consistent, and matches actual established practice, based on the descrepencies with the current merged language identified by @AA-Turner and discussed further with @willingc .