### PR TITLE
PEP 544: Fix example

### DIFF
--- a/pep-0544.txt
+++ b/pep-0544.txt
@@ -770,7 +770,7 @@ A class object is considered an implementation of a protocol if accessing
 all members on it results in types compatible with the protocol members.
 For example::
 
-  from typing import Any, Protocol
+  from typing import Any, Protocol, Type
 
   class ProtoA(Protocol):
       def meth(self, x: int) -> int: ...
@@ -780,8 +780,8 @@ For example::
   class C:
       def meth(self, x: int) -> int: ...
 
-  a: ProtoA = C  # Type check error, signatures don't match!
-  b: ProtoB = C  # OK
+  a: Type[ProtoA] = C  # OK
+  b: Type[ProtoB] = C  # Type check error, signatures don't match!
 
 
 ``NewType()`` and type aliases


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fix last example in PEP 544 - [Type[] and class objects vs protocols](https://www.python.org/dev/peps/pep-0544/#type-and-class-objects-vs-protocols).

### Changes
* `C` is a class, the annotations for `a` and `b` should thus include `Type`.
(The section title includes `"Type[] and class objects"` after all.)
* The type error is emitted for `b: Type[ProtoB] = C` and not `a`.