### PR TITLE
PEP 483: AnyStr reference and numbered list change

### DIFF
--- a/pep-0483.txt
+++ b/pep-0483.txt
@@ -180,11 +180,11 @@ is a subtype of the type of ``a_variable``", which states one of the
 fundamentals of OO programming.) The is-consistent-with relationship is
 defined by three rules:
 
--  A type ``t1`` is consistent with a type ``t2`` if ``t1`` is a
+1.  A type ``t1`` is consistent with a type ``t2`` if ``t1`` is a
    subtype of ``t2``. (But not the other way around.)
--  ``Any`` is consistent with every type. (But ``Any`` is not a subtype
+2.  ``Any`` is consistent with every type. (But ``Any`` is not a subtype
    of every type.)
--  Every type is consistent with ``Any``. (But every type is not a subtype
+3.  Every type is consistent with ``Any``. (But every type is not a subtype
    of ``Any``.)
 
 That's all! See Jeremy Siek's blog post `What is Gradual
@@ -441,9 +441,9 @@ replaced by the most-derived base class among ``t1``, etc. Examples:
 
 - Function type annotation with a constrained type variable::
 
-    S = TypeVar('S', str, bytes)
+    AnyStr = TypeVar('AnyStr', str, bytes)
 
-    def longest(first: S, second: S) -> S:
+    def longest(first: AnyStr, second: AnyStr) -> AnyStr:
         return first if len(first) >= len(second) else second
 
     result = longest('a', 'abc')  # The inferred type for result is str


### PR DESCRIPTION
1) Docs reference AnyStr, though it is not clear what AnyStr is.

>  The inferred type of result is MyStr (whereas in the AnyStr example it would be str)  ...

I assume it is a reference to the upper example.
Changed the S into AnyStr in that example.

<br>
2) Docs define the rules in a non-numbered format 

> The is-consistent-with relationship is defined by three rules:
> 
> - A type t1 is consistent with a type t2 if t1 is a subtype of t2. (But not the other way around.)
> - Any is consistent with every type. (But Any is not a subtype of every type.)
> - Every type is consistent with Any. (But every type is not a subtype of Any.)

Then docs reference the rules by numbers down in the text.
> Now it’s okay to assign a Manager instance to worker (rule 1):
> Now it’s okay to assign something to worker (rule 2):
> Of course it’s also okay to assign worker to something (rule 3),

Added  numbers for ease of reading.