### PR TITLE
PEP 20: Fix syntax highlighting and other minor syntax/formatting issues

### DIFF
--- a/pep-0020.txt
+++ b/pep-0020.txt
@@ -1,14 +1,11 @@
 PEP: 20
 Title: The Zen of Python
-Version: $Revision$
-Last-Modified: $Date$
-Author: tim.peters@gmail.com (Tim Peters)
+Author: Tim Peters <tim.peters@gmail.com>
 Status: Active
 Type: Informational
 Content-Type: text/x-rst
 Created: 19-Aug-2004
 Post-History: 22-Aug-2004
-
 
 
 Abstract
@@ -22,7 +19,7 @@ have been written down.
 The Zen of Python
 =================
 
-::
+.. code-block:: text
 
     Beautiful is better than ugly.
     Explicit is better than implicit.
@@ -48,7 +45,7 @@ The Zen of Python
 Easter Egg
 ==========
 
-::
+.. code-block:: pycon
 
   >>> import this
 
@@ -56,21 +53,12 @@ Easter Egg
 References
 ==========
 
-* Originally posted to comp.lang.python/python-list@python.org under a
-  thread called "The Way of Python"
-  https://groups.google.com/d/msg/comp.lang.python/B_VxeTBClM0/L8W9KlsiriUJ
+Originally posted to comp.lang.python/python-list@python.org under a
+thread called `"The Way of Python"
+<https://groups.google.com/d/msg/comp.lang.python/B_VxeTBClM0/L8W9KlsiriUJ>`__
 
 
 Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:


### PR DESCRIPTION
As reported by @brettcannon in #2430 , PEP 20 (PEP-0020), the Zen of Python, has some quirks under the new build system, particularly strangely-displayed syntax highlighting. This is due to the assumed default of `python` for code blocks, when they are actually just text here. As such, this PR converts the code blocks to the explicit ``.. code-block`` syntax with language declarations, plus updates/removes a few other out of date bits of the old format in the process.

Now that PEP 676 is accepted and live, I will update PEP 12 to explain this for current and future authors, and ensure the other active core/meta-PEPs also reflect it. Following that, I'll also go through and check the other old PEPs for similar issues, and fix those I find in as low-impact manner as practical (i.e. adding a ``.. language`` line at the top), However, we may as well just fix this now with a quick PR, since PEP 20 is a pretty "hot" and enduring PEP and the issue is pretty visible.

Fix #2430 