### PR TITLE
PEP 625: Package name normalization via PEP 427

### DIFF
--- a/pep-0625.rst
+++ b/pep-0625.rst
@@ -76,7 +76,8 @@ Specification
 The name of an sdist should be ``{distribution}-{version}.sdist``.
 
 * ``distribution`` is the name of the distribution as defined in :pep:`345`,
-  and normalised according to :pep:`503`, e.g. ``'pip'``, ``'flit-core'``.
+  and normalised according to :pep:`427`, e.g. ``'pip'``, ``'flit_core'``,
+  ``'zope.sqlalchemy'``.
 * ``version`` is the version of the distribution as defined in :pep:`440`,
   e.g. ``20.2``.
 


### PR DESCRIPTION
This keeps sdist package names in sync with wheel files.

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>

More discussion at https://discuss.python.org/t/amending-pep-427-and-pep-625-on-package-normalization-rules/17226/2