### PR TITLE
Display list names in Resolution and Discussions-To headers

### DIFF
--- a/pep-0256.txt
+++ b/pep-0256.txt
@@ -3,7 +3,7 @@ Title: Docstring Processing System Framework
 Version: $Revision$
 Last-Modified: $Date$
 Author: David Goodger <goodger@python.org>
-Discussions-To: <doc-sig@python.org>
+Discussions-To: doc-sig@python.org
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0258.txt
+++ b/pep-0258.txt
@@ -3,7 +3,7 @@ Title: Docutils Design Specification
 Version: $Revision$
 Last-Modified: $Date$
 Author: David Goodger <goodger@python.org>
-Discussions-To: <doc-sig@python.org>
+Discussions-To: doc-sig@python.org
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0287.txt
+++ b/pep-0287.txt
@@ -3,7 +3,7 @@ Title: reStructuredText Docstring Format
 Version: $Revision$
 Last-Modified: $Date$
 Author: David Goodger <goodger@python.org>
-Discussions-To: <doc-sig@python.org>
+Discussions-To: doc-sig@python.org
 Status: Active
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0305.txt
+++ b/pep-0305.txt
@@ -7,7 +7,7 @@ Author: Kevin Altis <altis@semi-retired.com>,
         Andrew McNamara <andrewm@object-craft.com.au>,
         Skip Montanaro <skip@pobox.com>,
         Cliff Wells <LogiplexSoftware@earthlink.net>
-Discussions-To: <csv@python.org>
+Discussions-To: csv@python.org
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0333.txt
+++ b/pep-0333.txt
@@ -3,7 +3,7 @@ Title: Python Web Server Gateway Interface v1.0
 Version: $Revision$
 Last-Modified: $Date$
 Author: Phillip J. Eby <pje@telecommunity.com>
-Discussions-To: Python Web-SIG <web-sig@python.org>
+Discussions-To: web-sig@python.org
 Status: Final
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0345.txt
+++ b/pep-0345.txt
@@ -3,7 +3,7 @@ Title: Metadata for Python Software Packages 1.2
 Version: $Revision$
 Last-Modified: $Date$
 Author: Richard Jones <richard@python.org>
-Discussions-To: Distutils SIG
+Discussions-To: distutils-sig@python.org
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0347.txt
+++ b/pep-0347.txt
@@ -3,7 +3,7 @@ Title: Migrating the Python CVS to Subversion
 Version: $Revision$
 Last-Modified: $Date$
 Author: Martin von Löwis <martin@v.loewis.de>
-Discussions-To: <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Final
 Type: Process
 Content-Type: text/x-rst

--- a/pep-0390.txt
+++ b/pep-0390.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Tarek Ziadé <tarek@ziade.org>
 BDFL-Delegate: Nick Coghlan
-Discussions-To: <distutils-sig@python.org>
+Discussions-To: distutils-sig@python.org
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0423.txt
+++ b/pep-0423.txt
@@ -3,7 +3,7 @@ Title: Naming conventions and recipes related to packaging
 Version: $Revision$
 Last-Modified: $Date$
 Author: Benoit Bryon <benoit@marmelune.net>
-Discussions-To: <distutils-sig@python.org>
+Discussions-To: distutils-sig@python.org
 Status: Deferred
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0426.txt
+++ b/pep-0426.txt
@@ -6,7 +6,7 @@ Author: Nick Coghlan <ncoghlan@gmail.com>,
         Daniel Holth <dholth@gmail.com>,
         Donald Stufft <donald@stufft.io>
 BDFL-Delegate: Donald Stufft <donald@stufft.io>
-Discussions-To: Distutils SIG <distutils-sig@python.org>
+Discussions-To: distutils-sig@python.org
 Status: Withdrawn
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0427.txt
+++ b/pep-0427.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Daniel Holth <dholth@gmail.com>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
-Discussions-To: <distutils-sig@python.org>
+Discussions-To: distutils-sig@python.org
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0436.txt
+++ b/pep-0436.txt
@@ -3,7 +3,7 @@ Title: The Argument Clinic DSL
 Version: $Revision$
 Last-Modified: $Date$
 Author: Larry Hastings <larry@hastings.org>
-Discussions-To: Python-Dev <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0439.txt
+++ b/pep-0439.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Richard Jones <richard@python.org>
 BDFL-Delegate:  Nick Coghlan <ncoghlan@gmail.com>
