### PR TITLE
PEP 484: Fix citation references

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -2489,14 +2489,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -46,7 +46,7 @@ Essentially, such a type checker acts as a very powerful linter.
 a similar checker at run time for Design By Contract enforcement or
 JIT optimization, those tools are not yet as mature.)
 
-The proposal is strongly inspired by mypy [mypy]_.  For example, the
+The proposal is strongly inspired by `mypy <mypy_>`_.  For example, the
 type "sequence of integers" can be written as ``Sequence[int]``.  The
 square brackets mean that no new syntax needs to be added to the
 language.  The example here uses a custom type ``Sequence``, imported
@@ -2457,6 +2457,9 @@ order: Stefan Behnel, William Edwards, Greg Ewing, Larry Hastings,
 Anders Hejlsberg, Alok Menghrajani, Travis E. Oliphant, Joe Pamer,
 Raoul-Gabriel Urma, and Julien Verlaguet.
 
+
+.. _mypy:
+   http://mypy-lang.org
 
 .. _gvr-artima:
    https://www.artima.com/weblogs/viewpost.jsp?thread=85551

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -2460,9 +2460,6 @@ Raoul-Gabriel Urma, and Julien Verlaguet.
 References
 ==========
 
-.. [mypy]
-   http://mypy-lang.org
-
 .. [gvr-artima]
    http://www.artima.com/weblogs/viewpost.jsp?thread=85551
 

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -68,8 +68,8 @@ Rationale and Goals
 
 :pep:`3107` added support for arbitrary annotations on parts of a
 function definition.  Although no meaning was assigned to annotations
-then, there has always been an implicit goal to use them for type
-hinting [gvr-artima]_, which is listed as the first possible use case
+then, there has always been an `implicit goal to use them for type
+hinting <gvr-artima_>`_, which is listed as the first possible use case
 in said PEP.
 
 This PEP aims to provide a standard syntax for type annotations,
@@ -760,8 +760,8 @@ to the list, which would violate the variable's type in the caller.
 It turns out such an argument acts *contravariantly*, whereas the
 intuitive answer (which is correct in case the function doesn't mutate
 its argument!) requires the argument to act *covariantly*.  A longer
-introduction to these concepts can be found on Wikipedia
-[wiki-variance]_ and in :pep:`483`; here we just show how to control
+introduction to these concepts can be found on `Wikipedia
+<wiki-variance_>`_ and in :pep:`483`; here we just show how to control
 a type checker's behavior.
 
 By default generic types are considered *invariant* in all type variables,
@@ -1660,7 +1660,7 @@ Additional notes on stub files:
   exported.  (This makes it easier to re-export all objects from a
   given module that may vary by Python version.)
 
-* Just like in normal Python files [importdocs]_, submodules
+* Just like in `normal Python files <importdocs_>`_, submodules
   automatically become exported attributes of their parent module
   when imported. For example, if the ``spam`` package has the
   following directory structure::
@@ -1861,8 +1861,8 @@ enabled by including a file named ``py.typed`` in the package.)
 The Typeshed Repo
 -----------------
 
-There is a shared repository where useful stubs are being collected
-[typeshed]_.  Policies regarding the stubs collected here will be
+There is a `shared repository <typeshed_>`_ where useful stubs are being
+collected.  Policies regarding the stubs collected here will be
 decided separately and reported in the repo's documentation.
 Note that stubs for a given package will not be included here
 if the package owners have specifically requested that they be omitted.
@@ -2365,8 +2365,9 @@ evaluation.  There are several things wrong with this idea, however.
   is unheard of in English, and in other languages (e.g. C++) it is
   used as a scoping operator, which is a very different beast.  In
   contrast, the single colon for type hints reads naturally -- and no
-  wonder, since it was carefully designed for this purpose (the idea
-  long predates :pep:`3107` [gvr-artima]_).  It is also used in the same
+  wonder, since it was carefully designed for this purpose
+  (`the idea <gvr-artima_>`_
+  long predates :pep:`3107`).  It is also used in the same
   fashion in other languages from Pascal to Swift.
 
 * What would you do for return type annotations?
