### PR TITLE
Meta: Clearly document current guidance for changing existing PEPs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -18,6 +18,61 @@ first in an appropriate venue, drafting a PEP and gathering feedback, and
 developing at least a prototype reference implementation of your idea.
 
 
+Contributing changes to existing PEPs
+-------------------------------------
+
+In general, PEPs that are not marked as Draft or Active are usually considered
+to be historical documents rather than documentation or living specifications.
+To propose a substantially revised version of the original ideas,
+you should generally consider opening a new PEP instead.
+As such, make sure to consider the type and status of the PEP(s)
+in question before proposing changes:
+
+* **Rejected**, **Deferred**, **Withdrawn** and **Superceded** PEPs should
+  usually only be modified when necessary to correct technical issues with
+  header processing or that prevent content from rendering as originally
+  intended.
+
+* **Final** PEPs are considered complete; while small fixes to clearly
+  unintentional errata in the document that meaningfully impair understanding
+  may be considered, substantive changes to the content generally will not.
+
+* **Accepted** PEPs may be updated to reflect minor details of the final
+  implementation, but significant changes to the normative specification
+  should be avoided.
+
+* **Provisional** PEPs can be incrementally modified if needed, though
+  major rewrites and compatibility breakage are discouraged unless absolutely
+  necessary and any changes should be preceded by discussion and general
+  consensus among the authors and the relevant community.
+
+* **Active** PEPs can and should be updated whenever the information described
+  changes. Substantive changes to governance PEPs should be reviewed by the
+  Steering Council (by opening an
+  `issue <https://github.com/python/steering-council/issues>`__ in the SC repo)
+  and are subject to any further conditions stated in the PEP itself.
+
+* **Draft** PEPs are freely open for discussion and proposed modification,
+  at the discretion of the author. Copyediting, formatting and proofreading
+  can be opened here as pull requests, while more substantive content
+  changes should generally be first proposed on the PEP's discussion thread
+  listed in its ``Discussions-To`` header.
+
+Also, while fixing spelling and formatting issues as part of more substantive
+copyediting and proofreading of draft and active PEPs is encouraged,
+we generally advise against PRs that simply mass-correct minor typos
+that don't significantly impair meaning and understanding.
+
+If you're unsure, in addition to the general guidance above,
+we encourage you to reach out first before opening a PR here.
+For example, you could contact the PEP author(s),
+propose your idea in a discussion venue appropriate to the PEP (e.g.
+`Typing-SIG <https://mail.python.org/archives/list/typing-sig@python.org/>`__
+for static typing, or the `Packaging Discourse
+<https://discuss.python.org/c/packaging/>`__ for packaging), and/or
+open an `issue on this repo <https://github.com/python/peps/issues>`__.
+
+
 Commit messages and PR titles
 -----------------------------
 
@@ -122,11 +177,3 @@ or against all files with
 .. code-block:: bash
 
     pre-commit run --all-files --hook-stage manual codespell
-
-**Note**: While fixing spelling mistakes as part of more substantive
-copyediting and proofreading of draft and active PEPs is okay,
-we generally advise against PRs that simply mass-correct minor typos on
-older PEPs that don't significantly impair meaning and understanding,
-as these tend to create a fairly high level of noise and churn for
-PEP readers, authors and editors relative to the amount of practical value
-they provide.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -29,22 +29,17 @@ depending on the PEP's status:
 
 * **Rejected**, **Deferred**, **Withdrawn** and **Superceded** PEPs should
   usually only be modified when necessary to correct technical issues with
-  header processing or that prevent content from rendering as originally
-  intended. Occasionally, a Deferred or even Withdrawn PEP may be resurrected
+  the syntax. Occasionally, a Deferred or even Withdrawn PEP may be resurrected
   with major updates, but it is often better to just propose a new one.
 
-* **Final** PEPs are considered complete; while small fixes to clearly
-  unintentional errors in the document that meaningfully impair understanding
-  may be considered, substantive changes to the content generally will not.
+* **Final** PEPs are considered complete, though small fixes to unintentional
+  errors in the document that impair understanding may be accepted.
 
 * **Accepted** PEPs may be updated to reflect minor details of the final
