### PR TITLE
PEP 427: Fix typo in file contents keys

### DIFF
--- a/pep-0427.txt
+++ b/pep-0427.txt
@@ -193,7 +193,7 @@ its version, e.g. ``1.0.0``, consist of:
 #. ``{distribution}-{version}.data/`` contains one subdirectory
    for each non-empty install scheme key not already covered, where
    the subdirectory name is an index into a dictionary of install paths
-   (e.g. ``data``, ``scripts``, ``include``, ``purelib``, ``platlib``).
+   (e.g. ``data``, ``scripts``, ``headers``, ``purelib``, ``platlib``).
 #. Python scripts must appear in ``scripts`` and begin with exactly
    ``b'#!python'`` in order to enjoy script wrapper generation and
    ``#!python`` rewriting at install time.  They may have any or no


### PR DESCRIPTION
This is a typo according to the PEP author. https://github.com/pypa/pip/issues/9616#issuecomment-780699010

See also https://github.com/pypa/packaging.python.org/pull/1072