### PR TITLE
PEP 544: Replace broken link to Zope documentation

### DIFF
--- a/pep-0544.txt
+++ b/pep-0544.txt
@@ -1377,7 +1377,8 @@ Support adapters and adaptation
 -------------------------------
 
 Adaptation was proposed by :pep:`246` (rejected) and is supported by
-``zope.interface``, see `https://docs.zope.org/zope.interface/adapter.html <https://web.archive.org/web/20160802080957/https://docs.zope.org/zope.interface/adapter.html>`_.
+``zope.interface``, see `the Zope documentation on adapter registries
+<https://web.archive.org/web/20160802080957/https://docs.zope.org/zope.interface/adapter.html>`_.
 Adapters is quite an advanced concept, and :pep:`484` supports unions and
 generic aliases that can be used instead of adapters. This can be illustrated
 with an example of ``Iterable`` protocol, there is another way of supporting

--- a/pep-0544.txt
+++ b/pep-0544.txt
@@ -1377,7 +1377,7 @@ Support adapters and adaptation
 -------------------------------
 
 Adaptation was proposed by :pep:`246` (rejected) and is supported by
-``zope.interface``, see https://docs.zope.org/zope.interface/adapter.html.
+``zope.interface``, see `https://docs.zope.org/zope.interface/adapter.html <https://web.archive.org/web/20160802080957/https://docs.zope.org/zope.interface/adapter.html>`_.
 Adapters is quite an advanced concept, and :pep:`484` supports unions and
 generic aliases that can be used instead of adapters. This can be illustrated
 with an example of ``Iterable`` protocol, there is another way of supporting


### PR DESCRIPTION
I've been reading through some PEPs to better educate myself about Python, and I found some room for improvement in PEP 544 "Protocols: Structural subtyping (static duck typing)". I made three separate commits to make it easier to accept/reject them individually:

- ~`PEP 544: Fix errors in class object example`~: While reading through the PEP, I noticed that the comments for type errors were reversed in the third code block in the "`Type[]` and class objects vs protocols" section. I ran the example through mypy 0.931 using Python 3.10.2 to verify I was correct, and it found some other errors that I needed to fix before I could get the expected error:
  ```console
  $ mypy example.py
  example.py:11: error: Incompatible types in assignment (expression has type "Type[C]", variable has type "ProtoA")
  example.py:12: error: Incompatible types in assignment (expression has type "Type[C]", variable has type "ProtoB")
  Found 2 errors in 1 file (checked 1 source file)
  $ mypy example.py
  example.py:12: error: Incompatible types in assignment (expression has type "Type[C]", variable has type "Type[ProtoB]")
  Found 1 error in 1 file (checked 1 source file)
  ```
  If these changes are wrong, then there is a bug in mypy that needs fixing.
- `PEP 544: Replace broken link to Zope documentation`: The documentation links to <https://www.zope.dev/zope.interface/adapter.html>, but it appears to have been broken for quite a while, possibly not too long after it was first added in ea2cd1593b22fb49038e9ad25e63a475cf8b441e. I replaced it with <https://web.archive.org/web/20160802080957/https://docs.zope.org/zope.interface/adapter.html>, which was the most recent version available. I also found <https://zopeinterface.readthedocs.io/en/latest/adapter.html>, which contains very similar content, but I personally believe the Wayback Machine link is safer because it is less likely to change.

  The change went over the line length limit, but linting checks still pass. Do I need to manually wrap the markup?

- ~`PEP 544: Rename confusing identifiers in example`~: I found that the second code block in the "Support `isinstance()` checks by default" section was confusing because of the multiple uses of `x` as an identifier. It is obviously subjective about whether this is confusing, but changing some of the usages seems like a safe change.

I decided to be a completionist and run all other Python code blocks through mypy to check for correctness. I intentionally skipped the "Rejected/Postponed Ideas" section because they probably shouldn't work. I also skipped the `zope` and non-Python code because those are more difficult to check. I for the most part found every example is correct, but I found two problems worth bringing up:

- The first code block in the "Explicitly declaring implementation" section includes a line with the comment `# Error, no default implementation`, even though it passes mypy checks and does not error when the line is executed. For context, here is a modified minimal version of the code block that can run without unrelated errors:

  ```python
  from abc import abstractmethod
  from typing import Protocol

  class PColor(Protocol):
      @abstractmethod
      def draw(self) -> str:
          ...

  class BadColor(PColor):
      def draw(self) -> str:
          return super().draw()  # Error, no default implementation

  bad = BadColor()
  bad.draw()
  ```

  I believe that either the comment should not be here or I should be writing up an issue for mypy. Alternatively, I might not be using the write mypy settings to detect this, but the `--strict` flag doesn't help, so I'm not sure there is a lot more to search there.

- I had to do a lot of cleanup to the code blocks to run them through mypy. Many would fail to run as Python scripts. Most of these were due to missing or incomplete imports, but others wouldn't even compile due to loose syntax. I am not proposing that the Python code in PEPs should be automatically validated, but given that the documentation for [`typing.Protocol`](https://docs.python.org/3.10/library/typing.html#typing.Protocol) says to "See PEP 544 for details.", this PEP is somewhat of an extension of the main documentation. I checked PEP 1 and PEP 12 to see if they have any guidance on this topic. They do not specify about code example validity, so I'm not sure if this is something I should try to fix.