### PR TITLE
PEP 673: Fix syntax highlighting

### DIFF
--- a/pep-0673.rst
+++ b/pep-0673.rst
@@ -322,7 +322,7 @@ have a ``LinkedList`` whose elements must be subclasses of the current class.
     # OK
     LinkedList[int](value=1, next=LinkedList[int](value=2))
     # Not OK
-    LinkedList[int](value=1, next=LinkedList[str](value=”hello”))
+    LinkedList[int](value=1, next=LinkedList[str](value="hello"))
 
 
 However, annotating the ``next`` attribute as ``LinkedList[T]`` allows invalid
@@ -411,7 +411,7 @@ This is equivalent to writing:
 
 ::
 
-    Self = TypeVar(“Self”, bound=”Container[Any]”)
+    Self = TypeVar("Self", bound="Container[Any]")
 
     class Container(Generic[T]):
         value: T
@@ -430,7 +430,7 @@ an object of generic type ``Container[T]``, ``Self`` is bound to
         int_container: Container[int]
         str_container: Container[str]
         reveal_type(int_container.set_value(42))  # => Container[int]
-        reveal_type(str_container.set_value(“hello”))  # => Container[str]
+        reveal_type(str_container.set_value("hello"))  # => Container[str]
 
     def object_with_generic_type(
         container: Container[T], value: T,


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/66076021/158484740-1a5c112d-972a-42b3-9062-11b57273669e.png)
![image](https://user-images.githubusercontent.com/66076021/158484791-38c4b134-698b-4542-a2db-f08492533048.png)

After:

![image](https://user-images.githubusercontent.com/66076021/158484878-ee656ebd-16aa-4315-a6d7-9e7765331ca7.png)
![image](https://user-images.githubusercontent.com/66076021/158484918-80945ec1-9ec0-45a5-902a-d4873cbc6345.png)
