### PR TITLE
PEP 362: Fix formatting of colons in field descriptions

### DIFF
--- a/pep-0362.txt
+++ b/pep-0362.txt
@@ -42,12 +42,12 @@ it stores a `Parameter object`_ in its ``parameters`` collection.
 
 A Signature object has the following public attributes and methods:
 
-* return_annotation : object
+* return_annotation \: object
     The "return" annotation for the function. If the function
     has no "return" annotation, this attribute is set to
     ``Signature.empty``.
 
-* parameters : OrderedDict
+* parameters \: OrderedDict
     An ordered mapping of parameters' names to the corresponding
     Parameter objects.
 
@@ -134,16 +134,16 @@ function parameter.
 
 A Parameter object has the following public attributes and methods:
 
-* name : str
+* name \: str
     The name of the parameter as a string.  Must be a valid
     python identifier name (with the exception of ``POSITIONAL_ONLY``
     parameters, which can have it set to ``None``.)
 
-* default : object
+* default \: object
     The default value for the parameter.  If the parameter has no
     default value, this attribute is set to ``Parameter.empty``.
 
-* annotation : object
+* annotation \: object
     The annotation for the parameter.  If the parameter has no
     annotation, this attribute is set to ``Parameter.empty``.
 
@@ -220,14 +220,14 @@ to the function's parameters.
 
 Has the following public attributes:
 
-* arguments : OrderedDict
+* arguments \: OrderedDict
     An ordered, mutable mapping of parameters' names to arguments' values.
     Contains only explicitly bound arguments.  Arguments for
     which ``bind()`` relied on a default value are skipped.
-* args : tuple
+* args \: tuple
     Tuple of positional arguments values.  Dynamically computed from
     the 'arguments' attribute.
-* kwargs : dict
+* kwargs \: dict
     Dict of keyword arguments values. Dynamically computed from
     the 'arguments' attribute.
 


### PR DESCRIPTION
Before:
<img width="848" alt="Screen Shot 2022-05-08 at 12 05 35 PM" src="https://user-images.githubusercontent.com/764688/167311780-18917b1d-d737-4aa6-a044-42ca25dea953.png">

After:
<img width="835" alt="Screen Shot 2022-05-08 at 12 06 04 PM" src="https://user-images.githubusercontent.com/764688/167311788-d4299db8-20b6-40a7-b642-5ac034fbf72e.png">
