### PR TITLE
Add issue template to avoid useless issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+Issue tracker is **ONLY** used for reporting bugs.
+
+New features should be discussed according to the following process:
+[PEP 1](https://peps.python.org/pep-0001/#start-with-an-idea-for-python)
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+<!--- Tell us what should be changed and why -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,6 +3,16 @@ Issue tracker is **ONLY** used for reporting bugs.
 New features should be discussed according to the following process:
 [PEP 1](https://peps.python.org/pep-0001/#start-with-an-idea-for-python)
 
+And according to [Contributing Guide](../CONTRIBUTING.rst):
+
+While fixing spelling mistakes as part of more substantive
+copyediting and proofreading of draft and active PEPs is okay,
+we generally advise against PRs that simply mass-correct minor typos on
+older PEPs that don't significantly impair meaning and understanding,
+as these tend to create a fairly high level of noise and churn for
+PEP readers, authors and editors relative to the amount of practical value
+they provide.
+
 <!--- Provide a general summary of the issue in the Title above -->
 
 <!--- Tell us what should be changed and why -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,5 @@
-Issue tracker is **ONLY** used for reporting bugs.
+Issue tracker is **ONLY** used for reporting bugs on documents (PEPs), not
+bugs in Python.
 
 New features should be discussed according to the following process:
 [PEP 1](https://peps.python.org/pep-0001/#start-with-an-idea-for-python)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,4 +16,8 @@ they provide.
 
 <!--- Provide a general summary of the issue in the Title above -->
 
-<!--- Tell us what should be changed and why -->
+### What did you spot, and where?
+
+### What did you expect to be changed?
+
+### Why?


### PR DESCRIPTION
Many issues are useless and can be avoided with an issue template. This template would have avoided (among others):
#2491 #2486 #2469 #2100 #2076 #1898 #1867 #1747 #1273
