### PR TITLE
Infra: Fix non-PEP txt files being included and erroring out the build

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -26,6 +26,16 @@ source_suffix = {
 
 # List of patterns (relative to source dir) to ignore when looking for source files.
 exclude_patterns = [
+    # .txt files in subdirs
+    "**/*.txt",
+    # .txt files in the root not matching PEP pattern
+    "*[!0-9].txt",
+    "*[!0-9]?.txt",
+    "*[!0-9]??.txt",
+    "*[!0-9]???.txt",
+    "*[!p]?????.txt",
+    "*[!e]??????.txt",
+    "*[!p]???????.txt",
     # Windows:
     "Thumbs.db",
     ".DS_Store",

--- a/conf.py
+++ b/conf.py
@@ -26,9 +26,9 @@ source_suffix = {
 
 # List of patterns (relative to source dir) to ignore when looking for source files.
 exclude_patterns = [
-    # .txt files in subdirs
+    # Any .txt files in subdirectories:
     "**/*.txt",
-    # .txt files in the root not matching PEP pattern
+    # Non-PEP .txt files in the root (i.e. not "pep-[0-9][0-9][0-9][0-9].txt"):
     "*[!0-9].txt",
     "*[!0-9]?.txt",
     "*[!0-9]??.txt",
@@ -36,18 +36,18 @@ exclude_patterns = [
     "*[!p]?????.txt",
     "*[!e]??????.txt",
     "*[!p]???????.txt",
-    # Windows:
-    "Thumbs.db",
-    ".DS_Store",
     # Git
     ".git",
+    # Python
+    "*env*",
     # Sphinx:
     "build",
-    # PEPs:
-    "pep-0012/*",
+    # Meta files:
     "README.rst",
     "CONTRIBUTING.rst",
     "pep_sphinx_extensions/LICENCE.rst",
+    # Non-built files:
+    "pep-0012/pep-NNNN.rst",
 ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/conf.py
+++ b/conf.py
@@ -39,8 +39,8 @@ exclude_patterns = [
     # Windows:
     "Thumbs.db",
     ".DS_Store",
-    # Python:
-    "*env*",
+    # Git
+    ".git",
     # Sphinx:
     "build",
     # PEPs:

--- a/conf.py
+++ b/conf.py
@@ -40,19 +40,14 @@ exclude_patterns = [
     "Thumbs.db",
     ".DS_Store",
     # Python:
-    ".venv",
-    "venv",
-    "requirements.txt",
+    "*env*",
     # Sphinx:
     "build",
-    "output.txt",  # Link-check output
     # PEPs:
-    "pep-0012",
+    "pep-0012/*",
     "README.rst",
     "CONTRIBUTING.rst",
     "pep_sphinx_extensions/LICENCE.rst",
-    # Miscellaneous
-    ".codespell",
 ]
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
Presently, as described in #2404 , Sphinx attempts to render any `.txt` files not explicitly excluded in `exclude_patterns` of `conf.py`, in the root or any subdirectories. This results in build failure if any are found, particularly in untracked files which we don't control (e.g. `vendor.txt` in venvs).

Per the [Sphinx docs](https://www.sphinx-doc.org/en/master/usage/configuration.html#id11) we can use full Unix shell-style glob syntax, so adding the glob `**/*.txt` to `exclude_patterns` neatly fixes most instance of this problem by ensuring that `.txt` files are not matched unless they are in the root directory (as all the valid PEPs are).

To handle any remaining cases, i.e. non-PEP `.txt` files that _are_ in the root directory and not explicitly excluded, adding `*[!0-9].txt`,`*[!0-9]?.txt`, `*[!0-9]??.txt`, `*[!0-9]???.txt`, `*[!p]?????.txt`, `*[!e]??????.txt`, and `*[!p]???????.txt` ensures that to be included, `.txt` files must match the equivalent  of the regex `^pep?[0-9]{4}\.txt$`, which is only used for PEPs.

This solution was tested on some sample files in the root and subdirectories, including the reported `venv-spam/vendor.txt`, and several with varying degrees of names somewhat similar to PEPs, and it excluded all of them, while not excluding any valid PEPs.

It also obviates the need for some of our other explicit excludes, but I opted to leave them for now

Fix #2404 