### PR TITLE
PEP 565: Fix footnotes

### DIFF
--- a/pep-0565.rst
+++ b/pep-0565.rst
@@ -365,14 +365,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0565.rst
+++ b/pep-0565.rst
@@ -164,7 +164,7 @@ no changes are needed beyond those in this PEP.
 
 Interactive shell implementations which use a namespace other than
 ``__main__`` will need to add their own filter. For example, IPython uses the
-following command ([8_]) to set up a suitable filter::
+following command ([8]_) to set up a suitable filter::
 
     warnings.filterwarnings("default", category=DeprecationWarning,
                                        module=self.user_ns.get("__name__"))
@@ -215,8 +215,8 @@ of the related documentation.
 Reference Implementation
 ========================
 
-A reference implementation is available in the PR [4_] linked from the
-related tracker issue for this PEP [5_].
+A reference implementation is available in the PR [4]_ linked from the
+related tracker issue for this PEP [5]_.
 
 As a side-effect of implementing this PEP, the internal warnings filter list
 will start allowing the use of plain strings as part of filter definitions (in
@@ -229,7 +229,7 @@ early access to the ``re`` module.
 Motivation
 ==========
 
-As discussed in [1_] and mentioned in [2_], Python 2.7 and Python 3.2 changed
+As discussed in [1]_ and mentioned in [2]_, Python 2.7 and Python 3.2 changed
 the default handling of ``DeprecationWarning`` such that:
 
 * the warning was hidden by default during normal code execution
@@ -289,7 +289,7 @@ deprecation warnings. Most notably:
   variable.
 * The standard library doesn't provide a straightforward way to opt-in to seeing
   all warnings emitted *by* a particular dependency prior to upgrading it
-  (the third-party ``warn`` module [3_] does provide this, but enabling it
+  (the third-party ``warn`` module [3]_ does provide this, but enabling it
   involves monkeypatching the standard library's ``warnings`` module).
 * When software has been factored out into support modules, but those modules
   have little or no automated test coverage, re-enabling deprecation warnings
@@ -326,7 +326,7 @@ changes in 3.7:
   off by default in regular interpreter builds: https://bugs.python.org/issue32088
 
 Independently of the proposed changes to the default filters in this PEP,
-issue 32229 [9_] is a proposal to add a ``warnings.hide_warnings`` API to
+issue 32229 [9]_ is a proposal to add a ``warnings.hide_warnings`` API to
 make it simpler for application developers to hide warnings during normal
 operation, while easily making them visible when testing.
 

--- a/pep-0565.rst
+++ b/pep-0565.rst
@@ -349,17 +349,17 @@ References
 .. [5] Tracker issue for PEP 565 implementation
    (https://bugs.python.org/issue31975)
 
-.. [6] First python-dev discussion thread
-   (https://mail.python.org/pipermail/python-dev/2017-November/150477.html)
-
-.. [7] Second python-dev discussion thread
-   (https://mail.python.org/pipermail/python-dev/2017-November/150819.html)
-
 .. [8] IPython's DeprecationWarning auto-configuration
    (https://github.com/ipython/ipython/blob/6.2.x/IPython/core/interactiveshell.py#L619)
 
 .. [9] ``warnings.hide_warnings`` API proposal
    (https://bugs.python.org/issue32229)
+
+* First python-dev discussion thread
+   (https://mail.python.org/pipermail/python-dev/2017-November/150477.html)
+
+* Second python-dev discussion thread
+   (https://mail.python.org/pipermail/python-dev/2017-November/150819.html)
 
 Copyright
 =========

--- a/pep-0565.rst
+++ b/pep-0565.rst
@@ -164,7 +164,7 @@ no changes are needed beyond those in this PEP.
 
 Interactive shell implementations which use a namespace other than
 ``__main__`` will need to add their own filter. For example, IPython uses the
-following command ([8]_) to set up a suitable filter::
+following command ([6]_) to set up a suitable filter::
 
     warnings.filterwarnings("default", category=DeprecationWarning,
                                        module=self.user_ns.get("__name__"))
@@ -326,7 +326,7 @@ changes in 3.7:
   off by default in regular interpreter builds: https://bugs.python.org/issue32088
 
 Independently of the proposed changes to the default filters in this PEP,
-issue 32229 [9]_ is a proposal to add a ``warnings.hide_warnings`` API to
+issue 32229 [7]_ is a proposal to add a ``warnings.hide_warnings`` API to
 make it simpler for application developers to hide warnings during normal
 operation, while easily making them visible when testing.
 
@@ -349,10 +349,10 @@ References
 .. [5] Tracker issue for PEP 565 implementation
    (https://bugs.python.org/issue31975)
 
-.. [8] IPython's DeprecationWarning auto-configuration
+.. [6] IPython's DeprecationWarning auto-configuration
    (https://github.com/ipython/ipython/blob/6.2.x/IPython/core/interactiveshell.py#L619)
 
-.. [9] ``warnings.hide_warnings`` API proposal
+.. [7] ``warnings.hide_warnings`` API proposal
    (https://bugs.python.org/issue32229)
 
 * First python-dev discussion thread

--- a/pep-0565.rst
+++ b/pep-0565.rst
@@ -321,9 +321,9 @@ changes in 3.7:
 
 * a new ``-X dev`` command line option that combines several developer centric
   settings (including ``-Wd``) into one command line flag:
-  https://bugs.python.org/issue32043
+  https://github.com/python/cpython/issues/76224
 * changing the behaviour in debug builds to show more of the warnings that are
-  off by default in regular interpreter builds: https://bugs.python.org/issue32088
+  off by default in regular interpreter builds: https://github.com/python/cpython/issues/76269
 
 Independently of the proposed changes to the default filters in this PEP,
 issue 32229 [7]_ is a proposal to add a ``warnings.hide_warnings`` API to
@@ -347,13 +347,13 @@ References
    (https://github.com/python/cpython/pull/4458)
 
 .. [5] Tracker issue for PEP 565 implementation
-   (https://bugs.python.org/issue31975)
+   (https://github.com/python/cpython/issues/76156)
 
 .. [6] IPython's ``DeprecationWarning`` auto-configuration
    (https://github.com/ipython/ipython/blob/6.2.x/IPython/core/interactiveshell.py#L619)
 
 .. [7] ``warnings.hide_warnings`` API proposal
-   (https://bugs.python.org/issue32229)
+   (https://github.com/python/cpython/issues/76410)
 
 * First python-dev discussion thread
    (https://mail.python.org/pipermail/python-dev/2017-November/150477.html)

--- a/pep-0565.rst
+++ b/pep-0565.rst
@@ -355,11 +355,11 @@ References
 .. [7] ``warnings.hide_warnings`` API proposal
    (https://github.com/python/cpython/issues/76410)
 
-* First python-dev discussion thread
-   (https://mail.python.org/pipermail/python-dev/2017-November/150477.html)
+* `First python-dev discussion thread
+  <https://mail.python.org/pipermail/python-dev/2017-November/150477.html>`__
 
-* Second python-dev discussion thread
-   (https://mail.python.org/pipermail/python-dev/2017-November/150819.html)
+* `Second python-dev discussion thread
+  <https://mail.python.org/pipermail/python-dev/2017-November/150819.html>`__
 
 Copyright
 =========

--- a/pep-0565.rst
+++ b/pep-0565.rst
@@ -14,14 +14,14 @@ Abstract
 ========
 
 In Python 2.7 and Python 3.2, the default warning filters were updated to hide
-DeprecationWarning by default, such that deprecation warnings in development
+``DeprecationWarning`` by default, such that deprecation warnings in development
 tools that were themselves written in Python (e.g. linters, static analysers,
 test runners, code generators), as well as any other applications that merely
 happened to be written in Python, wouldn't be visible to their users unless
 those users explicitly opted in to seeing them.
 
 However, this change has had the unfortunate side effect of making
-DeprecationWarning markedly less effective at its primary intended purpose:
+``DeprecationWarning`` markedly less effective at its primary intended purpose:
 providing advance notice of breaking changes in APIs (whether in CPython, the
 standard library, or in third party libraries) to users of those APIs.
 
@@ -74,10 +74,10 @@ to be::
 
 This means that in cases where the nominal location of the warning (as
 determined by the ``stacklevel`` parameter to ``warnings.warn``) is in the
-``__main__`` module, the first occurrence of each DeprecationWarning will once
+``__main__`` module, the first occurrence of each ``DeprecationWarning`` will once
 again be reported.
 
-This change will lead to DeprecationWarning being displayed by default for:
+This change will lead to ``DeprecationWarning`` being displayed by default for:
 
 * code executed directly at the interactive prompt
 * code executed directly as part of a single-file script
@@ -274,7 +274,7 @@ Limitations on PEP Scope
 
 This PEP exists specifically to explain both the proposed addition to the
 default warnings filter for 3.7, *and* to more clearly articulate the rationale
-for the original change to the handling of DeprecationWarning back in Python 2.7
+for the original change to the handling of ``DeprecationWarning`` back in Python 2.7
 and 3.2.
 
 This PEP does not solve all known problems with the current approach to handling
@@ -349,7 +349,7 @@ References
 .. [5] Tracker issue for PEP 565 implementation
    (https://bugs.python.org/issue31975)
 
-.. [6] IPython's DeprecationWarning auto-configuration
+.. [6] IPython's ``DeprecationWarning`` auto-configuration
    (https://github.com/ipython/ipython/blob/6.2.x/IPython/core/interactiveshell.py#L619)
 
 .. [7] ``warnings.hide_warnings`` API proposal


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fix these warnings:

```
pep-0565.rst:337: WARNING: Footnote [1] is not referenced.
pep-0565.rst:340: WARNING: Footnote [2] is not referenced.
pep-0565.rst:343: WARNING: Footnote [3] is not referenced.
pep-0565.rst:346: WARNING: Footnote [4] is not referenced.
pep-0565.rst:349: WARNING: Footnote [5] is not referenced.
pep-0565.rst:352: WARNING: Footnote [6] is not referenced.
pep-0565.rst:355: WARNING: Footnote [7] is not referenced.
pep-0565.rst:358: WARNING: Footnote [8] is not referenced.
pep-0565.rst:361: WARNING: Footnote [9] is not referenced.
```

1-5 and 8-9 were of the format `[1_]` instead of `[1]_`.

6-7 are not referred to, so changed those to bullet points.

And then renumbered 8-9 to 6-7.

---

Also:

* Consistently format DeprecationWarning as `DeprecationWarning` to match the majority in this document
* Replace BPO links with GitHub
* Remove redundant emacs metadata


# Preview

https://pep-previews--2741.org.readthedocs.build/pep-0565/
