### PR TITLE
Infra: Link topic index pages in rendered PEP topic headers

### DIFF
--- a/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
@@ -98,6 +98,15 @@ class PEPHeaders(transforms.Transform):
                     target = self.document.settings.pep_url.format(int(pep_str))
                     new_body += [nodes.reference("", pep_str, refuri=target), nodes.Text(", ")]
                 para[:] = new_body[:-1]  # drop trailing space
+            elif name == "topic":
+                new_body = []
+                for topic_name in body.astext().split(","):
+                    if topic_name:
+                        target = f"/topic/{topic_name.lower().strip()}"
+                        new_body += [
+                            nodes.reference("", topic_name, refuri=target),
+                            nodes.Text(", "),
+                        ]
             elif name in {"last-modified", "content-type", "version"}:
                 # Mark unneeded fields
                 fields_to_remove.append(field)

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
@@ -102,11 +102,13 @@ class PEPHeaders(transforms.Transform):
                 new_body = []
                 for topic_name in body.astext().split(","):
                     if topic_name:
-                        target = f"/topic/{topic_name.lower().strip()}"
+                        target = f"/topic/{topic_name.lower().strip()}/"
                         new_body += [
                             nodes.reference("", topic_name, refuri=target),
                             nodes.Text(", "),
                         ]
+                if new_body:
+                    para[:] = new_body[:-1]  # Drop trailing space/comma
             elif name in {"last-modified", "content-type", "version"}:
                 # Mark unneeded fields
                 fields_to_remove.append(field)


### PR DESCRIPTION
This makes the topic(s) listed in the Topic header in the rendered PEPs into actual links to the index page of the specified topic(s), which is very useful.

Fixes #2688 