### PR TITLE
PEP 681: Clarify impact of decorating an overload

### DIFF
--- a/pep-0681.rst
+++ b/pep-0681.rst
@@ -103,7 +103,9 @@ If ``dataclass_transform`` is applied to a function, using the decorated
 function as a decorator is assumed to apply dataclass-like semantics.
 If the function has overloads, the ``dataclass_transform`` decorator can
 be applied to the implementation of the function or any one, but not more
-than one, of the overloads.
+than one, of the overloads. When applied to an overload, the
+``dataclass_transform`` decorator still impacts all usage of the
+function.
 
 If ``dataclass_transform`` is applied to a class, dataclass-like
 semantics will be assumed for any class that derives from the


### PR DESCRIPTION
Clarify that decorating an overload with `dataclass_transform` impacts the function as a whole, not just usage of that one overload. The current language was reported as ambiguous in https://github.com/python/typing/discussions/1187.

cc: @zzzeek