### PR TITLE
PEP 553: Fix citation references

### DIFF
--- a/pep-0553.rst
+++ b/pep-0553.rst
@@ -285,14 +285,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0553.rst
+++ b/pep-0553.rst
@@ -280,9 +280,6 @@ References
 .. [impl]
    https://github.com/python/cpython/pull/3355
 
-.. [envar]
-   https://mail.python.org/pipermail/python-dev/2017-September/149447.html
-
 
 Copyright
 =========


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

The section that once referred to the `envar` citation was deleted in bede39a536b5afe42fdc3bec63b6c83fa9db3957, so let's remove the orphan citation to fix this warning:

```
pep-0553.rst:283: WARNING: Citation [envar] is not referenced.
```

Let's also remove redundant emacs metadata from the end of the file.