### PR TITLE
PEP 427: Do not escape period in package names

### DIFF
--- a/pep-0427.txt
+++ b/pep-0427.txt
@@ -167,7 +167,8 @@ Escaping and Unicode
 ''''''''''''''''''''
 
 Each component of the filename is escaped by replacing runs of
-non-alphanumeric characters with an underscore ``_``::
+non-alphanumeric characters minus the period character with an underscore
+``_``::
 
     re.sub("[^\w\d.]+", "_", distribution, re.UNICODE)
 


### PR DESCRIPTION
The suggested code and the text contradicated each other, after
discussing this seems the code example was the correct intent and is
what setuptools is doing.

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>


More discussion at https://discuss.python.org/t/amending-pep-427-and-pep-625-on-package-normalization-rules/17226/2