### PR TITLE
Accessibility: Add aria-label to clearly describe the dark mode button

### DIFF
--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -25,7 +25,7 @@
                 <li><a href="{{ pathto("pep-0000") }}">PEP Index</a> &raquo; </li>
                 <li>{{ title }}</li>
             </ul>
-            <button onClick="toggleColourScheme()"></button>
+            <button aria-label="Toggle dark mode" onClick="toggleColourScheme()"></button>
         </header>
         <article>
             {{ body }}


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

1. Go to https://web.dev/measure/
2. Enter https://peps.python.org/ and RUN AUDIT

(Alternatively, Chrome devtools has a Lighthouse tab to run the same thing.)

# Before

<img width="941" alt="image" src="https://user-images.githubusercontent.com/1324225/158079450-f104665b-dcf2-4150-9f3b-697c855866bf.png">

https://peps.python.org/

> **Buttons do not have an accessible name**
When a button doesn't have an accessible name, screen readers announce it as "button", making it unusable for users who rely on screen readers. Learn more.

https://web.dev/button-name/?utm_source=lighthouse&utm_medium=lr says:

> For buttons without visible labels, like icon buttons, use the `aria-label` attribute to clearly describe the action to anyone using an assistive technology [...]

# After

<img width="916" alt="image" src="https://user-images.githubusercontent.com/1324225/158079667-544fa6a1-5395-4b7b-8fdf-9644b8e45dc5.png">

https://pep-previews--2426.org.readthedocs.build/

(There are of course further manual accessibility things that can be checked.)