### PR TITLE
PEP 686: Update URLs, PEP references, Discussions-To and CODEOWNERS per PEP 12

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -565,6 +565,7 @@ pep-0683.rst  @ericsnowcurrently
 pep-0684.rst  @ericsnowcurrently
 # pep-0684.rst
 pep-0685.rst  @brettcannon
+pep-0686.rst  @methane
 # ...
 # pep-0754.txt
 # ...

--- a/pep-0686.rst
+++ b/pep-0686.rst
@@ -1,11 +1,13 @@
 PEP: 686
 Title: Make UTF-8 mode default
 Author: Inada Naoki <songofacandy@gmail.com>
+Discussions-To: https://discuss.python.org/t/14435
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 18-Mar-2022
 Python-Version: 3.12
+Post-History: `18-Mar-2022 <https://discuss.python.org/t/14435>`__
 
 
 Abstract

--- a/pep-0686.rst
+++ b/pep-0686.rst
@@ -11,7 +11,7 @@ Python-Version: 3.12
 Abstract
 ========
 
-This PEP proposes making UTF-8 mode [1]_ on by default.
+This PEP proposes making :pep:`UTF-8 mode <540>` on by default.
 
 With this change, Python uses UTF-8 for default encoding of files, stdio, and
 pipes consistently.
@@ -86,19 +86,21 @@ To resolve this backward incompatibility, users can do:
 
 * Disable UTF-8 mode
 * Use ``EncodingWarning`` to find where the default encoding is used and use
-  ``encoding="locale"`` option to keep using locale encoding. [2]_
+  ``encoding="locale"`` option to keep using locale encoding
+  (as defined in :pep:`597`).
 
 
 Preceding examples
 ==================
 
-* Ruby changed the default ``external_encoding`` to UTF-8 on Windows in Ruby
-  3.0 (2020). [3]_
-* Java changed the default text encoding to UTF-8 in JDK 18. (2022). [4]_
+* Ruby `changed <Feature #16604_>`__ the default ``external_encoding``
+  to UTF-8 on Windows in Ruby 3.0 (2020).
+* Java `changed <JEP 400_>`__ the default text encoding
+  to UTF-8 in JDK 18. (2022).
 
 Both Ruby and Java have an option for backward compatibility.
-They don't provide any warning like ``EncodingWarning`` [2]_ in Python for use
-of the default encoding.
+They don't provide any warning like :pep:`597`'s ``EncodingWarning``
+in Python for use of the default encoding.
 
 
 Rejected Alternative
@@ -114,7 +116,7 @@ ASCII. And some users use Python only on Unix with UTF-8 locale.
 
 So forcing users to specify the ``encoding`` option everywhere is too painful.
 
-Java also rejected this idea [4]_.
+Java also rejected this idea in `JEP 400`_.
 
 
 How to teach this
@@ -128,24 +130,12 @@ non-UTF-8 text files.
 For existing users, see `Backward compatibility`_ section.
 
 
-Resources
-=========
+References
+==========
 
-.. [1] `PEP 540 – Add a new UTF-8 Mode`__
+.. _Feature #16604: https://bugs.ruby-lang.org/issues/16604
 
-  __ https://peps.python.org/pep-0540/
-
-.. [2] `PEP 597 – Add optional EncodingWarning`__
-
-  __ https://peps.python.org/pep-0597/
-
-.. [3] `Set default for Encoding.default_external to UTF-8 on Windows`__
-
-   __ https://bugs.ruby-lang.org/issues/16604
-
-.. [4] `JEP 400: UTF-8 by Default`__
-
-   __ https://openjdk.java.net/jeps/400
+.. _JEP 400: https://openjdk.java.net/jeps/400
 
 
 Copyright


### PR DESCRIPTION
Technical-only updates to PEP 686 (PEP-0686) per PEP 12 (PEP-0012):

* Use the `:pep:` role instead of hardcoded PEP URLs (the checkers are supposed to catch this, but I was still in the process of updating it to check for the new URL format; I'll have that very shortly)
* Use links instead of footnotes for references (see #2130)
* Add the `Discussions-To` and `Post-History` headers now that the [thread](https://discuss.python.org/t/14435) is live (it should be updated whenever a new discussion thread for the PEP is posted, so people know where to go to give feedback)
* Add @methane as the owner of PEP 686 in `CODEOWNERS`

@methane in the process, I also noticed some grammar issues in the PEP, but I refrained from changing the text here. If you'd like me to follow up with another PR for your review addressing them, to help make the PEP easier for others to read and understand clearly, I would be happy to. Just let me know; it is up to you as the author of the PEP.