### PR TITLE
Infra: override RTD build commands

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -24,7 +24,7 @@ jobs:
           python -m pip install --upgrade pip
 
       - name: 🔧 Render PEPs
-        run: make pages -j$(nproc)
+        run: make pages JOBS=$(nproc)
 
         # remove the .doctrees folder when building for deployment as it takes two thirds of disk space
       - name: 🔥 Clean up files

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 PYTHON=python3
 VENVDIR=.venv
 JOBS=8
-RENDER_COMMAND=$(VENVDIR)/bin/python3 build.py -j $(JOBS)
+OUTPUT_DIR=build
+RENDER_COMMAND=$(VENVDIR)/bin/python3 build.py -j $(JOBS) -o $(OUTPUT_DIR)
 
 render: venv
 	$(RENDER_COMMAND)

--- a/build.py
+++ b/build.py
@@ -36,6 +36,12 @@ def create_parser():
     parser.add_argument("-j", "--jobs", type=int, default=1,
                         help="How many parallel jobs to run (if supported). "
                              "Integer, default 1.")
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        default="build",  # synchronise with render.yaml -> deploy step
+        help="Output directory, relative to root. Default 'build'.",
+    )
 
     return parser.parse_args()
 
@@ -57,7 +63,7 @@ if __name__ == "__main__":
 
     root_directory = Path(".").absolute()
     source_directory = root_directory
-    build_directory = root_directory / "build"  # synchronise with deploy-gh-pages.yaml -> deploy step
+    build_directory = root_directory / args.output_dir
     doctree_directory = build_directory / ".doctrees"
 
     # builder configuration

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,13 +1,12 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
-python:
-  install:
-    - requirements: requirements.txt
+  commands:
+    - make pages JOBS=$(nproc) OUTPUT_DIR=_readthedocs/html
 
 sphinx:
   builder: dirhtml


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

ReadTheDocs now has a beta feature to override the build commands:

* https://twitter.com/readthedocs/status/1549145303801946112
* https://docs.readthedocs.io/en/latest/build-customization.html#override-the-build-process

Right now, a whole bunch of dependencies are installed that we don't use.

This can be slow especially as some old dependencies are built from source because they don't support modern Python and don't have wheels available (e.g. https://github.com/readthedocs/readthedocs.org/issues/9118).

Instead, we can just `make pages` and only install the stuff we need.

This speeds up the build "command" time ~2.5 mins to ~2 mins (uploading following build takes ~100s in both cases).

---


# Before

<img width="818" alt="image" src="https://user-images.githubusercontent.com/1324225/180436072-6fda7cd7-71ed-4425-8466-a66af2d854d8.png">


Each build step took:

1. Command time: 2s
2. Command time: 0s
3. Command time: 0s
4. Command time: 0s
5. Command time: 1s
6. Command time: 9s
7. Command time: 33s
8. Command time: 4s
9. Command time: 0s
10. Command time: 98s

Total command time: 147s

Build took 241 seconds (includes upload time)

https://readthedocs.org/projects/pep-previews/builds/17496237/

# After

<img width="827" alt="image" src="https://user-images.githubusercontent.com/1324225/180436193-50450d98-018e-4d73-a34c-20bc59b77185.png">

1. Command time: 2s
2. Command time: 0s
3. Command time: 0s
4. Command time: 0s
5. Command time: 0s
6. Command time: 115s

Total command time: 117s

Build took 213 seconds (includes upload time)

https://readthedocs.org/projects/pep-previews/builds/17510658/

---

This also adds an option to `build.py` so we can output the build files directly in the `_readthedocs/html` required for RTD.

Also fix `render.yml`: call like `make pages JOBS=$(nproc)` instead of `make pages -j$(nproc)`.

