### PR TITLE
Infra: Fix canonical link tag to point to correct PEP URL

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/colour_scheme.js
+++ b/pep_sphinx_extensions/pep_theme/static/colour_scheme.js
@@ -1,3 +1,7 @@
+// Handle setting and changing the site's color scheme (light/dark)
+
+"use strict";
+
 const prefersDark = window.matchMedia("(prefers-color-scheme: dark)")
 
 const getColourScheme = () => document.documentElement.dataset.colour_scheme

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -1,4 +1,5 @@
 @charset "UTF-8";
+
 /* Styles for PEPs */
 
 /*
@@ -274,7 +275,7 @@ ul.breadcrumbs a {
     width: 1.2rem;
     height: 1.2rem;
     float: right;
-    translate: 0 50%;
+    transform: translate(0, 50%);
 }
 #colour-scheme-cycler svg {
     color: var(--colour-rule-strong);
@@ -367,7 +368,7 @@ dl.footnote > dd {
   padding: 0 !important;
   margin: -1px !important;
   overflow: hidden !important;
-  clip: rect(0,0,0,0) !important;
+  clip-path: polygon(0px 0px, 0px 0px,0px 0px, 0px 0px) !important;
   white-space: nowrap !important;
   border: 0 !important;
 }

--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -7,7 +7,7 @@
     <meta name="color-scheme" content="light dark" />
     <title>{{ title + " | peps.python.org"|safe }}</title>
     <link rel="shortcut icon" href="{{ pathto('_static/py.png', resource=True) }}"/>
-    <link rel="canonical" href="{{ pageurl|escape }}" />
+    <link rel="canonical" href="https://peps.python.org/{{ pagename }}/" />
     <link rel="stylesheet" href="{{ pathto('_static/style.css', resource=True) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/mq.css', resource=True) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', resource=True) }}" type="text/css" media="(prefers-color-scheme: light)" id="pyg-light" />

--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -2,19 +2,19 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="color-scheme" content="light dark" />
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light dark">
     <title>{{ title + " | peps.python.org"|safe }}</title>
-    <link rel="shortcut icon" href="{{ pathto('_static/py.png', resource=True) }}"/>
-    <link rel="canonical" href="https://peps.python.org/{{ pagename }}/" />
-    <link rel="stylesheet" href="{{ pathto('_static/style.css', resource=True) }}" type="text/css" />
-    <link rel="stylesheet" href="{{ pathto('_static/mq.css', resource=True) }}" type="text/css" />
-    <link rel="stylesheet" href="{{ pathto('_static/pygments.css', resource=True) }}" type="text/css" media="(prefers-color-scheme: light)" id="pyg-light" />
-    <link rel="stylesheet" href="{{ pathto('_static/pygments_dark.css', resource=True) }}" type="text/css" media="(prefers-color-scheme: dark)" id="pyg-dark" />
+    <link rel="shortcut icon" href="{{ pathto('_static/py.png', resource=True) }}">
+    <link rel="canonical" href="https://peps.python.org/{{ pagename }}/">
+    <link rel="stylesheet" href="{{ pathto('_static/style.css', resource=True) }}" type="text/css">
+    <link rel="stylesheet" href="{{ pathto('_static/mq.css', resource=True) }}" type="text/css">
+    <link rel="stylesheet" href="{{ pathto('_static/pygments.css', resource=True) }}" type="text/css" media="(prefers-color-scheme: light)" id="pyg-light">
+    <link rel="stylesheet" href="{{ pathto('_static/pygments_dark.css', resource=True) }}" type="text/css" media="(prefers-color-scheme: dark)" id="pyg-dark">
     <link rel="alternate" type="application/rss+xml" title="Latest PEPs" href="https://www.python.org/dev/peps/peps.rss">
     <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <meta name="description" content="Python Enhancement Proposals (PEPs)"/>
+    <meta name="description" content="Python Enhancement Proposals (PEPs)">
 </head>
 <body>
     {% include "partials/icons.html" %}
@@ -43,7 +43,7 @@
         <nav id="pep-sidebar">
             <h2>Contents</h2>
             {{ toc }}
-            <br />
+            <br>
             {%- if not sourcename.startswith("pep-0000") %}
             <a id="source" href="https://github.com/python/peps/blob/main/{{sourcename}}">Page Source (GitHub)</a>
             {%- endif %}


### PR DESCRIPTION
This fixes the issue with the link rel canonical tag pointing to the wrong path. It was apparently using the undocumented `pageurl` template variable; this correctly constructs the path to the canonical dirhtml URL (and will also work to point to the canonical page even on local builds, PR previews and other people's deploys, so it can be accurately tested to point to the real page and these non-canonical copies don't get picked up independently in search results).

Also, I took the opportunity to clean up a few other minor HTML, CSS and JS validation issues:

* Conformed the self-closing tags and inconsistent whitespace from the HTML template, the former of which [superfluous and not recommended in HTML5](https://stackoverflow.com/questions/3558119/are-non-void-self-closing-tags-valid-in-html5)
* Replaced the [deprecated `clip` property](https://developer.mozilla.org/en-US/docs/Web/CSS/clip) with the modern replacement [`clip-path`](https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path), which is [well supported](https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path#browser_compatibility) among all the modern browsers which support the other features used in the CSS and JS.
* Use the much [better-supported](https://caniuse.com/?search=transform) [`transform` property](https://developer.mozilla.org/en-US/docs/Web/CSS/transform) with `translate()` rather than the equivalent but [very poorly supported](https://caniuse.com/?search=translate) [`translate` property](https://developer.mozilla.org/en-US/docs/Web/CSS/translate).
* Add a missing strict mode declaration to the color scheme JS

Fixes #2599 