### PR TITLE
Dark mode: invert some images

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -438,6 +438,7 @@ an API can replace version 1.
 
 The possible paths of the status of PEPs are as follows:
 
+.. rst-class:: invert-in-dark-mode
 .. image:: pep-0001-process_flow.png
    :alt: PEP process flow diagram
 

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -438,8 +438,8 @@ an API can replace version 1.
 
 The possible paths of the status of PEPs are as follows:
 
-.. rst-class:: invert-in-dark-mode
 .. image:: pep-0001-process_flow.png
+   :class: invert-in-dark-mode
    :alt: PEP process flow diagram
 
 While not shown in the diagram, "Accepted" PEPs may technically move to

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -488,6 +488,7 @@ also indicates the types of keys used to sign each role, and which roles are
 trusted to sign for files available on PyPI.  The next two sections cover the
 details of signing repository files and the types of keys used for each role.
 
+.. rst-class:: invert-in-dark-mode
 .. image:: pep-0458-1.png
 
 Figure 1: An overview of the role metadata available on PyPI.

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -488,8 +488,8 @@ also indicates the types of keys used to sign each role, and which roles are
 trusted to sign for files available on PyPI.  The next two sections cover the
 details of signing repository files and the types of keys used for each role.
 
-.. rst-class:: invert-in-dark-mode
 .. image:: pep-0458-1.png
+   :class: invert-in-dark-mode
 
 Figure 1: An overview of the role metadata available on PyPI.
 

--- a/pep-0480.txt
+++ b/pep-0480.txt
@@ -206,8 +206,8 @@ projects are signed by an online key.  That is, an attacker is able to corrupt
 packages in the minimum security model, but not in the maximum model, without
 also compromising a developer's key.
 
-.. rst-class:: invert-in-dark-mode
 .. image:: pep-0480-1.png
+   :class: invert-in-dark-mode
 
 Figure 1: An overview of the metadata layout in the maximum security model.
 The maximum security model supports continuous delivery and survivable key

--- a/pep-0480.txt
+++ b/pep-0480.txt
@@ -206,6 +206,7 @@ projects are signed by an online key.  That is, an attacker is able to corrupt
 packages in the minimum security model, but not in the maximum model, without
 also compromising a developer's key.
 
+.. rst-class:: invert-in-dark-mode
 .. image:: pep-0480-1.png
 
 Figure 1: An overview of the metadata layout in the maximum security model.

--- a/pep-0495.txt
+++ b/pep-0495.txt
@@ -384,10 +384,10 @@ smaller after any transition that creates a fold.  The values returned
 by ``tzname()`` and ``dst()`` may or may not depend on the value of
 the ``fold`` attribute depending on the kind of the transition.
 
-.. rst-class:: invert-in-dark-mode
 .. image:: pep-0495-fold-2.png
   :align: center
   :width: 60%
+  :class: invert-in-dark-mode
 
 The sketch above illustrates the relationship between the UTC and
 local time around a fall-back transition.  The zig-zag line is a graph
@@ -410,10 +410,10 @@ local time that falls in a gap, the rules in effect before the
 transition should be used if ``fold=0``.  Otherwise, the rules in
 effect after the transition should be used.
 
-.. rst-class:: invert-in-dark-mode
 .. image:: pep-0495-gap.png
   :align: center
   :width: 60%
+  :class: invert-in-dark-mode
 
 The sketch above illustrates the relationship between the UTC and
 local time around a spring-forward transition.  At the transition, the

--- a/pep-0495.txt
+++ b/pep-0495.txt
@@ -384,6 +384,7 @@ smaller after any transition that creates a fold.  The values returned
 by ``tzname()`` and ``dst()`` may or may not depend on the value of
 the ``fold`` attribute depending on the kind of the transition.
 
+.. rst-class:: invert-in-dark-mode
 .. image:: pep-0495-fold-2.png
   :align: center
   :width: 60%
@@ -409,6 +410,7 @@ local time that falls in a gap, the rules in effect before the
 transition should be used if ``fold=0``.  Otherwise, the rules in
 effect after the transition should be used.
 
+.. rst-class:: invert-in-dark-mode
 .. image:: pep-0495-gap.png
   :align: center
   :width: 60%

--- a/pep-0525.txt
+++ b/pep-0525.txt
@@ -386,10 +386,10 @@ reference implementation introduces three new objects:
 methods).  Essentially, they control how asynchronous generators are
 iterated:
 
-.. rst-class:: invert-in-dark-mode
 .. image:: pep-0525-1.png
    :align: center
    :width: 80%
+   :class: invert-in-dark-mode
 
 
 PyAsyncGenASend and PyAsyncGenAThrow

--- a/pep-0525.txt
+++ b/pep-0525.txt
@@ -386,6 +386,7 @@ reference implementation introduces three new objects:
 methods).  Essentially, they control how asynchronous generators are
 iterated:
 
+.. rst-class:: invert-in-dark-mode
 .. image:: pep-0525-1.png
    :align: center
    :width: 80%

--- a/pep-0532.txt
+++ b/pep-0532.txt
@@ -680,8 +680,8 @@ The following diagram illustrates the core concepts behind the circuit
 breaking protocol (although it glosses over the technical detail of looking
 up the special methods via the type rather than the instance):
 
