### PR TITLE
PEP 615: Fix incorrect RFC link

### DIFF
--- a/pep-0615.rst
+++ b/pep-0615.rst
@@ -55,7 +55,7 @@ time zone database (also called the "tz" database or the Olson database
 distributed — it is present by default on many Unix-like operating systems.
 Great care goes into the stability of the database: there are IETF RFCs both
 for the maintenance procedures (:rfc:`6557`) and for the compiled
-binary (TZif) format (:rfc:`8636`).  As such, it is likely that adding
+binary (TZif) format (:rfc:`8536`).  As such, it is likely that adding
 support for the compiled outputs of the IANA database will add great value to
 end users even with the relatively long cadence of standard library releases.
 


### PR DESCRIPTION
PEP 615 "Support for the IANA Time Zone Database in the Standard Library" contains the following text:

> there are IETF RFCs both for the maintenance procedures ([RFC 6557](https://datatracker.ietf.org/doc/html/rfc6557.html)) and for the compiled binary (TZif) format ([RFC 8636](https://datatracker.ietf.org/doc/html/rfc8636.html))

The second RFC is titled "Public Key Cryptography for Initial Authentication in Kerberos (PKINIT) Algorithm Agility", so I don't think it's what was intended. The author likely intended to include [RFC 8**5**36](https://datatracker.ietf.org/doc/html/rfc8536.html), titled "The Time Zone Information Format (TZif)". This PR fixes the link so it points to the correct RFC.