### PR TITLE
Infra: Make colour theme cycler button accessible

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -2,7 +2,7 @@
 /* Styles for PEPs */
 
 /*
- * `initial` works like undefined variables, so `var(intial, x)` will resolve to `x`.
+ * `initial` works like undefined variables, so `var(initial, x)` will resolve to `x`.
  * A space means an empty value, so `var( , x) y` will resolve to `y`.
  */
 @media (prefers-color-scheme: dark) {
@@ -358,4 +358,16 @@ dl.footnote > dd {
 
 .reference.external > strong {
     font-weight: normal;  /* Fix strong links for :pep: and :rfc: roles */
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0,0,0,0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
 }

--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -31,9 +31,10 @@
                 <li>{{ title.split("–")[0].strip() }}</li>
             </ul>
             <button id="colour-scheme-cycler" onClick="setColourScheme(nextColourScheme())">
-                <svg class="colour-scheme-icon-when-auto"><use href="#svg-sun-half"></use></svg>
-                <svg class="colour-scheme-icon-when-dark"><use href="#svg-moon"></use></svg>
-                <svg class="colour-scheme-icon-when-light"><use href="#svg-sun"></use></svg>
+                <svg aria-hidden="true" class="colour-scheme-icon-when-auto"><use href="#svg-sun-half"></use></svg>
+                <svg aria-hidden="true" class="colour-scheme-icon-when-dark"><use href="#svg-moon"></use></svg>
+                <svg aria-hidden="true" class="colour-scheme-icon-when-light"><use href="#svg-sun"></use></svg>
+                <span class="visually-hidden">Toggle light / dark / auto colour theme</span>
             </button>
         </header>
         <article>


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

1. Run Lighthouse audit from Chrome devtools or using https://web.dev/

# Before

> Buttons do not have an accessible name

<img width="947" alt="image" src="https://user-images.githubusercontent.com/1324225/170888334-e64007c5-7cf0-4604-a332-7798b157b5d0.png">

https://web.dev/measure/?url=https%3A%2F%2Fpeps.python.org

# After

<img width="720" alt="image" src="https://user-images.githubusercontent.com/1324225/170888354-c22e1898-d14b-4f42-8002-26051d1ae5b3.png">

https://web.dev/measure/?url=https%3A%2F%2Fpep-previews--2619.org.readthedocs.build%2F

# Fix

Fixed following advice from https://kittygiraudel.com/2020/12/10/accessible-icon-links/

* Add `<span class="visually-hidden">Toggle light / dark / auto colour theme</span>` to the button
  * Visible to screenreaders, but visually hidden
  * Using the `visually-hidden` CSS class from [Furo](https://github.com/pradyunsg/furo/blob/0c2acbbd23f8146dd0ae50a2ba57258c1f63ea9f/src/furo/assets/styles/base/_screen-readers.sass) which is pretty similar to the one [from the blog](https://kittygiraudel.com/snippets/sr-only-class/)
* Conversely, add `aria-hidden="true"` to the SVGs so they are hidden from screen readers
* I didn't bother with the [Internet Explorer](https://death-to-ie11.com/) bit
