### PR TITLE
PEP 621: Fixed pyproject.toml example for authors

### DIFF
--- a/pep-0621.rst
+++ b/pep-0621.rst
@@ -466,8 +466,7 @@ Example
   license = {file = "LICENSE.txt"}
   keywords = ["egg", "bacon", "sausage", "tomatoes", "Lobster Thermidor"]
   authors = [
-    {email = "hi@pradyunsg.me"},
-    {name = "Tzu-Ping Chung"}
+    {name = "Tzu-Ping Chung" email = "hi@pradyunsg.me"}
   ]
   maintainers = [
     {name = "Brett Cannon", email = "brett@python.org"}


### PR DESCRIPTION
Hello there :wave: 

Following up on #2680, after recently switching setup.cfg and setup.py to a full pyproject.toml, I had to check some documentation. I found an inconsistency in the pyproject.toml example for "authors".

This PR fixes that!

Any feedback is welcome!
