### PR TITLE
PEP 0: Don't add title for empty references section

### DIFF
--- a/pep0/output.py
+++ b/pep0/output.py
@@ -284,7 +284,5 @@ def write_pep0(peps, output=sys.stdout):
     print(author_table_separator, file=output)
     print(file=output)
     print(file=output)
-    # References for introduction footnotes
-    emit_title("References", "references", output)
     print(constants.references, file=output)
     print(constants.footer, file=output)


### PR DESCRIPTION
PEP 0 has an empty references section at the bottom in the old docutils builder on Python.org (it renders as expected via PEP 676)...my fault, again. Apparently, despite my local testing previously, it doesn't actually get removed, at least when run via the Python.org system. Yet one more thing PEP 676 will fix, but for now, this removes that vestigial invisible section heading at the source. Tested to produce the expected results with `genpepindex.py` and `pep2html.py` (has no effect on the new build system).