### PR TITLE
Infra: more concise table headers

### DIFF
--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -88,8 +88,8 @@ class PEPZeroWriter:
         self.emit_newline()
         self.emit_text("   * - ")
         self.emit_text("     - PEP")
-        self.emit_text("     - PEP Title")
-        self.emit_text("     - PEP Author(s)")
+        self.emit_text("     - Title")
+        self.emit_text("     - Authors")
 
     def emit_title(self, text: str, *, symbol: str = "=") -> None:
         self.output.append(text)


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

"Author(s)" is a bit ugly, for a table heading we CAN just put "Authors" or "Author".

Also it should be clear that the title is the _PEP_ title, and the authors are the _PEP_ authors, in a list of PEPs on the PEP index page on https://peps.python.org/ :)

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/172682471-dc8cc1e0-2d3e-459b-8c80-0b4be4b79df6.png">

# Before


<img width="735" alt="image" src="https://user-images.githubusercontent.com/1324225/172682586-c51e1e57-ce12-4be0-99e8-eb8d0e3de29f.png">

# After

<img width="810" alt="image" src="https://user-images.githubusercontent.com/1324225/172682536-a3f24141-d8bb-4e5e-92fe-aad890d07570.png">
