### PR TITLE
PEP 681: Fix type annotation of field_descriptors param

### DIFF
--- a/pep-0681.rst
+++ b/pep-0681.rst
@@ -556,7 +556,7 @@ following declaration within their type stubs or source files:
       eq_default: bool = True,
       order_default: bool = False,
       kw_only_default: bool = False,
-      field_descriptors: Tuple[Union[type, Callable[..., Any]], ...] = (()),
+      field_descriptors: tuple[type | Callable[..., Any], ...] = (),
   ) -> Callable[[_T], _T]:
       # If used within a stub file, the following implementation can
       # be replaced with "...".

--- a/pep-0681.rst
+++ b/pep-0681.rst
@@ -203,7 +203,7 @@ customization of default behaviors:
       eq_default: bool = True,
       order_default: bool = False,
       kw_only_default: bool = False,
-      field_descriptors: Tuple[type, ...] = (()),
+      field_descriptors: Tuple[Union[type, Callable[..., Any]], ...] = (()),
   ) -> Callable[[_T], _T]: ...
 
 * ``eq_default`` indicates whether the ``eq`` parameter is assumed to

--- a/pep-0681.rst
+++ b/pep-0681.rst
@@ -203,7 +203,7 @@ customization of default behaviors:
       eq_default: bool = True,
       order_default: bool = False,
       kw_only_default: bool = False,
-      field_descriptors: Tuple[Union[type, Callable[..., Any]], ...] = (()),
+      field_descriptors: tuple[type | Callable[..., Any], ...] = (),
   ) -> Callable[[_T], _T]: ...
 
 * ``eq_default`` indicates whether the ``eq`` parameter is assumed to


### PR DESCRIPTION
Fix field_descriptors type annotation to match in-use alternate form.