### PR TITLE
Style: Reduce size of code font and improve responsiveness at narrow screen widths

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -4,9 +4,11 @@
 
 /* Further reduce width of fixed elements for smallest screens */
 @media (max-width: 32em) {
-    pre,
     code {
         word-break: break-all;
+    }
+    pre {
+        font-size: 0.75rem;
     }
     table th,
     table td {
@@ -25,6 +27,9 @@
     }
     nav#pep-sidebar {
         display: none;
+    }
+    pre {
+        font-size: 0.8175rem;
     }
     table th,
     table td {

--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -13,10 +13,6 @@
     pre {
         font-size: 0.75rem;
     }
-    table th,
-    table td {
-        font-size: 3vw;
-    }
 }
 
 /* Reduce padding & margins for smaller screens */

--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -18,7 +18,7 @@
 }
 
 /* Reduce padding & margins for smaller screens */
-@media (max-width: 36em) {
+@media (max-width: 40em) {
     section#pep-page-section {
         padding: 0.5rem;
     }
@@ -41,7 +41,7 @@
     }
 }
 
-@media (min-width: 36em) {
+@media (min-width: 40em) {
     section#pep-page-section {
         display: table;
         margin: 0 auto;

--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -4,6 +4,9 @@
 
 /* Further reduce width of fixed elements for smallest screens */
 @media (max-width: 32em) {
+    section#pep-page-section {
+        padding: 0.25rem;
+    }
     code {
         word-break: break-all;
     }
@@ -18,6 +21,9 @@
 
 /* Reduce padding & margins for smaller screens */
 @media (max-width: 36em) {
+    section#pep-page-section {
+        padding: 0.5rem;
+    }
     section#pep-page-section > header > h1 {
         padding-right: 0;
         border-right: none;
@@ -48,6 +54,7 @@
 
 @media (min-width: 54em) {
     section#pep-page-section {
+        display: table;
         max-width: 75em;
     }
     section#pep-page-section > article {

--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -7,10 +7,10 @@
     section#pep-page-section {
         padding: 0.25rem;
     }
-    code,
     dl.footnote > dt,
     dl.footnote > dd {
-        word-break: break-all;
+        padding-left: 0;
+        padding-right: 0;
     }
     pre {
         font-size: 0.75rem;

--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -62,6 +62,11 @@
         float: left;
         margin-right: 2%;
     }
+  /* Make Contents more visible on mobile */
+  details > summary {
+      font-size: 1rem;
+      width: max-content;
+  }
 }
 @media (min-width: 60em) {
     section#pep-page-section > article {

--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -43,17 +43,11 @@
 
 @media (min-width: 36em) {
     section#pep-page-section {
-        max-width: 40em;
-        width: 100%;
-        margin: 0 auto;
-        padding: .5rem 1rem 0;
-    }
-}
-
-@media (min-width: 54em) {
-    section#pep-page-section {
         display: table;
+        margin: 0 auto;
         max-width: 75em;
+        padding: 0.5rem 1rem 0;
+        width: 100%;
     }
     section#pep-page-section > article {
         max-width: 40em;
@@ -67,7 +61,7 @@
         float: left;
         margin-right: 2%;
     }