-  implementation, but significant changes to the normative specification
-  should be avoided.
+  implementation, but changes to the specification should be avoided.
 
-* **Provisional** PEPs can be incrementally modified if needed, though
-  major rewrites and compatibility breakage are discouraged unless absolutely
-  necessary and any changes should be preceded by discussion and general
-  consensus among the authors and the relevant community.
+* **Provisional** PEPs can be incrementally modified if needed, though rewrites
+  and compatibility breakage are discouraged unless absolutely necessary.
 
 * **Active** PEPs can and should be updated whenever the information described
   changes. Substantive changes to governance PEPs should be reviewed by the
@@ -53,8 +48,7 @@ depending on the PEP's status:
   and are subject to any further conditions stated in the PEP itself.
 
 * **Draft** PEPs are freely open for discussion and proposed modification
-  (though once submitted to the Steering Council or PEP-Delegate for final
-  review and resolution, significant alterations should be avoided).
+  until submitted to the Steering Council or PEP-Delegate.
   Copyediting, formatting and proofreading can be opened here as pull requests,
   while more substantive content changes should generally be first proposed
   on the PEP's discussion thread listed in its ``Discussions-To`` header.
@@ -64,8 +58,7 @@ copyediting and proofreading of draft and active PEPs is encouraged,
 we generally advise against PRs that simply mass-correct minor typos
 that don't significantly impair meaning and understanding.
 
-If you're unsure, in addition to the general guidance above,
-we encourage you to reach out first before opening a PR here.
+If you're unsure, we encourage you to reach out first before opening a PR here.
 For example, you could contact the PEP author(s),
 propose your idea in a discussion venue appropriate to the PEP (e.g.
 `Typing-SIG <https://mail.python.org/archives/list/typing-sig@python.org/>`__

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,15 +24,16 @@ Contributing changes to existing PEPs
 In general, most non-Draft/Active PEPs are considered to be historical
 documents rather than living specifications or documentation. Major changes to
 their core content usually require a new PEP, while smaller modifications may
-or may not be appropriate, depending on the PEP's status. See `PEP 1
-<https://www.python.org/dev/peps/pep-0001/#pep-maintenance>`__ for more.
+or may not be appropriate, depending on the PEP's status. See `PEP Maintenance
+<https://peps.python.org/pep-0001/#pep-maintenance>`_
+and `Changing Existing PEPs
+<https://peps.python.org/pep-0001/#changing-existing-peps>`_ in PEP 1 for more.
 
-Copyediting and proofreading Draft and Active PEPs (including fixing spelling
-and formatting issues) is welcomed (subject to review by the PEP authors),
-and can be done via pull request to this repo, though we generally advise
-against PRs that simply mass-correct minor typos on older PEPs which don't
-significantly impair meaning and understanding.
+Copyediting and proofreading Draft and Active PEPs is welcome (subject to
+review by the PEP author), and can be done via pull request to this repo.
 Substantive content changes should first be proposed on PEP discussion threads.
+We do advise against PRs that simply mass-correct minor typos on older PEPs
+which don't significantly impair meaning and understanding.
 
 If you're still unsure, we encourage you to reach out first before opening a
 PR here. For example, you could contact the PEP author(s), propose your idea in

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -28,9 +28,10 @@ or may not be appropriate, depending on the PEP's status. See `PEP 1
 <https://www.python.org/dev/peps/pep-0001/#pep-maintenance>`__ for more.
 
 Copyediting and proofreading Draft and Active PEPs (including fixing spelling
-and formatting issues) is welcomed, and can be done via pull request to this
-repo, though we generally advise against PRs that simply mass-correct minor
-typos on older PEPs which don't significantly impair meaning and understanding.
+and formatting issues) is welcomed (subject to review by the PEP authors),
+and can be done via pull request to this repo, though we generally advise
+against PRs that simply mass-correct minor typos on older PEPs which don't
+significantly impair meaning and understanding.
 Substantive content changes should first be proposed on PEP discussion threads.
 
 If you're still unsure, we encourage you to reach out first before opening a

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -79,6 +79,10 @@ Commit messages and PR titles
 When adding or modifying a PEP, please always include the PEP number in the
 commit summary and pull request title.
 For example, ``PEP NNN: <summary of changes>``.
