### PR TITLE
Infra: Test Python 3.11 beta

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python 3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 
       - name: Run pre-commit hooks
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -6,6 +6,10 @@ jobs:
   render-peps:
     name: Render PEPs
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.x", "3.11-dev"]
 
     steps:
       - name: 🛎️ Checkout
@@ -13,11 +17,11 @@ jobs:
         with:
           fetch-depth: 0  # fetch all history so that last modified date-times are accurate
 
-      - name: 🐍 Set up Python 3
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
-          cache: "pip"
+          python-version: ${{ matrix.python-version }}
+          cache: pip
 
       - name: 👷‍ Install dependencies
         run: |

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -37,7 +37,7 @@ jobs:
       - name: 🚀 Deploy to GitHub pages
         # This allows CI to build branches for testing
         if: (github.ref == 'refs/heads/main') && (matrix.python-version == '3.x')
-        uses: JamesIves/github-pages-deploy-action@v4.4.0
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: build # Synchronise with build.py -> build_directory
           single-commit: true # Delete existing files

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0  # fetch all history so that last modified date-times are accurate
 
       - name: 🐍 Set up Python 3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
           cache: "pip"
@@ -33,7 +33,7 @@ jobs:
       - name: 🚀 Deploy to GitHub pages
         # This allows CI to build branches for testing
         if: github.ref == 'refs/heads/main'
-        uses: JamesIves/github-pages-deploy-action@v4.2.2
+        uses: JamesIves/github-pages-deploy-action@v4.3.4
         with:
           branch: gh-pages # The branch to deploy to.
           folder: build # Synchronise with build.py -> build_directory

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -37,9 +37,8 @@ jobs:
       - name: 🚀 Deploy to GitHub pages
         # This allows CI to build branches for testing
         if: (github.ref == 'refs/heads/main') && (matrix.python-version == '3.x')
-        uses: JamesIves/github-pages-deploy-action@v4.3.4
+        uses: JamesIves/github-pages-deploy-action@v4.4.0
         with:
-          branch: gh-pages # The branch to deploy to.
           folder: build # Synchronise with build.py -> build_directory
           single-commit: true # Delete existing files
 

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0  # fetch all history so that last modified date-times are accurate
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: 🐍 Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -36,7 +36,7 @@ jobs:
 
       - name: 🚀 Deploy to GitHub pages
         # This allows CI to build branches for testing
-        if: github.ref == 'refs/heads/main'
+        if: (github.ref == 'refs/heads/main') && (matrix.python-version == '3.x')
         uses: JamesIves/github-pages-deploy-action@v4.3.4
         with:
           branch: gh-pages # The branch to deploy to.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11-dev"]
         os: [windows-latest, macos-latest, ubuntu-latest]
+        # lxml doesn't yet install for 3.11 on Windows
+        exclude:
+        - { python-version: "3.11-dev", os: windows-latest }
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+coverage.xml
 pep-0000.txt
 pep-0000.rst
 pep-????.html

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,11 @@ addopts = -r a --strict-config --strict-markers --import-mode=importlib --cov pe
 empty_parameter_set_mark = fail_at_collect
 filterwarnings =
     error
+    # Awaiting release of https://github.com/python-babel/babel/issues/873
+    # in Babel 2.11, due 2022-08-01 https://github.com/python-babel/babel/milestone/6?closed=1
+    ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning
+    # Awaiting https://github.com/sphinx-doc/sphinx/issues/10440
+    ignore:'imghdr' is deprecated and slated for removal in Python 3.13:DeprecationWarning
 minversion = 6.0
 testpaths = pep_sphinx_extensions
 xfail_strict = True


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->


Due to the recent delays in the 3.11 beta, it's very important to test it as widely as possible to help find issues before RC1.

https://discuss.python.org/t/the-cursed-release-of-python-3-11-0b4-is-now-available/17274?u=hugovk

---

Because we have test warnings turned into errors, temporarily ignore these in dependencies:

* Awaiting release of https://github.com/python-babel/babel/issues/873 in Babel 2.11, due 2022-08-01 https://github.com/python-babel/babel/milestone/6?closed=1
* Awaiting https://github.com/sphinx-doc/sphinx/issues/10440

Also skip testing 3.11 on Windows because lxml isn't yet available.