### PR TITLE
Style: Fix colors and style for all admonitions

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -34,15 +34,15 @@
     --colour-background: var(--light, white) var(--dark, #011);
     --colour-background-accent: var(--light, #ccc) var(--dark, #333);
     --colour-text: var(--light, #333) var(--dark, #ccc);
-    --colour-links: var(--light, #0072aa) var(--dark, #8bf);
+    --colour-links: var(--light, #069) var(--dark, #8bf);
     --colour-scrollbar: var(--light, #ccc) var(--dark, #333);
     --colour-rule-strong: var(--light, #888) var(--dark, #777);
     --colour-rule-light: var(--light, #ddd) var(--dark, #222);
     --colour-inline-code: var(--light, #f8f8f8) var(--dark, #333);
-    --colour-error: var(--light, #faa) var(--dark, #800);
-    --colour-warning: var(--light, #fca) var(--dark, #840);
+    --colour-error: var(--light, #fcc) var(--dark, #800);
+    --colour-warning: var(--light, #fdb) var(--dark, #804000);
     --colour-caution: var(--light, #ffa) var(--dark, #440);
-    --colour-attention: var(--light, #bcf) var(--dark, #034);
+    --colour-attention: var(--light, #bdf) var(--dark, #034);
     --colour-tip: var(--light, #bfc) var(--dark, #031);
 }
 

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -35,15 +35,16 @@
     --colour-background-accent: var(--light, #ccc) var(--dark, #333);
     --colour-text: var(--light, #333) var(--dark, #ccc);
     --colour-links: var(--light, #069) var(--dark, #8bf);
+    --colour-links-light: var(--light, #057) var(--dark, #acf);
     --colour-scrollbar: var(--light, #ccc) var(--dark, #333);
     --colour-rule-strong: var(--light, #888) var(--dark, #777);
     --colour-rule-light: var(--light, #ddd) var(--dark, #222);
     --colour-inline-code: var(--light, #f8f8f8) var(--dark, #333);
-    --colour-error: var(--light, #fcc) var(--dark, #800);
-    --colour-warning: var(--light, #fdb) var(--dark, #804000);
-    --colour-caution: var(--light, #ffa) var(--dark, #440);
-    --colour-attention: var(--light, #bdf) var(--dark, #034);
-    --colour-tip: var(--light, #bfc) var(--dark, #031);
+    --colour-error: var(--light, #faa) var(--dark, #800);
+    --colour-warning: var(--light, #fca) var(--dark, #840);
+    --colour-caution: var(--light, #ffa) var(--dark, #550);
+    --colour-attention: var(--light, #bdf) var(--dark, #045);
+    --colour-tip: var(--light, #bfc) var(--dark, #041);
 }
 
 img.invert-in-dark-mode {
@@ -296,6 +297,9 @@ div.admonition {
     margin-bottom: 1rem;
     margin-top: 1rem;
     padding: 0.5rem 0.75rem;
+}
+div.admonition a {
+    color: var(--colour-links-light);
 }
 
 div.danger,

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -287,14 +287,12 @@ ul.breadcrumbs a {
 :root[data-colour_scheme="light"] #colour-scheme-cycler svg.colour-scheme-icon-when-light {display: initial}
 
 /* Admonitions rules */
-div.note,
-div.warning {
-    padding: 0.5rem 0.75rem;
-    margin-top: 1rem;
-    margin-bottom: 1rem;
-}
-div.note {
+div.admonition {
     background-color: var(--colour-background-accent);
+    margin-bottom: 1rem;
+    margin-top: 1rem;
+    padding: 0.5rem 0.75rem;
+}
 }
 div.warning {
     background-color: var(--colour-warning);

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -32,14 +32,18 @@
 /* Set master colours */
 :root {
     --colour-background: var(--light, white) var(--dark, #011);
-    --colour-background-accent: var(--light, #eee) var(--dark, #333);
+    --colour-background-accent: var(--light, #ccc) var(--dark, #333);
     --colour-text: var(--light, #333) var(--dark, #ccc);
     --colour-links: var(--light, #0072aa) var(--dark, #8bf);
     --colour-scrollbar: var(--light, #ccc) var(--dark, #333);
     --colour-rule-strong: var(--light, #888) var(--dark, #777);
     --colour-rule-light: var(--light, #ddd) var(--dark, #222);
     --colour-inline-code: var(--light, #f8f8f8) var(--dark, #333);
-    --colour-warning: var(--light, #fee) var(--dark, #900);
+    --colour-error: var(--light, #faa) var(--dark, #800);
+    --colour-warning: var(--light, #fca) var(--dark, #840);
+    --colour-caution: var(--light, #ffa) var(--dark, #440);
+    --colour-attention: var(--light, #bcf) var(--dark, #034);
+    --colour-tip: var(--light, #bfc) var(--dark, #031);
 }
 
 img.invert-in-dark-mode {
@@ -293,10 +297,26 @@ div.admonition {
     margin-top: 1rem;
     padding: 0.5rem 0.75rem;
 }
+
+div.danger,
+div.error {
+    background-color: var(--colour-error);
 }
 div.warning {
     background-color: var(--colour-warning);
 }
+div.caution {
+    background-color: var(--colour-caution);
+}
+div.attention,
+div.important {
+    background-color: var(--colour-attention);
+}
+div.hint,
+div.tip {
+    background-color: var(--colour-tip);
+}
+
 p.admonition-title {
     font-weight: bold;
 }


### PR DESCRIPTION
Since the basic admonition admonition styles are just applied to a couple individual admonitions, rather than admonitions in general, those other than "warning" and "note" won't display as admonitions at all. In addition to fixing that, this PR adds appropriate, standard colors for each of the additional admonition types in both light and dark mode.

Discovered in and required by #2690 .

![image](https://user-images.githubusercontent.com/17051931/176793447-e1486d4e-d5e6-40d3-82ef-564f01f3213e.png)

<details>

<summary>Slightly outdated screenshots also showing status quo</summary>

![image](https://user-images.githubusercontent.com/17051931/176374062-a7af464e-2137-493c-8cc3-51519c3d394f.png)

![image](https://user-images.githubusercontent.com/17051931/176373791-0014d6f8-9bb7-4ae9-adb9-fb840839e69d.png)

</details>
