### PR TITLE
PEP 655: Add Discussions-To link to the actual thread

### DIFF
--- a/pep-0655.rst
+++ b/pep-0655.rst
@@ -2,7 +2,7 @@ PEP: 655
 Title: Marking individual TypedDict items as required or potentially-missing
 Author: David Foster <david at dafoster.net>
 Sponsor: Guido van Rossum <guido at python.org>
-Discussions-To: typing-sig at python.org
+Discussions-To: https://mail.python.org/archives/list/typing-sig@python.org/thread/53XVOD5ZUKJ263MWA6AUPEA6J7LBBLNV/
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
@@ -315,7 +315,7 @@ Usage in Python <3.11
 If your code supports Python <3.11 and wishes to use ``Required[]`` or
 ``NotRequired[]`` then it should use ``typing_extensions.TypedDict`` rather
 than ``typing.TypedDict`` because the latter will not understand
-``(Not)Required[]``. In particular ``__required_keys__`` and 
+``(Not)Required[]``. In particular ``__required_keys__`` and
 ``__optional_keys__`` on the resulting TypedDict type will not be correct:
 
 Yes (Python 3.11+ only):
@@ -346,11 +346,11 @@ No (Python <3.11 and 3.11+):
 
    from typing import TypedDict  # oops: should import from typing_extensions instead
    from typing_extensions import NotRequired
-   
+
    class Movie(TypedDict):
        title: str
        year: NotRequired[int]
-   
+
    assert Movie.__required_keys__ == frozenset({'title', 'year'})  # yikes
    assert Movie.__optional_keys__ == frozenset()  # yikes
 
@@ -464,7 +464,7 @@ as the type of a variable which is only conditionally defined:
 
    class MyClass:
        attr: int|Missing
-       
+
        def __init__(self, set_attr: bool) -> None:
            if set_attr:
                self.attr = 10
@@ -533,7 +533,7 @@ or a check against ``locals()`` for local variables:
        packet_bytes: Union[str, Missing]
        if packet_data is not None:
            packet_bytes = packet.data.encode('utf-8')
-       
+
        if 'packet_bytes' in locals():
            reveal_type(packet_bytes)  # bytes
            socket.send(packet_bytes)


### PR DESCRIPTION
A followup to the issue just raised on [Discourse](https://discuss.python.org/t/pep-655-required-and-notrequired-for-typeddict/13817) and #2266 . Currently, PEP 655 doesn't actually link the canonical discussion thread, requiring community members interesting in reading or contributing to the discussion to Google and guess to find the official discussion, or fragmenting it into multiple different threads, making following and reviewing it more difficult for both SC members/PEP-delegates and the community alike. This PR links what I believe is the correct thread, resolving this issue.

As an enhancement to the previous approach, and tested and confirmed with both build systems and our linting suite, it uses an inline link, which keeps the conciseness and human-readability of just stating the mailing list name, while still including the actual link.

CC: @davidfstr 