### PR TITLE
PEP 520: Fix citation references

### DIFF
--- a/pep-0520.txt
+++ b/pep-0520.txt
@@ -419,6 +419,8 @@ References
 * `Follow-up 2
   <https://mail.python.org/pipermail/python-dev/2015-May/140137.html>`__
 
+* `Follow-up 3
+  <https://mail.python.org/pipermail/python-dev/2016-June/144883.html>`__
 
 Copyright
 ===========

--- a/pep-0520.txt
+++ b/pep-0520.txt
@@ -419,7 +419,7 @@ References
 * `Follow-up 2
   <https://mail.python.org/pipermail/python-dev/2015-May/140137.html>`__
 
-* `Follow-up 3
+* `Nick Coghlan's concerns about mutability
   <https://mail.python.org/pipermail/python-dev/2016-June/144883.html>`__
 
 Copyright

--- a/pep-0520.txt
+++ b/pep-0520.txt
@@ -413,9 +413,6 @@ References
 .. [impl] issue #24254
    (https://bugs.python.org/issue24254)
 
-.. [nick_concern] Nick's concerns about mutability
-   (https://mail.python.org/pipermail/python-dev/2016-June/144883.html)
-
 .. [orig] original discussion
    (https://mail.python.org/pipermail/python-ideas/2013-February/019690.html)
 

--- a/pep-0520.txt
+++ b/pep-0520.txt
@@ -410,14 +410,14 @@ discovery is almost entirely an implementation detail.
 References
 ==========
 
-* Original discussion
-   (https://mail.python.org/pipermail/python-ideas/2013-February/019690.html)
+* `Original discussion
+  <https://mail.python.org/pipermail/python-ideas/2013-February/019690.html>`__
 
-* Follow-up 1
-   (https://mail.python.org/pipermail/python-dev/2013-June/127103.html)
+* `Follow-up 1
+  <https://mail.python.org/pipermail/python-dev/2013-June/127103.html>`__
 
-* Follow-up 2
-   (https://mail.python.org/pipermail/python-dev/2015-May/140137.html)
+* `Follow-up 2
+  <https://mail.python.org/pipermail/python-dev/2015-May/140137.html>`__
 
 
 Copyright

--- a/pep-0520.txt
+++ b/pep-0520.txt
@@ -344,8 +344,8 @@ be minimal.  All conforming implementations are expected to set
 Implementation
 ==============
 
-The implementation is found in the tracker. [impl_]
-
+The implementation is found in the
+`tracker <https://github.com/python/cpython/issues/68442>`__.
 
 Alternatives
 ============
@@ -409,9 +409,6 @@ discovery is almost entirely an implementation detail.
 
 References
 ==========
-
-.. [impl] issue #24254
-   (https://bugs.python.org/issue24254)
 
 * Original discussion
    (https://mail.python.org/pipermail/python-ideas/2013-February/019690.html)

--- a/pep-0520.txt
+++ b/pep-0520.txt
@@ -413,13 +413,13 @@ References
 .. [impl] issue #24254
    (https://bugs.python.org/issue24254)
 
-.. [orig] original discussion
+* Original discussion
    (https://mail.python.org/pipermail/python-ideas/2013-February/019690.html)
 
-.. [followup1] follow-up 1
+* Follow-up 1
    (https://mail.python.org/pipermail/python-dev/2013-June/127103.html)
 
-.. [followup2] follow-up 2
+* Follow-up 2
    (https://mail.python.org/pipermail/python-dev/2015-May/140137.html)
 
 


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

```
peps/pep-0520.txt:416: WARNING: Citation [nick_concern] is not referenced.
```

The [nick_concern_] reference source was deleted in a9ed29c (#35).

Let's delete this orhpan to fix a Sphinx warning.

---

```
peps/pep-0520.txt:419: WARNING: Citation [orig] is not referenced.
peps/pep-0520.txt:422: WARNING: Citation [followup1] is not referenced.
peps/pep-0520.txt:425: WARNING: Citation [followup2] is not referenced.
```

These were added in the very first commit (https://github.com/python/peps/commit/9a5e309b5da79d9749369a63911b1db2ae042b9d) and were orphans from the start.

Let's convert them into a bullet list.

---

The final reference (to the implementation on BPO) doesn't cause a warning, but let's switch it into a direct hyperlink to GH (re: https://github.com/python/peps/issues/2130).
