### PR TITLE
PEP 668: Keep the marker file in container images

### DIFF
--- a/pep-0668.rst
+++ b/pep-0668.rst
@@ -659,18 +659,14 @@ on Debian) depends on pipx.
 
 .. _pipx: https://github.com/pypa/pipx
 
-Remove the marker file in container images
-------------------------------------------
+Keep the marker file in container images
+----------------------------------------
 
 Distros that produce official images for single-application containers
-(e.g., Docker container images) should remove the
+(e.g., Docker container images) should keep the
 ``EXTERNALLY-MANAGED`` file, preferably in a way that makes it not
-come back if a user of that image installs package updates inside
-their image (think ``RUN apt-get dist-upgrade``). On dpkg-based
-systems, using ``dpkg-divert --local`` to persistently rename the file
-would work. On other systems, there may need to be some configuration
-flag available to a post-install script to re-remove the
-``EXTERNALLY-MANAGED`` file.
+go away if a user of that image installs package updates inside
+their image (think ``RUN apt-get dist-upgrade``).
 
 Create separate distro and local directories
 --------------------------------------------


### PR DESCRIPTION
This preserves the protections afforded by these changes, in container
images.

See [this comment](https://discuss.python.org/t/graceful-cooperation-between-external-and-python-package-managers-pep-668/10302/15?u=pradyunsg) for context.