### PR TITLE
PEP 1 & 12: Have Post-History link posts to preserve Discussions-To history

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -600,8 +600,8 @@ optional and are described below.  All other headers are required.
   * Requires: <pep numbers>
     Created: <date created on, in dd-mmm-yyyy format>
   * Python-Version: <version number>
-    Post-History: <dates, in dd-mmm-yyyy format, and corresponding links to
-                   PEP discussion threads>
+    Post-History: <dates, in dd-mmm-yyyy format,
+                   inline-linked to PEP discussion threads>
   * Replaces: <pep number>
   * Superseded-By: <pep number>
   * Resolution: <url>
@@ -658,7 +658,8 @@ Content-Type header is present.
 
 The Created header records the date that the PEP was assigned a
 number, while Post-History is used to record the dates of and corresponding
-inline links to the Discussions-To threads for the PEP.
+URLs to the Discussions-To threads for the PEP, with the former as the
+linked text, and the latter as the link target.
 Both headers should be in dd-mmm-yyyy format, e.g. 14-Aug-2001.
 
 Standards Track PEPs will typically have a Python-Version header which

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -660,7 +660,7 @@ The Created header records the date that the PEP was assigned a
 number, while Post-History is used to record the dates of and corresponding
 URLs to the Discussions-To threads for the PEP, with the former as the
 linked text, and the latter as the link target.
-Both headers should be in dd-mmm-yyyy format, e.g. 14-Aug-2001.
+Both sets of dates should be in ``dd-mmm-yyyy`` format, e.g. ``14-Aug-2001``.
 
 Standards Track PEPs will typically have a Python-Version header which
 indicates the version of Python that the feature will be released with.

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -208,8 +208,8 @@ The standard PEP workflow is:
   * The title accurately describes the content.
   * The PEP's language (spelling, grammar, sentence structure, etc.)
     and code style (examples should match :pep:`7` & :pep:`8`) should be
-    correct and conformant.  The PEP text will be automatically checked for 
-    correct reStructuredText formatting when the pull request is submitted. 
+    correct and conformant.  The PEP text will be automatically checked for
+    correct reStructuredText formatting when the pull request is submitted.
     PEPs with invalid reST markup will not be approved.
 
   Editors are generally quite lenient about this initial review,
@@ -286,13 +286,13 @@ the PEP Sponsor and PEP editors can advise them accordingly.
 If the chosen venue is not the `Python-Dev`_ mailing list,
 a brief announcement should be posted there when the draft PEP is
 committed to the PEP repository and available on the PEP website,
-with a link to the rendered PEP and the to canonical Discussions-To thread.
+with a link to the rendered PEP and to the canonical ``Discussions-To`` thread.
 
 If a PEP undergoes a significant re-write or other major, substantive
 changes to its proposed specification, a new thread should typically be created
 in the chosen venue to solicit additional feedback. If this occurs, the
-``Discussions-To`` link and ``Post-History`` in the PEP must be updated to
-reflect this new thread, and (if not the discussion venue) a further
+``Discussions-To`` link must be updated and a new ``Post-History`` entry added
+pointing to this new thread, and (if not the discussion venue) a further
 announcement sent to `Python-Dev`_ containing the same information as above
 and at least briefly summarizing the major changes.
 
@@ -600,7 +600,8 @@ optional and are described below.  All other headers are required.
   * Requires: <pep numbers>
     Created: <date created on, in dd-mmm-yyyy format>
   * Python-Version: <version number>
-    Post-History: <dates of postings to Python-Dev and/or the Discussions-To thread, in dd-mmm-yyyy format>
+    Post-History: <dates, in dd-mmm-yyyy format, and corresponding links to
+                   PEP discussion threads>
   * Replaces: <pep number>
   * Superseded-By: <pep number>
   * Resolution: <url>
@@ -656,8 +657,8 @@ compatibility, plain text is currently still the default if no
 Content-Type header is present.
 
 The Created header records the date that the PEP was assigned a
