### PR TITLE
Infra: Upload rendered PEPs as GitHub artifact

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.x'
 

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -45,3 +45,4 @@ jobs:
         with:
           name: peps
           path: build
+          retention-days: 7

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
       - name: 🛎️ Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0  # fetch all history so that last modified date-times are accurate
 
       - name: 🐍 Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.x'
           cache: "pip"
@@ -39,3 +39,9 @@ jobs:
           branch: gh-pages # The branch to deploy to.
           folder: build # Synchronise with build.py -> build_directory
           single-commit: true # Delete existing files
+
+      - name: 📦 Upload built PEPs as zipped artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: peps
+          path: build


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Similar to https://github.com/python/cpython/pull/30419.

Whilst we're deciding whether to use something like Read the Docs that builds [hosted previews of PRs](https://docs.readthedocs.io/en/stable/pull-requests.html), we can use https://github.com/actions/upload-artifact to create a zip of the rendered PEPs built on the CI.

This makes testing/reviewing a bit easier: no need to checkout the branch and build locally. Also reviewable on mobile.



