### PR TITLE
PEP 594: Revise EOL dates mentioned to reflect relevant Python versions

### DIFF
--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -105,12 +105,15 @@ Deprecation schedule
 ----
 
 Starting with Python 3.11, deprecated modules will start issuing
-``DeprecationWarning``. The estimated EOL of Python 3.11 is October 2027.
+``DeprecationWarning``. The estimated EOL of Python 3.10, the last
+version without the warning, is October 2026.
 
 3.12
 ----
 
 There should be no specific change compared to Python 3.11.
+This is the last version of Python with the deprecated modules,
+with an estimated EOL of October 2028.
 
 3.13
 ----


### PR DESCRIPTION
Per the consensus of the discussion in #2262 , it doesn't really make sense to mention the EOL date of Python 3.11 with the retargetting of PEP-0594 for Python 3.11-3.13, as opposed to Python 3.10 (last version without the warning) and/or Python 3.12 (last version with the deprecated modules). This revises that PEP to add both useful dates; I can revise this to eliminate one or the other can be eliminated if the PEP author desires, but I included both here for completeness. Thanks.