### PR TITLE
Fix pre-commit-config filename in codeowners and re-sort

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,9 +7,9 @@
 
 # PEP infrastructure
 .github/workflows/      @AA-Turner @CAM-Gerlach
+.pre-commit-config.yaml @CAM-Gerlach
 Makefile                @AA-Turner
 requirements.txt        @AA-Turner
-.pre-commit-config.yml  @CAM-Gerlach
 
 pep0/                   @AA-Turner
 docutils.conf           @AA-Turner
@@ -19,9 +19,9 @@ pep2rss.py              @AA-Turner
 
 pep_sphinx_extensions/  @AA-Turner
 AUTHOR_OVERRIDES.csv    @AA-Turner
-contents.rst            @AA-Turner
 build.py                @AA-Turner
 conf.py                 @AA-Turner
+contents.rst            @AA-Turner
 generate_rss.py         @AA-Turner
 
 pep-0001.txt  @warsaw @ncoghlan


### PR DESCRIPTION
The `.pre-commit-config` filename was mistakenly listed with the `yml` extension rather than the correct (and standards-conforming) `yaml` extension. Thus, it wasn't actually working correctly. Also, fixes a couple trivial sorting issues.