### PR TITLE
PEP 645: Mark as Withdrawn (and as Standards Track)

### DIFF
--- a/pep-0645.rst
+++ b/pep-0645.rst
@@ -21,7 +21,7 @@ The notation ``T|None`` introduced by :pep:`604` to write ``Optional[T]`` is a
 fine alternative to ``T?`` and does not require new syntax.
 
 Using ``T?`` to mean ``T|None`` is also inconsistent with TypeScript
-(a very popular language) where it roughly means ``NotRequired[T]``.
+where it roughly means ``NotRequired[T]``.
 Such inconsistency would likely confuse folks coming from TypeScript to Python.
 
 The above represents the consensus of 

--- a/pep-0645.rst
+++ b/pep-0645.rst
@@ -2,15 +2,27 @@ PEP: 645
 Title: Allow writing optional types as ``x?``
 Author: Maggie Moss <maggiebmoss@gmail.com>
 Sponsor: Guido van Rossum <guido@python.org>
-Status: Draft
-Type: Process
+Status: Withdrawn
+Type: Standards Track
 Content-Type: text/x-rst
 Created: 25-Aug-2020
+Resolution: https://mail.python.org/archives/list/typing-sig@python.org/message/E75SPV6DDHLEEFSA5MBN5HUOQWDMUQJ2/
 
 
 Abstract
 ========
 This PEP proposes adding a ``?`` operator for types to allow writing ``int?`` in place of ``Optional[int]``.
+
+
+PEP Withdrawl
+=============
+
+The notation ``T|None`` introduced by :pep:`604` to write ``Optional[T]`` is a
+fine alternative to ``T?`` and does not require new syntax.
+
+Using ``T?`` to mean ``T|None`` is also inconsistent with TypeScript
+(a very popular language) where there it roughly means ``NotRequired[T]``.
+Such inconsistency would likely confuse folks coming from TypeScript to Python.
 
 
 Motivation

--- a/pep-0645.rst
+++ b/pep-0645.rst
@@ -130,7 +130,7 @@ Backwards Compatibility
 Reference Implementation
 ========================
 
-A reference implementation can be found `here <https://github.com/python/cpython/compare/main...MaggieMoss:new-optional-syntax-postfix>`_ [5].
+A reference implementation can be found `here <https://github.com/python/cpython/compare/main...MaggieMoss:new-optional-syntax-postfix>`_.
 
 Rejected Ideas
 ==============
@@ -148,8 +148,6 @@ References
     (https://gist.github.com/MaggieMoss/fd8dfe002b2702fae243dbf81a62624e)
 .. [3] Github Issue Discussion of Optional syntax
     (https://github.com/python/typing/issues/429)
-.. [5] Reference Implementation
-    (https://github.com/python/cpython/compare/main...MaggieMoss:new-optional-syntax-postfix)
 
 Copyright
 =========

--- a/pep-0645.rst
+++ b/pep-0645.rst
@@ -14,8 +14,8 @@ Abstract
 This PEP proposes adding a ``?`` operator for types to allow writing ``int?`` in place of ``Optional[int]``.
 
 
-PEP Withdrawl
-=============
+PEP Withdrawal
+==============
 
 The notation ``T|None`` introduced by :pep:`604` to write ``Optional[T]`` is a
 fine alternative to ``T?`` and does not require new syntax.

--- a/pep-0645.rst
+++ b/pep-0645.rst
@@ -130,7 +130,7 @@ Backwards Compatibility
 Reference Implementation
 ========================
 
-A reference implementation can be found `here <https://github.com/python/cpython/compare/master...MaggieMoss:new-optional-syntax-postfix>`_ [5].
+A reference implementation can be found `here <https://github.com/python/cpython/compare/main...MaggieMoss:new-optional-syntax-postfix>`_ [5].
 
 Rejected Ideas
 ==============
@@ -149,7 +149,7 @@ References
 .. [3] Github Issue Discussion of Optional syntax
     (https://github.com/python/typing/issues/429)
 .. [5] Reference Implementation
-    (https://github.com/python/cpython/compare/master...MaggieMoss:new-optional-syntax-postfix)
+    (https://github.com/python/cpython/compare/main...MaggieMoss:new-optional-syntax-postfix)
 
 Copyright
 =========

--- a/pep-0645.rst
+++ b/pep-0645.rst
@@ -21,7 +21,7 @@ The notation ``T|None`` introduced by :pep:`604` to write ``Optional[T]`` is a
 fine alternative to ``T?`` and does not require new syntax.
 
 Using ``T?`` to mean ``T|None`` is also inconsistent with TypeScript
-(a very popular language) where there it roughly means ``NotRequired[T]``.
+(a very popular language) where it roughly means ``NotRequired[T]``.
 Such inconsistency would likely confuse folks coming from TypeScript to Python.
 
 The above represents the consensus of 

--- a/pep-0645.rst
+++ b/pep-0645.rst
@@ -24,6 +24,10 @@ Using ``T?`` to mean ``T|None`` is also inconsistent with TypeScript
 (a very popular language) where there it roughly means ``NotRequired[T]``.
 Such inconsistency would likely confuse folks coming from TypeScript to Python.
 
+The above represents the consensus of 
+`typing-sig <https://mail.python.org/archives/list/typing-sig@python.org/>`_ 
+and the sponsor of this PEP.
+
 
 Motivation
 ==========


### PR DESCRIPTION
Also, this PR supercedes https://github.com/python/peps/pull/2483 .

Approver for this is @gvanrossum (Sponsor of PEP 645). (The Author of PEP 645 has not been responsive in the past several weeks.)