+Likewise, prefix rendering infrastructure changes with ``Infra:``,
+linting-related alterations with ``Lint:`` and other non-PEP meta changes,
+such as updates to the Readme/Contributing Guide, issue/PR template, etc.,
+with ``Meta:``.
 
 
 Sign the CLA

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -21,62 +21,34 @@ developing at least a prototype reference implementation of your idea.
 Contributing changes to existing PEPs
 -------------------------------------
 
-In general, PEPs that are not marked as Draft, Active or Provisional are
-considered to be historical documents rather than living specifications
-or documentation. Major changes to their core content usually require
-a new PEP, while smaller modifications may or may not be appropriate,
-depending on the PEP's status:
+In general, most non-Draft/Active PEPs are considered to be historical
+documents rather than living specifications or documentation. Major changes to
+their core content usually require a new PEP, while smaller modifications may
+or may not be appropriate, depending on the PEP's status. See `PEP 1
+<https://www.python.org/dev/peps/pep-0001/#pep-maintenance>`__ for more.
 
-* **Rejected**, **Deferred**, **Withdrawn** and **Superceded** PEPs should
-  usually only be modified when necessary to correct technical issues with
-  the syntax. Occasionally, a Deferred or even Withdrawn PEP may be resurrected
-  with major updates, but it is often better to just propose a new one.
+Copyediting and proofreading Draft and Active PEPs (including fixing spelling
+and formatting issues) is welcomed, and can be done via pull request to this
+repo, though we generally advise against PRs that simply mass-correct minor
+typos on older PEPs which don't significantly impair meaning and understanding.
+Substantive content changes should first be proposed on PEP discussion threads.
 
-* **Final** PEPs are considered complete, though small fixes to unintentional
-  errors in the document that impair understanding may be accepted.
-
-* **Accepted** PEPs may be updated to reflect minor details of the final
-  implementation, but changes to the specification should be avoided.
-
-* **Provisional** PEPs can be incrementally modified if needed, though rewrites
-  and compatibility breakage are discouraged unless absolutely necessary.
-
-* **Active** PEPs can and should be updated whenever the information described
-  changes. Substantive changes to governance PEPs should be reviewed by the
-  Steering Council (by opening an
-  `issue <https://github.com/python/steering-council/issues>`__ in the SC repo)
-  and are subject to any further conditions stated in the PEP itself.
-
-* **Draft** PEPs are freely open for discussion and proposed modification
-  until submitted to the Steering Council or PEP-Delegate.
-  Copyediting, formatting and proofreading can be opened here as pull requests,
-  while more substantive content changes should generally be first proposed
-  on the PEP's discussion thread listed in its ``Discussions-To`` header.
-
-Also, while fixing spelling and formatting issues as part of more substantive
-copyediting and proofreading of draft and active PEPs is encouraged,
-we generally advise against PRs that simply mass-correct minor typos
-that don't significantly impair meaning and understanding.
-
-If you're unsure, we encourage you to reach out first before opening a PR here.
-For example, you could contact the PEP author(s),
-propose your idea in a discussion venue appropriate to the PEP (e.g.
-`Typing-SIG <https://mail.python.org/archives/list/typing-sig@python.org/>`__
-for static typing, or the `Packaging Discourse
-<https://discuss.python.org/c/packaging/>`__ for packaging), and/or
-open an `issue on this repo <https://github.com/python/peps/issues>`__.
+If you're still unsure, we encourage you to reach out first before opening a
+PR here. For example, you could contact the PEP author(s), propose your idea in
+a discussion venue appropriate to the PEP (such as `Typing-SIG
+<https://mail.python.org/archives/list/typing-sig@python.org/>`__ for static
+typing, or `Packaging Discourse <https://discuss.python.org/c/packaging/>`__
+for packaging), or `open an issue <https://github.com/python/peps/issues>`__.
 
 
 Commit messages and PR titles
 -----------------------------
 
