### PR TITLE
PEP 12: Update spacing/breaking conventions to match current practice

### DIFF
--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -185,14 +185,11 @@ illustrate the plaintext markup.
 General
 -------
 
-You must adhere to the Emacs convention of adding two spaces at the
-end of every sentence.  You should fill your paragraphs to column 70,
-but under no circumstances should your lines extend past column 79.
-If your code samples spill over column 79, you should rewrite them.
-
-Tab characters must never appear in the document at all.  A PEP should
-include the standard Emacs stanza included by example at the bottom of
-this PEP.
+Lines should usually not extend past column 79,
+excepting URLs and similar circumstances.
+Tab characters must never appear in the document at all.
+A PEP should include the standard Emacs stanza
+included by example at the bottom of this PEP.
 
 
 Section Headings

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -143,9 +143,6 @@ directions below.
 - Update your Footnotes section, listing any footnotes and
   non-inline link targets referenced by the text.
 
-- Leave the Emacs stanza at the end of this file alone, including the
-  formfeed character ("^L", or ``\f``).
-
 - Create a pull request against the https://github.com/python/peps
   repository.
 
@@ -188,8 +185,6 @@ General
 Lines should usually not extend past column 79,
 excepting URLs and similar circumstances.
 Tab characters must never appear in the document at all.
-A PEP should include the standard Emacs stanza
-included by example at the bottom of this PEP.
 
 
 Section Headings
@@ -603,8 +598,6 @@ visible in the processed document.  For example:
         This section should be updated in the final PEP.
         Ensure the date is accurate.
 
-The Emacs stanza at the bottom of this document is inside a comment.
-
 
 Escaping Mechanism
 ------------------
@@ -687,14 +680,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0012/pep-NNNN.rst
+++ b/pep-0012/pep-NNNN.rst
@@ -87,14 +87,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-
-..
-    Local Variables:
-    mode: indented-text
-    indent-tabs-mode: nil
-    sentence-end-double-space: t
-    fill-column: 70
-    coding: utf-8
-    End:


### PR DESCRIPTION
 As proposed by @JelleZijlstra in [this comment](https://discuss.python.org/t/one-sentence-per-line-for-peps-and-more/13920/13) and widely agreed on there.