### PR TITLE
Style: Fix unbounded max width causing very wide spans to overflow

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -50,7 +50,7 @@
         width: 100%;
     }
     section#pep-page-section > article {
-        max-width: 40em;
+        max-width: 37em;
         width: 74%;
         float: right;
         margin-right: 0;
@@ -69,7 +69,7 @@
 }
 @media (min-width: 60em) {
     section#pep-page-section > article {
-        max-width: none;
+        max-width: 56em;
         padding-left: 3.2%;
         padding-right: 3.2%;
     }


### PR DESCRIPTION
As originally reported by @pradyunsg on #2476 , PEP 440 (PEP-0440, namely [this section](https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions)) and possibly other specific PEPs that contain very long `<span>`s (i.e. syntax-highlighted text with the same color) inside scrolling literal blocks overflow the viewport at wider screen width, causing the rest of the page to overflow as well.

To make a long story short, after some investigation and testing, setting an appropriately-bounded `max-width` on the page content for the widest breakpoint (where it was previously unbounded) avoided this problem and ensured the page displayed identically to other PEPs with more typical content, while not affecting anything else.

Additionally, I noticed that `max-width` for the next-narrower breakpoint was not quite set correctly, leading to a modest overflow at widths near the breakpoint, which I fixed as well.

Fixes #2476 