@@ -2397,8 +2398,8 @@ evaluation.  There are several things wrong with this idea, however.
 Other forms of new syntax
 -------------------------
 
-A few other forms of alternative syntax have been proposed, e.g. the
-introduction of a ``where`` keyword [roberge]_, and Cobra-inspired
+A few other forms of alternative syntax have been proposed, e.g. `the
+introduction <roberge_>`_ of a ``where`` keyword, and Cobra-inspired
 ``requires`` clauses.  But these all share a problem with the double
 colon: they won't work for earlier versions of Python 3.  The same
 would apply to a new ``__future__`` import.
@@ -2433,12 +2434,12 @@ problem would that solve?  It would just be procrastination.
 PEP Development Process
 =======================
 
-A live draft for this PEP lives on GitHub [github]_.  There is also an
-issue tracker [issues]_, where much of the technical discussion takes
+A live draft for this PEP lives on `GitHub <github_>`_.  There is also an
+`issue tracker <issues_>`_, where much of the technical discussion takes
 place.
 
 The draft on GitHub is updated regularly in small increments.  The
-official PEPS repo [peps]_ is (usually) only updated when a new draft
+`official PEPS repo <peps_>`_ is (usually) only updated when a new draft
 is posted to python-dev.
 
 
@@ -2457,31 +2458,28 @@ Anders Hejlsberg, Alok Menghrajani, Travis E. Oliphant, Joe Pamer,
 Raoul-Gabriel Urma, and Julien Verlaguet.
 
 
-References
-==========
+.. _gvr-artima:
+   https://www.artima.com/weblogs/viewpost.jsp?thread=85551
 
-.. [gvr-artima]
-   http://www.artima.com/weblogs/viewpost.jsp?thread=85551
+.. _wiki-variance:
+   https://en.wikipedia.org/wiki/Covariance_and_contravariance_%28computer_science%29
 
-.. [wiki-variance]
-   http://en.wikipedia.org/wiki/Covariance_and_contravariance_%28computer_science%29
+.. _typeshed:
+   https://github.com/python/typeshed
 
-.. [typeshed]
-   https://github.com/python/typeshed/
+.. _roberge:
+   https://aroberge.blogspot.com/2015/01/type-hinting-in-python-focus-on.html
 
-.. [roberge]
-   http://aroberge.blogspot.com/2015/01/type-hinting-in-python-focus-on.html
-
-.. [github]
+.. _github:
    https://github.com/python/typing
 
-.. [issues]
+.. _issues:
    https://github.com/python/typing/issues
 
-.. [peps]
+.. _peps:
    https://hg.python.org/peps/file/tip/pep-0484.txt
 
-.. [importdocs]
+.. _importdocs:
    https://docs.python.org/3/reference/import.html#submodules
 
 

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -2438,7 +2438,7 @@ issue tracker [issues]_, where much of the technical discussion takes
 place.
 
 The draft on GitHub is updated regularly in small increments.  The
-official PEPS repo [peps_] is (usually) only updated when a new draft
+official PEPS repo [peps]_ is (usually) only updated when a new draft
 is posted to python-dev.
 
 

--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -2469,12 +2469,6 @@ References
 .. [typeshed]
    https://github.com/python/typeshed/
 
-.. [pyflakes]
-   https://github.com/pyflakes/pyflakes/
-
-.. [pylint]
-   http://www.pylint.org
-
 .. [roberge]
    http://aroberge.blogspot.com/2015/01/type-hinting-in-python-focus-on.html
 


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fix some Sphinx build warnings.

(for readability, paths trimmed in warnings shown here)

---

```
pep-0484.txt:2490: WARNING: Citation [peps] is not referenced.
```

This was a misplaced underscore, now fixed.

---


```
pep-0484.txt:2463: WARNING: duplicate citation mypy, other instance in pep-0482.txt
```

The exact same citation is already defined in `pep-482.txt`, Sphinx uses that one.

---

```
pep-0484.txt:2475: WARNING: duplicate citation pyflakes, other instance in pep-0482.txt
pep-0484.txt:2478: WARNING: duplicate citation pylint, other instance in pep-0482.txt
```

These aren't actually used in this file, we can delete them.

---

Also remove the redundant emacs metadata from the end of the file.
