### PR TITLE
PEP 681: Address Steering Council feedback

### DIFF
--- a/pep-0681.rst
+++ b/pep-0681.rst
@@ -81,7 +81,7 @@ sync will make it easier for dataclass users to understand and use
 support in type checkers.
 
 Additionally, we will consider adding ``dataclass_transform`` support
-in the future for features that have been adopted by miltiple
+in the future for features that have been adopted by multiple
 third-party libraries but are not supported by stdlib dataclass.
 
 

--- a/pep-0681.rst
+++ b/pep-0681.rst
@@ -80,6 +80,10 @@ sync will make it easier for dataclass users to understand and use
 ``dataclass_transform`` and will simplify the maintenance of dataclass
 support in type checkers.
 
+Additionally, we will consider adding ``dataclass_transform`` support
+in the future for features that have been adopted by miltiple
+third-party libraries but are not supported by stdlib dataclass.
+
 
 Specification
 =============
@@ -607,10 +611,7 @@ annotations but with no assignment should be treated as data fields.
 
 We considered supporting ``auto_attribs`` and a corresponding
 ``auto_attribs_default`` parameter, but decided against this because it
-is specific to attrs and appears to be a legacy behavior. Instead of
-supporting this in the new standard, we recommend that the maintainers
-of attrs move away from the legacy semantics and adopt
-``auto_attribs`` behaviors by default.
+is specific to attrs and appears to be a legacy behavior.
 
 Django does not support declaring fields using type annotations only,
 so Django users who leverage ``dataclass_transform`` should be aware
@@ -621,9 +622,9 @@ that they should always supply assigned values.
 
 The attrs library supports a bool parameter ``cmp`` that is equivalent
 to setting both ``eq`` and ``order`` to True. We chose not to support
-a ``cmp`` parameter, since it only applies to attrs. Attrs users
-should use the dataclass-standard ``eq`` and ``order`` parameter names
-instead.
+a ``cmp`` parameter, since it only applies to attrs. Users can work
+around this limitation by using the dataclass-standard ``eq`` and
+``order`` parameter names instead.
 
 Automatic field name aliasing
 -----------------------------
@@ -682,9 +683,9 @@ Class-wide default values
 -------------------------
 
 SQLAlchemy requested that we expose a way to specify that the default
-value of all fields in the transformed class is None. It is typical
-that all of their fields are optional, and None indicates that the
-field is not set.
+value of all fields in the transformed class is ``None``. It is typical
+that all of SQLAlchemy fields are optional, and ``None`` indicates that
+the field is not set.
 
 We chose not to support this feature, since it is specific to
 SQLAlchemy. Users can manually set ``default=None`` on these fields
@@ -728,9 +729,6 @@ information to derive the type of the input parameter. One possible
 solution would be to add support for a ``converter`` field specifier
 parameter but then use the ``Any`` type for the corresponding
 parameter in the ``__init__`` method.
-
-We chose not to support this feature and recommend that attrs users
-avoid converters.
 
 
 References

--- a/pep-0681.rst
+++ b/pep-0681.rst
@@ -82,7 +82,7 @@ support in type checkers.
 
 Additionally, we will consider adding ``dataclass_transform`` support
 in the future for features that have been adopted by multiple
-third-party libraries but are not supported by stdlib dataclass.
+third-party libraries but are not supported by dataclasses.
 
 
 Specification
@@ -611,7 +611,7 @@ annotations but with no assignment should be treated as data fields.
 
 We considered supporting ``auto_attribs`` and a corresponding
 ``auto_attribs_default`` parameter, but decided against this because it
-is specific to attrs and appears to be a legacy behavior.
+is specific to attrs.
 
 Django does not support declaring fields using type annotations only,
 so Django users who leverage ``dataclass_transform`` should be aware
@@ -622,9 +622,9 @@ that they should always supply assigned values.
 
 The attrs library supports a bool parameter ``cmp`` that is equivalent
 to setting both ``eq`` and ``order`` to True. We chose not to support
-a ``cmp`` parameter, since it only applies to attrs. Users can work
-around this limitation by using the dataclass-standard ``eq`` and
-``order`` parameter names instead.
+a ``cmp`` parameter, since it only applies to attrs. Users can emulate
+the ``cmp`` behaviour by using the ``eq`` and ``order`` parameter names
+instead.
 
 Automatic field name aliasing
 -----------------------------
@@ -684,7 +684,7 @@ Class-wide default values
 
 SQLAlchemy requested that we expose a way to specify that the default
 value of all fields in the transformed class is ``None``. It is typical
-that all of SQLAlchemy fields are optional, and ``None`` indicates that
+that all SQLAlchemy fields are optional, and ``None`` indicates that
 the field is not set.
 
 We chose not to support this feature, since it is specific to


### PR DESCRIPTION
- Changed wording of Rejected Ideas to avoid recommending changes in libraries or dictating how users respond to these limitations. @encukou 
- Added language in Rationale indicating that we will consider extending `dataclass_transform` in the future with features commonly used in libraries but not supported by `dataclass`. @AlexWaygood 