### PR TITLE
PEP 686: Postpone target version to 3.15

### DIFF
--- a/pep-0686.rst
+++ b/pep-0686.rst
@@ -6,7 +6,7 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 18-Mar-2022
-Python-Version: 3.13
+Python-Version: 3.15
 Post-History: `18-Mar-2022 <https://discuss.python.org/t/14435>`__,
               `31-Mar-2022 <https://discuss.python.org/t/14737>`__
 
@@ -49,7 +49,7 @@ Specification
 Enable UTF-8 mode by default
 ----------------------------
 
-Python will enable UTF-8 mode by default from Python 3.13.
+Python will enable UTF-8 mode by default from Python 3.15.
 
 Users can still disable UTF-8 mode by setting ``PYTHONUTF8=0`` or
 ``-X utf8=0``.


### PR DESCRIPTION
This change is based on SC feedback.
https://github.com/python/steering-council/issues/118#issuecomment-1108833536