### PR TITLE
PEP 1: Update outdated language referring to Travis CI and plain-text PEPs

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -204,10 +204,9 @@ The standard PEP workflow is:
     editors do not consider whether they seem likely to be accepted.
   * The title accurately describes the content.
   * The PEP's language (spelling, grammar, sentence structure, etc.)
-    and code style (examples should match :pep:`8` & :pep:`7`) should be
-    correct and conformant.  The PEP will be checked for formatting
-    (plain text or reStructuredText) by Travis CI, and will not be
-    approved until this passes.
+    and code style (examples should match :pep:`7` & :pep:`8`) should be
+    correct and conformant.  The PEP will be checked for reStructuredText
+    formatting by the repo's CIs, and will not be approved until this passes.
 
   Editors are generally quite lenient about this initial review,
   expecting that problems will be corrected by the reviewing process.
@@ -520,7 +519,7 @@ PEP Formats and Templates
 =========================
 
 PEPs are UTF-8 encoded text files using the reStructuredText_ format.
-ReStructuredText_ allows for rich markup that is still quite easy to
+reStructuredText allows for rich markup that is still quite easy to
 read, but also results in good-looking and functional HTML. :pep:`12`
 contains instructions and a :pep:`template <12#suggested-sections>`
 for reStructuredText PEPs.
@@ -602,11 +601,11 @@ Discussions-To header will not be obscured.
 The Type header specifies the type of PEP: Standards Track,
 Informational, or Process.
 
-The format of a PEP is specified with a Content-Type header.  The
-acceptable values are "text/plain" for plaintext PEPs (see :pep:`9`)
-and "text/x-rst" for reStructuredText PEPs (see :pep:`12`).
-reStructuredText is strongly preferred, but for backwards
-compatibility plain text is currently still the default if no
+The format of a PEP is specified with a Content-Type header.
+Valid values are ``text/plain`` for plaintext PEPs (see :pep:`9`)
+and ``text/x-rst`` for reStructuredText PEPs (see :pep:`12`).
+All new and active PEPs must use reStructuredText, but for backwards
+compatibility, plain text is currently still the default if no
 Content-Type header is present.
 
 The Created header records the date that the PEP was assigned a
@@ -718,8 +717,8 @@ For each new PEP that comes in an editor does the following:
 
 * Skim the PEP for obvious defects in language (spelling, grammar,
   sentence structure, etc.), and code style (examples should conform to
-  :pep:`8` & :pep:`7`).  Editors may correct problems themselves, but are
-  not required to do so.  (Text format is checked by Travis CI.)
+  :pep:`7` & :pep:`8`).  Editors may correct problems themselves, but are
+  not required to do so (reStructuredText syntax is checked by the repo's CIs).
 
 * If a project is portrayed as benefiting from or supporting the PEP, make sure
   there is some direct indication from the project included to make the support

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -205,8 +205,9 @@ The standard PEP workflow is:
   * The title accurately describes the content.
   * The PEP's language (spelling, grammar, sentence structure, etc.)
     and code style (examples should match :pep:`7` & :pep:`8`) should be
-    correct and conformant.  The PEP will be checked for reStructuredText
-    formatting by the repo's CIs, and will not be approved until this passes.
+    correct and conformant.  The PEP text will be automatically checked for 
+    correct reStructuredText formatting when the pull request is submitted. 
+    PEPs with invalid reST markup will not be approved.
 
   Editors are generally quite lenient about this initial review,
   expecting that problems will be corrected by the reviewing process.
@@ -718,7 +719,7 @@ For each new PEP that comes in an editor does the following:
 * Skim the PEP for obvious defects in language (spelling, grammar,
   sentence structure, etc.), and code style (examples should conform to
   :pep:`7` & :pep:`8`).  Editors may correct problems themselves, but are
-  not required to do so (reStructuredText syntax is checked by the repo's CIs).
+  not required to do so (reStructuredText syntax is checked by the repo's CI).
 
 * If a project is portrayed as benefiting from or supporting the PEP, make sure
   there is some direct indication from the project included to make the support


### PR DESCRIPTION
Presently, PEP 1 states that PEPs will be checked via Travis CI a couple places, which this PR updates to refer to generic "CI" (in case we change from GHA in the future, since such implementation details have no business being in a governance PEP). Also, it updates a few related outdated references referring to the legacy plain-text format in new/active PEPs.