### PR TITLE
Style: Scroll code blocks instead of wrapping them

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -101,25 +101,26 @@ cite {
 }
 
 /* Code rules (code literals and Pygments highlighting blocks) */
-pre,
-code {
+code,
+pre {
     font-family: ui-monospace, "Cascadia Mono", "Segoe UI Mono", "DejaVu Sans Mono", Consolas, monospace;
     font-size: 0.875rem;
-    white-space: pre-wrap;
     -webkit-hyphens: none;
     hyphens: none;
 }
 code {
     overflow-wrap: break-word;
     overflow-wrap: anywhere;
+    white-space: pre-wrap;
 }
 code.literal {
     font-size: .8em;
     background-color: var(--colour-inline-code);
 }
 pre {
+    overflow-x: auto;
     padding: .5rem .75rem;
-    word-break: break-all;
+    white-space: pre;
 }
 
 /* Contents rules */


### PR DESCRIPTION
As reported by @encukou and confirmed by @hugovk in #2439 , the current approach of wrapping code/literal blocks at narrow viewport widths makes them difficult to read, especially if they are particularly wide, include multiple columns of text, and are not correct syntax-highlighted, all of which is the case for, e.g., at least [one example block](https://peps.python.org/pep-0678/#raise-wrapper-explanation-from-err) in PEP 678.

A better approach, as discussed there, is to simply allow scrolling overly-wide code blocks instead of wrapping them, which is what GitHub and other sites do (as well as most editors by default, if soft-wrap is not enabled). This PR implements that approach, resolving the issue.

Before and after on a simulated iPhone SE (2nd gen), a particularly narrow device:

![image](https://user-images.githubusercontent.com/17051931/159783575-3287d0bf-30af-44e3-af12-b55cff69429f.png)
