### PR TITLE
Infra: Include trailing slash in RSS URLs to avoid 301 redirect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ venv:
 		echo "To recreate it, remove it first with \`make clean-venv'."; \
 	else \
 		$(PYTHON) -m venv $(VENVDIR); \
+		$(VENVDIR)/bin/python3 -m pip install -U pip wheel; \
 		$(VENVDIR)/bin/python3 -m pip install -r requirements.txt; \
 		echo "The venv has been created in the $(VENVDIR) directory"; \
 	fi

--- a/generate_rss.py
+++ b/generate_rss.py
@@ -167,7 +167,7 @@ def main():
             joined_authors = ", ".join(f"{name} ({email_address})" for name, email_address in parsed_authors)
         else:
             joined_authors = author
-        url = f"https://peps.python.org/pep-{pep_num:0>4}"
+        url = f"https://peps.python.org/pep-{pep_num:0>4}/"
 
         item = entry.FeedEntry()
         item.title(f"PEP {pep_num}: {title}")


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
https://peps.python.org/peps.rss includes links like:

```rss
      <guid isPermaLink="true">https://peps.python.org/pep-0686</guid>
```

Without the trailing `/`, there's an extra HTTP 301 redirect to add the slash, which adds a small but unnecessary delay which can vary between 20ms and 335ms.

See https://github.com/sphinx-doc/sphinx/pull/10288 for some network waterfall diagrams with and without the extra request.

So let's include it:

```rss
      <guid isPermaLink="true">https://peps.python.org/pep-0686/</guid>
```

Also update pip and include wheel in virtualenv creation to remove a couple of warnings, noticeable during `make rss`.