### PR TITLE
PEP 619: Remove duplicated expected release date

### DIFF
--- a/pep-0619.rst
+++ b/pep-0619.rst
@@ -75,7 +75,6 @@ Expected:
 - 3.10.6: Monday, 2022-10-03
 - 3.10.7: Monday, 2022-12-05
 - 3.10.8: Monday, 2023-02-06
-- 3.10.8: Monday, 2023-02-06
 
 Final regular bugfix release with binary installers:
 


### PR DESCRIPTION
Remove duplicated expected Python 3.10.8 release date.
This probably doesn't require the CLA.