-Discussions-To: <distutils-sig@python.org>
+Discussions-To: distutils-sig@python.org
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0440.txt
+++ b/pep-0440.txt
@@ -5,7 +5,7 @@ Last-Modified: $Date$
 Author: Nick Coghlan <ncoghlan@gmail.com>,
         Donald Stufft <donald@stufft.io>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
-Discussions-To: Distutils SIG <distutils-sig@python.org>
+Discussions-To: distutils-sig@python.org
 Status: Active
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0443.txt
+++ b/pep-0443.txt
@@ -3,7 +3,7 @@ Title: Single-dispatch generic functions
 Version: $Revision$
 Last-Modified: $Date$
 Author: Łukasz Langa <lukasz@python.org>
-Discussions-To: Python-Dev <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0444.txt
+++ b/pep-0444.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Chris McDonough <chrism@plope.com>,
         Armin Ronacher <armin.ronacher@active-4.com>
-Discussions-To: Python Web-SIG <web-sig@python.org>
+Discussions-To: web-sig@python.org
 Status: Deferred
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0457.txt
+++ b/pep-0457.txt
@@ -3,7 +3,7 @@ Title: Notation For Positional-Only Parameters
 Version: $Revision$
 Last-Modified: $Date$
 Author: Larry Hastings <larry@hastings.org>
-Discussions-To: Python-Dev <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Final
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0459.txt
+++ b/pep-0459.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Nick Coghlan <ncoghlan@gmail.com>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
-Discussions-To: Distutils SIG <distutils-sig@python.org>
+Discussions-To: distutils-sig@python.org
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0480.txt
+++ b/pep-0480.txt
@@ -6,7 +6,7 @@ Author: Trishank Karthik Kuppusamy <karthik@trishank.com>,
         Vladimir Diaz <vladimir.diaz@nyu.edu>,
         Justin Cappos <jcappos@nyu.edu>, Marina Moore <mm9693@nyu.edu>
 BDFL-Delegate: Donald Stufft <donald@stufft.io>
-Discussions-To: Packaging category on Python Discourse <https://discuss.python.org/c/packaging>
+Discussions-To: https://discuss.python.org/c/packaging
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0482.txt
+++ b/pep-0482.txt
@@ -3,7 +3,7 @@ Title: Literature Overview for Type Hints
 Version: $Revision$
 Last-Modified: $Date$
 Author: Łukasz Langa <lukasz@python.org>
-Discussions-To: Python-Ideas <python-ideas@python.org>
+Discussions-To: python-ideas@python.org
 Status: Final
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0483.txt
+++ b/pep-0483.txt
@@ -3,7 +3,7 @@ Title: The Theory of Type Hints
 Version: $Revision$
 Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>, Ivan Levkivskyi <levkivskyi@gmail.com>
-Discussions-To: Python-Ideas <python-ideas@python.org>
+Discussions-To: python-ideas@python.org
 Status: Final
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>, Jukka Lehtosalo <jukka.lehtosalo@iki.fi>, Łukasz Langa <lukasz@python.org>
 BDFL-Delegate: Mark Shannon
-Discussions-To: Python-Dev <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Provisional
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0491.txt
+++ b/pep-0491.txt
@@ -3,7 +3,7 @@ Title: The Wheel Binary Package Format 1.9
 Version: $Revision$
 Last-Modified: $Date$
 Author: Daniel Holth <dholth@gmail.com>
-Discussions-To: <distutils-sig@python.org>
+Discussions-To: distutils-sig@python.org
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0492.txt
+++ b/pep-0492.txt
@@ -3,7 +3,7 @@ Title: Coroutines with async and await syntax
 Version: $Revision$
 Last-Modified: $Date$
 Author: Yury Selivanov <yury@edgedb.com>
-Discussions-To: <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0495.txt
+++ b/pep-0495.txt
@@ -3,7 +3,7 @@ Title: Local Time Disambiguation
 Version: $Revision$
 Last-Modified: $Date$
 Author: Alexander Belopolsky <alexander.belopolsky@gmail.com>, Tim Peters <tim.peters@gmail.com>
-Discussions-To: Datetime-SIG <datetime-sig@python.org>
+Discussions-To: datetime-sig@python.org
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0500.txt
+++ b/pep-0500.txt
@@ -4,7 +4,7 @@ Title: A protocol for delegating datetime methods to their
 Version: $Revision$
 Last-Modified: $Date$
 Author: Alexander Belopolsky <alexander.belopolsky@gmail.com>, Tim Peters <tim.peters@gmail.com>
