### PR TITLE
PEP 517: Remove "Provisional acceptance" section now the PEP is Final

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -50,16 +50,6 @@ We therefore propose a new, relatively minimal interface for
 installation tools like ``pip`` to interact with package source trees
 and source distributions.
 
-=======================
- Provisional acceptance
-=======================
-
-In accordance with the PyPA's specification process, this PEP has been
-`provisionally accepted <https://www.pypa.io/en/latest/specifications/#provisional-acceptance>`_
-for initial implementation in ``pip`` and other PyPA tools.
-
-During this time, the specification is still subject to revision based
-on real world experience with those initial implementations.
 
 =======================
  Terminology and goals


### PR DESCRIPTION
PEP 517 was made final in https://github.com/python/peps/pull/1712, so the section is outdated and can be removed.