### PR TITLE
PEP 655: Highlight TypeScript code snippet correctly

### DIFF
--- a/pep-0655.rst
+++ b/pep-0655.rst
@@ -63,7 +63,7 @@ One might think it unusual to propose syntax that prioritizes marking
 *required* keys rather than syntax for *potentially-missing* keys, as is
 customary in other languages like TypeScript:
 
-::
+.. code-block:: typescript
 
    interface Movie {
        title: string;


### PR DESCRIPTION
Did add syntax-highlighting syntax as requested by {@AA-Turner , @hugovk , @CAM-Gerlach }.

However when I try to regenerate the PEP and view it locally, the marked block doesn't actually appear with any syntax-highlighted colors. Seems strange to use a notation that has no effect on the generated output.

Am I missing something? Is there a setting needed to actually enable syntax highlighting?