### PR TITLE
PEP 632: Remove `Topic: Packaging` header

### DIFF
--- a/pep-0632.rst
+++ b/pep-0632.rst
@@ -4,7 +4,6 @@ Author: Steve Dower <steve.dower@python.org>
 Discussions-To: https://discuss.python.org/t/pep-632-deprecate-distutils-module/5134
 Status: Accepted
 Type: Standards Track
-Topic: Packaging
 Content-Type: text/x-rst
 Created: 03-Sep-2020
 Python-Version: 3.10


### PR DESCRIPTION
This removes the header, as requested by the author in https://github.com/python/peps/pull/2636#discussion_r898173875.

