### PR TITLE
PEP 339: Fix broken link

### DIFF
--- a/pep-0339.txt
+++ b/pep-0339.txt
@@ -564,7 +564,7 @@ References
 .. _SPARK: http://pages.cpsc.ucalgary.ca/~aycock/spark/
 
 .. [#skip-peephole] Skip Montanaro's Peephole Optimizer Paper
-   (http://www.foretec.com/python/workshops/1998-11/proceedings/papers/montanaro/montanaro.html)
+   (https://legacy.python.org/workshops/1998-11/proceedings/papers/montanaro/montanaro.html)
 
 .. [#Bytecodehacks] Bytecodehacks Project
    (http://bytecodehacks.sourceforge.net/bch-docs/bch/index.html)


### PR DESCRIPTION
I stumbled upon this broken link while trying to find another obsolete link to this paper on www.python.org. I realize it's old news, but the fix seems trivial, and should stay unbroken as long as legacy.python.org is running.
