### PR TITLE
PEP 631: Update status to clarify incorperation into PEP 621

### DIFF
--- a/pep-0631.rst
+++ b/pep-0631.rst
@@ -3,11 +3,12 @@ Title: Dependency specification in pyproject.toml based on PEP 508
 Author: Ofek Lev <ofekmeister@gmail.com>
 Sponsor: Paul Ganssle <paul@ganssle.io>
 Discussions-To: https://discuss.python.org/t/5018
-Status: Accepted
+Status: Superseded
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 20-Aug-2020
 Post-History: 20-Aug-2020
+Superseded-By: 621
 Resolution: https://discuss.python.org/t/how-to-specify-dependencies-pep-508-strings-or-a-table-in-toml/5243/38
 
 Abstract
@@ -18,8 +19,7 @@ This PEP specifies how to write a project's dependencies in a
 using the :pep:`fields defined in PEP 621 <621#dependencies-optional-dependencies>`.
 
 .. note::
-    This PEP has been accepted and is expected to be merged into
-    :pep:`621`.
+    This PEP has been accepted and was merged into :pep:`621`.
 
 Entries
 =======


### PR DESCRIPTION
As [discussed on Discourse](https://discuss.python.org/t/updating-the-status-of-completed-peps/14853), PEP 631 is marked as accepted, but was later merged into PEP 621. As [I suggest there](https://discuss.python.org/t/updating-the-status-of-completed-peps/14853/5?u=cam-gerlach), it would make sense to mark it `Superseded` by PEP 621, to avoid any duplication or confusion over it still needing to be implemented independently, especially since PEP 621 in turn refers to the canonical PyPA specification. In addition, I also updated the note to make clear the merge happened.

As a minor note, I didn't add a `Replaces: 631` header on PEP 621 since it didn't seem conceptually appropriate here (and if there must always be a 1:1 relationship between these headers, we could just generate them automatically rather than requiring PEP authors/editors to do so manually).