### PR TITLE
PEP 585: remove mention of removal date

### DIFF
--- a/pep-0585.rst
+++ b/pep-0585.rst
@@ -123,9 +123,8 @@ about such deprecated usage when the target version of the checked
 program is signalled to be Python 3.9 or newer.  It's recommended to
 allow for those warnings to be silenced on a project-wide basis.
 
-The deprecated functionality will be removed from the ``typing`` module
-in the first Python version released 5 years after the release of
-Python 3.9.0.
+The deprecated functionality will eventually be removed from the
+``typing`` module.
 
 
 Parameters to generics are available at runtime


### PR DESCRIPTION
A definite timeline contradicts the CPython documentation, e.g. see
https://github.com/python/cpython/pull/91864

Removal will break pretty much all code written to support Python 3.8
and earlier that uses type hints. I'm not sure the one year between 3.8
going EOL and the removal date mentioned here is enough to expect all
libraries with type hints to update.

Note that the goal here isn't to litigate a removal date, but just to
reduce FUD for Python users and to stay consistent with
CPython docs.

Apologies if this is controversial, in which case I can start a discuss
thread or something.