### PR TITLE
PEP 594: Mark as accepted

### DIFF
--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -3,7 +3,7 @@ Title: Removing dead batteries from the standard library
 Author: Christian Heimes <christian@python.org>,
         Brett Cannon <brett@python.org>
 Discussions-To: https://discuss.python.org/t/13508
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 20-May-2019


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

The SC announcement:

> We are accepting [PEP-594 2](https://peps.python.org/pep-0594/) _Removing dead batteries from the standard library_.
> 
> It removes a non-controversial set of very old unmaintained or obsolete libraries from the Python standard library. We expect this PEP to be a one time event, and for future deprecations to be handled differently.
> 
> One thing we’d like to see happen while implementing it: Document the status of the modules being deprecated and removed and backport those deprecation updates to older CPython branch documentation (at least back to 3.9). That gets the notices in front of more people who may use the docs for their specific Python version.
> 
> Particular care should also be taken during the pre-release cycles that remove deprecated modules. If it turns out the removal of a module proves to be a problem in practice despite the clear deprecation, deferring the removal of that module should be considered to avoid disruption.
> 
> Doing a “mass cleanup” of long obsolete modules is a sign that we as a project have been ignoring rather than maintaining parts of the standard library, or not doing so with the diligence being in the standard library implies they deserve. Resolving ongoing discussions around how we define the stdlib for the long term does not block this PEP. It seems worthwhile for us to conduct regular reviews of the contents of the stdlib every few releases so we can avoid accumulating such a large pile of dead batteries, but this is outside the scope of this particular PEP.
> 
> – Greg for the PSC

https://discuss.python.org/t/pep-594-take-2-removing-dead-batteries-from-the-standard-library/13508/22