-When adding or modifying a PEP, please always include the PEP number in the
-commit summary and pull request title.
-For example, ``PEP NNN: <summary of changes>``.
-Likewise, prefix rendering infrastructure changes with ``Infra:``,
-linting-related alterations with ``Lint:`` and other non-PEP meta changes,
-such as updates to the Readme/Contributing Guide, issue/PR template, etc.,
-with ``Meta:``.
+When adding or modifying a PEP, please include the PEP number in the commit
+summary and pull request title. For example, ``PEP NNN: <summary of changes>``.
+Likewise, prefix rendering infrastructure changes with ``Infra:``, linting
+alterations with ``Lint:`` and other non-PEP meta changes, such as updates to
+the Readme/Contributing Guide, issue/PR template, etc., with ``Meta:``.
 
 
 Sign the CLA

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -21,20 +21,20 @@ developing at least a prototype reference implementation of your idea.
 Contributing changes to existing PEPs
 -------------------------------------
 
-In general, PEPs that are not marked as Draft or Active are usually considered
-to be historical documents rather than documentation or living specifications.
-To propose a substantially revised version of the original ideas,
-you should generally consider opening a new PEP instead.
-As such, make sure to consider the type and status of the PEP(s)
-in question before proposing changes:
+In general, PEPs that are not marked as Draft, Active or Provisional are
+considered to be historical documents rather than living specifications
+or documentation. Major changes to their core content usually require
+a new PEP, while smaller modifications may or may not be appropriate,
+depending on the PEP's status:
 
 * **Rejected**, **Deferred**, **Withdrawn** and **Superceded** PEPs should
   usually only be modified when necessary to correct technical issues with
   header processing or that prevent content from rendering as originally
-  intended.
+  intended. Occasionally, a Deferred or even Withdrawn PEP may be resurrected
+  with major updates, but it is often better to just propose a new one.
 
 * **Final** PEPs are considered complete; while small fixes to clearly
-  unintentional errata in the document that meaningfully impair understanding
+  unintentional errors in the document that meaningfully impair understanding
   may be considered, substantive changes to the content generally will not.
 
 * **Accepted** PEPs may be updated to reflect minor details of the final
@@ -52,11 +52,12 @@ in question before proposing changes:
   `issue <https://github.com/python/steering-council/issues>`__ in the SC repo)
   and are subject to any further conditions stated in the PEP itself.
 
-* **Draft** PEPs are freely open for discussion and proposed modification,
-  at the discretion of the author. Copyediting, formatting and proofreading
-  can be opened here as pull requests, while more substantive content
-  changes should generally be first proposed on the PEP's discussion thread
-  listed in its ``Discussions-To`` header.
+* **Draft** PEPs are freely open for discussion and proposed modification
+  (though once submitted to the Steering Council or PEP-Delegate for final
+  review and resolution, significant alterations should be avoided).
+  Copyediting, formatting and proofreading can be opened here as pull requests,
+  while more substantive content changes should generally be first proposed
+  on the PEP's discussion thread listed in its ``Discussions-To`` header.
 
 Also, while fixing spelling and formatting issues as part of more substantive
 copyediting and proofreading of draft and active PEPs is encouraged,

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -476,11 +476,6 @@ followed in these cases will depend on the nature and purpose of the PEP
 being updated. Substantive changes to governance PEPs must be reviewed by the
 Steering Council (by opening a `Steering Council issue`_).
 
-Draft PEPs are freely open for discussion and proposed modification,
-at the discretion of the authors, until submitted to the
-Steering Council or PEP-Delegate for review and resolution.
-Substantive content changes should generally be first proposed on
-the PEP's discussion thread listed in its ``Discussions-To`` header.
 Occasionally, a Deferred or even a Withdrawn PEP may be resurrected
 with major updates, but it is often better to just propose a new one.
 
