### PR TITLE
PEP 686: Update Discussions-To to match Post-History

### DIFF
--- a/pep-0686.rst
+++ b/pep-0686.rst
@@ -1,14 +1,14 @@
 PEP: 686
 Title: Make UTF-8 mode default
 Author: Inada Naoki <songofacandy@gmail.com>
-Discussions-To: https://discuss.python.org/t/14435
+Discussions-To: https://discuss.python.org/t/14737
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 18-Mar-2022
 Python-Version: 3.13
 Post-History: `18-Mar-2022 <https://discuss.python.org/t/14435>`__,
-   `31-Mar-2022 <https://discuss.python.org/t/14737>`__
+              `31-Mar-2022 <https://discuss.python.org/t/14737>`__
 
 
 Abstract


### PR DESCRIPTION
#2489 updated the `Post-History` to add the new thread (thanks for the quick update, @methane !). The `Discussions-To` was not updated, though, which this PR does (as well as a formatting fix). In the future, I'd like to generate `Discussions-To` automatically if it is not provided from the latest `Post-History` entry, so PEP authors only need to update it one place, but that's not implemented quite yet and there was some disagreement about the idea. (To note, the checks in #2484 actually caught this automatically)