### PR TITLE
PEP 501: Fix footnotes

### DIFF
--- a/pep-0501.txt
+++ b/pep-0501.txt
@@ -554,14 +554,14 @@ Acknowledgements
 References
 ==========
 
-* %-formatting
-  (https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting)
+* `%-formatting
+  <https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting>`_
 
-* str.format
-  (https://docs.python.org/3/library/string.html#formatstrings)
+* `str.format
+  <https://docs.python.org/3/library/string.html#formatstrings>`_
 
-* string.Template documentation
-  (https://docs.python.org/3/library/string.html#template-strings)
+* `string.Template documentation
+  <https://docs.python.org/3/library/string.html#template-strings>`_
 
 * :pep:`215`: String Interpolation
 
@@ -571,14 +571,14 @@ References
 
 * :pep:`498`: Literal string formatting
 
-* FormattableString and C# native string interpolation
-  (https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated)
+* `FormattableString and C# native string interpolation
+  <https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated>`_
 
-* IFormattable interface in C# (see remarks for globalization notes)
-  (https://docs.microsoft.com/en-us/dotnet/api/system.iformattable)
+* `IFormattable interface in C# (see remarks for globalization notes)
+  <https://docs.microsoft.com/en-us/dotnet/api/system.iformattable>`_
 
-* Running external commands in Julia
-  (https://docs.julialang.org/en/v1/manual/running-external-programs/)
+* `Running external commands in Julia
+  <https://docs.julialang.org/en/v1/manual/running-external-programs/>`_
 
 Copyright
 =========

--- a/pep-0501.txt
+++ b/pep-0501.txt
@@ -584,13 +584,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0501.txt
+++ b/pep-0501.txt
@@ -554,31 +554,31 @@ Acknowledgements
 References
 ==========
 
-.. [#] %-formatting
-       (https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting)
+* %-formatting
+  (https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting)
 
-.. [#] str.format
-       (https://docs.python.org/3/library/string.html#formatstrings)
+* str.format
+  (https://docs.python.org/3/library/string.html#formatstrings)
 
-.. [#] string.Template documentation
-       (https://docs.python.org/3/library/string.html#template-strings)
+* string.Template documentation
+  (https://docs.python.org/3/library/string.html#template-strings)
 
-.. [#] :pep:`215`: String Interpolation
+* :pep:`215`: String Interpolation
 
-.. [#] :pep:`292`: Simpler String Substitutions
+* :pep:`292`: Simpler String Substitutions
 
-.. [#] :pep:`3101`: Advanced String Formatting
+* :pep:`3101`: Advanced String Formatting
 
-.. [#] :pep:`498`: Literal string formatting
+* :pep:`498`: Literal string formatting
 
-.. [#] FormattableString and C# native string interpolation
-       (https://msdn.microsoft.com/en-us/library/dn961160.aspx)
+* FormattableString and C# native string interpolation
+  (https://msdn.microsoft.com/en-us/library/dn961160.aspx)
 
-.. [#] IFormattable interface in C# (see remarks for globalization notes)
-       (https://msdn.microsoft.com/en-us/library/system.iformattable.aspx)
+* IFormattable interface in C# (see remarks for globalization notes)
+  (https://msdn.microsoft.com/en-us/library/system.iformattable.aspx)
 
-.. [#] Running external commands in Julia
-       (http://julia.readthedocs.org/en/latest/manual/running-external-programs/)
+* Running external commands in Julia
+  (http://julia.readthedocs.org/en/latest/manual/running-external-programs/)
 
 Copyright
 =========

--- a/pep-0501.txt
+++ b/pep-0501.txt
@@ -572,13 +572,13 @@ References
 * :pep:`498`: Literal string formatting
 
 * FormattableString and C# native string interpolation
-  (https://msdn.microsoft.com/en-us/library/dn961160.aspx)
+  (https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated)
 
 * IFormattable interface in C# (see remarks for globalization notes)
-  (https://msdn.microsoft.com/en-us/library/system.iformattable.aspx)
+  (https://docs.microsoft.com/en-us/dotnet/api/system.iformattable)
 
 * Running external commands in Julia
-  (http://julia.readthedocs.org/en/latest/manual/running-external-programs/)
+  (https://docs.julialang.org/en/v1/manual/running-external-programs/)
 
 Copyright
 =========


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fix these warnings:

```
pep-0501.txt:557: WARNING: Footnote [#] is not referenced.
pep-0501.txt:560: WARNING: Footnote [#] is not referenced.
pep-0501.txt:563: WARNING: Footnote [#] is not referenced.
pep-0501.txt:566: WARNING: Footnote [#] is not referenced.
pep-0501.txt:568: WARNING: Footnote [#] is not referenced.
pep-0501.txt:570: WARNING: Footnote [#] is not referenced.
pep-0501.txt:572: WARNING: Footnote [#] is not referenced.
pep-0501.txt:574: WARNING: Footnote [#] is not referenced.
pep-0501.txt:577: WARNING: Footnote [#] is not referenced.
pep-0501.txt:580: WARNING: Footnote [#] is not referenced.
```

These aren't referenced in the body text so let's convert them to bullet points (like in https://github.com/python/peps/pull/2644 and others).

Plus update/fix some links and remove redundant emacs metadata.

# Preview

https://pep-previews--2715.org.readthedocs.build/pep-0501/
