### PR TITLE
PEP 690: Fix omission of `-L` in example

### DIFF
--- a/pep-0690.rst
+++ b/pep-0690.rst
@@ -166,7 +166,7 @@ will be enough to trigger the import of ``spam.py``::
     print("imports done")
     spam
 
-Now if we run ``python eggs.py``, we will see the output ``"imports done"``
+Now if we run ``python -L eggs.py``, we will see the output ``"imports done"``
 printed first, then a 10 second delay, and then ``"spam loaded"`` printed after
 that.
 


### PR DESCRIPTION
the example describes the behavior under lazy imports, so it should use `-L`