### PR TITLE
PEP 680: Further explain why files are read as binary

### DIFF
--- a/pep-0680.rst
+++ b/pep-0680.rst
@@ -290,8 +290,8 @@ be worked around in user code, or by using a third-party library.
 The proposed API takes a binary file, while ``toml.load`` takes a text file and
 ``json.load`` takes either. Using a binary file allows us to ensure UTF-8 is
 the encoding used (ensuring correct parsing on platforms with other default
-encodings, such as Windows), and avoid incorrectly parsing single carriage
-returns as valid TOML due to universal newlines in text mode.
+encodings, such as Windows), and avoid incorrectly parsing files containing
+single carriage returns as valid TOML due to universal newlines in text mode.
 
 
 Type accepted as the first argument of ``tomllib.loads``

--- a/pep-0680.rst
+++ b/pep-0680.rst
@@ -289,8 +289,9 @@ be worked around in user code, or by using a third-party library.
 
 The proposed API takes a binary file, while ``toml.load`` takes a text file and
 ``json.load`` takes either. Using a binary file allows us to ensure UTF-8 is
-the encoding used, and avoid incorrectly parsing single carriage returns as
-valid TOML due to universal newlines in text mode.
+the encoding used (ensuring correct parsing on platforms with other default
+encodings, such as Windows), and avoid incorrectly parsing single carriage
+returns as valid TOML due to universal newlines in text mode.
 
 
 Type accepted as the first argument of ``tomllib.loads``


### PR DESCRIPTION
On the discuss thread, questions were brought up about the binary file type: https://discuss.python.org/t/pep-680-tomllib-support-for-parsing-toml-in-the-standard-library/13040/43
Ensuring that it's easy to correctly parse TOML files containing non-ASCII characters on Windows is a good reason to use binary files. This PR adds some words to highlight this reason for using binary files.

cc @hukkin 