### PR TITLE
Update pep-0469.txt

### DIFF
--- a/pep-0469.txt
+++ b/pep-0469.txt
@@ -91,7 +91,7 @@ mapping at the time the method was called. This has a few consequences:
   mapping
 
 The semantic equivalent of these operations in Python 3 are
-``list(d.keys())``, ``list(d.values())`` and ``list(d.iteritems())``.
+``list(d.keys())``, ``list(d.values())`` and ``list(d.items())``.
 
 
 Iterator objects


### PR DESCRIPTION
<!--
PEP 469 "Migration of dict iteration code to Python 3"

Stating the 'dict.iteritems()' function being a python 3 method was probably a typo.

In addition, please sign the CLA.

-->
