### PR TITLE
PEP 634: Fix duplicate labels

### DIFF
--- a/pep-0634.rst
+++ b/pep-0634.rst
@@ -35,7 +35,7 @@ introduction to the concepts, syntax and semantics of patterns.
 Syntax and Semantics
 ====================
 
-See `Appendix A`_ for the complete grammar.
+See :ref:`Appendix A <634-appendix-a>` for the complete grammar.
 
 Overview and Terminology
 ------------------------
@@ -134,7 +134,7 @@ The precise pattern binding rules vary per pattern type and are
 specified below.
 
 
-.. _guards:
+.. _634-guards:
 
 Guards
 ^^^^^^
@@ -169,7 +169,7 @@ A match statement may have at most one irrefutable case block, and it
 must be last.
 
 
-.. _patterns:
+.. _634-patterns:
 
 Patterns
 --------
@@ -225,7 +225,7 @@ until one succeeds.  The OR pattern is then deemed to succeed.
 If none of the subpatterns succeed the OR pattern fails.
 
 
-.. _literal_pattern:
+.. _634-literal_pattern:
 
 Literal Patterns
 ^^^^^^^^^^^^^^^^
@@ -261,7 +261,7 @@ value expressed by the literal, using the following comparisons rules:
   using the ``is`` operator.
 
 
-.. _capture_pattern:
+.. _634-capture_pattern:
 
 Capture Patterns
 ^^^^^^^^^^^^^^^^
@@ -284,7 +284,7 @@ disallows for example ``case x, x: ...`` but allows ``case [x] | x:
 ...``.
 
 
-.. _wildcard_pattern:
+.. _634-wildcard_pattern:
 
 Wildcard Pattern
 ^^^^^^^^^^^^^^^^
@@ -331,7 +331,7 @@ A parenthesized pattern has no additional syntax.  It allows users to
 add parentheses around patterns to emphasize the intended grouping.
 
 
-.. _sequence_pattern:
+.. _634-sequence_pattern:
 
 Sequence Patterns
 ^^^^^^^^^^^^^^^^^
@@ -411,7 +411,7 @@ then matched to the corresponding subject items, as for a fixed-length
 sequence.
 
 
-.. _mapping_pattern:
+.. _634-mapping_pattern:
 
 Mapping Patterns
 ^^^^^^^^^^^^^^^^
@@ -466,7 +466,7 @@ with keys that were already present when the match statement was
 entered.
 
 
-.. _class_pattern:
+.. _634-class_pattern:
 
 Class Patterns
 ^^^^^^^^^^^^^^
@@ -592,7 +592,7 @@ existing standard library classes and adding ``__match_args__`` where
 it looks beneficial.
 
 
-.. _Appendix A:
+.. _634-appendix-a:
 
 Appendix A -- Full Grammar
 ==========================

--- a/pep-0634.rst
+++ b/pep-0634.rst
@@ -682,13 +682,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fix these warnings (like we did in https://github.com/python/peps/pull/2718):

```
pep-0634.rst:140: WARNING: duplicate label guards, other instance in pep-0622.rst
pep-0634.rst:175: WARNING: duplicate label patterns, other instance in pep-0622.rst
pep-0634.rst:231: WARNING: duplicate label literal_pattern, other instance in pep-0622.rst
pep-0634.rst:267: WARNING: duplicate label capture_pattern, other instance in pep-0622.rst
pep-0634.rst:290: WARNING: duplicate label wildcard_pattern, other instance in pep-0622.rst
pep-0634.rst:337: WARNING: duplicate label sequence_pattern, other instance in pep-0622.rst
pep-0634.rst:417: WARNING: duplicate label mapping_pattern, other instance in pep-0622.rst
pep-0634.rst:472: WARNING: duplicate label class_pattern, other instance in pep-0622.rst
pep-0634.rst:598: WARNING: duplicate label appendix a, other instance in pep-0622.rst
```

Sphinx treats labels as "global" in the whole docs scope, not at the level of individual documents. So let's use a unambiguous label prefixed with the PEP number, similar to [PEP 639](https://peps.python.org/pep-0639/) / https://raw.githubusercontent.com/python/peps/main/pep-0639.rst

We still get similar anchors like `#guards`:

* https://peps.python.org/pep-0634/#guards
* https://pep-previews--2735.org.readthedocs.build/pep-0634/#guards

---

Also remove redundant emacs metadata.

# Preview

https://pep-previews--2735.org.readthedocs.build/pep-0634/
