### PR TITLE
Multiple PEPs: Move Packaging PEPs to Standards Track and mark as Final

### DIFF
--- a/pep-0440.txt
+++ b/pep-0440.txt
@@ -6,9 +6,9 @@ Author: Nick Coghlan <ncoghlan@gmail.com>,
         Donald Stufft <donald@stufft.io>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
 Discussions-To: distutils-sig@python.org
-Status: Active
+Status: Final
 Topic: Packaging
-Type: Informational
+Type: Standards Track
 Content-Type: text/x-rst
 Created: 18-Mar-2013
 Post-History: 30-Mar-2013, 27-May-2013, 20-Jun-2013,

--- a/pep-0503.txt
+++ b/pep-0503.txt
@@ -5,8 +5,8 @@ Last-Modified: $Date$
 Author: Donald Stufft <donald@stufft.io>
 BDFL-Delegate: Donald Stufft <donald@stufft.io>
 Discussions-To: distutils-sig@python.org
-Status: Accepted
-Type: Informational
+Status: Final
+Type: Standards Track
 Topic: Packaging
 Content-Type: text/x-rst
 Created: 04-Sep-2015

--- a/pep-0508.txt
+++ b/pep-0508.txt
@@ -5,8 +5,8 @@ Last-Modified: $Date$
 Author: Robert Collins <rbtcollins@hp.com>
 BDFL-Delegate: Donald Stufft <donald@stufft.io>
 Discussions-To: distutils-sig@python.org
-Status: Active
-Type: Informational
+Status: Final
+Type: Standards Track
 Topic: Packaging
 Content-Type: text/x-rst
 Created: 11-Nov-2015

--- a/pep-0600.rst
+++ b/pep-0600.rst
@@ -7,8 +7,8 @@ Author: Nathaniel J. Smith <njs@pobox.com>,
 Sponsor: Paul Moore <p.f.moore@gmail.com>
 BDFL-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/the-next-manylinux-specification/1043
-Status: Accepted
-Type: Informational
+Status: Final
+Type: Standards Track
 Topic: Packaging
 Content-Type: text/x-rst
 Created: 03-May-2019

--- a/pep-0627.rst
+++ b/pep-0627.rst
@@ -3,8 +3,8 @@ Title: Recording installed projects
 Author: Petr Viktorin <encukou@gmail.com>
 BDFL-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-627/4126
-Status: Accepted
-Type: Informational
+Status: Final
+Type: Standards Track
 Topic: Packaging
 Content-Type: text/x-rst
 Created: 15-Jul-2020

--- a/pep-0656.rst
+++ b/pep-0656.rst
@@ -4,8 +4,8 @@ Author: Tzu-ping Chung <uranusjr@gmail.com>
 Sponsor: Brett Cannon <brett@python.org>
 PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/7165
-Status: Accepted
-Type: Informational
+Status: Final
+Type: Standards Track
 Topic: Packaging
 Content-Type: text/x-rst
 Created: 17-Mar-2021


### PR DESCRIPTION
These all introduce or update existing Python Packaging Specifications,
and should follow the PyPA Specification processes. These are expected
to be Standards Track PEPs and are not informational.

This change also ensures that they get listed under the correct section
on the Packaging topic index.

See https://discuss.python.org/t/splitting-out-the-packaging-peps-on-the-pep-site/14111/33?u=pradyunsg for details and motivation.