### PR TITLE
purge CDN cache on deploy

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -42,7 +42,8 @@ jobs:
 
       - name: ♻️  Purge CDN cache
         if: github.ref == 'refs/heads/main'
-        run: curl -H "Accept: application/json" -H "Fastly-Key: $FASTLY_TOKEN" -X POST "https://api.fastly.com/service/$FASTLY_SERVICE_ID/purge_all"
+        run: |
+          curl -H "Accept: application/json" -H "Fastly-Key: $FASTLY_TOKEN" -X POST "https://api.fastly.com/service/$FASTLY_SERVICE_ID/purge_all"
         env:
           FASTLY_TOKEN: ${{ secrets.FASTLY_TOKEN }}
           FASTLY_SERVICE_ID: ${{ secrets.FASTLY_SERVICE_ID }}

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -39,3 +39,10 @@ jobs:
           branch: gh-pages # The branch to deploy to.
           folder: build # Synchronise with build.py -> build_directory
           single-commit: true # Delete existing files
+
+      - name: ♻️  Purge CDN cache
+        if: github.ref == 'refs/heads/main'
+        run: curl -H "Accept: application/json" -H "Fastly-Key: $FASTLY_TOKEN" -X POST "https://api.fastly.com/service/$FASTLY_SERVICE_ID/purge_all"
+        env:
+          FASTLY_TOKEN: ${{ secrets.FASTLY_TOKEN }}
+          FASTLY_SERVICE_ID: ${{ secrets.FASTLY_SERVICE_ID }}


### PR DESCRIPTION
issues a purge all to the Fastly service that fronts peps.python.org to make new changes appear fast..... lier.

otherwise this would have led to up to 1 hour delay for changes.