### PR TITLE
PEP 619, 664: Fix release date in comment

### DIFF
--- a/pep-0619.rst
+++ b/pep-0619.rst
@@ -19,7 +19,7 @@ items.
 
 .. Small features may be added up to the first beta
    release.  Bugs may be fixed until the final release,
-   which is planned for end of October 2021.
+   which is planned for October 2021.
 
 Release Manager and Crew
 ========================

--- a/pep-0664.rst
+++ b/pep-0664.rst
@@ -19,7 +19,7 @@ items.
 
 .. Small features may be added up to the first beta
    release.  Bugs may be fixed until the final release,
-   which is planned for end of October 2021.
+   which is planned for October 2022.
 
 Release Manager and Crew
 ========================
@@ -53,7 +53,7 @@ Actual:
 - 3.11.0 beta 1: Sunday, 2022-05-08
   (No new features beyond this point.)
 - 3.11.0 beta 2: Tuesday, 2022-05-31
-- 3.11.0 beta 3: Wesnesday, 2022-06-01
+- 3.11.0 beta 3: Wednesday, 2022-06-01
 
 Expected:
 


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

* 3.10 was planned for the _start_ of October 2021.
* 3.11 is planned for the _start_ of October _2022_.

For both, I think we can just say October [YYYY].
