### PR TITLE
Infra: generate machine-readable PEP index

### DIFF
--- a/pep_sphinx_extensions/pep_zero_generator/parser.py
+++ b/pep_sphinx_extensions/pep_zero_generator/parser.py
@@ -91,6 +91,20 @@ class PEP:
         # Parse PEP authors
         self.authors: list[Author] = _parse_authors(self, metadata["Author"], authors_overrides)
 
+        # Other headers
+        self.created = metadata["Created"]
+        self.discussions_to = metadata["Discussions-To"]
+        self.python_version = metadata["Python-Version"]
+        self.replaces = metadata["Replaces"]
+        self.requires = metadata["Requires"]
+        self.resolution = metadata["Resolution"]
+        self.superseded_by = metadata["Superseded-By"]
+        if metadata["Post-History"]:
+            # Squash duplicate whitespace
+            self.post_history = " ".join(metadata["Post-History"].split())
+        else:
+            self.post_history = None
+
     def __repr__(self) -> str:
         return f"<PEP {self.number:0>4} - {self.title}>"
 

--- a/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
+++ b/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
@@ -32,9 +32,8 @@ if TYPE_CHECKING:
 
 
 def create_pep_json(peps: list[parser.PEP]) -> str:
-    pep_list = [
-        {
-            "number": pep.number,
+    pep_dict = {
+        pep.number: {
             "title": pep.title,
             "authors": ", ".join(pep.authors.nick for pep.authors in pep.authors),
             "discussions_to": pep.discussions_to,
@@ -50,8 +49,8 @@ def create_pep_json(peps: list[parser.PEP]) -> str:
             "url": f"https://peps.python.org/pep-{pep.number:0>4}/",
         }
         for pep in sorted(peps)
-    ]
-    return json.dumps(pep_list, indent=0)
+    }
+    return json.dumps(pep_dict, indent=1)
 
 
 def create_pep_zero(app: Sphinx, env: BuildEnvironment, docnames: list[str]) -> None:

--- a/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
+++ b/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import csv
 import json
-import os
 from pathlib import Path
 import re
 from typing import TYPE_CHECKING
@@ -32,22 +31,27 @@ if TYPE_CHECKING:
     from sphinx.environment import BuildEnvironment
 
 
-def create_pep_json(peps: list[parser.PEP], out_dir: str) -> None:
+def create_pep_json(peps: list[parser.PEP]) -> str:
     pep_list = [
         {
             "number": pep.number,
             "title": pep.title,
             "authors": ", ".join(pep.authors.nick for pep.authors in pep.authors),
+            "discussions_to": pep.discussions_to,
             "status": pep.status,
             "type": pep.pep_type,
+            "created": pep.created,
+            "python_version": pep.python_version,
+            "post_history": pep.post_history,
+            "resolution": pep.resolution,
+            "requires": pep.requires,
+            "replaces": pep.replaces,
+            "superseded_by": pep.superseded_by,
             "url": f"https://peps.python.org/pep-{pep.number:0>4}/",
         }
         for pep in sorted(peps)
     ]
-
-    out_file = os.path.join(out_dir, "peps.json")
-    with open(out_file, "w", encoding="UTF-8") as f:
-        json.dump(pep_list, f, indent=0)
+    return json.dumps(pep_list, indent=0)
 
 
 def create_pep_zero(app: Sphinx, env: BuildEnvironment, docnames: list[str]) -> None:
@@ -83,4 +87,5 @@ def create_pep_zero(app: Sphinx, env: BuildEnvironment, docnames: list[str]) -> 
     env.found_docs.add(pep_zero_filename)
 
     # Create peps.json
-    create_pep_json(peps, app.outdir)
+    pep0_json = create_pep_json(peps)
+    Path(app.outdir, "peps.json").write_text(pep0_json, encoding="utf-8")

--- a/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
+++ b/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
@@ -37,7 +37,7 @@ def create_pep_json(peps: list[parser.PEP], out_dir: str) -> None:
         {
             "number": pep.number,
             "title": pep.title,
-            "authors": ", ".join([pep.authors.nick for pep.authors in pep.authors]),
+            "authors": ", ".join(pep.authors.nick for pep.authors in pep.authors),
             "status": pep.status,
             "type": pep.pep_type,
             "url": f"https://peps.python.org/pep-{pep.number:0>4}/",

--- a/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
+++ b/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
@@ -88,4 +88,6 @@ def create_pep_zero(app: Sphinx, env: BuildEnvironment, docnames: list[str]) -> 
 
     # Create peps.json
     pep0_json = create_pep_json(peps)
-    Path(app.outdir, "peps.json").write_text(pep0_json, encoding="utf-8")
+    out_dir = Path(app.outdir) / "api"
+    out_dir.mkdir(exist_ok=True)
+    Path(out_dir, "peps.json").write_text(pep0_json, encoding="utf-8")

--- a/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
+++ b/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
@@ -18,6 +18,8 @@ to allow it to be processed as normal.
 from __future__ import annotations
 
 import csv
+import json
+import os
 from pathlib import Path
 import re
 from typing import TYPE_CHECKING
@@ -30,9 +32,25 @@ if TYPE_CHECKING:
     from sphinx.environment import BuildEnvironment
 
 
-def create_pep_zero(_: Sphinx, env: BuildEnvironment, docnames: list[str]) -> None:
-    # Sphinx app object is unneeded by this function
+def create_pep_json(peps: list[parser.PEP], out_dir: str) -> None:
+    pep_list = [
+        {
+            "number": pep.number,
+            "title": pep.title,
+            "authors": ", ".join([pep.authors.nick for pep.authors in pep.authors]),
+            "status": pep.status,
+            "type": pep.pep_type,
+            "url": f"https://peps.python.org/pep-{pep.number:0>4}/",
+        }
+        for pep in sorted(peps)
+    ]
 
+    out_file = os.path.join(out_dir, "peps.json")
+    with open(out_file, "w", encoding="UTF-8") as f:
+        json.dump(pep_list, f, indent=0)
+
+
+def create_pep_zero(app: Sphinx, env: BuildEnvironment, docnames: list[str]) -> None:
     # Read from root directory
     path = Path(".")
 
@@ -63,3 +81,6 @@ def create_pep_zero(_: Sphinx, env: BuildEnvironment, docnames: list[str]) -> No
     docnames.insert(1, pep_zero_filename)
     # Add to files for writer
     env.found_docs.add(pep_zero_filename)
+
+    # Create peps.json
+    create_pep_json(peps, app.outdir)


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

[PEP 0](https://peps.python.org/pep-0000/) is a human-readable PEP index.

It would be useful to create a machine-readable version for, well, machines to read and process. This PR creates a `peps.json` of the key fields.

Preview:

```json
[
{
"number": 1,
"title": "PEP Purpose and Guidelines",
"authors": "Warsaw, Hylton, Goodger, Coghlan",
"status": "Active",
"type": "Process",
"url": "https://peps.python.org/pep-0001/"
},
{
"number": 2,
"title": "Procedure for Adding New Modules",
"authors": "Faassen",
"status": "Superseded",
"type": "Process",
"url": "https://peps.python.org/pep-0002/"
},
{
"number": 3,
"title": "Guidelines for Handling Bug Reports",
"authors": "Hylton",
"status": "Withdrawn",
"type": "Process",
"url": "https://peps.python.org/pep-0003/"
},
...
```

https://pep-previews--2475.org.readthedocs.build/peps.json