-number, while Post-History is used to record the dates of when new
-versions of the PEP are posted to Python-Dev and/or the Discussions-To thread.
+number, while Post-History is used to record the dates of and corresponding
+inline links to the Discussions-To threads for the PEP.
 Both headers should be in dd-mmm-yyyy format, e.g. 14-Aug-2001.
 
 Standards Track PEPs will typically have a Python-Version header which

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -130,8 +130,8 @@ directions below.
       Post-History: `14-Aug-2001 <https://www.example.com/thread_1>`_,
                     `03-Sept-2001 <https://www.example.com/thread_2>`_
 
-  You must manually add new dates/links and commit them as soon as you post a
-  new discussion thread (with a pull request, if you don't have push rights).
+  You must manually add new dates/links as soon as you post a
+  new discussion thread.
 
 - Add a Replaces header if your PEP obsoletes an earlier PEP.  The
   value of this header is the number of the PEP that your new PEP is

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -7,7 +7,7 @@ Status: Active
 Type: Process
 Content-Type: text/x-rst
 Created: 05-Aug-2002
-Post-History: 30-Aug-2002
+Post-History: `30-Aug-2002 <https://mail.python.org/archives/list/python-dev@python.org/thread/KX3AS7QAY26QH3WIUAEOCCNXQ4V2TGGV/>`_
 
 
 .. note::
@@ -113,20 +113,25 @@ directions below.
   first appearance in.  Do not use an alpha or beta release
   designation here.  Thus, if the last version of Python was 2.2 alpha
   1 and you're hoping to get your new feature into Python 2.2, set the
-  header to::
+  header to:
+
+  .. code-block:: email
 
       Python-Version: 2.2
 
-- Leave Post-History alone for now; you'll add dates to this header
-  each time you post your PEP to the designated discussion forum (and announce
-  it on Python-Dev, if needed; see the ``Discussions-To`` header above).
+- Leave Post-History alone for now; you'll add dates and corresponding links
+  to this header each time you post your PEP to the designated discussion forum
+  (and update the ``Discussions-To`` header with said link, as above).
   If you posted threads for your PEP on August 14, 2001 and September 3, 2001,
-  the Post-History header would look like::
+  the Post-History header would look something like:
 
-      Post-History: 14-Aug-2001, 03-Sept-2001
+  .. code-block:: email
 
-  You must manually add new dates and commit them (with a pull request
-  if you don't have push privileges).
+      Post-History: `14-Aug-2001 <https://www.example.com/thread_1>`_,
+                    `03-Sept-2001 <https://www.example.com/thread_2>`_
+
+  You must manually add new dates/links and commit them as soon as you post a
+  new discussion thread (with a pull request, if you don't have push rights).
 
 - Add a Replaces header if your PEP obsoletes an earlier PEP.  The
   value of this header is the number of the PEP that your new PEP is
@@ -152,7 +157,9 @@ directions below.
 For reference, here are all of the possible header fields (everything
 in brackets should either be replaced or have the field removed if
 it has a leading ``*`` marking it as optional and it does not apply to
-your PEP)::
+your PEP):
+
+.. code-block:: email
 
   PEP: [NNN]
   Title: [...]
@@ -166,7 +173,7 @@ your PEP)::
   Requires: *[NNN]
   Created: [DD-MMM-YYYY]
   Python-Version: *[M.N]
-  Post-History: [DD-MMM-YYYY]
+  Post-History: [`DD-MMM-YYYY <URL>`_]
   Replaces: *[NNN]
   Superseded-By: *[NNN]
   Resolution:

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -121,7 +121,11 @@ directions below.
 
 - Leave Post-History alone for now; you'll add dates and corresponding links
   to this header each time you post your PEP to the designated discussion forum
-  (and update the ``Discussions-To`` header with said link, as above).
+  (and update the Discussions-To header with said link, as above).
+  For each thread, use the date (in the ``dd-mmm-yyy`` format) as the
+  linked text, and insert the URLs inline as anonymous reST `hyperlinks`_,
+  with commas in between each posting.
+
   If you posted threads for your PEP on August 14, 2001 and September 3, 2001,
   the Post-History header would look like, e.g.:
 

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -7,7 +7,7 @@ Status: Active
 Type: Process
 Content-Type: text/x-rst
 Created: 05-Aug-2002
-Post-History: `30-Aug-2002 <https://mail.python.org/archives/list/python-dev@python.org/thread/KX3AS7QAY26QH3WIUAEOCCNXQ4V2TGGV/>`_
+Post-History: `30-Aug-2002 <https://mail.python.org/archives/list/python-dev@python.org/thread/KX3AS7QAY26QH3WIUAEOCCNXQ4V2TGGV/>`__
 
 
 .. note::
@@ -123,14 +123,14 @@ directions below.
   to this header each time you post your PEP to the designated discussion forum
   (and update the ``Discussions-To`` header with said link, as above).
   If you posted threads for your PEP on August 14, 2001 and September 3, 2001,
-  the Post-History header would look something like:
+  the Post-History header would look like, e.g.:
 
   .. code-block:: email
 
-      Post-History: `14-Aug-2001 <https://www.example.com/thread_1>`_,
-                    `03-Sept-2001 <https://www.example.com/thread_2>`_
+      Post-History: `14-Aug-2001 <https://www.example.com/thread_1>`__,
+                    `03-Sept-2001 <https://www.example.com/thread_2>`__
 
-  You must manually add new dates/links as soon as you post a
+  You should add the new dates/links here as soon as you post a
   new discussion thread.
 
 - Add a Replaces header if your PEP obsoletes an earlier PEP.  The
@@ -173,7 +173,7 @@ your PEP):
   Requires: *[NNN]
   Created: [DD-MMM-YYYY]
   Python-Version: *[M.N]
