### PR TITLE
Infra: Improve email and link processing and rendering in headers

### DIFF
--- a/pep-0009.txt
+++ b/pep-0009.txt
@@ -8,7 +8,8 @@ Type: Process
 Content-Type: text/x-rst
 Created: 14-Aug-2001
 Post-History:
-Resolution: https://mail.python.org/mailman/private/peps/2016-January/001165.html
+Resolution: https://mail.python.org/archives/list/python-dev@python.org/thread/2YMHVPRDWGQLA5A2FKXE2JMLM2HQEEGW/
+
 
 ::
 

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
@@ -171,12 +171,7 @@ def _process_discourse_url(parts: list[str]) -> tuple[str, str]:
             f"{'/'.join(parts)} not a link to a Discourse thread or category")
 
     first_subpart = parts[4]
-    try:
-        int(first_subpart)
-    except ValueError:
-        has_title = True
-    else:
-        has_title = False
+    has_title = not first_subpart.isnumeric()
 
     if "t" in parts:
         item_type = "post" if len(parts) > (5 + has_title) else "thread"

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
@@ -102,6 +102,14 @@ class PEPHeaders(transforms.Transform):
                 # Mark unneeded fields
                 fields_to_remove.append(field)
 
+            # Remove any trailing commas and whitespace in the headers
+            if para and isinstance(para[-1], nodes.Text):
+                last_node = para[-1]
+                if last_node.astext().strip() == ",":
+                    last_node.parent.remove(last_node)
+                else:
+                    para[-1] = last_node.rstrip().rstrip(",")
+
         # Remove unneeded fields
         for field in fields_to_remove:
             field.parent.remove(field)

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
@@ -110,11 +110,22 @@ def _process_list_url(list_url: str) -> tuple[str, str]:
         if len(parts) > 6 and parts[6] in {"message", "thread"}:
             url_type = parts[6]
 
+    # Mailman3 list info structure is
+    # https://mail.python.org/mailman3/lists/<list_name>.python.org/
+    elif "mailman3" in parts:
+        list_name = (
+            parts[parts.index("mailman3") + 2].removesuffix(".python.org"))
+
     # Pipermail (Mailman) archive structure is
     # https://mail.python.org/pipermail/<list_name>/<month>-<year>/<id>
     elif "pipermail" in parts:
         list_name = parts[parts.index("pipermail") + 1]
         url_type = "message" if len(parts) > 6 else "list"
+
+    # Mailman listinfo structure is
+    # https://mail.python.org/mailman/listinfo/<list_name>
+    elif "listinfo" in parts:
+        list_name = parts[parts.index("listinfo") + 1]
 
     # Not a link to a mailing list, message or thread
     else:


### PR DESCRIPTION
After some time reading, writing and interacting with the recently-added automatic formatting of links in the Discussions-To, Post-History and Resolution headers originally added in #2351 and improved in #2361, I've implemented a number of improvements and fixes that make both the URL and the link text more useful, handle many additional common cases, include the Post-History field as well, and prepare for other potential future enhancements. In particular, they now:

* Link to the relevant main page of python.org and googlegroups.com mailing lists for non-thread links, where users can subscribe to the list, browse relevant threads and post a reply (via mailto or web), as well as view more information about the venue
* Support Discourse, with the link title "Discourse thread" for threads and "<Category> Discourse category" (e.g. "Packaging Discourse category") for categories, rather than a bare link
* Explicitly describe the target type in the link text (e.g. "Python-Ideas list", "Typing-SIG thread", "Python-Dev message", "Discord post", "Packaging Discourse category", etc), making it more clear and less confusing at a glance what they represent
* Show the friendly name/description of the link target in the titletext when hovering over links in the Post-History section, making it easier to see where and how the PEP was posted to each time without having to click through to the link
* Work for list info pages for Mailman and Mailman3, not just the list archives
* Are refactored to be more cleanly implemented and easily extensible to future link types and the logic re-used for other purposes

This also makes it easy to adopt the Post-History field formatting for the Resolution field, in order to use the much more useful and interesting resolution date as the link text, while retaining the auto-generated venue/target information as the title text, though that will be a separate followup issue/PR. I will have another PR shortly (already almost done) that updates the linters to provide more immediate, specific and precise feedback on the header field format to complement the various recent backend improvements in automatically parsing and rendering them.