-.. rst-class:: invert-in-dark-mode
 .. image:: pep-0532/circuit-breaking-protocol.svg
+   :class: invert-in-dark-mode
    :alt: diagram of circuit breaking protocol applied to ternary expression
 
 We will work through the following expression::

--- a/pep-0532.txt
+++ b/pep-0532.txt
@@ -680,6 +680,7 @@ The following diagram illustrates the core concepts behind the circuit
 breaking protocol (although it glosses over the technical detail of looking
 up the special methods via the type rather than the instance):
 
+.. rst-class:: invert-in-dark-mode
 .. image:: pep-0532/circuit-breaking-protocol.svg
    :alt: diagram of circuit breaking protocol applied to ternary expression
 

--- a/pep-0550.rst
+++ b/pep-0550.rst
@@ -1565,10 +1565,10 @@ coroutine.
 Appendix: HAMT Performance Analysis
 ===================================
 
-.. rst-class:: invert-in-dark-mode
 .. figure:: pep-0550-hamt_vs_dict-v2.png
    :align: center
    :width: 100%
+   :class: invert-in-dark-mode
 
    Figure 1.  Benchmark code can be found here: [9]_.
 
@@ -1579,10 +1579,10 @@ The above chart demonstrates that:
 
 * ``dict.copy()`` becomes very slow around 100 items.
 
-.. rst-class:: invert-in-dark-mode
 .. figure:: pep-0550-lookup_hamt.png
    :align: center
    :width: 100%
+   :class: invert-in-dark-mode
 
    Figure 2.  Benchmark code can be found here: [10]_.
 

--- a/pep-0550.rst
+++ b/pep-0550.rst
@@ -1565,6 +1565,7 @@ coroutine.
 Appendix: HAMT Performance Analysis
 ===================================
 
+.. rst-class:: invert-in-dark-mode
 .. figure:: pep-0550-hamt_vs_dict-v2.png
    :align: center
    :width: 100%
@@ -1578,6 +1579,7 @@ The above chart demonstrates that:
 
 * ``dict.copy()`` becomes very slow around 100 items.
 
+.. rst-class:: invert-in-dark-mode
 .. figure:: pep-0550-lookup_hamt.png
    :align: center
    :width: 100%

--- a/pep-0603.rst
+++ b/pep-0603.rst
@@ -295,6 +295,7 @@ fairly detailed description of the algorithm as well.
 Performance
 -----------
 
+.. rst-class:: invert-in-dark-mode
 .. figure:: pep-0603-hamt_vs_dict.png
    :align: center
    :width: 100%
@@ -309,6 +310,7 @@ The above chart demonstrates that:
 * ``dict.copy()`` becomes less efficient when using around
   100-200 items.
 
+.. rst-class:: invert-in-dark-mode
 .. figure:: pep-0603-lookup_hamt.png
    :align: center
    :width: 100%

--- a/pep-0603.rst
+++ b/pep-0603.rst
@@ -295,10 +295,10 @@ fairly detailed description of the algorithm as well.
 Performance
 -----------
 
-.. rst-class:: invert-in-dark-mode
 .. figure:: pep-0603-hamt_vs_dict.png
    :align: center
    :width: 100%
+   :class: invert-in-dark-mode
 
    Figure 1.  Benchmark code can be found here: [3]_.
 
@@ -310,10 +310,10 @@ The above chart demonstrates that:
 * ``dict.copy()`` becomes less efficient when using around
   100-200 items.
 
-.. rst-class:: invert-in-dark-mode
 .. figure:: pep-0603-lookup_hamt.png
    :align: center
    :width: 100%
+   :class: invert-in-dark-mode
 
    Figure 2.  Benchmark code can be found here: [4]_.
 

--- a/pep-3147.txt
+++ b/pep-3147.txt
@@ -316,6 +316,7 @@ Flow chart
 
 Here is a flow chart describing how modules are loaded:
 
+.. rst-class:: invert-in-dark-mode
 .. image:: pep-3147-1.png
    :scale: 75
 

--- a/pep-3147.txt
+++ b/pep-3147.txt
@@ -316,9 +316,9 @@ Flow chart
 
 Here is a flow chart describing how modules are loaded:
 
-.. rst-class:: invert-in-dark-mode
 .. image:: pep-3147-1.png
    :scale: 75
+   :class: invert-in-dark-mode
 
 
 Alternative Python implementations

--- a/pep_sphinx_extensions/pep_theme/static/dark.css
+++ b/pep_sphinx_extensions/pep_theme/static/dark.css
@@ -17,6 +17,6 @@
     --colour-warning: #900;
 }
 
-.invert-in-dark-mode {
+img.invert-in-dark-mode {
     filter: invert(1);
 }

--- a/pep_sphinx_extensions/pep_theme/static/dark.css
+++ b/pep_sphinx_extensions/pep_theme/static/dark.css
@@ -16,3 +16,7 @@
     --colour-inline-code: #333;
     --colour-warning: #900;
 }
+
+.invert-in-dark-mode {
+    filter: invert(1);
+}


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

As detailed at https://discuss.python.org/t/styling-of-peps/13270/25?u=hugovk and https://discuss.python.org/t/styling-of-peps/13270/26?u=hugovk, a number of images need adapting to display in dark mode.

Use CSS to invert those images in PEP-0001 and marked :arrows_counterclockwise: above.