### PR TITLE
PEP 673: Fix a couple of typos

### DIFF
--- a/pep-0673.rst
+++ b/pep-0673.rst
@@ -479,7 +479,7 @@ Use in Protocols
 
     from typing import Protocol, Self
 
-    class Shape(Protocol):
+    class ShapeProtocol(Protocol):
         scale: float
 
         def set_scale(self, scale: float) -> Self:
@@ -494,7 +494,7 @@ is treated equivalently to:
 
     SelfShape = TypeVar("SelfShape", bound="ShapeProtocol")
 
-    class Shape(Protocol):
+    class ShapeProtocol(Protocol):
         scale: float
 
         def set_scale(self: SelfShape, scale: float) -> SelfShape:

--- a/pep-0673.rst
+++ b/pep-0673.rst
@@ -658,7 +658,7 @@ The following uses of ``Self`` are rejected.
     class Bar(Generic[T]):
         def bar(self) -> T: ...
 
-    class Baz(Foo[Self]): ...  # Rejected
+    class Baz(Bar[Self]): ...  # Rejected
 
 We reject type aliases containing ``Self``. Supporting ``Self``
 outside class definitions can require a lot of special-handling in


### PR DESCRIPTION
Changes:

- Name protocol to match usage
  It would have been possible here to change the bound of the `TypeVar` on line 495 to 'Shape', however I've opted to change the names of the definitions so that they match the later (similar) definitions of this protocol.

- Fix example generic class name
  I'm guessing this was just a copy/pasta error or similar; there is no generic class named 'Foo' which is in scope here, however there is a 'Bar' that has just been defined and isn't yet used. 
