### PR TITLE
Lint: Implement check for spaces, not tabs per PEP 12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,12 @@ repos:
   # Local checks for PEP headers and more
   - repo: local
     hooks:
+      - id: check-no-tabs
+        name: "Check tabs not used in PEPs"
+        language: pygrep
+        entry: '\t'
+        files: '^pep-\d+\.(rst|txt)$'
+        types: [text]
       - id: check-required-fields
         name: "Check PEPs have all required fields"
         language: pygrep

--- a/pep-8100.rst
+++ b/pep-8100.rst
@@ -200,102 +200,102 @@ Active Python core developers
 
 ::
 
-	Alex Gaynor
-	Alex Martelli
-	Alexander Belopolsky
-	Alexandre Vassalotti
-	Amaury Forgeot d'Arc
-	Andrew Kuchling
-	Andrew Svetlov
-	Antoine Pitrou
-	Armin Ronacher
-	Barry Warsaw
-	Benjamin Peterson
-	Berker Peksag
-	Brett Cannon
-	Brian Curtin
-	Carol Willing
-	Chris Jerdonek
-	Chris Withers
-	Christian Heimes
-	David Malcolm
-	David Wolever
-	Davin Potts
-	Dino Viehland
-	Donald Stufft
-	Doug Hellmann
-	Eli Bendersky
-	Emily Morehouse
-	Éric Araujo
-	Eric Snow
-	Eric V. Smith
-	Ethan Furman
-	Ezio Melotti
-	Facundo Batista
-	Fred Drake
-	Georg Brandl
-	Giampaolo Rodola'
-	Gregory P. Smith
-	Guido van Rossum
-	Hyeshik Chang
-	Hynek Schlawack
-	INADA Naoki
-	Ivan Levkivskyi
-	Jack Diederich
-	Jack Jansen
-	Jason R. Coombs
-	Jeff Hardy
-	Jeremy Hylton
-	Jesús Cea
-	Julien Palard
-	Kurt B. Kaiser
-	Kushal Das
-	Larry Hastings
-	Lars Gustäbel
-	Lisa Roach
-	Łukasz Langa
-	Marc-Andre Lemburg
-	Mariatta
-	Mark Dickinson
-	Mark Hammond
-	Mark Shannon
-	Martin Panter
-	Matthias Klose
-	Meador Inge
-	Michael Hudson-Doyle
-	Nathaniel J. Smith
-	Ned Deily
-	Neil Schemenauer
-	Nick Coghlan
-	Pablo Galindo
-	Paul Moore
-	Petr Viktorin
-	Petri Lehtinen
-	Philip Jenvey
-	R. David Murray
-	Raymond Hettinger
-	Robert Collins
-	Ronald Oussoren
-	Sandro Tosi
-	Senthil Kumaran
-	Serhiy Storchaka
-	Sjoerd Mullender
-	Stefan Krah
-	Steve Dower
-	Steven Daprano
-	T. Wouters
-	Tal Einat
-	Terry Jan Reedy
-	Thomas Heller
-	Tim Golden
-	Tim Peters
-	Trent Nelson
-	Victor Stinner
-	Vinay Sajip
-	Walter Dörwald
-	Xiang Zhang
-	Yury Selivanov
-	Zachary Ware
+    Alex Gaynor
+    Alex Martelli
+    Alexander Belopolsky
+    Alexandre Vassalotti
+    Amaury Forgeot d'Arc
+    Andrew Kuchling
+    Andrew Svetlov
+    Antoine Pitrou
+    Armin Ronacher
+    Barry Warsaw
+    Benjamin Peterson
+    Berker Peksag
+    Brett Cannon
+    Brian Curtin
+    Carol Willing
+    Chris Jerdonek
+    Chris Withers
+    Christian Heimes
+    David Malcolm
+    David Wolever
+    Davin Potts
+    Dino Viehland
+    Donald Stufft
+    Doug Hellmann
+    Eli Bendersky
+    Emily Morehouse
+    Éric Araujo
+    Eric Snow
+    Eric V. Smith
+    Ethan Furman
+    Ezio Melotti
+    Facundo Batista
+    Fred Drake
+    Georg Brandl
+    Giampaolo Rodola'
+    Gregory P. Smith
+    Guido van Rossum
+    Hyeshik Chang
+    Hynek Schlawack
+    INADA Naoki
+    Ivan Levkivskyi
+    Jack Diederich
+    Jack Jansen
+    Jason R. Coombs
+    Jeff Hardy
+    Jeremy Hylton
+    Jesús Cea
+    Julien Palard
+    Kurt B. Kaiser
+    Kushal Das
+    Larry Hastings
+    Lars Gustäbel
+    Lisa Roach
+    Łukasz Langa
+    Marc-Andre Lemburg
+    Mariatta
+    Mark Dickinson
+    Mark Hammond
+    Mark Shannon
+    Martin Panter
+    Matthias Klose
+    Meador Inge
+    Michael Hudson-Doyle
+    Nathaniel J. Smith
+    Ned Deily
+    Neil Schemenauer
+    Nick Coghlan
+    Pablo Galindo
+    Paul Moore
+    Petr Viktorin
+    Petri Lehtinen
+    Philip Jenvey
+    R. David Murray
+    Raymond Hettinger
+    Robert Collins
+    Ronald Oussoren
+    Sandro Tosi
+    Senthil Kumaran
+    Serhiy Storchaka
+    Sjoerd Mullender
+    Stefan Krah
+    Steve Dower
+    Steven Daprano
+    T. Wouters
+    Tal Einat
+    Terry Jan Reedy
+    Thomas Heller
+    Tim Golden
+    Tim Peters
+    Trent Nelson
+    Victor Stinner
+    Vinay Sajip
+    Walter Dörwald
+    Xiang Zhang
+    Yury Selivanov
+    Zachary Ware
 
 
 .. [1] This repository is private and accessible only to Python Core

