### PR TITLE
PEP 690: Add flexibility to set_eager_imports()

### DIFF
--- a/pep-0690.rst
+++ b/pep-0690.rst
@@ -193,8 +193,8 @@ a list of module names within which all imports will be eager::
 The effect of this is also shallow: all imports within ``one.mod`` will be
 eager, but not imports in all modules imported by ``one.mod``.
 
-Or a callback object which receives a module name returns whether the import
-for such name should be eager::
+``set_eager_imports()`` can instead take a callback which receives a module name and returns
+whether the import of this module should be eager::
 
     import re
     from importlib import set_eager_imports

--- a/pep-0690.rst
+++ b/pep-0690.rst
@@ -194,7 +194,7 @@ The effect of this is also shallow: all imports within ``one.mod`` will be
 eager, but not imports in all modules imported by ``one.mod``.
 
 ``set_eager_imports()`` can also take a callback which receives a module name and returns
-whether the import of this module should be eager::
+whether imports within this module should be eager::
 
     import re
     from importlib import set_eager_imports

--- a/pep-0690.rst
+++ b/pep-0690.rst
@@ -193,7 +193,7 @@ a list of module names within which all imports will be eager::
 The effect of this is also shallow: all imports within ``one.mod`` will be
 eager, but not imports in all modules imported by ``one.mod``.
 
-``set_eager_imports()`` can instead take a callback which receives a module name and returns
+``set_eager_imports()`` can also take a callback which receives a module name and returns
 whether the import of this module should be eager::
 
     import re

--- a/pep-0690.rst
+++ b/pep-0690.rst
@@ -193,6 +193,17 @@ a list of module names within which all imports will be eager::
 The effect of this is also shallow: all imports within ``one.mod`` will be
 eager, but not imports in all modules imported by ``one.mod``.
 
+Or a callback object which receives a module name returns whether the import
+for such name should be eager::
+
+    import re
+    from importlib import set_eager_imports
+    
+    def eager_imports(name):
+        return re.match(r"foo\.[^.]+\.logger", name)
+
+    set_eager_imports(eager_imports)
+
 
 Backwards Compatibility
 =======================


### PR DESCRIPTION
This adds a callback to the proposed `importlib.set_eager_imports()`.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
