### PR TITLE
PEP 675: use semicolon instead of comma

### DIFF
--- a/pep-0675.rst
+++ b/pep-0675.rst
@@ -847,7 +847,7 @@ shell command:
     subprocess.run(f"echo 'Hello {name}'", shell=True)
 
 If user-controlled data is included in the command string, the code is
-vulnerable to "command injection", i.e., an attacker can run malicious
+vulnerable to "command injection"; i.e., an attacker can run malicious
 commands. For example, a value of ``' && rm -rf / #`` would result in
 the following destructive command being run:
 


### PR DESCRIPTION
See this [FAQ](https://www.chicagomanualofstyle.org/qanda/data/faq/topics/Punctuation/faq0036.html).