### PR TITLE
PEP 594: Remove old lib2to3 keep table entry and fix RST syntax issues

### DIFF
--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -508,7 +508,6 @@ Some modules were originally proposed for deprecation.
     colorsys,\-,"colormath, colour, colorspacious, Pillow"
     fileinput,\-,argparse
     getopt,\-,"argparse, optparse"
-    lib2to3,\-,
     optparse,**3.2**,argparse
     wave,\-,
 

--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -227,7 +227,7 @@ File Format is an old audio format from 1988 based on Amiga IFF. It was most
 commonly used on the Apple Macintosh. These days only few specialized
 application use AIFF.
 
-A user disclosed [8]_ that the post production film industry makes heavy
+A user disclosed [6]_ that the post production film industry makes heavy
 use of the AIFC file format. The usage of the ``aifc`` module in closed source
 and internal software was unknown prior to the first posting of this PEP. This
 may be a compelling argument to keep the ``aifc`` module in the standard
@@ -351,7 +351,9 @@ related to executing code are:
 - ``valid_boundary`` (undocumented) with ``re.compile("^[ -~]{0,200}[!-~]$")``
 
 As an explicit example of how close ``parse_header`` and
-``email.message.Message`` are::
+``email.message.Message`` are:
+
+.. code-block:: pycon
 
   >>> from cgi import parse_header
   >>> from email.message import Message
@@ -666,9 +668,7 @@ References
 .. [3] https://blogs.msmvps.com/installsite/blog/2015/05/03/the-future-of-windows-installer-msi-in-the-light-of-windows-10-and-the-universal-windows-platform/
 .. [4] https://twitter.com/ChristianHeimes/status/1130257799475335169
 .. [5] https://twitter.com/dabeaz/status/1130278844479545351
-.. [6] https://mail.python.org/pipermail/python-dev/2019-May/157464.html
-.. [7] https://discuss.python.org/t/switch-pythons-parsing-tech-to-something-more-powerful-than-ll-1/379
-.. [8] https://mail.python.org/pipermail/python-dev/2019-May/157634.html
+.. [6] https://mail.python.org/pipermail/python-dev/2019-May/157634.html
 
 
 Copyright


### PR DESCRIPTION
While it was removed from the prose, the table still mentions `lib2to3` as being a module to keep. This removes it from the table as well, along with fixing a few RST syntax issues.