### PR TITLE
PEP 1: Make text/x-rst officially the default and update accordingly

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -205,8 +205,8 @@ The standard PEP workflow is:
   * The title accurately describes the content.
   * The PEP's language (spelling, grammar, sentence structure, etc.)
     and code style (examples should match :pep:`7` & :pep:`8`) should be
-    correct and conformant.  The PEP text will be automatically checked for 
-    correct reStructuredText formatting when the pull request is submitted. 
+    correct and conformant.  The PEP text will be automatically checked for
+    correct reStructuredText formatting when the pull request is submitted.
     PEPs with invalid reST markup will not be approved.
 
   Editors are generally quite lenient about this initial review,
@@ -547,7 +547,7 @@ optional and are described below.  All other headers are required.
     Status: <Draft | Active | Accepted | Provisional | Deferred | Rejected |
              Withdrawn | Final | Superseded>
     Type: <Standards Track | Informational | Process>
-  * Content-Type: <text/x-rst | text/plain>
+  * Content-Type: text/x-rst
   * Requires: <pep numbers>
     Created: <date created on, in dd-mmm-yyyy format>
   * Python-Version: <version number>
@@ -603,11 +603,9 @@ The Type header specifies the type of PEP: Standards Track,
 Informational, or Process.
 
 The format of a PEP is specified with a Content-Type header.
-Valid values are ``text/plain`` for plaintext PEPs (see :pep:`9`)
-and ``text/x-rst`` for reStructuredText PEPs (see :pep:`12`).
-All new and active PEPs must use reStructuredText, but for backwards
-compatibility, plain text is currently still the default if no
-Content-Type header is present.
+All PEPs must use reStructuredText (see :pep:`12`),
+and have a value of ``text/x-rst``, the default.
+Previously, plaintext PEPs used ``text/plain`` (see :pep:`9`).
 
 The Created header records the date that the PEP was assigned a
 number, while Post-History is used to record the dates of when new

--- a/pep-0012/pep-NNNN.rst
+++ b/pep-0012/pep-NNNN.rst
@@ -6,6 +6,7 @@ PEP-Delegate: <PEP delegate's real name>
 Discussions-To: <email address or URL>
 Status: <REQUIRED: Draft | Active | Accepted | Provisional | Deferred | Rejected | Withdrawn | Final | Superseded>
 Type: <REQUIRED: Standards Track | Informational | Process>
+Content-Type: text/x-rst
 Requires: <pep numbers>
 Created: <date created on, in dd-mmm-yyyy format>
 Python-Version: <version number>

--- a/pep2html.py
+++ b/pep2html.py
@@ -260,7 +260,7 @@ def fixfile(inpath, input_lines, outfile):
                     v = date
         elif k.lower() in ('content-type',):
             url = PEPURL % 9
-            pep_type = v or 'text/plain'
+            pep_type = v or 'text/x-rst'
             v = '<a href="%s">%s</a> ' % (url, escape(pep_type))
         elif k.lower() == 'version':
             if v.startswith('$' 'Revision: ') and v.endswith(' $'):
@@ -569,7 +569,7 @@ def fix_rst_pep(inpath, input_lines, outfile):
 
 def get_pep_type(input_lines):
     """
-    Return the Content-Type of the input.  "text/plain" is the default.
+    Return the Content-Type of the input.  "text/x-rst" is the default.
     Return ``None`` if the input is not a PEP.
     """
     pep_type = None
@@ -579,11 +579,11 @@ def get_pep_type(input_lines):
             # End of the RFC 2822 header (first blank line).
             break
         elif line.startswith('content-type: '):
-            pep_type = line.split()[1] or 'text/plain'
+            pep_type = line.split()[1] or 'text/x-rst'
             break
         elif line.startswith('pep: '):
             # Default PEP type, used if no explicit content-type specified:
-            pep_type = 'text/plain'
+            pep_type = 'text/x-rst'
     return pep_type
 
 


### PR DESCRIPTION
As mentioned in #2352 , despite every single PEP in the repo, even PEP-0009, using `Content-Type: text/x-rst`, the obsolete plain text format described in said PEP, with `Content-Type: text/plain`, is still the default (at least in the old docutils-based system; this is fixed in the new PEP 676 Sphinx-based one).

Therefore, this flips the default to `text/x-rst`, and updates PEP 1 and the reST PEP template accordingly (which up until now, lacked a Content-Type header entirely, meaning that PEPs would in fact render as plain-text). This makes the Sphinx and docutils build systems consistent, allows simplifying the Readme, Contributing Guide, PEP 1 and the template, and sets the stage for eliminating this now-redundant field entirely in the future (e.g. if/when acceptance of PEP 676).