### PR TITLE
PEP 12: Update guidance on linking PEPs/RFCs per recent changes, and add check for it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,3 +127,16 @@ repos:
         args: ['--multiline']
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]
+      - id: check-direct-pep-links
+        name: "Check that PEPs aren't linked directly"
+        language: pygrep
+        entry: 'dev/peps/pep-\d+'
+        files: '^pep-\d+\.(rst|txt)$'
+        exclude: '^pep-(0009|0287|8001)\.(rst|txt)$'
+        types: [text]
+      - id: check-direct-rfc-links
+        name: "Check that RFCs aren't linked directly"
+        language: pygrep
+        entry: '(rfc-editor\.org|ietf\.org)/[\.\-_\?\&\#\w/]*[Rr][Ff][Cc][\-_]?\d+'
+        files: '\.(rst|txt)$'
+        types: [text]

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -475,47 +475,50 @@ Footnotes containing the URLs from external targets will be generated
 automatically at the end of the References section of the PEP, along
 with footnote references linking the reference text to the footnotes.
 
-Text of the form "PEP x" or "RFC x" (where "x" is a number) will be
-linked automatically to the appropriate URLs.
+To refer to PEPs or RFCs, always use the ``:pep:`` and ``:rfc:`` roles,
+never hardcoded URLs.
+For example:
+
+.. code-block:: rst
+
+    See :pep:`1` for more information on how to write a PEP,
+    and :pep:`the Hyperlink section of PEP 12 <12#hyperlinks>` for how to link.
+
+This renders as:
+
+    See :pep:`1` for more information on how to write a PEP,
+    and :pep:`the Hyperlink section of PEP 12 <12#hyperlinks>` for how to link.
+
+PEP numbers in the text are never padded, and there is a space (not a dash)
+between "PEP" or "RFC" and the number; the above roles will take care of
+that for you.
 
 
 Footnotes
 ---------
 
 Footnote references consist of a left square bracket, a number, a
-right square bracket, and a trailing underscore::
+right square bracket, and a trailing underscore:
+
+.. code-block:: rst
 
     This sentence ends with a footnote reference [1]_.
 
 Whitespace must precede the footnote reference.  Leave a space between
 the footnote reference and the preceding word.
 
