### PR TITLE
PEP 682: Discussions-To and minor fixes

### DIFF
--- a/pep-0682.rst
+++ b/pep-0682.rst
@@ -104,7 +104,7 @@ one-dimensional numerical arrays would be complicated by such pre-rounding:
         """Format a vector (any iterable) using given per-term format string."""
         return f"[{','.join(f'{term:{format_spec}}' for term in v)}]"
 
-To date, there doesn't appear to be other widely-used languages or libraries
+To date, there doesn't appear to be any other widely-used language or library
 providing a formatting option for negative zero.  However, the same ``z``
 option syntax and semantics specified below have been `proposed for C++
 std::format()`_.  While the proposal was withdrawn for C++20, a consensus

--- a/pep-0682.rst
+++ b/pep-0682.rst
@@ -113,11 +113,11 @@ one-dimensional numerical arrays would be complicated by such pre-rounding:
         return f"[{','.join(f'{term:{format_spec}}' for term in v)}]"
 
 To date, there doesn't appear to be other widely-used languages or libraries
-providing such a formatting option for negative zero.  However, the same
-``z`` option syntax and semantics has been `proposed for C++ std::format()`_.
-While the proposal was withdrawn for C++20, a consensus proposal is promised
-for C++23.  (The original `feature request`_ prompting this PEP was argued
-without knowledge of the C++ proposal.)
+providing a formatting option for negative zero.  However, the same ``z``
+option syntax and semantics specified below have been `proposed for C++
+std::format()`_.  While the proposal was withdrawn for C++20, a consensus
+proposal is promised for C++23.  (The original `feature request`_ prompting
+this PEP was argued without knowledge of the C++ proposal.)
 
 .. _`proposed for C++ std::format()`: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1496r2.pdf
 .. _`feature request`: https://bugs.python.org/issue45995

--- a/pep-0682.rst
+++ b/pep-0682.rst
@@ -27,9 +27,7 @@ zero to be normalized to positive zero.
 Motivation
 ==========
 
-Here is negative zero:
-
-.. code-block:: pycon
+Here is negative zero::
 
     >>> x = -0.
     >>> x
@@ -38,9 +36,7 @@ Here is negative zero:
 When formatting a number, negative zero can result from rounding.  Assuming
 the user's intention is truly to discard precision, the distinction between
 negative and positive zero of the rounded result might be considered an
-unwanted artifact:
-
-.. code-block:: pycon
+unwanted artifact::
 
     >>> for x in (.002, -.001, .060):
     ...     print(f'{x: .1f}')
@@ -49,18 +45,14 @@ unwanted artifact:
      0.1
 
 There are various approaches to clearing the sign of a negative zero.  It
-can be achieved without a conditional by adding positive zero:
-
-.. code-block:: pycon
+can be achieved without a conditional by adding positive zero::
 
     >>> x = -0.
     >>> x + 0.
     0.0
 
 To normalize negative zero when formatting, it is necessary to perform
-a redundant (and error-prone) pre-rounding of the input:
-
-.. code-block:: pycon
+a redundant (and error-prone) pre-rounding of the input::
 
     >>> for x in (.002, -.001, .060):
     ...     print(f'{round(x, 1) + 0.: .1f}')
@@ -138,9 +130,7 @@ where ``z`` is allowed for numerical types other than integer.  Support for
 allowing the specifier to be used in f-strings, built-in ``format()``, and
 ``str.format()``.  The %-formatting style will not support the new option.
 
-Synopsis:
-
-.. code-block:: pycon
+Synopsis::
 
     >>> x = -.00001
     >>> f'{x:z.1f}'

--- a/pep-0682.rst
+++ b/pep-0682.rst
@@ -2,13 +2,13 @@ PEP: 682
 Title: Format Specifier for Signed Zero
 Author: John Belmonte <john@neggie.net>
 Sponsor: Mark Dickinson <dickinsm@gmail.com>
-Discussions-To:
+Discussions-To: https://discuss.python.org/t/pep-682-format-specifier-for-signed-zero/13596
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 29-Jan-2022
 Python-Version: 3.11
-Post-History:
+Post-History: 08-Feb-2022
 
 
 Abstract


### PR DESCRIPTION
  * fill in `Discussions-To`
  * fix wording of Rationale forward references
  * remove use of `code-block:: pycon`, since it applies a proportional font to `>>>` and `...`, which looks odd and misaligns indents