-Discussions-To: Datetime-SIG <datetime-sig@python.org>
+Discussions-To: datetime-sig@python.org
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0508.txt
+++ b/pep-0508.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Robert Collins <rbtcollins@hp.com>
 BDFL-Delegate: Donald Stufft <donald@stufft.io>
-Discussions-To: distutils-sig <distutils-sig@python.org>
+Discussions-To: distutils-sig@python.org
 Status: Active
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0513.txt
+++ b/pep-0513.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Robert T. McGibbon <rmcgibbo@gmail.com>, Nathaniel J. Smith <njs@pobox.com>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
-Discussions-To: Distutils SIG <distutils-sig@python.org>
+Discussions-To: distutils-sig@python.org
 Status: Superseded
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0516.txt
+++ b/pep-0516.txt
@@ -5,7 +5,7 @@ Last-Modified: $Date$
 Author: Robert Collins <rbtcollins@hp.com>,
         Nathaniel Smith <njs@pobox.com>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
-Discussions-To: distutils-sig <distutils-sig@python.org>
+Discussions-To: distutils-sig@python.org
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -5,7 +5,7 @@ Last-Modified: $Date$
 Author: Nathaniel J. Smith <njs@pobox.com>,
         Thomas Kluyver <thomas@kluyver.me.uk>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
-Discussions-To: <distutils-sig@python.org>
+Discussions-To: distutils-sig@python.org
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0518.txt
+++ b/pep-0518.txt
@@ -6,7 +6,7 @@ Author: Brett Cannon <brett@python.org>,
         Nathaniel Smith <njs@pobox.com>,
         Donald Stufft <donald@stufft.io>
 BDFL-Delegate: Nick Coghlan
-Discussions-To: distutils-sig <distutils-sig at python.org>
+Discussions-To: distutils-sig@python.org
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0525.txt
+++ b/pep-0525.txt
@@ -3,7 +3,7 @@ Title: Asynchronous Generators
 Version: $Revision$
 Last-Modified: $Date$
 Author: Yury Selivanov <yury@edgedb.com>
-Discussions-To: <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0530.txt
+++ b/pep-0530.txt
@@ -3,7 +3,7 @@ Title: Asynchronous Comprehensions
 Version: $Revision$
 Last-Modified: $Date$
 Author: Yury Selivanov <yury@edgedb.com>
-Discussions-To: <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0541.txt
+++ b/pep-0541.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Łukasz Langa <lukasz@python.org>
 BDFL-Delegate: Mark Mangoba <mmangoba@python.org>
-Discussions-To: distutils-sig <distutils-sig@python.org>
+Discussions-To: distutils-sig@python.org
 Status: Final
 Type: Process
 Content-Type: text/x-rst

--- a/pep-0544.txt
+++ b/pep-0544.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Ivan Levkivskyi <levkivskyi@gmail.com>, Jukka Lehtosalo <jukka.lehtosalo@iki.fi>, Łukasz Langa <lukasz@python.org>
 BDFL-Delegate: Guido van Rossum <guido@python.org>
-Discussions-To: Python-Dev <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0549.rst
+++ b/pep-0549.rst
@@ -3,7 +3,7 @@ Title: Instance Descriptors
 Version: $Revision$
 Last-Modified: $Date$
 Author: larry@hastings.org (Larry Hastings)
-Discussions-To: Python-Dev <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0558.rst
+++ b/pep-0558.rst
@@ -2,7 +2,7 @@ PEP: 558
 Title: Defined semantics for locals()
 Author: Nick Coghlan <ncoghlan@gmail.com>
 BDFL-Delegate: Nathaniel J. Smith
-Discussions-To: <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0563.rst
+++ b/pep-0563.rst
@@ -3,7 +3,7 @@ Title: Postponed Evaluation of Annotations
 Version: $Revision$
 Last-Modified: $Date$
 Author: Łukasz Langa <lukasz@python.org>
-Discussions-To: Python-Dev <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0566.rst
+++ b/pep-0566.rst
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Dustin Ingram <di@python.org>
 BDFL-Delegate: Daniel Holth
-Discussions-To: distutils-sig <distutils-sig at python.org>
+Discussions-To: distutils-sig@python.org
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0571.rst
+++ b/pep-0571.rst
@@ -6,7 +6,7 @@ Author: Mark  Williams <mrw@enotuniq.org>,
         Geoffrey Thomas <geofft@ldpreload.com>,
         Thomas Kluyver <thomas@kluyver.me.uk>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