@@ -705,23 +700,21 @@ Alternatively, all support files may be placed in a subdirectory called
 are no constraints on the names used in files.
 
 
-Reporting PEP Bugs, or Submitting PEP Updates
-=============================================
+Changing Existing PEPs
+======================
 
-How you report a bug, or submit a PEP update depends on several
-factors, such as the maturity of the PEP, the preferences of the PEP
-author, and the nature of your comments.  For the early draft stages
-of the PEP, it's probably best to send your comments and changes
-directly to the PEP author.  For more mature, or finished PEPs you may
-want to submit corrections as a `GitHub issue`_ or `GitHub pull request`_ so that
-your changes don't get lost.
+Draft PEPs are freely open for discussion and proposed modification, at the
+discretion of the authors, until submitted to the Steering Council or
+PEP-Delegate for review and resolution. Substantive content changes should
+generally be first proposed on the PEP's discussion thread listed in its
+``Discussions-To`` header, while copyedits and corrections can be submitted
+as a `GitHub issue`_ or `GitHub pull request`_.
+PEP authors with write access to the PEP repository can update the PEPs
+themselves by using ``git push`` or a GitHub PR to submit their changes.
+For guidance on modifying other PEPs, consult the `PEP Maintenance`_ section.
 
-When in doubt about where to send your changes, please check first
-with the PEP author and/or a PEP editor.
-
-PEP authors with write access to the PEP repository can update the
-PEPs themselves by using "git push" or the GitHub PR interface to submit their
-changes.
+See the `Contributing Guide`_ for additional details, and when in doubt,
+please check first with the PEP author and/or a PEP editor.
 
 
 Transferring PEP Ownership
@@ -885,6 +878,7 @@ Footnotes
 
 .. _PyPA Specifications: https://packaging.python.org/en/latest/specifications/
 
+.. _Contributing Guide: https://github.com/python/peps/blob/main/CONTRIBUTING.rst
 
 
 Copyright

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -458,19 +458,30 @@ if they are never meant to be completed.  E.g. :pep:`1` (this PEP).
 PEP Maintenance
 ---------------
 
-In general, Standards track PEPs are no longer modified after they have
-reached the Final state. Once a PEP has been completed, the Language and
-Standard Library References become the formal documentation of the expected
-behavior.
+In general, PEPs are no longer substantially modified after they have reached
+the Final, Rejected or Superseded state. Once a PEP has been completed,
+it is considered to be a historical document rather than living specifications.
+Formal documentation of the expected behavior should be maintained elsewhere,
+such as the `Language Reference`_ for core features, the `Library Reference`_
+for standard library modules or the `PyPA Specifications`_ for packaging.
 
 If changes based on implementation experience and user feedback are made to
-Standards track PEPs while in the Accepted or Provisional State, those changes
+Standards track PEPs while in the Accepted or Provisional state, they
 should be noted in the PEP, such that the PEP accurately describes the state of
 the implementation at the point where it is marked Final.
 
-Informational and Process PEPs may be updated over time to reflect changes
-to development practices and other details. The precise process followed in
-these cases will depend on the nature and purpose of the PEP being updated.
+Active Informational and Process PEPs may be updated over time to reflect
+changes to development practices and other details. The precise process
+followed in these cases will depend on the nature and purpose of the PEP
+being updated. Substantive changes to governance PEPs must be reviewed by the
+Steering Council (by opening a `Steering Council issue`_).
+
+Draft PEPs are freely open for discussion and proposed modification until
+submitted to the Steering Council or PEP-Delegate for review and resolution.
+Substantive content changes should generally be first proposed on
+the PEP's discussion thread listed in its ``Discussions-To`` header.
+Occasionally, a Deferred or even a Withdrawn PEP may be resurrected
+with major updates, but it is often better to just propose a new one.
 
 
 What belongs in a successful PEP?
@@ -866,6 +877,13 @@ Footnotes
 .. _Typing-SIG: https://mail.python.org/mailman3/lists/typing-sig.python.org/
 
 .. _Packaging category: https://discuss.python.org/c/packaging/
