### PR TITLE
PEP 675: Establish typing context in the Abstract

### DIFF
--- a/pep-0675.rst
+++ b/pep-0675.rst
@@ -15,11 +15,12 @@ Post-History:
 Abstract
 ========
 
-There is currently no way to specify that a function parameter can be
-of any literal string type; we have to specify the precise literal
-string, such as ``Literal["foo"]``. This PEP introduces a supertype of
-literal string types: ``LiteralString``. This allows a function to
-accept arbitrary literal string types, such as ``Literal["foo"]`` or
+Using static type annotations, there is currently no way to specify
+that a function parameter can be of any literal string type.
+We have to specify the precise literal string, such as
+``Literal["foo"]``. This PEP introduces a supertype of literal string
+types: ``LiteralString``. This allows a function to accept arbitrary
+literal string types, such as ``Literal["foo"]`` or
 ``Literal["bar"]``.
 
 


### PR DESCRIPTION
The document was drafted and discussed on typing-sig, which is perfectly acceptable for this PEP.
But as a general PEP, it should briefly establish its context.

(The PR just adds `Using static type annotations,`, splits a  sentence that becomes too long, and adjusts capitalization.)

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
