### PR TITLE
PEP 688: Link to current docs

### DIFF
--- a/pep-0688.rst
+++ b/pep-0688.rst
@@ -20,7 +20,8 @@ Motivation
 ==========
 
 The CPython C API provides a versatile mechanism for accessing the
-underlying memory of an object—the buffer protocol from :pep:`3118`.
+underlying memory of an object—the `buffer protocol <https://docs.python.org/3/c-api/buffer.html>`__
+introduced in :pep:`3118`.
 Functions that accept binary data are usually written to handle any
 object implementing the buffer protocol. For example, at the time of writing,
 there are around 130 functions in CPython using the Argument Clinic


### PR DESCRIPTION
Link to current documentation of the protocol first and make the
PEP secondary (it might still be useful for the original motivation/rationale).
