### PR TITLE
Lint: call tools inside venv using make's PYTHON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ venv:
 	./$(VENV_DIR)/bin/python -m pip install -r requirements.txt
 
 lint:
-	pre-commit --version > /dev/null || $(PYTHON) -m pip install pre-commit
-	pre-commit run --all-files
+	$(PYTHON) -m pre_commit --version > /dev/null || $(PYTHON) -m pip install pre-commit
+	$(PYTHON) -m pre_commit run --all-files
 
 spellcheck:
-	pre-commit --version > /dev/null || $(PYTHON) -m pip install pre-commit
-	pre-commit run --all-files --hook-stage manual codespell
+	$(PYTHON) -m pre_commit --version > /dev/null || $(PYTHON) -m pip install pre-commit
+	$(PYTHON) -m pre_commit run --all-files --hook-stage manual codespell

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,46 @@
 # Builds PEP files to HTML using sphinx
 
 PYTHON=python3
-VENV_DIR=venv
+VENVDIR=venv
 JOBS=8
-RENDER_COMMAND=$(PYTHON) build.py -j $(JOBS)
+RENDER_COMMAND=$(VENVDIR)/bin/python3 build.py -j $(JOBS)
 
-render:
+render: venv
 	$(RENDER_COMMAND)
 
-pages: rss
+pages: venv rss
 	$(RENDER_COMMAND) --build-dirs
 
-fail-warning:
+fail-warning: venv
 	$(RENDER_COMMAND) --fail-on-warning
 
-check-links:
+check-links: venv
 	$(RENDER_COMMAND) --check-links
 
-rss:
-	$(PYTHON) generate_rss.py
+rss: venv
+	$(VENVDIR)/bin/python3 generate_rss.py
 
-clean:
+clean: clean-venv
 	-rm -rf build
 
+clean-venv:
+	rm -rf $(VENVDIR)
+
 venv:
-	$(PYTHON) -m venv $(VENV_DIR)
-	./$(VENV_DIR)/bin/python -m pip install -r requirements.txt
+	@if [ -d $(VENVDIR) ] ; then \
+		echo "venv already exists."; \
+		echo "To recreate it, remove it first with \`make clean-venv'."; \
+	else \
+		$(PYTHON) -m venv $(VENVDIR); \
+		$(VENVDIR)/bin/python3 -m pip install -U pip setuptools; \
+		$(VENVDIR)/bin/python3 -m pip install -r requirements.txt; \
+		echo "The venv has been created in the $(VENVDIR) directory"; \
+	fi
 
-lint:
-	$(PYTHON) -m pre_commit --version > /dev/null || $(PYTHON) -m pip install pre-commit
-	$(PYTHON) -m pre_commit run --all-files
+lint: venv
+	$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit
+	$(VENVDIR)/bin/python3 -m pre_commit run --all-files
 
-spellcheck:
-	$(PYTHON) -m pre_commit --version > /dev/null || $(PYTHON) -m pip install pre-commit
-	$(PYTHON) -m pre_commit run --all-files --hook-stage manual codespell
+spellcheck: venv
+	$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit
+	$(VENVDIR)/bin/python3 -m pre_commit run --all-files --hook-stage manual codespell

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Builds PEP files to HTML using sphinx
 
 PYTHON=python3
-VENVDIR=venv
+VENVDIR=.venv
 JOBS=8
 RENDER_COMMAND=$(VENVDIR)/bin/python3 build.py -j $(JOBS)
 
@@ -32,7 +32,6 @@ venv:
 		echo "To recreate it, remove it first with \`make clean-venv'."; \
 	else \
 		$(PYTHON) -m venv $(VENVDIR); \
-		$(VENVDIR)/bin/python3 -m pip install -U pip setuptools; \
 		$(VENVDIR)/bin/python3 -m pip install -r requirements.txt; \
 		echo "The venv has been created in the $(VENVDIR) directory"; \
 	fi


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

For https://github.com/python/peps/issues/2402.
Fixes https://github.com/python/peps/issues/2403.

The pre-commit tool can be called as a module as `pre_commit`: https://github.com/pre-commit/pre-commit/issues/1627#issuecomment-704373290

This allows us to choose which Python version to use:

```sh
make lint
make PYTHON=python3.7 lint
make PYTHON=/Users/huvankem/.pyenv/shims/python3.8 lint
```

And the tools are installed inside a venv using the given Python version.

This is based on the CPython docs [`makefile`](https://github.com/python/cpython/blob/main/Doc/Makefile) and devguide [`makefile`](https://github.com/python/devguide/blob/main/Makefile), so should follow a familiar pattern.
