### PR TITLE
PEP 7: Revert "Add note about greppable exception messages (#2605)"

### DIFF
--- a/pep-0007.txt
+++ b/pep-0007.txt
@@ -71,12 +71,6 @@ Code lay-out
   previous rule together don't give you enough room to code, your code
   is too complicated -- consider using subroutines.
 
-* Strive to keep exception message string literals on one line,
-  in order to make them easily greppable.
-  If your exception message breaks the 79 character line width rule,
-  try to mitigate it by reducing indent, or just bend that rule.
-  (Practicality beats purity.)
-
 * No line should end in whitespace.  If you think you need significant
   trailing whitespace, think again -- somebody's editor might delete
   it as a matter of routine.


### PR DESCRIPTION
Based on post-merge feedback, it was decided to revert this change.

See the original PR (GH-2605), the proposed PR for PEP 8 (GH-2606), and
the issue (GH-2604) for the discussions.

This reverts commit c7877394784070af2db09e162007c828dc831f99.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
