### PR TITLE
PEP 654: Fix output of two examples

### DIFF
--- a/pep-0654.rst
+++ b/pep-0654.rst
@@ -893,19 +893,16 @@ chaining:
     ...
       | ExceptionGroup
       +-+---------------- 1 ----------------
-        | ExceptionGroup
-        +-+---------------- 1 ----------------
-          | Traceback (most recent call last):
-          |   File "<stdin>", line 2, in <module>
-          | TypeError: bad type
-          +------------------------------------
-        |
-        | The above exception was the direct cause of the following exception:
-        |
         | Traceback (most recent call last):
-        |   File "<stdin>", line 4, in <module>
-        | ValueError: bad value
+        |   File "<stdin>", line 2, in <module>
+        | TypeError: bad type
         +------------------------------------
+
+    The above exception was the direct cause of the following exception:
+
+    Traceback (most recent call last):
+      File "<stdin>", line 4, in <module>
+    ValueError: bad value
     >>>
 
 
@@ -921,12 +918,9 @@ other clauses from the same ``try`` statement:
     ... except* ValueError:
     ...     print('never')
     ...
-      | ExceptionGroup
-      +-+---------------- 1 ----------------
-        | Traceback (most recent call last):
-        |   File "<stdin>", line 4, in <module>
-        | ValueError: 2
-        +----------------------------------------
+    Traceback (most recent call last):
+      File "<stdin>", line 4, in <module>
+    ValueError: 2
     >>>
 
 


### PR DESCRIPTION
I just ran the examples in the PEP and found two that have a stale output.
Quite a while back we decided that we won't add an implicit wrap by an ExceptionGroup when propagating only one exception from an except*.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
