### PR TITLE
PEP 681: Rejected Ideas cleanup

### DIFF
--- a/pep-0681.rst
+++ b/pep-0681.rst
@@ -699,9 +699,6 @@ As this is not broadly applicable to dataclass libraries, this
 additional logic is not accommodated with this proposal, so
 users of Django would need to explicitly declare the ``id`` field.
 
-This limitation may make it impractical to use the
-``dataclass_transform`` mechanism with Django.
-
 Class-wide default values
 -------------------------
 
@@ -714,32 +711,29 @@ We chose not to support this feature, since it is specific to
 SQLAlchemy. Users can manually set ``default=None`` on these fields
 instead.
 
-Open Issues
-===========
-
 ``converter`` field descriptor parameter
 ----------------------------------------
 
 The attrs library supports a ``converter`` field descriptor parameter,
-which is a callable that is called by the generated
+which is a ``Callable`` that is called by the generated
 ``__init__`` method to convert the supplied value to some other
 desired value. This is tricky to support since the parameter type in
-the synthesized __init__ method needs to accept uncovered values, but
-the resulting field is typed according to the output of the converter.
-
-There may be no good way to support this because there's not enough
-information to derive the type of the input parameter. We currently
-have two ideas:
-
-1. Add support for a ``converter`` field descriptor parameter but then
-   use the Any type for the corresponding parameter in the  __init__
-   method.
-
-2. Say that converters are unsupported and recommend that attrs users
-   avoid them.
+the synthesized ``__init__`` method needs to accept uncovered values,
+but the resulting field is typed according to the output of the
+converter.
 
 Some aspects of this issue are detailed in a
 `Pyright discussion <#converters_>`_.
+
+There may be no good way to support this because there's not enough
+information to derive the type of the input parameter. One possible
+solution would be to add support for a ``converter`` field descriptor
+parameter but then use the ``Any`` type for the corresponding
+parameter in the ``__init__`` method.
+
+We chose not to support this feature and recommend that attrs users
+avoid converters.
+
 
 References
 ==========


### PR DESCRIPTION
1. Remove line about `dataclass_transform` likely not working well for Django since Django users have told us the opposite.
2. Move `converter` Open Issue to Rejected Ideas.