### PR TITLE
PEP 675: Update logging annotation example with overload

### DIFF
--- a/pep-0675.rst
+++ b/pep-0675.rst
@@ -956,6 +956,11 @@ proposed in `Issue 46200 <https://bugs.python.org/issue46200>`_):
 
 ::
 
+    @typing.overload
+    def info(msg: str) -> None:
+        ...
+
+    @typing.overload
     def info(msg: LiteralString, *args: object) -> None:
         ...
 


### PR DESCRIPTION
This allows logging.info(f-string) or other premade thing
while still preventing format injection.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