--- a/pep-8101.rst
+++ b/pep-8101.rst
@@ -186,88 +186,88 @@ Active Python core developers
 
 ::
 
-	Abhilash Raj
-	Alex Gaynor
-	Alex Martelli
-	Alexander Belopolsky
-	Andrew Kuchling
-	Andrew Svetlov
-	Antoine Pitrou
-	Barry Warsaw
-	Benjamin Peterson
-	Berker Peksağ
-	Brett Cannon
-	Brian Curtin
-	Brian Quinlan
-	Carol Willing
-	Cheryl Sabella
-	Chris Withers
-	Christian Heimes
-	Christian Tismer
-	Davin Potts
-	Dino Viehland
-	Donald Stufft
-	Emily Morehouse
-	Éric Araujo
-	Eric Snow
-	Eric V. Smith
-	Ethan Furman
-	Ezio Melotti
-	Facundo Batista
-	Fred Drake
-	Giampaolo Rodolà
-	Gregory P. Smith
-	Guido van Rossum
-	Inada Naoki
-	Ivan Levkivskyi
-	Jason R. Coombs
-	Jeremy Kloth
-	Jesús Cea
-	Joannah Nanjekye
-	Julien Palard
-	Kurt B. Kaiser
-	Kushal Das
-	Larry Hastings
-	Lisa Roach
-	Łukasz Langa
-	Marc-André Lemburg
-	Mariatta
-	Mark Dickinson
-	Mark Shannon
-	Matthias Klose
-	Michael Foord
-	Nathaniel J. Smith
-	Ned Deily
-	Neil Schemenauer
-	Nick Coghlan
-	Pablo Galindo
-	Paul Ganssle
-	Paul Moore
-	Petr Viktorin
-	R. David Murray
-	Raymond Hettinger
-	Robert Collins
-	Ronald Oussoren
-	Senthil Kumaran
-	Serhiy Storchaka
-	Skip Montanaro
-	Stefan Behnel
-	Stefan Krah
-	Steve Dower
-	Steven D'Aprano
-	Stéphane Wirtel
-	Tal Einat
-	Terry Jan Reedy
-	Thomas Wouters
-	Tim Golden
-	Tim Peters
-	Victor Stinner
-	Vinay Sajip
-	Walter Dörwald
-	Xavier de Gaye
-	Xiang Zhang
-	Yury Selivanov
-	Zachary Ware
+    Abhilash Raj
+    Alex Gaynor
+    Alex Martelli
+    Alexander Belopolsky
+    Andrew Kuchling
+    Andrew Svetlov
+    Antoine Pitrou
+    Barry Warsaw
+    Benjamin Peterson
+    Berker Peksağ
+    Brett Cannon
+    Brian Curtin
+    Brian Quinlan
+    Carol Willing
+    Cheryl Sabella
+    Chris Withers
+    Christian Heimes
+    Christian Tismer
+    Davin Potts
+    Dino Viehland
+    Donald Stufft
+    Emily Morehouse
+    Éric Araujo
+    Eric Snow
+    Eric V. Smith
+    Ethan Furman
+    Ezio Melotti
+    Facundo Batista
+    Fred Drake
+    Giampaolo Rodolà
+    Gregory P. Smith
+    Guido van Rossum
+    Inada Naoki
+    Ivan Levkivskyi
+    Jason R. Coombs
+    Jeremy Kloth
+    Jesús Cea
+    Joannah Nanjekye
+    Julien Palard
+    Kurt B. Kaiser
+    Kushal Das
+    Larry Hastings
+    Lisa Roach
+    Łukasz Langa
+    Marc-André Lemburg
+    Mariatta
+    Mark Dickinson
+    Mark Shannon
+    Matthias Klose
+    Michael Foord
+    Nathaniel J. Smith
+    Ned Deily
+    Neil Schemenauer
+    Nick Coghlan
+    Pablo Galindo
+    Paul Ganssle
+    Paul Moore
+    Petr Viktorin
+    R. David Murray
+    Raymond Hettinger
+    Robert Collins
+    Ronald Oussoren
+    Senthil Kumaran
+    Serhiy Storchaka
+    Skip Montanaro
+    Stefan Behnel
+    Stefan Krah
+    Steve Dower
+    Steven D'Aprano
+    Stéphane Wirtel
+    Tal Einat
+    Terry Jan Reedy
+    Thomas Wouters
+    Tim Golden
+    Tim Peters
+    Victor Stinner
+    Vinay Sajip
+    Walter Dörwald
+    Xavier de Gaye
+    Xiang Zhang
+    Yury Selivanov
+    Zachary Ware
 
 
 .. [1] This repository is private and accessible only to Python Core

