### PR TITLE
PEP 687: Fix reference to PEP 489

### DIFF
--- a/pep-0687.rst
+++ b/pep-0687.rst
@@ -48,7 +48,7 @@ The body of :pep:`630` will be converted to a HOWTO in the Python
 documentation, and that PEP will be retired (marked Final).
 
 All extension modules in the standard library will be converted to multi-phase
-initialization introduced in :pep:`484`.
+initialization introduced in :pep:`489`.
 
 All stdlib extension modules will be *isolated*. That is:
 


### PR DESCRIPTION
As far as I can tell, PEP 484 is a typo and unrelated to this PEP.