### PR TITLE
PEP 396: Fix `importlib.metadata.version` reference

### DIFF
--- a/pep-0396.txt
+++ b/pep-0396.txt
@@ -29,7 +29,7 @@ PEP Rejection
 
 This PEP was formally rejected on 2021-04-14.  The packaging ecosystem
 has changed significantly in the intervening years since this PEP was
-first written, and APIs such as ``importlib.metadata.versions()`` [11]_
+first written, and APIs such as ``importlib.metadata.version()`` [11]_
 provide for a much better experience.
 
 User Stories


### PR DESCRIPTION
Fix reference to `importlib.metadata.version()` in PEP 396.