-Discussions-To: Distutils SIG <distutils-sig@python.org>
+Discussions-To: distutils-sig@python.org
 Status: Superseded
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0581.rst
+++ b/pep-0581.rst
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Mariatta <mariatta@python.org>
 BDFL-Delegate: Barry Warsaw <barry@python.org>
-Discussions-To: https://discuss.python.org/c/core-dev
+Discussions-To: https://discuss.python.org/c/core-workflow
 Status: Accepted
 Type: Process
 Content-Type: text/x-rst

--- a/pep-0581.rst
+++ b/pep-0581.rst
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Mariatta <mariatta@python.org>
 BDFL-Delegate: Barry Warsaw <barry@python.org>
-Discussions-To: Core-Workflow Category on Discourse
+Discussions-To: https://discuss.python.org/c/core-dev
 Status: Accepted
 Type: Process
 Content-Type: text/x-rst

--- a/pep-0585.rst
+++ b/pep-0585.rst
@@ -3,7 +3,7 @@ Title: Type Hinting Generics In Standard Collections
 Version: $Revision$
 Last-Modified: $Date$
 Author: Łukasz Langa <lukasz@python.org>
-Discussions-To: Typing-Sig <typing-sig@python.org>
+Discussions-To: typing-sig@python.org
 Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0586.rst
+++ b/pep-0586.rst
@@ -2,7 +2,7 @@ PEP: 586
 Title: Literal Types
 Author: Michael Lee <michael.lee.0x2a@gmail.com>, Ivan Levkivskyi <levkivskyi@gmail.com>, Jukka Lehtosalo <jukka.lehtosalo@iki.fi>
 BDFL-Delegate: Guido van Rossum <guido@python.org>
-Discussions-To: Typing-Sig <typing-sig@python.org>
+Discussions-To: typing-sig@python.org
 Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0588.rst
+++ b/pep-0588.rst
@@ -2,7 +2,7 @@ PEP: 588
 Title: GitHub Issues Migration Plan
 Author: Mariatta <mariatta@python.org>
 BDFL-Delegate: Barry Warsaw <barry@python.org>
-Discussions-To: Core-Workflow Category on Discourse
+Discussions-To: https://discuss.python.org/c/core-dev
 Status: Draft
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0588.rst
+++ b/pep-0588.rst
@@ -2,7 +2,7 @@ PEP: 588
 Title: GitHub Issues Migration Plan
 Author: Mariatta <mariatta@python.org>
 BDFL-Delegate: Barry Warsaw <barry@python.org>
-Discussions-To: https://discuss.python.org/c/core-dev
+Discussions-To: https://discuss.python.org/c/core-workflow
 Status: Draft
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0600.rst
+++ b/pep-0600.rst
@@ -6,7 +6,7 @@ Author: Nathaniel J. Smith <njs@pobox.com>
         Thomas Kluyver <thomas@kluyver.me.uk>
 Sponsor: Paul Moore <p.f.moore@gmail.com>
 BDFL-Delegate: Paul Moore <p.f.moore@gmail.com>
-Discussions-To: Discourse https://discuss.python.org/t/the-next-manylinux-specification/1043
+Discussions-To: https://discuss.python.org/t/the-next-manylinux-specification/1043
 Status: Accepted
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -3,7 +3,7 @@ Title: Parameter Specification Variables
 Author: Mark Mendoza <mendoza.mark.a@gmail.com>
 Sponsor: Guido van Rossum <guido@python.org>
 BDFL-Delegate: Guido van Rossum <guido@python.org>
-Discussions-To: Typing-Sig <typing-sig@python.org>
+Discussions-To: typing-sig@python.org
 Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0617.rst
+++ b/pep-0617.rst
@@ -5,7 +5,7 @@ Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>,
  Pablo Galindo <pablogsal@python.org>,
  Lysandros Nikolaou <lisandrosnik@gmail.com>
-Discussions-To: Python-Dev <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -9,7 +9,7 @@ Author: Brandt Bucher <brandt@python.org>,
         Guido van Rossum <guido@python.org>,
         Talin <viridia@gmail.com>
 BDFL-Delegate:
-Discussions-To: Python-Dev <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Superseded
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0634.rst
+++ b/pep-0634.rst
@@ -5,7 +5,7 @@ Last-Modified: $Date$
 Author: Brandt Bucher <brandt@python.org>,
         Guido van Rossum <guido@python.org>
 BDFL-Delegate:
