### PR TITLE
Infra: don't wrap PEP numbers in PEP 0 tables

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -202,6 +202,9 @@ table td {
     text-align: left;
     padding: 0.25rem 0.5rem 0.2rem;
 }
+table tr td.num {
+    white-space: nowrap;
+}
 table td + td {
     border-left: 1px solid var(--colour-rule-light);
 }


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fixes https://github.com/python/peps/issues/2520.

# Before

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/163115528-5328727d-51a2-43a7-aa89-a84c39b58621.png">

https://peps.python.org/

# After

TODO
