### PR TITLE
PEP 678: add post-history, minor tweaks following discussion

### DIFF
--- a/pep-0678.rst
+++ b/pep-0678.rst
@@ -8,7 +8,7 @@ Content-Type: text/x-rst
 Requires: 654
 Created: 20-Dec-2021
 Python-Version: 3.11
-Post-History:
+Post-History: 2022-01-27
 
 
 Abstract

--- a/pep-0678.rst
+++ b/pep-0678.rst
@@ -2,6 +2,7 @@ PEP: 678
 Title: Enriching Exceptions with Notes
 Author: Zac Hatfield-Dodds <zac@zhd.dev>
 Sponsor: Irit Katriel
+Discussions-To: https://discuss.python.org/t/pep-678-enriching-exceptions-with-notes/13374
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
@@ -276,9 +277,9 @@ to include other objects is fully backwards-compatible.  In the absence of any p
 use-case (see also `Non-goals`_), we prefer to begin with a restrictive API that can
 be relaxed later.
 
-We also note that converting an object to string may raise an exception, and that the
-traceback involved will usually be more helpful if this occurs when the note is attached
-rather than after propogation when the exception and note is being formatted for display.
+We also note that converting an object to a string may raise an exception.  It's more helpful
+for the traceback to point to the location where the note is attached to the exception,
+rather than where the exception and note are being formatted for display after propagation.
 
 
 Add a helper function ``contextlib.add_exc_note()``

--- a/pep-0678.rst
+++ b/pep-0678.rst
@@ -111,7 +111,7 @@ exception includes a note of the minimal failing example::
 Non-goals
 ---------
 ``__note__`` is *not* intended to carry structured data.  If your note is for use by
-a program rather than display to a human, we recommend instead choosing a convention
+a program rather than display to a human, we recommend instead (or additionally) choosing a convention
 for an attribute like e.g. ``err._parse_errors = ...`` on the error or ``ExceptionGroup`` [1]_ [2]_
 
 As a rule of thumb, prefer `exception chaining <https://docs.python.org/3/tutorial/errors.html#exception-chaining>`__
@@ -276,10 +276,14 @@ to include other objects is fully backwards-compatible.  In the absence of any p
 use-case (see also `Non-goals`_), we prefer to begin with a restrictive API that can
 be relaxed later.
 
+We also note that converting an object to string may raise an exception, and that the
+traceback involved will usually be more helpful if this occurs when the note is attached
+rather than after propogation when the exception and note is being formatted for display.
+
 
 Add a helper function ``contextlib.add_exc_note()``
 ---------------------------------------------------
-It was suggested that we add a utility such as the one below to the standard
+It was suggested [11]_ that we add a utility such as the one below to the standard
 library. We are open to this idea, but do not see it as a core part of the
 proposal of this PEP as it can be added as an enhancement later.
 
@@ -323,6 +327,7 @@ References
 .. [8] https://github.com/python/cpython/pull/28569#discussion_r721768348
 .. [9] https://bugs.python.org/issue45607
 .. [10] https://github.com/python/cpython/blob/69ef1b59983065ddb0b712dac3b04107c5059735/Lib/http/client.py#L596-L597
+.. [11] https://www.reddit.com/r/Python/comments/rmrvxv/pep_678_enriching_exceptions_with_notes/hptbul1/
 
 
 


### PR DESCRIPTION
Following [the post on python-dev](https://mail.python.org/archives/list/python-dev@python.org/thread/IMNZE4HN7VNWS5SROMFOLHQQVYHUYT77/) which requested [comments to this Discuss thread](https://discuss.python.org/t/pep-678-enriching-exceptions-with-notes/13374), I've updated PEP 678 with Post-History and some minor clarifications following that discussion.

I believe that after this PR is merged, the PEP is ready for consideration by the Steering Council.

My deep thanks again to everyone who has helped me through this, especially the many thoughtful commenters, those who proof-read and contributed fixes, and to Irit for her support and sponsorship throughout :pray: 