-  /* Make Contents more visible on mobile */
+  /* Make less prominent when sidebar ToC is available */
   details > summary {
       font-size: 1rem;
       width: max-content;

--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -1,7 +1,21 @@
 @charset "UTF-8";
+
 /* Media Queries */
-@media (max-width: 32.5em) {
-    /* Reduce padding & margins for the smallest screens */
+
+/* Further reduce width of fixed elements for smallest screens */
+@media (max-width: 32em) {
+    pre,
+    code {
+        word-break: break-all;
+    }
+    table th,
+    table td {
+        font-size: 3vw;
+    }
+}
+
+/* Reduce padding & margins for smaller screens */
+@media (max-width: 36em) {
     section#pep-page-section > header > h1 {
         padding-right: 0;
         border-right: none;
@@ -17,7 +31,8 @@
         padding: 0 0.1rem;
     }
 }
-@media (min-width: 32.5em) {
+
+@media (min-width: 36em) {
     section#pep-page-section {
         max-width: 40em;
         width: 100%;
@@ -25,6 +40,7 @@
         padding: .5rem 1rem 0;
     }
 }
+
 @media (min-width: 54em) {
     section#pep-page-section {
         max-width: 75em;

--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -7,7 +7,9 @@
     section#pep-page-section {
         padding: 0.25rem;
     }
-    code {
+    code,
+    dl.footnote > dt,
+    dl.footnote > dd {
         word-break: break-all;
     }
     pre {

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -19,7 +19,6 @@
 :root {color-scheme: light dark}
 html {
     overflow-y: scroll;
-    -webkit-font-smoothing: antialiased;
     margin: 0;
     line-height: 1.4;
     font-weight: normal;
@@ -279,16 +278,11 @@ dl.footnote dd {
 
 /* Sidebar formatting */
 #pep-sidebar {
-    overflow-y: scroll;
+    overflow-y: auto;
     position: sticky;
     top: 0;
     height: 100vh;
-    scrollbar-width: thin;  /* CSS Standards, not *yet* widely supported */
-    scrollbar-color: var(--colour-scrollbar) transparent;
 }
-#pep-sidebar::-webkit-scrollbar {width: 6px}
-#pep-sidebar::-webkit-scrollbar-track {background: transparent}
-#pep-sidebar::-webkit-scrollbar-thumb {background: var(--colour-scrollbar)}
 #pep-sidebar > h2 {
     font-size: 1.4rem;
 }

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -177,6 +177,9 @@ sup {top: -0.5em}
 sub {bottom: -0.25em}
 
 /* Table rules */
+div.table-wrapper {
+    overflow-x: auto;
+}
 table {
     width: 100%;
     border-collapse: collapse;

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -121,7 +121,13 @@ pre {
 
 /* Contents rules */
 details > summary {
+    cursor: pointer;
+    font-size: 1.6rem;
     font-weight: bold;
+    margin-bottom: 1em;
+}
+details > summary:hover {
+    text-decoration: underline;
 }
 
 /* Definition list rules */

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -41,7 +41,6 @@ p {margin: .5rem 0}
 
 /* Header rules */
 h1 {
-    line-height: 2.3;
     font-size: 2rem;
     font-weight: bold;
     margin-top: 2rem;

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -32,8 +32,7 @@ body {
     background-color: var(--colour-background);
 }
 section#pep-page-section {
-    padding: 0.25rem 0.25rem 0;
-    display: table;
+    padding: 0.25rem;
 }
 
 /* Reduce margin sizes for body text */

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -75,8 +75,10 @@ a,
 a:active,
 a:visited {
     color: var(--colour-links);
-    text-decoration-color: var(--colour-background-accent);
     display: inline;
+    overflow-wrap: break-word;
+    overflow-wrap: anywhere;
+    text-decoration-color: var(--colour-background-accent);
 }
 a:hover,
 a:focus {
@@ -104,9 +106,12 @@ code {
     font-family: ui-monospace, "Cascadia Mono", "Segoe UI Mono", "DejaVu Sans Mono", Consolas, monospace;
     font-size: 0.875rem;
     white-space: pre-wrap;
-    word-wrap: break-word;
     -webkit-hyphens: none;
     hyphens: none;
+}
+code {
+    overflow-wrap: break-word;
+    overflow-wrap: anywhere;
 }
 code.literal {
     font-size: .8em;

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -117,6 +117,7 @@ code.literal {
 }
 pre {
     padding: .5rem .75rem;
+    word-break: break-all;
 }
 
 /* Contents rules */

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -105,6 +105,7 @@ cite {
 pre,
 code {
     font-family: ui-monospace, "Cascadia Mono", "Segoe UI Mono", "DejaVu Sans Mono", Consolas, monospace;
+    font-size: 0.875rem;
     white-space: pre-wrap;
     word-wrap: break-word;
     -webkit-hyphens: none;

--- a/pep_sphinx_extensions/pep_theme/static/wrap_tables.js
+++ b/pep_sphinx_extensions/pep_theme/static/wrap_tables.js
@@ -1,0 +1,30 @@
+// Wrap the tables in PEP bodies in a div, to allow for responsive scrolling
+
+"use strict";
+
+const pepContentId = "pep-content";
+
+
+// Wrap passed table element in wrapper divs
+function wrapTable (table) {
+    const wrapper = document.createElement("div");
+    wrapper.classList.add("table-wrapper");
+    table.parentNode.insertBefore(wrapper, table);
+    wrapper.appendChild(table);
+}
+
+
+// Wrap all tables in the PEP content in wrapper divs
+function wrapPepContentTables () {
+    const pepContent = document.getElementById(pepContentId);
+    const bodyTables = pepContent.getElementsByTagName("table");
+    Array.from(bodyTables).forEach(wrapTable);
+}
+
+
+// Wrap the tables as soon as the DOM is loaded
+document.addEventListener("DOMContentLoaded", () => {
+    if (document.getElementById(pepContentId)) {
+        wrapPepContentTables();
+    }
+})

--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -41,5 +41,6 @@
         </nav>
     </section>
     <script src="{{ pathto('_static/colour_scheme.js', resource=True) }}"></script>
+    <script src="{{ pathto('_static/wrap_tables.js', resource=True) }}"></script>
 </body>
 </html>


### PR DESCRIPTION
Right now, the code font is much larger than the prose font, which varies by platform (due to the former using a system font stack, while the latter uses a web font). As a stopgap solution, to ensure 79 characters fit on a line under all but the most constrained screen resolutions, and reduce the perceptible size difference between the prose and code fonts while making it more motivated, this PR follows @pradyunsg 's suggestion reduce the code font size to something similar to what Furo uses, 0.875rem/14px as was suggested and discussed there, until we decide on a final resolution to the font stack issue.

Furthermore, as also suggested by @methane on #2347 , it allows code blocks to break by letter than than by word, resolving formatting issues at narrow screen widths and matching the behavior of most editors/IDEs (while ensuring inline code breaks cleanly).

Resolves #2437
Resolves #2449