-When referring to another PEP, include the PEP number in the body
-text, such as "PEP 1".  The title may optionally appear.  Add a
-footnote reference following the title.  For example::
-
-    Refer to PEP 1 [2]_ for more information.
-
-Add a footnote that includes the PEP's title and author.  It may
-optionally include the explicit URL on a separate line, but only in
-the References section.  Footnotes begin with ".. " (the explicit
+Footnotes begin with ".. " (the explicit
 markup start), followed by the footnote marker (no underscores),
-followed by the footnote body.  For example::
+followed by the footnote body.  For example:
+
+.. code-block:: rst
 
     References
     ==========
 
-    .. [2] PEP 1, "PEP Purpose and Guidelines", Warsaw, Hylton
-       (http://www.python.org/dev/peps/pep-0001)
+    .. [1] Note that the footnote reference is a numbered one.
 
-If you decide to provide an explicit URL for a PEP, please use this as
-the URL template::
-
-    http://www.python.org/dev/peps/pep-xxxx
-
-PEP numbers in URLs must be padded with zeros from the left, so as to
-be exactly 4 characters wide; however, PEP numbers in the text are
-never padded.
+    .. [2] Donald Knuth's *The TeXbook*, pages 195 and 196.
 
 During the course of developing your PEP, you may have to add, remove,
 and rearrange footnote references, possibly resulting in mismatched
@@ -523,20 +526,20 @@ references, obsolete footnotes, and confusion.  Auto-numbered
 footnotes allow more freedom.  Instead of a number, use a label of the
 form "#word", where "word" is a mnemonic consisting of alphanumerics
 plus internal hyphens, underscores, and periods (no whitespace or
-other characters are allowed).  For example::
+other characters are allowed).  For example:
 
-    Refer to PEP 1 [#PEP-1]_ for more information.
+.. code-block:: rst
+
+    Refer to The TeXbook [#TeXbook]_ for more information.
 
     References
     ==========
 
-    .. [#PEP-1] PEP 1, "PEP Purpose and Guidelines", Warsaw, Hylton
+    .. [#TeXbook] Donald Knuth's *The TeXbook*, pages 195 and 196.
 
-       http://www.python.org/dev/peps/pep-0001
 
 Footnotes and footnote references will be numbered automatically, and
-the numbers will always match.  Once a PEP is finalized, auto-numbered
-labels should be replaced by numbers for simplicity.
+the numbers will always match.
 
 
 Images

--- a/pep-0340.txt
+++ b/pep-0340.txt
@@ -461,7 +461,7 @@ accepted, these can be changed to just "yield" of course.)
    Used as follows::
 
         block auto_retry(3, IOError):
-            f = urllib.urlopen("http://www.python.org/dev/peps/pep-0340/")
+            f = urllib.urlopen("https://www.example.com/")
             print f.read()
 
 5. It is possible to nest blocks and combine templates::

--- a/pep-0427.txt
+++ b/pep-0427.txt
@@ -312,9 +312,9 @@ checker only needs to establish that RECORD matches the signature.
 
 See
 
-- https://datatracker.ietf.org/doc/html/rfc7515
+- :rfc:`7515`
 - https://datatracker.ietf.org/doc/html/draft-jones-jose-jws-json-serialization.html
-- https://datatracker.ietf.org/doc/html/rfc7517
+- :rfc:`7517`
 - https://datatracker.ietf.org/doc/html/draft-jones-jose-json-private-key.html
 
 

--- a/pep-0491.txt
+++ b/pep-0491.txt
@@ -394,9 +394,9 @@ checker only needs to establish that RECORD matches the signature.
 
 See
 
-- https://datatracker.ietf.org/doc/html/rfc7515
+- :rfc:`7515`
 - https://datatracker.ietf.org/doc/html/draft-jones-jose-jws-json-serialization.html
-- https://datatracker.ietf.org/doc/html/rfc7517
+- :rfc:`7517`
 - https://datatracker.ietf.org/doc/html/draft-jones-jose-json-private-key.html
 
 


### PR DESCRIPTION
In #2209 , @AA-Turner removed the legacy implicit PEP/RFC link logic, and batch-converted existing PEPs to use explicit `:pep:` and `:rfc::` roles to reference other PEPs and RFCs, rather than relying on hacky, fragile and limited implicit links, or hardcoding URLs (often in footnotes). However, PEP 12 has not been updated accordingly to reflect this, still containing a substantial quantity of outdated language on this point.

Therefore, it was updated to update these now-misleading descriptions and examples, describe the new practice and explain and give examples of its use. This also, as a necessary side effect, addresses the most straightforward and obvious aspects of #2130 , though I will address the remaining parts of it not directly concerned with PEP/RFC links and footnotes thereof in another separate PR immediately after this one is merged, to keep things focused here.

Furthermore, some users may still be tempted to do the latter, whether due to the limitations of GitHub's rendered previews (as saw in #2282 ), or simply being unaware of the role's existence. Ensuring we always reference PEPs with the appropriate roles rather than hard links is simpler, more concise and more reliable, ensures they are formatted correctly and (with the new build system proposed in PEP-0676) allows us to do things like automatically including the PEP title in the link titletext, as users have requested.

Therefore, as originally prompted by @AA-Turner 's [suggestion](https://github.com/python/peps/pull/2282#discussion_r793558574_) on #2282 , this PR adds a cheap Pre-Commit pygrep check for direct hardcoded URLs to other PEPs and RFCs. This avoids regressions in future PEPs (and spot-fixes the couple remaining instances not caught by that PR) and allowing authors and reviewers to easily spot where this occurs and replace it with the simpler, more concise, more reliable and more functional roles.

As a historical note, these changes were originally included in #2286 , but @AA-Turner and @JelleZijlstra wisely suggested splitting them out, as they deserved to be addressed separately.

* [x] Describe using `:pep:` and `:rfc:` roles in PEP 12, and update/remove outdated references section content
* [x] Add new pre-commit check for bare/direct PEP and RFC links
* [x] Update a couple PEPs that still used the deprecated PEP/RFC references