### PR TITLE
PEP 594: Update Discussions-To link and date with posting of new thread

### DIFF
--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -2,13 +2,13 @@ PEP: 594
 Title: Removing dead batteries from the standard library
 Author: Christian Heimes <christian@python.org>,
         Brett Cannon <brett@python.org>
-Discussions-To: https://discuss.python.org/t/pep-594-removing-dead-batteries-from-the-standard-library/1704
+Discussions-To: https://discuss.python.org/t/13508
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 20-May-2019
 Python-Version: 3.11
-Post-History: 21-May-2019
+Post-History: 21-May-2019, 04-Feb-2022
 
 
 Abstract


### PR DESCRIPTION
A [new discussion thread](https://discuss.python.org/t/pep-594-take-2-removing-dead-batteries-from-the-standard-library/13508) was opened for this PEP on Discourse following the last round of updates; this updates the PEP headers to reflect that.

First noticed by @hugovk in #2334 