### PR TITLE
Fix issue 2737 - Missing Python-Version in PEP 613

### DIFF
--- a/pep-0613.rst
+++ b/pep-0613.rst
@@ -7,6 +7,7 @@ Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 21-Jan-2020
+Python-Version: 3.10
 Post-History: 21-Jan-2020
 
 


### PR DESCRIPTION
Fix issue 2737 - Missing Python-Version in [PEP 613](https://peps.python.org/pep-0613/).