### PR TITLE
PEP 517: add missing def for the mandatory hook build_wheel signature

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -340,7 +340,7 @@ get_requires_for_build_sdist
 ::
 
   def get_requires_for_build_sdist(config_settings=None):
-    ...
+      ...
 
 This hook MUST return an additional list of strings containing :pep:`508`
 dependency specifications, above and beyond those specified in the

--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -210,7 +210,7 @@ build_wheel
 
 ::
 
-    build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
         ...
 
 Must build a .whl file, and place it in the specified ``wheel_directory``. It


### PR DESCRIPTION
All the other example hooks have a `def` so this looks like a typo.