### PR TITLE
PEP 11: add `wasm32-emscripten` and `wasm32-wasi` to tier 3

### DIFF
--- a/pep-0011.txt
+++ b/pep-0011.txt
@@ -124,10 +124,12 @@ Tier 3
 Target Triple                    Notes                       Contacts
 ================================ =========================== ========
 aarch64-pc-windows-msvc                                      Steve Dower
+armv7l-unknown-linux-gnueabihf   Raspberry Pi OS, glibc, gcc Gregory P. Smith
 powerpc64le-unknown-linux-gnu    glibc, clang                Victor Stinner
 s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
+wasm32-unknown-emscripten                                    Christian Heimes, Brett Cannon
+wasm32-unknown-wasi                                          Christian Heimes, Brett Cannon
 x86_64-unknown-freebsd           BSD libc, clang             Victor Stinner
-armv7l-unknown-linux-gnueabihf   Raspberry Pi OS, glibc, gcc Gregory P. Smith
 ================================ =========================== ========
 
 


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
