### PR TITLE
PEP 1: Update "issue tracker" to link to GitHub Issues

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -124,7 +124,7 @@ Start with an idea for Python
 The PEP process begins with a new idea for Python.  It is highly
 recommended that a single PEP contain a single key proposal or new
 idea; the more focused the PEP, the more successful it tends to be.
-Small enhancements and bug fixes often don't need a PEP and
+Most enhancements and bug fixes don't need a PEP and
 can be submitted directly to the `Python issue tracker`_.
 The PEP editors reserve the
 right to reject PEP proposals if they appear too unfocused or too

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -123,13 +123,12 @@ Start with an idea for Python
 
 The PEP process begins with a new idea for Python.  It is highly
 recommended that a single PEP contain a single key proposal or new
-idea. Small enhancements or changes often don't need a PEP and can
-be integrated into the Python development workflow by reporting an
-issue to the Python `issue tracker`_ and/or submitting a `pull request`_.
-The more focused the PEP, the more successful it tends to be.
-The PEP editors reserve the right to reject PEP proposals if they
-appear too unfocused or too broad.  If in doubt,
-split your PEP into several well-focused ones.
+idea; the more focused the PEP, the more successful it tends to be.
+Small enhancements and bug fixes often don't need a PEP and
+can be submitted directly to the `Python issue tracker`_.
+The PEP editors reserve the
+right to reject PEP proposals if they appear too unfocused or too
+broad.  If in doubt, split your PEP into several well-focused ones.
 
 Each PEP must have a champion -- someone who writes the PEP using the style
 and format described below, shepherds the discussions in the appropriate
@@ -835,9 +834,7 @@ Footnotes
 
 .. _.github/CODEOWNERS: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-.. _issue tracker: https://github.com/python/cpython/issues
-
-.. _pull request: https://github.com/python/cpython/pulls
+.. _Python issue tracker: https://github.com/python/cpython/issues
 
 .. _CC0-1.0-Universal: https://choosealicense.com/licenses/cc0-1.0/
 

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -123,12 +123,13 @@ Start with an idea for Python
 
 The PEP process begins with a new idea for Python.  It is highly
 recommended that a single PEP contain a single key proposal or new
-idea. Small enhancements or patches often don't need
-a PEP and can be injected into the Python development workflow with a
-patch submission to the Python `issue tracker`_. The more focused the
-PEP, the more successful it tends to be.  The PEP editors reserve the
-right to reject PEP proposals if they appear too unfocused or too
-broad.  If in doubt, split your PEP into several well-focused ones.
+idea. Small enhancements or changes often don't need a PEP and can
+be integrated into the Python development workflow by reporting an
+issue to the Python `issue tracker`_ and/or submitting a `pull request`_.
+The more focused the PEP, the more successful it tends to be.
+The PEP editors reserve the right to reject PEP proposals if they
+appear too unfocused or too broad.  If in doubt,
+split your PEP into several well-focused ones.
 
 Each PEP must have a champion -- someone who writes the PEP using the style
 and format described below, shepherds the discussions in the appropriate
@@ -835,6 +836,8 @@ Footnotes
 .. _.github/CODEOWNERS: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 .. _issue tracker: https://github.com/python/cpython/issues
+
+.. _pull request: https://github.com/python/cpython/pulls
 
 .. _CC0-1.0-Universal: https://choosealicense.com/licenses/cc0-1.0/
 

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -834,7 +834,7 @@ Footnotes
 
 .. _.github/CODEOWNERS: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-.. _issue tracker: https://bugs.python.org/
+.. _issue tracker: https://github.com/python/cpython/issues
 
 .. _CC0-1.0-Universal: https://choosealicense.com/licenses/cc0-1.0/
 


### PR DESCRIPTION
with all the issues migrated to GitHub Issues, it makes sense now for PEP-1 to point to GitHub Issues over BPO