### PR TITLE
PEP 675: remove unnecessary reference to Self type PEP

### DIFF
--- a/pep-0675.rst
+++ b/pep-0675.rst
@@ -734,8 +734,9 @@ type checker.
 This extension to the ``LiteralString`` concept would dramatically
 increase the scope of the proposal by requiring changes to one of the
 most fundamental types in Python. While runtime taint checking on
-strings has been `considered <https://bugs.python.org/issue500698>`_
-and `attempted <https://github.com/felixgr/pytaint>`_ in the past, and
+strings, similar to Perl's `taint <https://metacpan.org/pod/Taint>`_,
+has been `considered <https://bugs.python.org/issue500698>`_ and
+`attempted <https://github.com/felixgr/pytaint>`_ in the past, and
 others may consider it in the future, such extensions are out of scope
 for this PEP.
 
@@ -1283,7 +1284,7 @@ Thanks
 Thanks to the following people for their feedback on the PEP:
 
 Edward Qiu, Jia Chen, Shannon Zhu, Gregory P. Smith, Никита Соболев,
-CAM Gerlach, and Shengye Wan
+CAM Gerlach, Arie Bovenberg, David Foster, and Shengye Wan
 
 Copyright
 =========

--- a/pep-0675.rst
+++ b/pep-0675.rst
@@ -562,8 +562,8 @@ annotating it as ``x: LiteralString``:
 Runtime Behavior
 ================
 
-We propose an implementation for ``typing.LiteralString`` similar to that for
-``typing.Self`` from :pep:`673`.
+We propose an implementation for ``typing.LiteralString`` similar to
+``typing.NoReturn``.
 
 
 Rejected Alternatives


### PR DESCRIPTION
We don't strictly rely on Self type PEP and people on typing-sig asked that we mention it in the "Requires" field. Better to just remove the dependency.

Also link to Perl's taint (runtime taint-checking) and thank David and Arie.

cc @gbleaney 