### PR TITLE
PEP 282: Improve upon colloquial phrasing

### DIFF
--- a/pep-0282.txt
+++ b/pep-0282.txt
@@ -133,9 +133,9 @@ Logger names fit into a "dotted name" namespace, with dots
 (periods) indicating sub-namespaces.  The namespace of logger
 objects therefore corresponds to a single tree data structure.
 
-* "" is the root of the namespace
-* "Zope" would be a child node of the root
-* "Zope.ZODB" would be a child node of "Zope"
+* ``""`` is the root of the namespace
+* ``"Zope"`` would be a child node of the root
+* ``"Zope.ZODB"`` would be a child node of ``"Zope"``
 
 These Logger objects create **LogRecord** objects which are passed
 to **Handler** objects for output.  Both Loggers and Handlers may

--- a/pep-0282.txt
+++ b/pep-0282.txt
@@ -64,7 +64,7 @@ Simple Example
 This shows a very simple example of how the logging package can be
 used to generate simple logging output on stderr.
 
-::
+.. code-block:: python
 
     --------- mymodule.py -------------------------------
     import logging
@@ -75,6 +75,8 @@ used to generate simple logging output on stderr.
             #do stuff...
             raise TypeError, "Bogus type error for testing"
     -----------------------------------------------------
+
+.. code-block:: python 
 
     --------- myapp.py ----------------------------------
     import mymodule, logging
@@ -91,7 +93,9 @@ used to generate simple logging output on stderr.
     log.info("Ending my app")
     -----------------------------------------------------
 
-    % python myapp.py
+.. code-block:: console 
+
+    $ python myapp.py
 
     INFO:MyApp: Starting my app
     DEBUG:MyModule: Doin' stuff...
@@ -107,7 +111,9 @@ used to generate simple logging output on stderr.
 
 The above example shows the default output format.  All
 aspects of the output format should be configurable, so that
-you could have output formatted like this::
+you could have output formatted like this:
+
+.. code-block:: text 
 
     2002-04-19 07:56:58,174 MyModule   DEBUG - Doin' stuff...
 
@@ -127,11 +133,9 @@ Logger names fit into a "dotted name" namespace, with dots
 (periods) indicating sub-namespaces.  The namespace of logger
 objects therefore corresponds to a single tree data structure.
 
-::
-
-   "" is the root of the namespace
-   "Zope" would be a child node of the root
-   "Zope.ZODB" would be a child node of "Zope"
+* "" is the root of the namespace
+* "Zope" would be a child node of the root
+* "Zope.ZODB" would be a child node of "Zope"
 
 These Logger objects create **LogRecord** objects which are passed
 to **Handler** objects for output.  Both Loggers and Handlers may
@@ -170,13 +174,13 @@ This is done through a module-level function::
 Levels
 ======
 
-The logging levels, in increasing order of importance, are::
+The logging levels, in increasing order of importance, are:
 
-    DEBUG
-    INFO
-    WARN
-    ERROR
-    CRITICAL
+* DEBUG
+* INFO
+* WARN
+* ERROR
+* CRITICAL
 
 The term CRITICAL is used in preference to FATAL, which is used by
 log4j.  The levels are conceptually the same - that of a serious,

--- a/pep-0282.txt
+++ b/pep-0282.txt
@@ -71,7 +71,7 @@ used to generate simple logging output on stderr.
     log = logging.getLogger("MyModule")
 
     def doIt():
-            log.debug("Doing stuff...")
+            log.debug("Doin' stuff...")
             #do stuff...
             raise TypeError, "Bogus type error for testing"
     -----------------------------------------------------
@@ -94,7 +94,7 @@ used to generate simple logging output on stderr.
     % python myapp.py
 
     INFO:MyApp: Starting my app
-    DEBUG:MyModule: Doing stuff...
+    DEBUG:MyModule: Doin' stuff...
     ERROR:MyApp: There was a problem.
     Traceback (most recent call last):
             File "myapp.py", line 9, in ?
@@ -109,11 +109,11 @@ The above example shows the default output format.  All
 aspects of the output format should be configurable, so that
 you could have output formatted like this::
 
-    2002-04-19 07:56:58,174 MyModule   DEBUG - Doing stuff...
+    2002-04-19 07:56:58,174 MyModule   DEBUG - Doin' stuff...
 
     or just
 
-    Doing stuff...
+    Doin' stuff...
 
 
 Control Flow

--- a/pep-0282.txt
+++ b/pep-0282.txt
@@ -71,7 +71,7 @@ used to generate simple logging output on stderr.
     log = logging.getLogger("MyModule")
 
     def doIt():
-            log.debug("Doin' stuff...")
+            log.debug("Doing stuff...")
             #do stuff...
             raise TypeError, "Bogus type error for testing"
     -----------------------------------------------------
@@ -94,7 +94,7 @@ used to generate simple logging output on stderr.
     % python myapp.py
 
     INFO:MyApp: Starting my app
-    DEBUG:MyModule: Doin' stuff...
+    DEBUG:MyModule: Doing stuff...
     ERROR:MyApp: There was a problem.
     Traceback (most recent call last):
             File "myapp.py", line 9, in ?
@@ -109,11 +109,11 @@ The above example shows the default output format.  All
 aspects of the output format should be configurable, so that
 you could have output formatted like this::
 
-    2002-04-19 07:56:58,174 MyModule   DEBUG - Doin' stuff...
+    2002-04-19 07:56:58,174 MyModule   DEBUG - Doing stuff...
 
     or just
 
-    Doin' stuff...
+    Doing stuff...
 
 
 Control Flow


### PR DESCRIPTION
Syntax highligting interprets ' as start of a string and colors the following text differently.
Also this change makes the text fragment better readable for non-English native speakers.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
