### PR TITLE
PEP 680: Fix link

### DIFF
--- a/pep-0680.rst
+++ b/pep-0680.rst
@@ -33,7 +33,7 @@ Further, many Python tools are now configurable via TOML, such as
 ``black``, ``mypy``, ``pytest``, ``tox``, ``pylint`` and ``isort``.
 Many that are not, such as ``flake8``, cite the lack of standard library
 support as a `main reason why
-<https://github.com/PyCQA/flake8/issues/234#issuecomment-812800657>`__.
+<https://github.com/PyCQA/flake8/issues/234#issuecomment-812800722>`__.
 Given the special place TOML already has in the Python ecosystem, it makes sense
 for it to be an included battery.
 


### PR DESCRIPTION
If I'm not mistaken, the link pointed to a comment from a flake8 user/contributor. I changed it to point to a comment by a maintainer.
