### PR TITLE
PEP 621: Fix missing schemes in example project.urls

### DIFF
--- a/pep-0621.rst
+++ b/pep-0621.rst
@@ -490,10 +490,10 @@ Example
   ]
 
   [project.urls]
-  homepage = "example.com"
-  documentation = "readthedocs.org"
-  repository = "github.com"
-  changelog = "github.com/me/spam/blob/master/CHANGELOG.md"
+  homepage = "https://example.com"
+  documentation = "https://readthedocs.org"
+  repository = "https://github.com"
+  changelog = "https://github.com/me/spam/blob/master/CHANGELOG.md"
 
   [project.scripts]
   spam-cli = "spam:main_cli"


### PR DESCRIPTION
PyPI seems to reject these as-is (probably expectedly).

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
