### PR TITLE
PEP 691: Fix minor nits with headers and reST syntax

### DIFF
--- a/pep-0691.rst
+++ b/pep-0691.rst
@@ -4,11 +4,11 @@ Author: Donald Stufft <donald@stufft.io>,
         Pradyun Gedam <pradyunsg@gmail.com>,
         Cooper Lees <me@cooperlees.com>,
         Dustin Ingram <di@python.org>
+PEP-Delegate: Brett Cannon <brett@python.org>
+Discussions-To: https://discuss.python.org/t/pep-691-json-based-simple-api-for-python-package-indexes/15553
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
-PEP-Delegate: Brett Cannon <brett@python.org>
-Discussions-To: https://discuss.python.org/t/pep-691-json-based-simple-api-for-python-package-indexes/15553
 Created: 04-May-2022
 Post-History: `05-May-2022 <https://discuss.python.org/t/pep-691-json-based-simple-api-for-python-package-indexes/15553>`__
 
@@ -290,9 +290,11 @@ This PEP proposes that all responses from the Simple API will have a standard
 content type that describes what the response is (a Simple API response), what
 version of the API it represents, and what serialization format has been used.
 
-The structure of this content type will be::
+The structure of this content type will be:
 
-  application/vnd.pypi.simple.$version+format
+.. code-block:: text
+
+    application/vnd.pypi.simple.$version+format
 
 Since only major versions should be disruptive to clients attempting to
 understand one of these API responses, only the major version will be included
@@ -403,7 +405,7 @@ so the risks for actual breakages is low.
 
 An example of how a client can operate would look like:
 
-.. code-block:: python3
+.. code-block:: python
 
     import cgi
     import requests
@@ -839,10 +841,10 @@ how they use the Simple + JSON APIs today:
   - List of all files for a particular release
   - Metadata of each individual artifact:
 
-    - was it yanked? (`data-yanked`)
-    - what's the python-requires? (`data-python-requires`)
+    - was it yanked? (``data-yanked``)
+    - what's the python-requires? (``data-python-requires``)
     - what's the hash of this file? (currently, hash in URL)
-    - Full metadata (`data-dist-info-metadata`)
+    - Full metadata (``data-dist-info-metadata``)
     - [Bonus] what are the declared dependencies, if available (list-of-strings, null if unavailable)?
 
 - ``bandersnatch`` - Only uses legacy JSON API + XMLRPC today:
@@ -859,11 +861,12 @@ how they use the Simple + JSON APIs today:
 
     - Write out the JSON to mirror storage today (disk/S3)
 
-      - Required metadata used (via Package class - https://github.com/pypa/bandersnatch/blob/main/src/bandersnatch/package.py):
+      - Required metadata used
+        (via `Package class <https://github.com/pypa/bandersnatch/blob/main/src/bandersnatch/package.py>`__):
 
-        - metadata["info"]
-        - metadata["last_serial"]
-        - metadata["releases"]
+        - ``metadata["info"]``
+        - ``metadata["last_serial"]``
+        - ``metadata["releases"]``
 
           - digests
           - URL


### PR DESCRIPTION
Seems like most of the issues originally brought up in #2578 post-merge were fixed in the meantime, but there were a few remaining minor header/syntax/formatting nits I've fixed here.

@dstufft @di @cooperlees @pradyunsg 