### PR TITLE
PEP 675: add "Type" to title and add post history

### DIFF
--- a/pep-0675.rst
+++ b/pep-0675.rst
@@ -1,5 +1,5 @@
 PEP: 675
-Title: Arbitrary Literal Strings
+Title: Arbitrary Literal String Type
 Version: $Revision$
 Last-Modified: $Date$
 Author: Pradeep Kumar Srinivasan <gohanpra@gmail.com>, Graham Bleaney <gbleaney@gmail.com>
@@ -10,14 +10,14 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 30-Nov-2021
 Python-Version: 3.11
-Post-History:
+Post-History: 07-Feb-2022
 
 Abstract
 ========
 
-Using static type annotations, there is currently no way to specify
-that a function parameter can be of any literal string type.
-We have to specify the precise literal string, such as
+There is currently no way to specify, using type annotations, that a
+function parameter can be of any literal string type. We have to
+specify a precise literal string type, such as
 ``Literal["foo"]``. This PEP introduces a supertype of literal string
 types: ``LiteralString``. This allows a function to accept arbitrary
 literal string types, such as ``Literal["foo"]`` or


### PR DESCRIPTION
The new title makes it much clearer that this PEP is about types rather than string values.

Also adjusted the wording of the first line of the Abstract. I changed
"static type annotations" to "type annotations" since the "static" part
is redundant.

cc @gbleaney 