### PR TITLE
PEP 660: Mark as Final

### DIFF
--- a/pep-0660.rst
+++ b/pep-0660.rst
@@ -3,7 +3,7 @@ Title: Editable installs for pyproject.toml based builds (wheel based)
 Author: Daniel Holth <dholth@gmail.com>, Stéphane Bidoul <stephane.bidoul@gmail.com>
 Sponsor: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/draft-pep-editable-installs-for-pep-517-style-build-backends/8510
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Packaging
 Content-Type: text/x-rst


### PR DESCRIPTION
This PEP has been implemented across multiple tools now.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

This is motivated by trimming the list of “may not be implemented yet” PEPs on the Packaging subindex up to date / relevant.