### PR TITLE
PEP 594: Fix typo: deprecate nis in 3.11 not 3.8

### DIFF
--- a/pep-0594.rst
+++ b/pep-0594.rst
@@ -147,7 +147,7 @@ audio processing.
     imghdr,3.11,3.13,1992,no,"filetype_, puremagic_, python-magic_"
     msilib,3.11,3.13,2006,no,\-
     nntplib,3.11,3.13,1992,no,\-
-    nis,3.8 (3.0\*),3.13,1992,no,\-
+    nis,3.11 (3.0\*),3.13,1992,no,\-
     ossaudiodev,3.11,3.13,2002,no,\-
     pipes,3.11,3.13,1992,no,"subprocess_"
     smtpd,"**3.4.7**, **3.5.4**",3.12,2001,**yes**,"aiosmtpd_"


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

It looks like 3.8 was the targeted version in the [first draft](https://github.com/python/peps/blob/7799178afdf53a2a681a3ed1bf85fd6303355348/pep-0594.rst), that was missed when updating 3.8 to 3.11 in the [recent revival](https://github.com/python/peps/commit/9906d568766862be269534468fcd4b9e1a8deaa6)?

At least there are no existing deprecations for it (yet).