+
+.. _Language Reference: https://docs.python.org/3/reference/index.html
+
+.. _Library Reference: https://docs.python.org/3/library/index.html
+
+.. _PyPA Specifications: https://packaging.python.org/en/latest/specifications/
+
 
 
 Copyright

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -459,15 +459,15 @@ PEP Maintenance
 ---------------
 
 In general, PEPs are no longer substantially modified after they have reached
-the Final, Rejected or Superseded state. Once a PEP has been completed,
-it is considered to be a historical document rather than living specifications.
+the Accepted, Final, Rejected or Superseded state. Once resolution is reached,
+a PEP is considered a historical document rather than a living specification.
 Formal documentation of the expected behavior should be maintained elsewhere,
 such as the `Language Reference`_ for core features, the `Library Reference`_
 for standard library modules or the `PyPA Specifications`_ for packaging.
 
 If changes based on implementation experience and user feedback are made to
-Standards track PEPs while in the Accepted or Provisional state, they
-should be noted in the PEP, such that the PEP accurately describes the state of
+Standards track PEPs while in the Provisional or (with SC approval) Accepted
+state, they should be noted in the PEP, such that the PEP accurately describes
 the implementation at the point where it is marked Final.
 
 Active Informational and Process PEPs may be updated over time to reflect
@@ -476,8 +476,9 @@ followed in these cases will depend on the nature and purpose of the PEP
 being updated. Substantive changes to governance PEPs must be reviewed by the
 Steering Council (by opening a `Steering Council issue`_).
 
-Draft PEPs are freely open for discussion and proposed modification until
-submitted to the Steering Council or PEP-Delegate for review and resolution.
+Draft PEPs are freely open for discussion and proposed modification,
+at the discretion of the authors, until submitted to the
+Steering Council or PEP-Delegate for review and resolution.
 Substantive content changes should generally be first proposed on
 the PEP's discussion thread listed in its ``Discussions-To`` header.
 Occasionally, a Deferred or even a Withdrawn PEP may be resurrected

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -470,11 +470,10 @@ Standards track PEPs while in the Provisional or (with SC approval) Accepted
 state, they should be noted in the PEP, such that the PEP accurately describes
 the implementation at the point where it is marked Final.
 
-Active Informational and Process PEPs may be updated over time to reflect
+Active (Informational and Process) PEPs may be updated over time to reflect
 changes to development practices and other details. The precise process
 followed in these cases will depend on the nature and purpose of the PEP
-being updated. Substantive changes to governance PEPs must be reviewed by the
-Steering Council (by opening a `Steering Council issue`_).
+in question.
 
 Occasionally, a Deferred or even a Withdrawn PEP may be resurrected
 with major updates, but it is often better to just propose a new one.


### PR DESCRIPTION
As has come up on many issues and PRs submitted here (e.g. #2151, #2199. #2265, #2318. #2332 being but a few recent examples off the top of my head), it would be of benefit to provide clear unambiguous up-front guidance on whether, when and where to propose changes to existing PEPs. Therefore, this PR adds this near the top of the Contributing Guide (which is exposed fairly prominently by the GitHub UI), to explictly explain the established, mostly unwritten practice here.

Specifically, it:

* [x] Clarifies that non-Draft/Active PEPs are historical documents that should generally be left alone
* [x] Briefly describes what types of changes are appropriate for each major type/status of PEP
* [x] Mentions that issues/PRs here are not usually a good place for substantive debate on PEP content, and redirects users to appropriate discussion venues and/or proposing a new PEP if they'd like to see substantive changes
* [x] Notes that the SC should be notified and any PEP-specific procedures followed when changing governance PEP (to avoid any future uncertainty like on #2346)
* [x] Retains and emphasizes the specific discouragement of mass-spellcheck/etc, PRs changing old PEPs (originally added in #2338 as requested in #2151)

Also, I added a sentence to the "Commit messages and PR titles" section clarifying prefix usage for non-PEP PR titles/commit messages, as that has been the source of some confusion lately by multiple PEP editors (e.g. on  #2364 and #2375 )