### PR TITLE
PEP 681: Remove hash alias for unsafe_hash

### DIFF
--- a/pep-0681.rst
+++ b/pep-0681.rst
@@ -195,7 +195,6 @@ the bool value (``True`` or ``False``) to be statically evaluated.
 * ``eq``.  ``order``, ``frozen``, ``init`` and ``unsafe_hash`` are parameters
   supported in the stdlib dataclass, with meanings defined in 
   :pep:`PEP 557 <557#id7>`.
-* ``hash`` is an alias for the ``unsafe_hash`` parameter.
 * ``kw_only``, ``match_args`` and ``slots`` are parameters supported
   in the stdlib dataclass, first introduced in Python 3.10.
 


### PR DESCRIPTION
@davidfstr pointed out that having a `hash` alias for `unsafe_hash` is disguising a potentially unsafe feature as safe.

We don't remember why we added a `hash` alias. It may have been a mistake. Or it may have been added because attrs uses hash instead of unsafe_hash. However, [the attrs documentation](https://www.attrs.org/en/stable/hashing.html) recommends against setting hash, so this should be unusual. Attrs can add an `unsafe_hash` alias on their side if needed.

cc: @hynek