### PR TITLE
PEP 691: Copyright

### DIFF
--- a/pep-0691.rst
+++ b/pep-0691.rst
@@ -878,3 +878,10 @@ how they use the Simple + JSON APIs today:
     - [Bonus] Get all packages with serial
 
       - XML-RPC Call: ``list_packages_with_serial``
+
+
+Copyright
+=========
+
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.

--- a/pep-0691.rst
+++ b/pep-0691.rst
@@ -10,8 +10,7 @@ Content-Type: text/x-rst
 PEP-Delegate: Brett Cannon <brett@python.org>
 Discussions-To: https://discuss.python.org/t/pep-691-json-based-simple-api-for-python-package-indexes/15553
 Created: 04-May-2022
-Post-History: `05-May-2022 <https://discuss.python.org/t/pep-691-json-based-simple-api-for-python-package-indexes/15553>`__,
-              `08-May-2022 <https://discuss.python.org/t/pep-691-json-based-simple-api-for-python-package-indexes/15553/28>`__
+Post-History: `05-May-2022 <https://discuss.python.org/t/pep-691-json-based-simple-api-for-python-package-indexes/15553>`__
 
 
 Abstract

--- a/pep-0691.rst
+++ b/pep-0691.rst
@@ -10,7 +10,8 @@ Content-Type: text/x-rst
 PEP-Delegate: Brett Cannon <brett@python.org>
 Discussions-To: https://discuss.python.org/t/pep-691-json-based-simple-api-for-python-package-indexes/15553
 Created: 04-May-2022
-Post-History: `05-May-2022 <https://discuss.python.org/t/pep-691-json-based-simple-api-for-python-package-indexes/15553>`__
+Post-History: `05-May-2022 <https://discuss.python.org/t/pep-691-json-based-simple-api-for-python-package-indexes/15553>`__,
+              `08-May-2022 <https://discuss.python.org/t/pep-691-json-based-simple-api-for-python-package-indexes/15553/28>`__
 
 
 Abstract


### PR DESCRIPTION
- ~~Adds the Post History for Today~~
- Adds a Copyright to the PEP

To merge this, we'll need permission from all the existing authors to copyright their work under the included license.

- [x] @dstufft 
- [x] @pradyunsg 
- [x] @cooperlees 
- [x] @di 

