### PR TITLE
Meta: Classify Accepted Process PEPs as non-historical & mark PEP 8001 Final

### DIFF
--- a/pep-8001.rst
+++ b/pep-8001.rst
@@ -13,7 +13,7 @@ Author: Brett Cannon <brett@python.org>,
         Tal Einat <tal@python.org>,
         Tim Peters <tim.peters@gmail.com>,
         Zachary Ware <zachary.ware@gmail.com>
-Status: Accepted
+Status: Final
 Type: Process
 Content-Type: text/x-rst
 Created: 24-Aug-2018

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -222,7 +222,7 @@ def _classify_peps(peps: list[PEP]) -> tuple[list[PEP], ...]:
         elif pep.status == STATUS_DEFERRED:
             deferred.append(pep)
         elif pep.pep_type == TYPE_PROCESS:
-            if pep.status == STATUS_ACTIVE:
+            if pep.status in {STATUS_ACCEPTED, STATUS_ACTIVE}:
                 meta.append(pep)
             elif pep.status in {STATUS_WITHDRAWN, STATUS_REJECTED}:
                 dead.append(pep)


### PR DESCRIPTION
Currently, `Accepted` but not yet implemented (`Active`) PEPs of the `Process` types are getting dumped into the "Historical" category, which isn't accurate and makes them much less visible, despite being in the process of implementation. Both PEP 581 (PEP-0581), the GitHub issue migration, and PEP 676 (PEP-0676), outlining the new PEP build system, fall into this category, despite both being actively in the process of being implemented and certainly not "historical".

Also, I noted PEP 8001 (PEP-8001) on the governance model vote is still listed as "Accepted", despite said vote having concluded (and the resulting decided-upon SC governance model fully implemented) years ago, so it _does_ belong in the "historical" category.

As such, I've tweaked the classification logic to sort `Accepted` Process PEPs in to non-Historical category, along with `Active` ones, and updated PEP 8001 to `Final` since the process it describes is long concluded and now of only historical interest.