### PR TITLE
Remove pre-wrap CSS rule that breaks multi-line inline literals

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -111,7 +111,6 @@ pre {
 code {
     overflow-wrap: break-word;
     overflow-wrap: anywhere;
-    white-space: pre-wrap;
 }
 code.literal {
     font-size: .8em;


### PR DESCRIPTION
As written up in detail at https://github.com/python/peps/issues/2511, this rule breaks the rendering of 199 inline literals across all the PEPs, and appears to have no reason to exist. I therefore propose to remove it.

Resolves #2511.