### PR TITLE
PEP 11: Use powerpc64le instead of powerpcle

### DIFF
--- a/pep-0011.txt
+++ b/pep-0011.txt
@@ -96,16 +96,16 @@ Tier 2
   reverted within 24 hours**.
 - Failures on these platforms **block a release**.
 
-=========================== ========================== ============================================== ========
-Target Triple               Notes                      Buildbot                                       Contacts
-=========================== ========================== ============================================== ========
-aarch64-apple-darwin        clang                      https://buildbot.python.org/all/#/builders/725 Ned Deily, Ronald Oussoren, Dong-hee Na
-aarch64-unknown-linux-gnu   glibc, gcc                 https://buildbot.python.org/all/#/builders/125 Petr Viktorin, Victor Stinner
+============================= ========================== ============================================== ========
+Target Triple                 Notes                      Buildbot                                       Contacts
+============================= ========================== ============================================== ========
+aarch64-apple-darwin          clang                      https://buildbot.python.org/all/#/builders/725 Ned Deily, Ronald Oussoren, Dong-hee Na
+aarch64-unknown-linux-gnu     glibc, gcc                 https://buildbot.python.org/all/#/builders/125 Petr Viktorin, Victor Stinner
 
-                            glibc, clang               https://buildbot.python.org/all/#/builders/234 Victor Stinner, Gregory P. Smith
-powerpcle-unknown-linux-gnu glibc, gcc                 https://buildbot.python.org/all/#/builders/90  Petr Viktorin, Victor Stinner
-x86_64-unknown-linux-gnu    glibc, clang               https://buildbot.python.org/all/#/builders/441 Victor Stinner, Gregory P. Smith
-=========================== ========================== ============================================== ========
+                              glibc, clang               https://buildbot.python.org/all/#/builders/234 Victor Stinner, Gregory P. Smith
+powerpc64le-unknown-linux-gnu glibc, gcc                 https://buildbot.python.org/all/#/builders/90  Petr Viktorin, Victor Stinner
+x86_64-unknown-linux-gnu      glibc, clang               https://buildbot.python.org/all/#/builders/441 Victor Stinner, Gregory P. Smith
+============================= ========================== ============================================== ========
 
 
 Tier 3
@@ -116,15 +116,15 @@ Tier 3
 - No response SLA to failures.
 - Failures on these platforms do **not** block a release.
 
-============================== =========================== ============================================== ========
-Target Triple                  Notes                       Buildbot                                       Contacts
-============================== =========================== ============================================== ========
-aarch64-pc-windows-msvc                                    https://buildbot.python.org/all/#/builders/729 Steve Dower
-powerpcle-unknown-linux-gnu    glibc, clang                https://buildbot.python.org/all/#/builders/435 Victor Stinner
-s390x-unknown-linux-gnu        glibc, gcc                  https://buildbot.python.org/all/#/builders/223 Victor Stinner
-x86_64-unknown-freebsd         BSD libc, clang             https://buildbot.python.org/all/#/builders/172 Victor Stinner
-armv7l-unknown-linux-gnueabihf Raspberry Pi OS, glibc, gcc https://buildbot.python.org/all/#/builders/424 Gregory P. Smith
-============================== =========================== ============================================== ========
+================================ =========================== ============================================== ========
+Target Triple                    Notes                       Buildbot                                       Contacts
+================================ =========================== ============================================== ========
+aarch64-pc-windows-msvc                                      https://buildbot.python.org/all/#/builders/729 Steve Dower
+powerpc64le-unknown-linux-gnu    glibc, clang                https://buildbot.python.org/all/#/builders/435 Victor Stinner
+s390x-unknown-linux-gnu          glibc, gcc                  https://buildbot.python.org/all/#/builders/223 Victor Stinner
+x86_64-unknown-freebsd           BSD libc, clang             https://buildbot.python.org/all/#/builders/172 Victor Stinner
+armv7l-unknown-linux-gnueabihf   Raspberry Pi OS, glibc, gcc https://buildbot.python.org/all/#/builders/424 Gregory P. Smith
+================================ =========================== ============================================== ========
 
 
 All other platforms


### PR DESCRIPTION
PEP 11 refers to the platform as ``powerpcle-unknown-linux-gnu`` but
build system and ABI use ``powerpc64le`` instead of ``powerpcle``.

```
sysconfig[HOST_GNU_TYPE]: powerpc64le-unknown-linux-gnu
sysconfig[MACHDEP]: linux
sysconfig[MULTIARCH]: powerpc64le-linux-gnu
sysconfig[SOABI]: cpython-312d-powerpc64le-linux-gnu
```

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