--- a/pep-8102.rst
+++ b/pep-8102.rst
@@ -194,97 +194,97 @@ Active Python core developers
 
 ::
 
-	Abhilash Raj
-	Alex Gaynor
-	Alex Martelli
-	Alexander Belopolsky
-	Andrew Kuchling
-	Andrew Svetlov
-	Antoine Pitrou
-	Barry Warsaw
-	Batuhan Taskaya
-	Benjamin Peterson
-	Berker Peksağ
-	Brandt Bucher
-	Brett Cannon
-	Brian Curtin
-	Brian Quinlan
-	Carol Willing
-	Cheryl Sabella
-	Chris Jerdonek
-	Chris Withers
-	Christian Heimes
-	Christian Tismer
-	Davin Potts
-	Dino Viehland
-	Donald Stufft
-	Dong-hee Na
-	Emily Morehouse
-	Éric Araujo
-	Eric Snow
-	Eric V. Smith
-	Ethan Furman
-	Ezio Melotti
-	Facundo Batista
-	Fred Drake
-	Georg Brandl
-	Giampaolo Rodolà
-	Gregory P. Smith
-	Guido van Rossum
-	Hynek Schlawack
-	Inada Naoki
-	Ivan Levkivskyi
-	Jack Jansen
-	Jason R. Coombs
-	Jeremy Kloth
-	Jesús Cea
-	Joannah Nanjekye
-	Julien Palard
-	Karthikeyan Singaravelan
-	Kurt B. Kaiser
-	Kushal Das
-	Kyle Stanley
-	Larry Hastings
-	Lisa Roach
-	Łukasz Langa
-	Lysandros Nikolaou
-	Marc-André Lemburg
-	Mariatta
-	Mark Dickinson
-	Mark Hammond
-	Mark Shannon
-	Matthias Klose
-	Michael Foord
-	Nathaniel J. Smith
-	Ned Deily
-	Neil Schemenauer
-	Nick Coghlan
-	Pablo Galindo
-	Paul Ganssle
-	Paul Moore
-	Petr Viktorin
-	R. David Murray
-	Raymond Hettinger
-	Robert Collins
-	Ronald Oussoren
-	Sandro Tosi
-	Senthil Kumaran
-	Serhiy Storchaka
-	Stefan Behnel
-	Steve Dower
-	Steven D'Aprano
-	Stéphane Wirtel
-	Tal Einat
-	Terry Jan Reedy
-	Thomas Wouters
-	Tim Golden
-	Tim Peters
-	Victor Stinner
-	Vinay Sajip
-	Walter Dörwald
-	Xiang Zhang
-	Yury Selivanov
-	Zachary Ware
+    Abhilash Raj
+    Alex Gaynor
+    Alex Martelli
+    Alexander Belopolsky
+    Andrew Kuchling
+    Andrew Svetlov
+    Antoine Pitrou
+    Barry Warsaw
+    Batuhan Taskaya
+    Benjamin Peterson
+    Berker Peksağ
+    Brandt Bucher
+    Brett Cannon
+    Brian Curtin
+    Brian Quinlan
+    Carol Willing
+    Cheryl Sabella
+    Chris Jerdonek
+    Chris Withers
+    Christian Heimes
+    Christian Tismer
+    Davin Potts
+    Dino Viehland
+    Donald Stufft
+    Dong-hee Na
+    Emily Morehouse
+    Éric Araujo
+    Eric Snow
+    Eric V. Smith
+    Ethan Furman
+    Ezio Melotti
+    Facundo Batista
+    Fred Drake
+    Georg Brandl
+    Giampaolo Rodolà
+    Gregory P. Smith
+    Guido van Rossum
+    Hynek Schlawack
+    Inada Naoki
+    Ivan Levkivskyi
+    Jack Jansen
+    Jason R. Coombs
+    Jeremy Kloth
+    Jesús Cea
+    Joannah Nanjekye
+    Julien Palard
+    Karthikeyan Singaravelan
+    Kurt B. Kaiser
+    Kushal Das
+    Kyle Stanley
+    Larry Hastings
+    Lisa Roach
+    Łukasz Langa
+    Lysandros Nikolaou
+    Marc-André Lemburg
+    Mariatta
+    Mark Dickinson
+    Mark Hammond
+    Mark Shannon
+    Matthias Klose
+    Michael Foord
+    Nathaniel J. Smith
+    Ned Deily
+    Neil Schemenauer
+    Nick Coghlan
+    Pablo Galindo
+    Paul Ganssle
+    Paul Moore
+    Petr Viktorin
+    R. David Murray
+    Raymond Hettinger
+    Robert Collins
+    Ronald Oussoren
+    Sandro Tosi
+    Senthil Kumaran
+    Serhiy Storchaka
+    Stefan Behnel
+    Steve Dower
+    Steven D'Aprano
+    Stéphane Wirtel
+    Tal Einat
+    Terry Jan Reedy
+    Thomas Wouters
+    Tim Golden
+    Tim Peters
+    Victor Stinner
+    Vinay Sajip
+    Walter Dörwald
+    Xiang Zhang
+    Yury Selivanov
+    Zachary Ware
 
 
 .. [1] This repository is private and accessible only to Python Core

