### PR TITLE
PEP 681: Remove discussion of alternate form

### DIFF
--- a/pep-0681.rst
+++ b/pep-0681.rst
@@ -532,36 +532,6 @@ decorated with ``dataclass_transform`` is in use.
   `ignored by dataclass mechanisms <#class-var_>`_.
 
 
-Alternate form
---------------
-
-To avoid delaying adoption of this proposal until after
-``dataclass_transform`` has been added to the ``typing`` module, type
-checkers may support the alternative form ``__dataclass_transform__``.
-This form can be defined locally without any reliance on the
-``typing`` or ``typing_extensions`` modules, and allows immediate
-adoption of this specification by library authors. Type checkers that
-have not yet adopted this specification will retain their current
-behavior.
-
-To use this alternate form, library authors should include the
-following declaration within their type stubs or source files:
-
-.. code-block:: python
-
-  _T = TypeVar("_T")
-  
-  def __dataclass_transform__(
-      *,
-      eq_default: bool = True,
-      order_default: bool = False,
-      kw_only_default: bool = False,
-      field_descriptors: tuple[type | Callable[..., Any], ...] = (),
-  ) -> Callable[[_T], _T]:
-      # If used within a stub file, the following implementation can
-      # be replaced with "...".
-      return lambda a: a
-
 Undefined behavior
 ------------------
 
@@ -573,13 +543,14 @@ behavior is undefined. Library authors should avoid these scenarios.
 Reference Implementation
 ========================
 
-The `Pyright <#pyright_>`_ type checker supports the
-``__dataclass_transform__`` `alternate form`_. Pyright's
+`Pyright <#pyright_>`_ contains the reference implementation of type
+checker support for ``dataclass_transform``. Pyright's
 ``dataClasses.ts`` `source file <#pyright-impl_>`_ would be a good
 starting point for understanding the implementation.
 
 The `attrs <#attrs-usage_>`_ and `pydantic <#pydantic-usage_>`_
-libraries are using the ``__dataclass_transform__`` `alternate form`_.
+libraries are using ``dataclass_transform`` and serve as real-world
+examples of its usage.
 
 
 Rejected Ideas


### PR DESCRIPTION
Removed the "Alternate form" section and the mention of the alternate form in the "Reference Implementation" section.

Now that the `dataclass_transform` decorator is available in `typing_extensions`, the fact that Pyright supports the dundered alternate form (`__dataclass_transform__`) is not particularly interesting and has caused some reader confusion.

This needed to be removed before requesting PEP approval anyway.

cc: @davidfstr