### PR TITLE
PEP 684: Fix invalid format for Discussions-To header

### DIFF
--- a/pep-0684.rst
+++ b/pep-0684.rst
@@ -1,7 +1,7 @@
 PEP: 684
 Title: A Per-Interpreter GIL
 Author: Eric Snow <ericsnowcurrently@gmail.com>
-Discussions-To: `python-dev@python.org <https://mail.python.org/archives/list/python-dev@python.org/thread/CF7B7FMACFYDAHU6NPBEVEY6TOSGICXU/>`__
+Discussions-To: https://mail.python.org/archives/list/python-dev@python.org/thread/CF7B7FMACFYDAHU6NPBEVEY6TOSGICXU/
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst


### PR DESCRIPTION
In #2393 , the ``Discussions-To`` header of PEP 684 was updated to an invalid format, per the initial discussion in #2266  documentation in #2346 , initial processing implementation in #2351 , final implementation and full conform in #2361 , and as stated in PEP 1 (PEP-0001) and PEP 12 (PEP-0012) and approved by the Steering Council in python/steering-council#113 . This PR fixes that.

To note, I've already implemented and tested updates to the validators to catch regressions like this and hopefully avoid this incident in the future, so that the headers can be easily parsed programmatically (which allows us to do all sorts of nice things without having to touch existing PEPs or ask anything more of PEP authors), and PEP authors are given immediate and specific feedback in case of mistakes. They're just blocked on #2375 which is blocked on #2358 , which should hopefully all be merged very soon.