--- a/pep-8103.rst
+++ b/pep-8103.rst
@@ -191,82 +191,82 @@ Active Python core developers
 
 ::
 
-	Abhilash Raj
-	Alex Gaynor
-	Ammar Askar
-	Andrew Kuchling
-	Andrew Svetlov
-	Antoine Pitrou
-	Barry Warsaw
-	Batuhan Taskaya
-	Benjamin Peterson
-	Berker Peksağ
-	Brandt Bucher
-	Brett Cannon
-	Brian Curtin
-	Brian Quinlan
-	Carol Willing
-	Cheryl Sabella
-	Chris Jerdonek
-	Chris Withers
-	Christian Heimes
-	Dino Viehland
-	Dong-hee Na
-	Éric Araujo
-	Eric Snow
-	Eric V. Smith
-	Ethan Furman
-	Facundo Batista
-	Fred Drake
-	Giampaolo Rodolà
-	Gregory P. Smith
-	Guido van Rossum
-	Hynek Schlawack
-	Inada Naoki
-	Irit Katriel
-	Ivan Levkivskyi
-	Jason R. Coombs
-	Jeremy Kloth
-	Jesús Cea
-	Joannah Nanjekye
-	Julien Palard
-	Karthikeyan Singaravelan
-	Ken Jin
-	Kushal Das
-	Kyle Stanley
-	Larry Hastings
-	Lisa Roach
-	Łukasz Langa
-	Lysandros Nikolaou
-	Marc-André Lemburg
-	Mariatta
-	Mark Dickinson
-	Mark Shannon
-	Nathaniel J. Smith
-	Ned Deily
-	Neil Schemenauer
-	Nick Coghlan
-	Pablo Galindo
-	Paul Ganssle
-	Paul Moore
-	Petr Viktorin
-	Raymond Hettinger
-	Ronald Oussoren
-	Senthil Kumaran
-	Serhiy Storchaka
-	Stefan Behnel
-	Stéphane Wirtel
-	Steve Dower
-	Tal Einat
-	Terry Jan Reedy
-	Thomas Wouters
-	Tim Golden
-	Tim Peters
-	Victor Stinner
-	Vinay Sajip
-	Xiang Zhang
-	Yury Selivanov
-	Zachary Ware
+    Abhilash Raj
+    Alex Gaynor
+    Ammar Askar
+    Andrew Kuchling
+    Andrew Svetlov
+    Antoine Pitrou
+    Barry Warsaw
+    Batuhan Taskaya
+    Benjamin Peterson
+    Berker Peksağ
+    Brandt Bucher
+    Brett Cannon
+    Brian Curtin
+    Brian Quinlan
+    Carol Willing
+    Cheryl Sabella
+    Chris Jerdonek
+    Chris Withers
+    Christian Heimes
+    Dino Viehland
+    Dong-hee Na
+    Éric Araujo
+    Eric Snow
+    Eric V. Smith
+    Ethan Furman
+    Facundo Batista
+    Fred Drake
+    Giampaolo Rodolà
+    Gregory P. Smith
+    Guido van Rossum
+    Hynek Schlawack
+    Inada Naoki
+    Irit Katriel
+    Ivan Levkivskyi
+    Jason R. Coombs
+    Jeremy Kloth
+    Jesús Cea
+    Joannah Nanjekye
+    Julien Palard
+    Karthikeyan Singaravelan
+    Ken Jin
+    Kushal Das
+    Kyle Stanley
+    Larry Hastings
+    Lisa Roach
+    Łukasz Langa
+    Lysandros Nikolaou
+    Marc-André Lemburg
+    Mariatta
+    Mark Dickinson
+    Mark Shannon
+    Nathaniel J. Smith
+    Ned Deily
+    Neil Schemenauer
+    Nick Coghlan
+    Pablo Galindo
+    Paul Ganssle
+    Paul Moore
+    Petr Viktorin
+    Raymond Hettinger
+    Ronald Oussoren
+    Senthil Kumaran
+    Serhiy Storchaka
+    Stefan Behnel
+    Stéphane Wirtel
+    Steve Dower
+    Tal Einat
+    Terry Jan Reedy
+    Thomas Wouters
+    Tim Golden
+    Tim Peters
+    Victor Stinner
+    Vinay Sajip
+    Xiang Zhang
+    Yury Selivanov
+    Zachary Ware
 
 
 .. [1] This repository is private and accessible only to Python Core


### PR DESCRIPTION
In [a comment](https://github.com/python/peps/pull/2374#discussion_r818033566) on #2374 , @hugovk mentioned that while PEP 12 unequivocally specifies that tabs should not be used in PEPs and spaces used instead, we don't currently have a linting check for this (which I thought we did). This allowed tabs to slip into list of core developers present in PEPs 8100-8103. Therefore, we convert them to spaces, in conformance with PEP 12 and the rest of the PEPs, and implement a simple linting check in case any sneak by in the future.