### PR TITLE
Style: Retitle inline 'Contents' to 'Table of Contents' for clarity

### DIFF
--- a/pep_sphinx_extensions/pep_processor/html/pep_html_translator.py
+++ b/pep_sphinx_extensions/pep_processor/html/pep_html_translator.py
@@ -91,7 +91,7 @@ class PEPTranslator(html5.HTML5Translator):
 
     def visit_bullet_list(self, node):
         if isinstance(node.parent, nodes.section) and "contents" in node.parent["names"]:
-            self.body.append("<details><summary>Contents</summary>")
+            self.body.append("<details><summary>Table of Contents</summary>")
             self.context.append("</details>")
         super().visit_bullet_list(node)
 


### PR DESCRIPTION
This simply changes the title of the inline dropdown table of contents from `Contents` to `Table of Contents`, to be more clear and avoid confusion. I just changed it in the output HTML translator, so it shouldn't require touching anything else.

Fixes #2540 