### PR TITLE
PEP 541: Fix markup in nested lists

### DIFF
--- a/pep-0541.txt
+++ b/pep-0541.txt
@@ -72,16 +72,16 @@ The use cases covered by this document are:
 
 * Abandoned projects:
 
-    * continued maintenance by a different set of users; or
-    * removal from the Index for use with a different project.
+  * continued maintenance by a different set of users; or
+  * removal from the Index for use with a different project.
 
 * Active projects:
 
-    * resolving disputes over a name.
+  * resolving disputes over a name.
 
 * Invalid projects:
 
-   * projects subject to a claim of intellectual property infringement.
+  * projects subject to a claim of intellectual property infringement.
 
 The proposed extension to the Terms of Use, as expressed in the
 Implementation section, will be published as a separate document on the


### PR DESCRIPTION
Noticed when checking through the changed files in #2361, simple enough to fix.

reST is very pernickety about nested lists -- the two extra spaces here created a block-quote with a list inside it, which I don't expect was intended.

A