### PR TITLE
PEP 635: fix duplicate labels

### DIFF
--- a/pep-0635.rst
+++ b/pep-0635.rst
@@ -1278,13 +1278,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0635.rst
+++ b/pep-0635.rst
@@ -397,7 +397,7 @@ and not for individual patterns.
               return a + [p] + b
 
 
-.. _patterns:
+.. _635-patterns:
 
 Patterns
 --------
@@ -586,7 +586,7 @@ without adding a significant benefit.  It can always be added later.
       return expr
 
 
-.. _literal_pattern:
+.. _635-literal_pattern:
 
 Literal Patterns
 ~~~~~~~~~~~~~~~~
@@ -675,7 +675,7 @@ being.
       return expr
 
 
-.. _capture_pattern:
+.. _635-capture_pattern:
 
 Capture Patterns
 ~~~~~~~~~~~~~~~~
@@ -734,7 +734,7 @@ especially given that we expect capture patterns to be very common.
               return sum(a) / len(a)
 
 
-.. _wildcard_pattern:
+.. _635-wildcard_pattern:
 
 Wildcard Pattern
 ~~~~~~~~~~~~~~~~
@@ -901,7 +901,7 @@ Allowing users to explicitly specify the grouping is particularly helpful
 in case of OR patterns.
 
 
-.. _sequence_pattern:
+.. _635-sequence_pattern:
 
 Sequence Patterns
 ~~~~~~~~~~~~~~~~~
@@ -961,7 +961,7 @@ enumerate all other types that may be used to represent bytes
 (e.g. some, but not all, instances of ``memoryview`` and ``array.array``).
 
 
-.. _mapping_pattern:
+.. _635-mapping_pattern:
 
 Mapping Patterns
 ~~~~~~~~~~~~~~~~
@@ -1008,7 +1008,7 @@ unexpected side effect.
                   change_red_to_blue(child)
 
 
-.. _class_pattern:
+.. _635-class_pattern:
 
 Class Patterns
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fix these warnings:

```
pep-0635.rst:403: WARNING: duplicate label patterns, other instance in pep-0634.rst
pep-0635.rst:592: WARNING: duplicate label literal_pattern, other instance in pep-0634.rst
pep-0635.rst:681: WARNING: duplicate label capture_pattern, other instance in pep-0634.rst
pep-0635.rst:740: WARNING: duplicate label wildcard_pattern, other instance in pep-0634.rst
pep-0635.rst:907: WARNING: duplicate label sequence_pattern, other instance in pep-0634.rst
pep-0635.rst:967: WARNING: duplicate label mapping_pattern, other instance in pep-0634.rst
pep-0635.rst:1014: WARNING: duplicate label class_pattern, other instance in pep-0634.rst
```

Like https://github.com/python/peps/pull/2735, we still get the same anchors in both:

* https://peps.python.org/pep-0635/#sequence-pattern
* https://pep-previews--2742.org.readthedocs.build/pep-0635/#sequence-pattern

Also remove redundant emacs metadata.

# Preview

https://pep-previews--2742.org.readthedocs.build/pep-0635/

