### PR TITLE
PEP 596: Add 3.9.12 release

### DIFF
--- a/pep-0596.rst
+++ b/pep-0596.rst
@@ -80,10 +80,11 @@ Actual:
 - 3.9.9: Monday, 2021-11-15
 - 3.9.10: Monday, 2022-01-14
 - 3.9.11: Wednesday, 2022-03-16
+- 3.9.12: Wednesday, 2022-03-23
 
 Expected:
 
-- 3.9.12: Monday, 2022-05-16 (final regular bugfix release with binary
+- 3.9.13: Monday, 2022-05-16 (final regular bugfix release with binary
   installers)
 
 
@@ -91,7 +92,7 @@ Source-only security fix releases
 ---------------------------------
 
 Provided irregularly on an "as-needed" basis until October 2025,
-starting with 3.9.13.
+starting with 3.9.14.
 
 
 3.9 Lifespan


### PR DESCRIPTION
https://discuss.python.org/t/python-3-10-4-and-3-9-12-are-now-available-out-of-schedule/14568

https://docs.python.org/release/3.9.12/whatsnew/changelog.html

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
