### PR TITLE
Infra: remove two of the five instances of title at top of pages

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -300,9 +300,6 @@ dl.footnote dd {
 #pep-sidebar ul a {
     text-decoration: none;
 }
-#toc-title {
-    font-weight: bold;
-}
 #source {
     padding-bottom: 2rem;
     font-weight: bold;

--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -23,7 +23,8 @@
             <h1>Python Enhancement Proposals</h1>
             <ul class="breadcrumbs">
                 <li><a href="https://www.python.org/" title="The Python Programming Language">Python</a> &raquo; </li>
-                <li><a href="{{ pathto("pep-0000") }}">PEP Index</a></li>
+                <li><a href="{{ pathto("pep-0000") }}">PEP Index</a> &raquo; </li>
+                <li>{{ title.split("–")[0].strip() }}</li>
             </ul>
             <button aria-label="Toggle dark mode" onClick="toggleColourScheme()"></button>
         </header>

--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -33,7 +33,6 @@
         </article>
         <nav id="pep-sidebar">
             <h2>Contents</h2>
-            <p id="toc-title">{{ title }}</p>
             {{ toc }}
             <br />
             {%- if not sourcename.startswith("pep-0000") %}

--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -23,8 +23,7 @@
             <h1>Python Enhancement Proposals</h1>
             <ul class="breadcrumbs">
                 <li><a href="https://www.python.org/" title="The Python Programming Language">Python</a> &raquo; </li>
-                <li><a href="{{ pathto("pep-0000") }}">PEP Index</a> &raquo; </li>
-                <li>{{ title }}</li>
+                <li><a href="{{ pathto("pep-0000") }}">PEP Index</a></li>
             </ul>
             <button aria-label="Toggle dark mode" onClick="toggleColourScheme()"></button>
         </header>


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

We currently have the PEP title shown four times at the top of each page:

![image](https://user-images.githubusercontent.com/1324225/163670503-74359862-9782-4f02-a839-55def4f9f011.png)

https://peps.python.org/8

* https://github.com/python/peps/issues/2514#issuecomment-1100505799 will remove the one from the table
* the main title should stay
* the one at the top line is questionable, should that go?
* but the one on the left the top of the contents is unnecessary

This PR removes the contents title on the left:

![image](https://user-images.githubusercontent.com/1324225/163670788-602f1a15-6d35-468c-bf55-10bbe11e5e5e.png)
