### PR TITLE
PEP 609: Rename to Python Packaging Authority (PyPA) Governance

### DIFF
--- a/pep-0609.rst
+++ b/pep-0609.rst
@@ -1,5 +1,5 @@
 PEP: 609
-Title: PyPA Governance
+Title: Python Packaging Authority (PyPA) Governance
 Version: $Revision$
 Last-Modified: $Date$
 Author: Dustin Ingram <di@python.org>,


### PR DESCRIPTION
This makes it clearer what the acronym stands for, by presenting the
full form in addition to the acronym.
