### PR TITLE
PEP 675: Add explicit `circumference` method

### DIFF
--- a/pep-0673.rst
+++ b/pep-0673.rst
@@ -227,7 +227,8 @@ value of type ``Shape``, when in fact it should be ``Circle``:
 
 ::
 
-    class Circle(Shape): ...
+    class Circle(Shape):
+        def circumference(self) -> float: ...
 
     shape = Shape.from_config({"scale": 7.0})
     # => Shape


### PR DESCRIPTION
Not adding a `radius` attribute, because the Circle class needs to be
instantiable from just the `scale` config value. So, I'm going with a
method.

cc @JelleZijlstra  @Gobot1234

Closes #2617 