### PR TITLE
PEP 554: Fix citation references

### DIFF
--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -565,7 +565,7 @@ each with different goals.  Most center on correctness and usability.
 
 One class of concurrency models focuses on isolated threads of
 execution that interoperate through some message passing scheme.  A
-notable example is `Communicating Sequential Processes`_ (CSP) (upon
+notable example is Communicating Sequential Processes [CSP]_ (upon
 which Go's concurrency is roughly based).  The isolation inherent to
 subinterpreters makes them well-suited to this approach.
 
@@ -1639,8 +1639,6 @@ References
 
 .. [c-api]
    https://docs.python.org/3/c-api/init.html#sub-interpreter-support
-
-.. _Communicating Sequential Processes:
 
 .. [CSP]
    https://en.wikipedia.org/wiki/Communicating_sequential_processes

--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -1672,18 +1672,11 @@ References
 .. [global-atexit]
    https://bugs.python.org/issue6531
 
-.. [mp-conn]
-   https://docs.python.org/3/library/multiprocessing.html#connection-objects
-
 .. [bug-rate]
    https://mail.python.org/pipermail/python-ideas/2017-September/047094.html
 
 .. [benefits]
    https://mail.python.org/pipermail/python-ideas/2017-September/047122.html
-
-.. [main-thread]
-   https://mail.python.org/pipermail/python-ideas/2017-September/047144.html
-   https://mail.python.org/pipermail/python-dev/2017-September/149566.html
 
 .. [reset_globals]
    https://mail.python.org/pipermail/python-dev/2017-September/149545.html
@@ -1710,6 +1703,12 @@ References
 .. _extension-docs:
    https://docs.python.org/3/extending/index.html
 
+* mp-conn
+    https://docs.python.org/3/library/multiprocessing.html#connection-objects
+
+* main-thread
+    https://mail.python.org/pipermail/python-ideas/2017-September/047144.html
+    https://mail.python.org/pipermail/python-dev/2017-September/149566.html
 
 Copyright
 =========

--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -519,7 +519,7 @@ Introducing an API for a new concurrency model, like happened with
 asyncio, is an extremely large project that requires a lot of careful
 consideration.  It is not something that can be done a simply as this
 PEP proposes and likely deserves significant time on PyPI to mature.
-(See `Nathaniel's post <nathaniel-asyncio>`_ on python-dev.)
+(See `Nathaniel's post <nathaniel-asyncio_>`_ on python-dev.)
 
 However, this PEP does not propose any new concurrency API.  At most
 it exposes minimal tools (e.g. subinterpreters, channels) which may
@@ -1706,7 +1706,7 @@ References
 .. [cache-line-ping-pong]
    https://mail.python.org/archives/list/python-dev@python.org/message/3HVRFWHDMWPNR367GXBILZ4JJAUQ2STZ/
 
-.. [nathaniel-asyncio]
+.. _nathaniel-asyncio:
    https://mail.python.org/archives/list/python-dev@python.org/message/TUEAZNZHVJGGLL4OFD32OW6JJDKM6FAS/
 
 .. [extension-docs]

--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -1014,7 +1014,7 @@ the following:
 
 A separate page will be added to the docs for resources to help
 extension maintainers ensure their modules can be used safely in
-subinterpreters, under `Extending Python <extension-docs>`_.  The page
+subinterpreters, under `Extending Python <extension-docs_>`_.  The page
 will include the following information:
 
 * a summary about subinterpreters (similar to the same in the new
@@ -1707,7 +1707,7 @@ References
 .. _nathaniel-asyncio:
    https://mail.python.org/archives/list/python-dev@python.org/message/TUEAZNZHVJGGLL4OFD32OW6JJDKM6FAS/
 
-.. [extension-docs]
+.. _extension-docs:
    https://docs.python.org/3/extending/index.html
 
 


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->


```
pep-0554.rst:1709: WARNING: Citation [nathaniel-asyncio] is not referenced.
pep-0554.rst:1712: WARNING: Citation [extension-docs] is not referenced.
```

Fixed by converting to inline links.

---

```
pep-0554.rst:1645: WARNING: Citation [CSP] is not referenced.
```

This citation was added in https://github.com/python/peps/pull/419.

The text uses:
```rst
`Communicating Sequential Processes`_ (CSP)
```

and:

```rst
.. _Communicating Sequential Processes:

.. [CSP]
   https://en.wikipedia.org/wiki/Communicating_sequential_processes
   https://github.com/futurecore/python-csp
```

So let's change this to a single citation:

```rst
Communicating Sequential Processes [CSP]_
```

and:

```rst
.. [CSP]
   https://en.wikipedia.org/wiki/Communicating_sequential_processes
   https://github.com/futurecore/python-csp
```


---

```
pep-0554.rst:1677: WARNING: Citation [mp-conn] is not referenced.
```


This citation was added in https://github.com/python/peps/pull/424, but removed/orphaned in https://github.com/python/peps/pull/1390.

Let's remove the orphan.

---

```
pep-0554.rst:1686: WARNING: Citation [main-thread] is not referenced.
```


Similarly, added in https://github.com/python/peps/pull/426 and removed/orphaned in https://github.com/python/peps/pull/944.
