### PR TITLE
PEP 686: Change target version to 3.13

### DIFF
--- a/pep-0686.rst
+++ b/pep-0686.rst
@@ -56,7 +56,7 @@ User can still disable UTF-8 mode by setting ``PYTHONUTF8=0`` or ``-X utf8=0``.
 -------------------------
 
 Currently, ``TextIOWrapper`` uses ``locale.getpreferredencoding(False)``
-when ``encoding="locale"`` option is specified. It is "UTF-8" in UTF-8 mode.
+when ``encoding="locale"`` option is specified. It is ``"UTF-8"`` in UTF-8 mode.
 
 This behavior is inconsistent with the :pep:`597` motivation. 
 ``TextIOWrapper`` should use locale encoding when ``encoding="locale"`` is

--- a/pep-0686.rst
+++ b/pep-0686.rst
@@ -56,7 +56,7 @@ User can still disable UTF-8 mode by setting ``PYTHONUTF8=0`` or ``-X utf8=0``.
 -------------------------
 
 Currently, ``TextIOWrapper`` uses ``locale.getpreferredencoding(False)``
-when ``encoding="locale"`` option is specified. It is `"UTF-8"` in UTF-8 mode.
+when ``encoding="locale"`` option is specified. It is "UTF-8" in UTF-8 mode.
 
 This behavior is inconsistent with the :pep:`597` motivation. 
 ``TextIOWrapper`` should use locale encoding when ``encoding="locale"`` is

--- a/pep-0686.rst
+++ b/pep-0686.rst
@@ -6,7 +6,7 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 18-Mar-2022
-Python-Version: 3.12
+Python-Version: 3.13
 Post-History: `18-Mar-2022 <https://discuss.python.org/t/14435>`__
 
 
@@ -55,14 +55,18 @@ User can still disable UTF-8 mode by setting ``PYTHONUTF8=0`` or ``-X utf8=0``.
 ``locale.get_encoding()``
 -------------------------
 
-Add ``locale.get_encoding()``. It is same to
-``locale.getpreferredencoding(False)`` except it don't follow UTF-8 mode.
+Currently, ``TextIOWrapper`` uses ``locale.getpreferredencoding(False)``
+when ``encoding="locale"`` option is specified. It is `"UTF-8"` in UTF-8 mode.
 
-This API will be used by ``io.TextIOWrapper`` to support ``encoding="locale"``
-option.
+This behavior is inconsistent with the :pep:`597` motivation. 
+``TextIOWrapper`` should use locale encoding when ``encoding="locale"`` is
+passed before/after the default encoding is changed to UTF-8.
 
-This change will be released in Python 3.11 so that users can prepare before
-UTF-8 mode is enabled by default.
+To fix this inconsistency, we will add ``locale.get_encoding()``. It is same
+to ``locale.getpreferredencoding(False)`` but it ignore the UTF-8 mode.
+
+This change will be released in Python 3.11 so that users can use UTF-8 mode
+that is same to Python 3.13.
 
 
 Backward Compatibility


### PR DESCRIPTION
https://discuss.python.org/t/pep-686-make-utf-8-mode-default/14435/25?u=methane