### PR TITLE
Infra: Table lines instead of zebra stripes

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -231,8 +231,8 @@ table {
 table caption {
     margin: 1rem 0 .75rem;
 }
-table tbody tr:nth-of-type(odd) {
-    background-color: var(--colour-background-accent);
+table tr {
+    border-bottom: 1px solid var(--colour-rule-strong);
 }
 table th,
 table td {


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

For consideration, styling can be adjusted.

@gvanrossum said:

> In PEP 11 I see a table that has very heavy shading of alternate rows. This makes it seem that those rows are more important than the others. Can we please not use this style? Certainly there's a way to get thin lines between rows instead of the alternate shading.

The results of [three user studies](https://alistapart.com/article/zebrastripingmoredataforthecase/) recommends using "zebra stripes", but if not, then a lined table:

> The results of the three studies conducted to date suggest that the safest option is to shade the alternating, individual rows of your table with a single color. Taking this approach is likely to ensure that:
> 
> * task performance is better, or at least no worse, than with other table styles, and
> * the aesthetic sensibilities and subjective preferences of the majority of your users are catered for.
> 
> If zebra striping of this type cannot be done easily, then ruling a line between each row may be the next best option.

And:

> Firstly, if, in your particular circumstance, the cost associated with implementing single-color, single-row zebra striping is acceptable—and I have been told of several cases where this is not the case—then this should be done. Otherwise, stick with a plain or lined design.

# Before

<table>
<tr>
	<td><img width="808" alt="image" src="https://user-images.githubusercontent.com/1324225/181000861-eb920db9-ee00-461e-a3a4-db9240c87cd0.png">
	<td><img width="813" alt="image" src="https://user-images.githubusercontent.com/1324225/181000925-f4c085ca-73dc-4c89-a062-b9f7d0c8c343.png">
</table>

https://peps.python.org/pep-0011/#tier-1

# After

<table>
<tr>
	<td><img width="807" alt="image" src="https://user-images.githubusercontent.com/1324225/181001439-1f4bcd17-cce6-46d0-a2ca-0d8797144bfe.png">
	<td><img width="802" alt="image" src="https://user-images.githubusercontent.com/1324225/181001397-751d7da2-5081-43c7-b8f6-2d1bdf6aad90.png">
</table>

https://pep-previews--2734.org.readthedocs.build/pep-0011/#tier-1
