### PR TITLE
PEP 678: update status to Accepted

### DIFF
--- a/pep-0678.rst
+++ b/pep-0678.rst
@@ -3,13 +3,14 @@ Title: Enriching Exceptions with Notes
 Author: Zac Hatfield-Dodds <zac@zhd.dev>
 Sponsor: Irit Katriel
 Discussions-To: https://discuss.python.org/t/pep-678-enriching-exceptions-with-notes/13374
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
 Requires: 654
 Created: 20-Dec-2021
 Python-Version: 3.11
 Post-History: 27-Jan-2022
+Resolution: https://discuss.python.org/t/pep-678-enriching-exceptions-with-notes/13374/100
 
 
 Abstract


### PR DESCRIPTION
Per the `Resolution` link, the SC has accepted PEP-678.  As I understand it the status is therefore updated to `Accepted`, and will reach `Final` after https://github.com/python/cpython/pull/31317 is merged.

(🥳)