### PR TITLE
Infra: Mute table zebra stripes to de-emphasise different rows

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -34,7 +34,7 @@
 :root {
     --colour-background: var(--light, white) var(--dark, #011);
     --colour-background-accent-strong: var(--light, #ccc) var(--dark, #333);
-    --colour-background-accent-light: var(--light, #eee) var(--dark, #222);
+    --colour-background-accent-light: var(--light, #ddd) var(--dark, #222);
     --colour-text: var(--light, #333) var(--dark, #ccc);
     --colour-links: var(--light, #069) var(--dark, #8bf);
     --colour-links-light: var(--light, #057) var(--dark, #acf);

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -33,7 +33,8 @@
 /* Set master colours */
 :root {
     --colour-background: var(--light, white) var(--dark, #011);
-    --colour-background-accent: var(--light, #ccc) var(--dark, #333);
+    --colour-background-accent-strong: var(--light, #ccc) var(--dark, #333);
+    --colour-background-accent-light: var(--light, #eee) var(--dark, #222);
     --colour-text: var(--light, #333) var(--dark, #ccc);
     --colour-links: var(--light, #069) var(--dark, #8bf);
     --colour-links-light: var(--light, #057) var(--dark, #acf);
@@ -116,7 +117,7 @@ a:visited {
     display: inline;
     overflow-wrap: break-word;
     overflow-wrap: anywhere;
-    text-decoration-color: var(--colour-background-accent);
+    text-decoration-color: var(--colour-background-accent-strong);
 }
 a:hover,
 a:focus {
@@ -225,14 +226,14 @@ div.table-wrapper {
 table {
     width: 100%;
     border-collapse: collapse;
-    border-top: 1px solid var(--colour-background-accent);
-    border-bottom: 1px solid var(--colour-background-accent);
+    border-top: 1px solid var(--colour-background-accent-light);
+    border-bottom: 1px solid var(--colour-background-accent-light);
 }
 table caption {
     margin: 1rem 0 .75rem;
 }
 table tbody tr:nth-of-type(odd) {
-    background-color: var(--colour-background-accent);
+    background-color: var(--colour-background-accent-light);
 }
 table th,
 table td {
@@ -294,7 +295,7 @@ ul.breadcrumbs a {
 
 /* Admonitions rules */
 div.admonition {
-    background-color: var(--colour-background-accent);
+    background-color: var(--colour-background-accent-strong);
     margin-bottom: 1rem;
     margin-top: 1rem;
     padding: 0.5rem 0.75rem;


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Alternative to and closes https://github.com/python/peps/pull/2734.

Mute the table "zebra stripes", so some rows don't look more important than others.

Re: https://github.com/python/peps/pull/2734#issuecomment-1197502489 - let's use a different CSS colour for this, so we don't affect the colour already tuned for admonitions.

# Before

<table>
<tr>
	<td><img width="808" alt="image" src="https://user-images.githubusercontent.com/1324225/181000861-eb920db9-ee00-461e-a3a4-db9240c87cd0.png">
	<td><img width="813" alt="image" src="https://user-images.githubusercontent.com/1324225/181000925-f4c085ca-73dc-4c89-a062-b9f7d0c8c343.png">
</table>


# After

<table>
<tr>
	<td>
<img width="810" alt="image" src="https://user-images.githubusercontent.com/1324225/181209972-710a75a7-5601-4399-a104-29013128ec61.png">
	<td>
<img width="807" alt="image" src="https://user-images.githubusercontent.com/1324225/181209918-d47bac24-4ac1-417a-8720-be1d9d88077c.png">
</table>


---

PS @CAM-Gerlach: you suggested `#111111` in https://github.com/python/peps/pull/2734#issuecomment-1197502489, I went with `#222222` in this PR because I think `#111111` looks a bit too muted:

<img width="401" alt="image" src="https://user-images.githubusercontent.com/1324225/181477835-7ac32989-e44a-468d-b755-47a4e46b13f2.png">

What do you think?
