### PR TITLE
Infra: Fix Sphinx HTML language code to be the international 'en'

### DIFF
--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -1,6 +1,6 @@
 {# Master template for simple pages (e.g. RST files) #}
 <!DOCTYPE html>
-<html lang="en-GB">
+<html lang="en">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
As originally discussed and agreed with @brettcannon [elsewhere](https://github.com/python/peps/commit/0d93abf9bf53e127202299a56a242bfc3a69f900#r67498108), the localized `en-GB` is used instead of the international `en` in the Sphinx theme template, which is inconsistent with the main Python.org and the current PEPs site. Furthermore, it isn't really accurate, since `en-GB` is not the dialect used in many, if not most PEPs, as opposed to other varieties of English, nor do PEP 1 or PEP 12 mandate any particular variety. Finally, Python itself is based in the US and a is thoroughly international project, so I don't think we should be officially favoring one particular English locale over any other.