### PR TITLE
PEP 681: Add kwargs on dataclass_transform

### DIFF
--- a/pep-0681.rst
+++ b/pep-0681.rst
@@ -221,6 +221,7 @@ customization of default behaviors:
       order_default: bool = False,
       kw_only_default: bool = False,
       field_specifiers: tuple[type | Callable[..., Any], ...] = (),
+      **kwargs: Any,
   ) -> Callable[[_T], _T]: ...
 
 * ``eq_default`` indicates whether the ``eq`` parameter is assumed to
@@ -245,6 +246,11 @@ customization of default behaviors:
   function (``field``) that instantiates this class, so if we were
   describing the stdlib dataclass behavior, we would provide the
   tuple argument ``(dataclasses.Field, dataclasses.field)``.
+* ``kwargs`` allows arbitrary additional keyword args to be passed to
+  ``dataclass_transform``. This gives type checkers the freedom to
+  support experimental parameters without needing to wait for changes
+  in ``typing.py``. Type checkers should report errors for any
+  unrecognized parameters.
 
 In the future, we may add additional parameters to
 ``dataclass_transform`` as needed to support common behaviors in user
@@ -465,10 +471,10 @@ Runtime behavior
 ----------------
 
 At runtime, the ``dataclass_transform`` decorator's only effect is to
-set a string attribute named ``__dataclass_transform__`` on the
-decorated function or class to support introspection. The value of the
-attribute should be a dict mapping the names of the
-``dataclass_transform`` parameters to their values.
+set an attribute named ``__dataclass_transform__`` on the decorated
+function or class to support introspection. The value of the attribute
+should be a dict mapping the names of the ``dataclass_transform``
+parameters to their values.
 
 For example:
 
@@ -479,6 +485,7 @@ For example:
     "order_default": False,
     "kw_only_default": False,
     "field_specifiers": (),
+    "kwargs": {}
   }
 
 


### PR DESCRIPTION
Added **kwargs on dataclass_transform so type checkers can experiment with new parameters without waiting for a corresponding change in typing.py.