### PR TITLE
PEP 655: Motivation: Enables mixed key requiredness in the TypedDict alternative syntax

### DIFF
--- a/pep-0655.rst
+++ b/pep-0655.rst
@@ -74,7 +74,7 @@ Rationale
 =========
 
 One might think it unusual to propose syntax that prioritizes marking
-*required* keys rather than syntax for marking *potentially-missing* keys, as is
+*required* keys rather than *potentially-missing* keys, as is
 customary in other languages like TypeScript:
 
 .. code-block:: typescript

--- a/pep-0655.rst
+++ b/pep-0655.rst
@@ -55,12 +55,25 @@ a mix of both required and potentially-missing keys:
        title: str
        year: NotRequired[int]
 
+This PEP also makes it possible to define TypedDicts in the
+:pep:`alternative syntax <589#alternative-syntax>`
+with a mix of required and potentially-missing keys,
+which is not currently possible at all because the alternative syntax does
+not support inheritance:
+
+::
+
+   Actor = TypedDict('Actor', {
+       'name': str,
+       'in': NotRequired[List[str]],  # "in" is a keyword, so needs alternative syntax
+   })
+
 
 Rationale
 =========
 
 One might think it unusual to propose syntax that prioritizes marking
-*required* keys rather than syntax for *potentially-missing* keys, as is
+*required* keys rather than syntax for marking *potentially-missing* keys, as is
 customary in other languages like TypeScript:
 
 .. code-block:: typescript

--- a/pep-0655.rst
+++ b/pep-0655.rst
@@ -56,7 +56,7 @@ a mix of both required and potentially-missing keys:
        year: NotRequired[int]
 
 This PEP also makes it possible to define TypedDicts in the
-:pep:`alternative syntax <589#alternative-syntax>`
+:pep:`alternative functional syntax <589#alternative-syntax>`
 with a mix of required and potentially-missing keys,
 which is not currently possible at all because the alternative syntax does
 not support inheritance:
@@ -152,7 +152,7 @@ same time:
        year: NotRequired[Required[int]]  # ERROR
 
 
-The :pep:`alternative syntax <589#alternative-syntax>`
+The :pep:`alternative functional syntax <589#alternative-syntax>`
 for TypedDict also supports
 ``Required[]`` and ``NotRequired[]``:
 

--- a/pep-0655.rst
+++ b/pep-0655.rst
@@ -65,7 +65,8 @@ not support inheritance:
 
    Actor = TypedDict('Actor', {
        'name': str,
-       'in': NotRequired[List[str]],  # "in" is a keyword, so needs alternative syntax
+       # "in" is a keyword, so the functional syntax is necessary
+       'in': NotRequired[List[str]],
    })
 
 


### PR DESCRIPTION
Thanks for the related feedback @JelleZijlstra and Mehdi Drissi!