### PR TITLE
Infra: build peps.rss from input txt and rst files

### DIFF
--- a/generate_rss.py
+++ b/generate_rss.py
@@ -79,10 +79,17 @@ def pep_abstract(full_path: Path) -> str:
 
 def main():
     # get the directory with the PEP sources
+    in_dir = Path(__file__).parent
+
+    # get the output directory for target HTML files
     out_dir = Path(__file__).parent / "build"
 
-    # get list of peps with creation time (from "Created:" string in pep source)
-    peps_with_dt = sorted((pep_creation(path), path) for path in out_dir.glob("pep-????.*"))
+    # get list of source peps
+    peps = list(in_dir.glob('pep-*.txt'))
+    peps.extend(in_dir.glob('pep-*.rst'))
+
+    # sort peps by creation time (from "Created:" string in pep source)
+    peps_with_dt = sorted((pep_creation(path), path) for path in peps)
 
     # generate rss items for 10 most recent peps
     items = []

--- a/generate_rss.py
+++ b/generate_rss.py
@@ -85,8 +85,8 @@ def main():
     out_dir = Path(__file__).parent / "build"
 
     # get list of source peps
-    peps = list(in_dir.glob('pep-*.txt'))
-    peps.extend(in_dir.glob('pep-*.rst'))
+    peps = list(in_dir.glob('pep-[0-9][0-9][0-9][0-9].txt'))
+    peps.extend(in_dir.glob('pep-[0-9][0-9][0-9][0-9].rst'))
 
     # sort peps by creation time (from "Created:" string in pep source)
     peps_with_dt = sorted((pep_creation(path), path) for path in peps)


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fixes https://github.com/python/peps/issues/2406.

The RSS builder must run on the input TXT and RST files, not the target HTML files, similar to how it was done in the old `pep2rss.py`:

https://github.com/python/peps/blob/08e37f7c23b5ac3a6feb8e4c24c3bc8871192f72/pep2rss.py#L63-L66

To test, run `python3 generate_rss.py` and check `build/peps.rss` has the most recently created PEPs.

For comparison, here's `pep.rss` from two days ago:

* https://web.archive.org/web/20220308231429/https://www.python.org/dev/peps/peps.rss/
