### PR TITLE
Style: Fix vertical margins of def lists w/o <p>s to match those with

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -127,6 +127,9 @@ details > summary {
 dl dt {
     font-weight: bold;
 }
+dl dd {
+    margin-bottom: 0.5rem;
+}
 
 /* Horizontal rule rule */
 hr {

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -21,7 +21,7 @@ html {
     overflow-y: scroll;
     -webkit-font-smoothing: antialiased;
     margin: 0;
-    line-height: 1.4rem;
+    line-height: 1.4;
     font-weight: normal;
     font-size: 1rem;
     font-family: "Source Sans Pro", Arial, sans-serif;
@@ -41,7 +41,7 @@ p {margin: .5rem 0}
 
 /* Header rules */
 h1 {
-    line-height: 2.3rem;
+    line-height: 2.3;
     font-size: 2rem;
     font-weight: bold;
     margin-top: 2rem;
@@ -198,7 +198,7 @@ section#pep-page-section > header {
 }
 section#pep-page-section > header > h1 {
     font-size: 1.1rem;
-    line-height: 1.4rem;
+    line-height: 1.4;
     margin: 0;
     display: inline-block;
     padding-right: .6rem;


### PR DESCRIPTION
In #2300 , it was reported that the vertical margin varies substantially between entries with multiple paragraphs (i.e, another `<p>` element) and those that only have one (i.e. just text, no `<p>`). Furthermore, the margins are still pretty tight as @pradyunsg reported, making them uncomfortable to read; they should be at least equivalent to the normal margin between paragraph-level elements. 

PEP 639 is a canonical example [without](https://peps.python.org/pep-0639/#terminology) and [with](https://pep-previews--2427.org.readthedocs.build/pep-0639/#terminology) this PR.

----

![image](https://user-images.githubusercontent.com/17051931/158073265-e2c76c60-3183-42c1-a0e6-d1620f6a2f37.png)

----

This resolves both of those concerns by just ensuring that `dl dd` (except headers and footnotes, which are already overridden) have the same `0.5rem` bottom vertical margin as paragraphs do:

----

![image](https://user-images.githubusercontent.com/17051931/158075060-4f4ac3f2-3412-4865-a7bc-4d27a21ea05c.png)

----

@pradyunsg Are there any additional vertical line spacing concerns you'd like me to address at this time?

Resolves #2300 