### PR TITLE
Infra: Exclude .git directory from Sphinx processing

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -41,8 +41,9 @@ exclude_patterns = [
     "README.rst",
     "CONTRIBUTING.rst",
     "pep_sphinx_extensions/LICENCE.rst",
-    # Miscellaneous
+    # Miscellaneous:
     ".codespell",
+    ".git",
 ]
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

For https://github.com/python/peps/issues/2404#issuecomment-1065839981.

Whichever of #2405 and #2415 we choose, we definitely don't want Sphinx to process the contents of the `.git` directory. Let's explicitly exclude it.

