### PR TITLE
Style: Reduce space consumed by headers and improve alignment

### DIFF
--- a/pep_sphinx_extensions/pep_processor/transforms/pep_title.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_title.py
@@ -22,13 +22,19 @@ class PEPTitle(transforms.Transform):
         pep_header_details = {}
 
         # Iterate through the header fields, which are the first section of the document
+        desired_fields = {"PEP", "Title"}
+        fields_to_remove = []
         for field in self.document[0]:
             # Hold details of the attribute's tag against its details
             row_attributes = {sub.tagname: sub.rawsource for sub in field}
             pep_header_details[row_attributes["field_name"]] = row_attributes["field_body"]
 
+            # Store the redundant fields in the table for removal
+            if row_attributes["field_name"] in desired_fields:
+                fields_to_remove.append(field)
+
             # We only need the PEP number and title
-            if pep_header_details.keys() >= {"PEP", "Title"}:
+            if pep_header_details.keys() >= desired_fields:
                 break
 
         # Create the title string for the PEP
@@ -45,6 +51,10 @@ class PEPTitle(transforms.Transform):
         self.document.children = [pep_title_node]
         pep_title_node.extend(document_children)
         self.document.note_implicit_target(pep_title_node, pep_title_node)
+
+        # Remove the now-redundant fields
+        for field in fields_to_remove:
+            field.parent.remove(field)
 
 
 def _line_to_nodes(text: str) -> list[nodes.Node]:

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -41,8 +41,8 @@ p {margin: .5rem 0}
 h1 {
     font-size: 2rem;
     font-weight: bold;
-    margin-top: 2rem;
-    margin-bottom: 1.5rem;
+    margin-top: 1.25rem;
+    margin-bottom: 1rem;
 }
 h2 {
     font-size: 1.6rem;
@@ -145,7 +145,7 @@ dl dd {
 hr {
     border: 0;
     border-top: 1px solid var(--colour-rule-light);
-    margin: 1.75rem 0;
+    margin: 0;
 }
 /*Image rules */
 img {
@@ -266,21 +266,30 @@ dl.rfc2822,
 dl.footnote {
     display: grid;
     grid-template-columns: fit-content(30%) auto;
-    line-height: 1.875;
     width: 100%;
-    border-top: 1px solid var(--colour-rule-strong);
 }
-dl.rfc2822 > dt, dl.rfc2822 > dd,
-dl.footnote > dt, dl.footnote > dd {
+dl.footnote {
+    border-top: 1px solid var(--colour-rule-strong);
+    line-height: 1.875;
+}
+dl.rfc2822 > dt,
+dl.rfc2822 > dd {
+    padding: .1rem .3rem .1rem;
+}
+dl.footnote > dt,
+dl.footnote > dd {
     padding: .25rem .5rem .2rem;
     border-bottom: 1px solid var(--colour-rule-strong);
+}
+dl.rfc2822 > dt {
+    text-align: right;
 }
 dl.footnote > dt {
     font-weight: normal;
     border-right: 1px solid var(--colour-background);
 }
-dl.rfc2822 dd,
-dl.footnote dd {
+dl.rfc2822 > dd,
+dl.footnote > dd {
     margin: 0;
 }
 


### PR DESCRIPTION
As discussed on #2514 , the headers at the top consume excessive vertical space, particularly on mobile which some style tweaks could dramatically improve with no loss of information. Furthermore, there are some odd gaps and spacing between the various elements that could be fixed, and the title and PEP number is redundant and can be removed, as it is present no less than four other places (the main title, the breadcrumbs, the sidebar [as addressed by #2532], and the tab title).

To note, while it is included in the comparisons below, this PR defers the implementation of removing or `abbr`-ing the email address to a followup PR, as it may require a bit more discussion and is better done after #2484 is merged.

**Desktop (Before/After)**

![image](https://user-images.githubusercontent.com/17051931/163673530-0535ac8e-3ae7-4487-b077-e033adbe512c.png)

**Mobile (Before/Previous/Latest)**

![image](https://user-images.githubusercontent.com/17051931/163673407-4d1139f5-c77a-4ad1-996f-9d04585a33b8.png)

Fixes #2514 