-Discussions-To: Python-Dev <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0635.rst
+++ b/pep-0635.rst
@@ -5,7 +5,7 @@ Last-Modified: $Date$
 Author: Tobias Kohn <kohnt@tobiaskohn.ch>,
         Guido van Rossum <guido@python.org>
 BDFL-Delegate:
-Discussions-To: Python-Dev <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Final
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0636.rst
+++ b/pep-0636.rst
@@ -5,7 +5,7 @@ Last-Modified: $Date$
 Author: Daniel F Moisset <dfmoisset@gmail.com>
 Sponsor: Guido van Rossum <guido@python.org>
 BDFL-Delegate:
-Discussions-To: Python-Dev <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Final
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0642.rst
+++ b/pep-0642.rst
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Nick Coghlan <ncoghlan@gmail.com>
 BDFL-Delegate:
-Discussions-To: Python-Dev <python-dev@python.org>
+Discussions-To: python-dev@python.org
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0647.rst
+++ b/pep-0647.rst
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Eric Traut <erictr at microsoft.com>
 Sponsor: Guido van Rossum <guido@python.org>
-Discussions-To: Typing-Sig <typing-sig@python.org>
+Discussions-To: typing-sig@python.org
 Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0673.rst
+++ b/pep-0673.rst
@@ -5,7 +5,7 @@ Last-Modified: $Date$
 Author: Pradeep Kumar Srinivasan <gohanpra@gmail.com>,
         James Hilton-Balfe <gobot1234yt@gmail.com>
 Sponsor: Jelle Zijlstra <jelle.zijlstra@gmail.com>
-Discussions-To: Typing-Sig <typing-sig@python.org>
+Discussions-To: typing-sig@python.org
 Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-3124.txt
+++ b/pep-3124.txt
@@ -3,7 +3,7 @@ Title: Overloading, Generic Functions, Interfaces, and Adaptation
 Version: $Revision$
 Last-Modified: $Date$
 Author: Phillip J. Eby <pje@telecommunity.com>
-Discussions-To: Python 3000 List <python-3000@python.org>
+Discussions-To: python-3000@python.org
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-3127.txt
+++ b/pep-3127.txt
@@ -3,7 +3,7 @@ Title: Integer Literal Support and Syntax
 Version: $Revision$
 Last-Modified: $Date$
 Author: Patrick Maupin <pmaupin@gmail.com>
-Discussions-To: Python-3000@python.org
+Discussions-To: python-3000@python.org
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-3128.txt
+++ b/pep-3128.txt
@@ -3,7 +3,7 @@ Title: BList: A Faster List-like Type
 Version: $Revision$
 Last-Modified: $Date$
 Author: Daniel Stutzbach <daniel@stutzbachenterprises.com>
-Discussions-To: Python 3000 List <python-3000@python.org>
+Discussions-To: python-3000@python.org
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-3144.txt
+++ b/pep-3144.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Peter Moody <pmoody@google.com>
 BDFL-Delegate: Nick Coghlan
-Discussions-To: <ipaddr-py-dev@googlegroups.com>
+Discussions-To: ipaddr-py-dev@googlegroups.com
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-3156.txt
+++ b/pep-3156.txt
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>
 BDFL-Delegate: Antoine Pitrou <antoine@python.org>
-Discussions-To: <python-tulip@googlegroups.com>
+Discussions-To: python-tulip@googlegroups.com
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-3333.txt
+++ b/pep-3333.txt
@@ -3,7 +3,7 @@ Title: Python Web Server Gateway Interface v1.0.1
 Version: $Revision$
 Last-Modified: $Date$
 Author: P.J. Eby <pje@telecommunity.com>
-Discussions-To: Python Web-SIG <web-sig@python.org>
+Discussions-To: web-sig@python.org
 Status: Final
 Type: Informational
 Content-Type: text/x-rst

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
@@ -99,27 +99,19 @@ class PEPHeaders(transforms.Transform):
 
 
 def _pretty_thread(text: nodes.Text) -> nodes.Text:
-    # we want to keep these as lowercase:
-    if "python-dev" in text:
-        return nodes.Text("python-dev")
-    if "python-committers" in text:
-        return nodes.Text("python-committers")
-
-    parts = text.split("/")
+    parts = text.title().replace("Sig", "SIG").split("/")
 
     # mailman structure is
     # https://mail.python.org/archives/list/<list name>/thread/<id>
     try:
