### PR TITLE
Infra: Restore PEPs RSS feed in <head>

### DIFF
--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="{{ pathto('_static/dark.css', resource=True) }}" type="text/css" media="(prefers-color-scheme: dark)" id="css-dark"/>
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', resource=True) }}" type="text/css" media="(prefers-color-scheme: light)" id="pyg" />
     <link rel="stylesheet" href="{{ pathto('_static/pygments_dark.css', resource=True) }}" type="text/css" media="(prefers-color-scheme: dark)" id="pyg-dark" />
+    <link rel="alternate" type="application/rss+xml" title="Latest PEPs" href="https://www.python.org/dev/peps/peps.rss">
     <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <meta name="description" content="Python Enhancement Proposals (PEPs)"/>
 </head>


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

For https://github.com/python/peps/issues/2508.

Previously title was "Python Enhancement Proposals", changing it here to "Latest PEPs" on @encukou's suggestion. I agree: it's both more descriptive and concise, and if you're visiting this PEPs site, you know what a PEP is.

The old PEPs site, by virtue of being part of python.org, also had these three RSS feeds:

```html
    <link rel="alternate" type="application/rss+xml" title="Python Job Opportunities"
          href="https://www.python.org/jobs/feed/rss/">
    <link rel="alternate" type="application/rss+xml" title="Python Software Foundation News"
          href="https://feeds.feedburner.com/PythonSoftwareFoundationNews">
    <link rel="alternate" type="application/rss+xml" title="Python Insider"
          href="https://feeds.feedburner.com/PythonInsider">
```

Do we want to include any them here? Anything others?

# Demo

View source of https://pep-previews--2509.org.readthedocs.build/ or https://pep-previews--2509.org.readthedocs.build/pep-0008/