### PR TITLE
PEP 675: Add link to official discussion thread

### DIFF
--- a/pep-0675.rst
+++ b/pep-0675.rst
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Pradeep Kumar Srinivasan <gohanpra@gmail.com>, Graham Bleaney <gbleaney@gmail.com>
 Sponsor: Jelle Zijlstra <jelle.zijlstra@gmail.com>
-Discussions-To: Typing-Sig <typing-sig@python.org>
+Discussions-To: https://mail.python.org/archives/list/typing-sig@python.org/thread/VB74EHNM4RODDFM64NEEEBJQVAUAWIAW/
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst


### PR DESCRIPTION
It looks like PEP 675 hasn't yet been updated with the link to the latest official discussion thread (potentially contributing to the uncertainty of the community member on #2282 as to where to submit substantive feedback), which I believe I found after a fair amount of digging and a bit of guesswork. As such, this PR does just that.

CC: @pradeep90 