### PR TITLE
PEP 7: Python 3.11 uses C99 and C11

### DIFF
--- a/pep-0007.txt
+++ b/pep-0007.txt
@@ -34,7 +34,7 @@ C dialect
 * Python 3.11 and newer versions use C11 without optional features.
   The public C API should be compatible with C++.
 
-* Python 3.6 to 3.10 uses C89 with several select C99 features:
+* Python 3.6 to 3.10 use C89 with several select C99 features:
 
   - Standard integer types in ``<stdint.h>`` and ``<inttypes.h>``. We
     require the fixed width integer types.
@@ -44,11 +44,8 @@ C dialect
   - booleans
   - C++-style line comments
 
-  Future C99 features may be added to this list in the future
-  depending on compiler support (mostly significantly MSVC).
-
 * Python versions before 3.6 used ANSI/ISO standard C (the 1989 version
-  of the standard).  This means (amongst many other things) that all
+  of the standard).  This meant (amongst many other things) that all
   declarations must be at the top of a block (not necessarily at the
   top of function).
 

--- a/pep-0007.txt
+++ b/pep-0007.txt
@@ -31,13 +31,10 @@ particular rule:
 C dialect
 =========
 
-* Python versions before 3.6 use ANSI/ISO standard C (the 1989 version
-  of the standard).  This means (amongst many other things) that all
-  declarations must be at the top of a block (not necessarily at the
-  top of function).
+* Python 3.11 and newer versions use C11 without optional features.
+  The public C API should be compatible with C++.
 
-* Python versions greater than or equal to 3.6 use C89 with several
-  select C99 features:
+* Python 3.6 to 3.10 uses C89 with several select C99 features:
 
   - Standard integer types in ``<stdint.h>`` and ``<inttypes.h>``. We
     require the fixed width integer types.
@@ -49,6 +46,11 @@ C dialect
 
   Future C99 features may be added to this list in the future
   depending on compiler support (mostly significantly MSVC).
+
+* Python versions before 3.6 used ANSI/ISO standard C (the 1989 version
+  of the standard).  This means (amongst many other things) that all
+  declarations must be at the top of a block (not necessarily at the
+  top of function).
 
 * Don't use compiler-specific extensions, such as those of GCC or MSVC
   (e.g. don't write multi-line strings without trailing backslashes).

--- a/pep-0007.txt
+++ b/pep-0007.txt
@@ -31,7 +31,8 @@ particular rule:
 C dialect
 =========
 
-* Python 3.11 and newer versions use C11 without optional features.
+* Python 3.11 and newer versions use C11 without `optional features
+  <https://en.wikipedia.org/wiki/C11_%28C_standard_revision%29#Optional_features>`_.
   The public C API should be compatible with C++.
 
 * Python 3.6 to 3.10 use C89 with several select C99 features:


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
