### PR TITLE
PEP 0: Author override for my last name

### DIFF
--- a/AUTHOR_OVERRIDES.csv
+++ b/AUTHOR_OVERRIDES.csv
@@ -1,5 +1,6 @@
 Overridden Name,Surname First,Name Reference
 The Python core team and community,"The Python core team and community",python-dev
+Erik De Bonte,"De Bonte, Erik",De Bonte
 Greg Ewing,"Ewing, Gregory",Ewing
 Guido van Rossum,"van Rossum, Guido (GvR)",GvR
 Inada Naoki,"Inada, Naoki",Inada


### PR DESCRIPTION
`pep_zero_generator` currently considers my last name to be "Bonte" instead of "De Bonte". I have added an entry in `AUTHOR_OVERRIDES.csv` to fix this.

The [algorithm in `_parse_name`](https://github.com/python/peps/blob/main/pep_sphinx_extensions/pep_zero_generator/author.py#L78) that only includes the next to last word (ex. "De") in the surname if that word is all lowercase seems reasonable. I'm hesitant to change that.