### PR TITLE
PEP 650: Withdraw and move to Standards Track

### DIFF
--- a/pep-0650.rst
+++ b/pep-0650.rst
@@ -4,8 +4,8 @@ Author: Vikram Jayanthi <vikramjayanthi@google.com>,
         Dustin Ingram <di@python.org>,
         Brett Cannon <brett@python.org>
 Discussions-To: https://discuss.python.org/t/pep-650-specifying-installer-requirements-for-python-projects/6657
-Status: Draft
-Type: Process
+Status: Withdrawn
+Type: Standards Track
 Topic: Packaging
 Content-Type: text/x-rst
 Created: 16-Jul-2020


### PR DESCRIPTION
The discussion and interest in this PEP has died down.

Moving to Standards Track in line with the packaging specification process.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

This should probably wait for approval from at least one of the authors.