### PR TITLE
PEP 257: Use `sys.maxsize`

### DIFF
--- a/pep-0257.txt
+++ b/pep-0257.txt
@@ -224,14 +224,14 @@ of the algorithm::
         # and split into a list of lines:
         lines = docstring.expandtabs().splitlines()
         # Determine minimum indentation (first line doesn't count):
-        indent = sys.maxint
+        indent = sys.maxsize
         for line in lines[1:]:
             stripped = line.lstrip()
             if stripped:
                 indent = min(indent, len(line) - len(stripped))
         # Remove indentation (first line is special):
         trimmed = [lines[0].strip()]
-        if indent < sys.maxint:
+        if indent < sys.maxsize:
             for line in lines[1:]:
                 trimmed.append(line[indent:].rstrip())
         # Strip off trailing and leading blank lines:


### PR DESCRIPTION
In python3, sys.maxint changed to sys.maxsize.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