-        list_name = parts[parts.index("archives") + 2].removesuffix("@python.org")
-        return nodes.Text(list_name.title().replace("Sig", "SIG").replace("-", " "))
+        return nodes.Text(parts[parts.index("Archives") + 2].removesuffix("@Python.Org"))
     except ValueError:
         pass
 
     # pipermail structure is
     # https://mail.python.org/pipermail/<list name>/<month-year>/<id>
     try:
-        list_name = parts[parts.index("pipermail") + 1]
-        return nodes.Text(list_name.title().replace("Sig", "SIG").replace("-", " "))
+        return nodes.Text(parts[parts.index("Pipermail") + 1])
     except ValueError:
         # archives and pipermail not in list, e.g. PEP 245
         return text

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
@@ -68,19 +68,20 @@ class PEPHeaders(transforms.Transform):
                 raise PEPParsingError(msg)
 
             para = body[0]
-            if name in {"author", "bdfl-delegate", "pep-delegate", "discussions-to", "sponsor"}:
+            if name in {"author", "bdfl-delegate", "pep-delegate", "sponsor"}:
                 # mask emails
                 for node in para:
                     if not isinstance(node, nodes.reference):
                         continue
-                    if name == "discussions-to":
-                        if node["refuri"].startswith("http"):
-                            node[0] = _list_name_from_thread(node)
-                        else:
-                            node[0] = _mask_email(node)
-                            node["refuri"] += f"?subject=PEP%20{pep_num}"
-                    else:
-                        node.replace_self(_mask_email(node))
+                    node.replace_self(_mask_email(node))
+            elif name in {"discussions-to", "resolution"}:
+                # only handle threads, email addresses in Discussions-To aren't
+                # masked.
+                for node in para:
+                    if not isinstance(node, nodes.reference):
+                        continue
+                    if node["refuri"].startswith("https://mail.python.org"):
+                        node[0] = _pretty_thread(node[0])
             elif name in {"replaces", "superseded-by", "requires"}:
                 # replace PEP numbers with normalised list of links to PEPs
                 new_body = []
@@ -97,20 +98,28 @@ class PEPHeaders(transforms.Transform):
             field.parent.remove(field)
 
 
-def _list_name_from_thread(node: nodes.reference) -> nodes.raw:
+def _pretty_thread(text: nodes.Text) -> nodes.Text:
+    # we want to keep these as lowercase:
+    if "python-dev" in text:
+        return nodes.Text("python-dev")
+    if "python-committers" in text:
+        return nodes.Text("python-committers")
+
+    parts = text.split("/")
+
     # mailman structure is
     # https://mail.python.org/archives/list/<list name>/thread/<id>
+    try:
+        list_name = parts[parts.index("archives") + 2].removesuffix("@python.org")
+        return nodes.Text(list_name.title().replace("Sig", "SIG").replace("-", " "))
+    except ValueError:
+        pass
+
     # pipermail structure is
     # https://mail.python.org/pipermail/<list name>/<month-year>/<id>
-    parts = node[0].split("/")
     try:
-        list_name = parts[parts.index("archives") + 2]
-        masked_name = list_name.replace("@", "&#32;&#97;t&#32;")
+        list_name = parts[parts.index("pipermail") + 1]
+        return nodes.Text(list_name.title().replace("Sig", "SIG").replace("-", " "))
     except ValueError:
-        try:
-            list_name = parts[parts.index("pipermail") + 1]
-            masked_name = list_name + "&#32;&#97;t&#32;python.org"
-        except ValueError:
-            # archives and pipermail not in list, e.g. PEP 245
-            return node[0]
-    return nodes.raw("", masked_name, format="html")
+        # archives and pipermail not in list, e.g. PEP 245
+        return text

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_zero.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_zero.py
@@ -85,9 +85,6 @@ def _mask_email(ref: nodes.reference) -> nodes.reference:
     The returned node has no refuri link attribute.
 
     """
-    if "refuri" not in ref or not ref["refuri"].startswith("mailto:"):
+    if not ref.get("refuri", "").startswith("mailto:"):
         return ref
-    list_name = ref["refuri"].removeprefix("mailto:").strip()
-    if list_name in {"peps@python.org", "python-list@python.org", "python-dev@python.org"}:
-        return ref[0]
     return nodes.raw("", ref[0].replace("@", "&#32;&#97;t&#32;"), format="html")


### PR DESCRIPTION
As a follow-up to #2351, this "prettifies" thread links by extracting the list name for display. I also included Resolution as it seemed odd to normalise one but not the other.

As part of this I also normalised all the mailing list values in Discussions-To (first commit) -- this is not strictly essential but is on the "would be nice" list.

A