### PR TITLE
PEP 681: Describe CPython changes and include docs link

### DIFF
--- a/pep-0681.rst
+++ b/pep-0681.rst
@@ -39,6 +39,10 @@ These behaviors include:
   individual fields that a static type checker must be aware of,
   such as whether a default value is provided for the field.
 
+This proposal does not affect CPython directly except for the addition
+of a ``dataclass_transform`` decorator in typing.py.
+
+
 Motivation
 ==========
 

--- a/pep-0681.rst
+++ b/pep-0681.rst
@@ -43,7 +43,7 @@ The full behavior of the stdlib dataclass is described in the `Python
 documentation <#dataclass-docs_>`_.
 
 This proposal does not affect CPython directly except for the addition
-of a ``dataclass_transform`` decorator in typing.py.
+of a ``dataclass_transform`` decorator in ``typing.py``.
 
 
 Motivation

--- a/pep-0681.rst
+++ b/pep-0681.rst
@@ -39,6 +39,9 @@ These behaviors include:
   individual fields that a static type checker must be aware of,
   such as whether a default value is provided for the field.
 
+The full behavior of the stdlib dataclass is described in the `Python
+documentation <#dataclass-docs_>`_.
+
 This proposal does not affect CPython directly except for the addition
 of a ``dataclass_transform`` decorator in typing.py.
 
@@ -683,6 +686,7 @@ Some aspects of this issue are detailed in a
 
 References
 ==========
+.. _#dataclass-docs: https://docs.python.org/3.11/library/dataclasses.html
 .. _#pyright: https://github.com/Microsoft/pyright
 .. _#pyright-impl: https://github.com/microsoft/pyright/blob/main/packages/pyright-internal/src/analyzer/dataClasses.ts
 .. _#attrs-usage: https://github.com/python-attrs/attrs/pull/796


### PR DESCRIPTION
Responding to @encukou's feedback on Typing SIG

- Added sentence in abstract explaining the PEP's impact on CPython
- Added link in abstract to dataclasses documentation