### PR TITLE
PEP 11: Switch to a list table

### DIFF
--- a/pep-0011.txt
+++ b/pep-0011.txt
@@ -99,16 +99,41 @@ Tier 2
   reverted within 24 hours**.
 - Failures on these platforms **block a release**.
 
-============================= ========================== ========
-Target Triple                 Notes                      Contacts
-============================= ========================== ========
-aarch64-apple-darwin          clang                      Ned Deily, Ronald Oussoren, Dong-hee Na
-aarch64-unknown-linux-gnu     glibc, gcc                 Petr Viktorin, Victor Stinner
+.. list-table::
+   :header-rows: 1
+   :widths: auto
 
-                              glibc, clang               Victor Stinner, Gregory P. Smith
-powerpc64le-unknown-linux-gnu glibc, gcc                 Petr Viktorin, Victor Stinner
-x86_64-unknown-linux-gnu      glibc, clang               Victor Stinner, Gregory P. Smith
-============================= ========================== ========
+   * - Target Triple
+     - Details
+     - Buildbot
+     - Contacts
+
+   * - aarch64-apple-darwin
+     - clang
+     - `725 <https://buildbot.python.org/all/#/builders/725>`__
+     - * Ned Deily
+       * Ronald Oussoren
+       * Dong-hee Na
+   * - aarch64-unknown-linux-gnu
+     - glibc, gcc
+     - `125 <https://buildbot.python.org/all/#/builders/125>`__
+     - * Petr Viktorin
+       * Victor Stinner
+   * - aarch64-unknown-linux-gnu
+     - glibc, clang
+     - `234 <https://buildbot.python.org/all/#/builders/234>`__
+     - * Victor Stinner
+       * Gregory P. Smith
+   * - powerpc64le-unknown-linux-gnu
+     - glibc, gcc
+     - `90 <https://buildbot.python.org/all/#/builders/90>`__
+     - * Petr Viktorin
+       * Victor Stinner
+   * - x86_64-unknown-linux-gnu
+     - glibc, clang
+     - `441 <https://buildbot.python.org/all/#/builders/441>`__
+     - * Victor Stinner
+       * Gregory P. Smith
 
 
 Tier 3
@@ -120,15 +145,35 @@ Tier 3
 - No response SLA to failures.
 - Failures on these platforms do **not** block a release.
 
-================================ =========================== ========
-Target Triple                    Notes                       Contacts
-================================ =========================== ========
-aarch64-pc-windows-msvc                                      Steve Dower
-powerpc64le-unknown-linux-gnu    glibc, clang                Victor Stinner
-s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
-x86_64-unknown-freebsd           BSD libc, clang             Victor Stinner
-armv7l-unknown-linux-gnueabihf   Raspberry Pi OS, glibc, gcc Gregory P. Smith
-================================ =========================== ========
+.. list-table::
+   :header-rows: 1
+   :widths: auto
+
+   * - Target Triple
+     - Details
+     - Buildbot
+     - Contacts
+
+   * - aarch64-pc-windows-msvc
+     - ---
+     - `729 <https://buildbot.python.org/all/#/builders/729>`__
+     - Steve Dower
+   * - powerpc64le-unknown-linux-gnu
+     - glibc, clang
+     - `435 <https://buildbot.python.org/all/#/builders/435>`__
+     - Victor Stinner
+   * - s390x-unknown-linux-gnu
+     - glibc, gcc
+     - `223 <https://buildbot.python.org/all/#/builders/223>`__
+     - Victor Stinner
+   * - x86_64-unknown-freebsd
+     - BSD libc, clang
+     - `172 <https://buildbot.python.org/all/#/builders/172>`__
+     - Victor Stinner
+   * - armv7l-unknown-linux-gnueabihf
+     - Raspberry Pi OS, glibc, gcc
+     - `424 <https://buildbot.python.org/all/#/builders/424>`__
+     - Gregory P. Smith
 
 
 All other platforms


### PR DESCRIPTION
@brettcannon, here is a proposal for different source formatting for PEP-11 tables. I find it better, but feel free to close if you disagree.

The normal ReST table format is confusing if the lines are long and wrapped, like when they included handy links to individual buildbots. (I was surprised when they got removed in a8a7bd5a8a23481b10c6b4d227d4a507572ba119, without a PR...)
The list-table directive makes tables from nested lists, which is friendly for reviewers on smaller screens if lines get long again, and it also makes nicer diffs when column sizes need to change.

One disadvantage is that list-table doesn't support "rowspan", so the `aarch64-unknown-linux-gnu` triplet is repeated.
On the other hand, buildbot links can be added back, and there's no soft limit to more Contacts.
