### PR TITLE
Meta: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -641,6 +641,8 @@ pep-3154.txt  @pitrou
 pep-3155.txt  @pitrou
 pep-3156.txt  @gvanrossum
 # ...
+# pep-3333.txt
+# ...
 pep-8000.rst  @warsaw
 pep-8001.rst  @brettcannon @tiran @dstufft @ericsnowcurrently @gpshead @ambv @Mariatta @njsmith @pablogsal @rhettinger @taleinat @tim-one @zware
 pep-8002.rst  @warsaw @ambv @pitrou @dhellmann @willingc

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -224,7 +224,7 @@ pep-0361.txt  @warsaw
 pep-0362.txt  @brettcannon @1st1 @larryhastings
 # pep-0363.txt
 pep-0364.txt  @warsaw
-# pep-0365.txt  @pjeby
+# pep-0365.txt
 pep-0366.txt  @ncoghlan
 # pep-0367.txt
 # pep-0368.txt

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -192,7 +192,7 @@ pep-0329.txt  @rhettinger
 # pep-0330.txt
 # pep-0331.txt
 # pep-0332.txt
-pep-0333.txt  @pjeby
+# pep-0333.txt
 # pep-0334.txt
 # pep-0335.txt
 # pep-0336.txt
@@ -201,7 +201,7 @@ pep-0338.txt  @ncoghlan
 pep-0339.txt  @brettcannon
 pep-0340.txt  @gvanrossum
 pep-0341.txt  @birkenfeld
-pep-0342.txt  @gvanrossum @pjeby
+pep-0342.txt  @gvanrossum
 pep-0343.txt  @gvanrossum @ncoghlan
 # pep-0344.txt
 # pep-0345.txt
@@ -224,7 +224,7 @@ pep-0361.txt  @warsaw
 pep-0362.txt  @brettcannon @1st1 @larryhastings
 # pep-0363.txt
 pep-0364.txt  @warsaw
-pep-0365.txt  @pjeby
+# pep-0365.txt  @pjeby
 pep-0366.txt  @ncoghlan
 # pep-0367.txt
 # pep-0368.txt
@@ -260,7 +260,7 @@ pep-0398.txt  @birkenfeld
 pep-0399.txt  @brettcannon
 pep-0400.txt  @vstinner
 pep-0401.txt  @warsaw @brettcannon
-pep-0402.txt  @pjeby
+# pep-0402.txt
 pep-0403.txt  @ncoghlan
 pep-0404.txt  @warsaw
 # pep-0405.txt
@@ -554,7 +554,7 @@ pep-0665.rst  @brettcannon
 pep-0667.rst  @markshannon
 pep-0668.rst  @dstufft
 pep-0669.rst  @markshannon
-pep-0670.rst  @vstinner @erlend-aasland
+pep-0670.rst  @vstinner
 pep-0671.rst  @rosuav
 pep-0672.rst  @encukou
 pep-0673.rst  @jellezijlstra
@@ -605,7 +605,7 @@ pep-3119.txt  @gvanrossum
 # pep-3121.txt
 pep-3122.txt  @brettcannon
 # pep-3123.txt
-pep-3124.txt  @pjeby
+# pep-3124.txt
 # pep-3125.txt
 pep-3126.txt  @rhettinger
 # pep-3127.txt
@@ -640,8 +640,6 @@ pep-3151.txt  @pitrou
 pep-3154.txt  @pitrou
 pep-3155.txt  @pitrou
 pep-3156.txt  @gvanrossum
-# ...
-pep-3333.txt  @pjeby
 # ...
 pep-8000.rst  @warsaw
 pep-8001.rst  @brettcannon @tiran @dstufft @ericsnowcurrently @gpshead @ambv @Mariatta @njsmith @pablogsal @rhettinger @taleinat @tim-one @zware


### PR DESCRIPTION
All entries here must be for people who have push access to the repo.

@pjeby left the core dev team in 2020 according to https://devguide.python.org/developers/

@erlend-aasland is not a core dev (yet)

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