-  Post-History: [`DD-MMM-YYYY <URL>`_]
+  Post-History: [`DD-MMM-YYYY <URL>`__]
   Replaces: *[NNN]
   Superseded-By: *[NNN]
   Resolution:

--- a/pep-0012/pep-NNNN.rst
+++ b/pep-0012/pep-NNNN.rst
@@ -9,7 +9,7 @@ Type: <REQUIRED: Standards Track | Informational | Process>
 Requires: <pep numbers>
 Created: <date created on, in dd-mmm-yyyy format>
 Python-Version: <version number>
-Post-History: <REQUIRED: dates of postings to Python-Dev and/or the Discussions-To thread, in dd-mmm-yyyy format>
+Post-History: <REQUIRED: dates, in dd-mmm-yyyy format, and corresponding links to PEP discussion threads>
 Replaces: <pep number>
 Superseded-By: <pep number>
 Resolution: <url>


### PR DESCRIPTION
As requested on #2335 by multiple people, [discussed and documented](https://github.com/python/peps/issues/2266#issuecomment-1045676523) in #2266 and as a followup to PR #2346 , where it was also independently requested by another reviewer.

The `Discussions-To` link, while helpful in providing the latest/current thread (which is hopefully cross-linked to any previous threads) is currently transient, and does not preserve the history of previous discussion threads. This is useful to retain for most of the same reasons linking the current thread is, to document and allow readers to explore and learn from the discussions that led to a PEP, enable the Steering Council, PEP-Delegate and other reviewers to examine the full discussion history, and track such threads for authors and other interested parties.

Therefore, the obvious place to preserve this information is in the `Post-History` header, and the most straightforward way to do so, with no changes to any existing code, just guidance, is via regular reST inline links on the dates. Inline-linking the existing dates retains the current rendered format, while offering readers direct access to the actual mentioned posts/threads with just a click. This doesn't affect any current linting or processing, since the Post-History field does not have a programmatically-enforced structure (as a number of PEPs didn't strictly follow the format anyway).

As such, this PR makes the relatively modest updates to PEP 1, PEP 12 and the template to formally describe this revised usage. It also incorporates a few straightforward fixes to the content added/modified in #2266 . As the changes are purely technical in nature, this PR should be able to be merged once at least a few PEP editors approve.