### PR TITLE
PEP 693: Python 3.12 Release Schedule

### DIFF
--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -1,7 +1,5 @@
 PEP: 693
 Title: Python 3.12 Release Schedule
-Version: $Revision$
-Last-Modified: $Date$
 Author: Thomas Wouters <thomas@python.org>
 Status: Draft
 Type: Informational
@@ -19,7 +17,7 @@ items.
 
 .. Small features may be added up to the first beta
    release.  Bugs may be fixed until the final release,
-   which is planned for end of October 2023.
+   which is planned for October 2023.
 
 
 Release Manager and Crew
@@ -70,7 +68,7 @@ Subsequent bugfix releases every two months.
 -------------
 
 3.12 will receive bugfix updates approximately every 2 months for
-approximately 18 months.  Some time after the release of 3.12.0 final,
+approximately 18 months.  Some time after the release of 3.13.0 final,
 the ninth and final 3.12 bugfix update will be released.  After that,
 it is expected that security updates (source only) will be released
 until 5 years after the release of 3.12.0 final, so until approximately
@@ -91,11 +89,3 @@ Copyright
 This document has been placed in the public domain.
 
 
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 72
-  coding: utf-8
-  End:

--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -86,6 +86,7 @@ Some of the notable features of Python 3.12 include:
 Copyright
 =========
 
-This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.
+This document is placed in the public domain or under the CC0-1.0-Universal
+license, whichever is more permissive.
 
 

--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -1,0 +1,101 @@
+PEP: 693
+Title: Python 3.12 Release Schedule
+Version: $Revision$
+Last-Modified: $Date$
+Author: Thomas Wouters <thomas@python.org>
+Status: Draft
+Type: Informational
+Content-Type: text/x-rst
+Created: 24-May-2022
+Python-Version: 3.12
+
+
+Abstract
+========
+
+This document describes the development and release schedule for
+Python 3.12.  The schedule primarily concerns itself with PEP-sized
+items.
+
+.. Small features may be added up to the first beta
+   release.  Bugs may be fixed until the final release,
+   which is planned for end of October 2023.
+
+
+Release Manager and Crew
+========================
+
+- 3.12 Release Manager: Thomas Wouters
+- Windows installers: Steve Dower
+- Mac installers: Ned Deily
+- Documentation: Julien Palard
+
+
+Release Schedule
+================
+
+3.12.0 schedule
+---------------
+
+Note: the dates below use a 17-month development period that results
+in a 12-month release cadence between major versions, as defined by
+:pep:`602`.
+
+Actual:
+
+- 3.12 development begins: Monday, 2022-05-08
+
+Expected:
+
+- 3.12.0 alpha 1: Monday, 2022-10-03
+- 3.12.0 alpha 2: Monday, 2022-11-07
+- 3.12.0 alpha 3: Monday, 2022-12-05
+- 3.12.0 alpha 4: Monday, 2023-01-09
+- 3.12.0 alpha 5: Monday, 2023-02-06
+- 3.12.0 alpha 6: Monday, 2023-03-06
+- 3.12.0 alpha 7: Monday, 2023-04-03
+- 3.12.0 beta 1: Monday, 2023-05-08
+  (No new features beyond this point.)
+- 3.12.0 beta 2: Monday, 2023-05-29
+- 3.12.0 beta 3: Monday, 2023-06-19
+- 3.12.0 beta 4: Monday, 2023-07-10
+- 3.12.0 candidate 1: Monday, 2023-07-31
+- 3.12.0 candidate 2: Monday, 2023-09-04
+- 3.12.0 final:  Monday, 2023-10-02
+
+Subsequent bugfix releases every two months.
+
+
+3.12 Lifespan
+-------------
+
+3.12 will receive bugfix updates approximately every 2 months for
+approximately 18 months.  Some time after the release of 3.12.0 final,
+the ninth and final 3.12 bugfix update will be released.  After that,
+it is expected that security updates (source only) will be released
+until 5 years after the release of 3.12.0 final, so until approximately
+October 2028.
+
+
+Features for 3.12
+=================
+
+Some of the notable features of Python 3.12 include:
+
+ ** TBD **
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+..
+  Local Variables:
+  mode: indented-text
+  indent-tabs-mode: nil
+  sentence-end-double-space: t
+  fill-column: 72
+  coding: utf-8
+  End:

--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -86,6 +86,6 @@ Some of the notable features of Python 3.12 include:
 Copyright
 =========
 
-This document has been placed in the public domain.
+This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.
 
 


### PR DESCRIPTION
Add the tentative release schedule PEP for Python 3.12.