### PR TITLE
PEP 570: Mark as Final

### DIFF
--- a/pep-0570.rst
+++ b/pep-0570.rst
@@ -8,7 +8,7 @@ Author: Larry Hastings <larry@hastings.org>,
         Eric N. Vander Weele <ericvw@gmail.com>
 BDFL-Delegate: Guido van Rossum <guido@python.org>
 Discussions-To: https://discuss.python.org/t/pep-570-python-positional-only-parameters/1078
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 20-Jan-2018


### PR DESCRIPTION
As discussed in #2479 , PEP 570 (positional-only parameters) was implemented and documented in Python 3.8 but not marked Final, likely as an oversight. This fixes that.

Fixes #2479 