### PR TITLE
Infra: Fix docutils deprecation warning when generating RSS

### DIFF
--- a/generate_rss.py
+++ b/generate_rss.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import re
 
 import docutils
-from docutils import frontend
 from docutils import nodes
 from docutils import utils
 from docutils.parsers import rst
@@ -23,14 +22,6 @@ PEP_ROOT = Path(__file__).parent
 # Monkeypatch feedgen.util.formatRFC2822
 def _format_rfc_2822(dt: datetime.datetime) -> str:
     return email.utils.format_datetime(dt, usegmt=True)
-
-
-# Monkeypatch nodes.Node.findall for forwards compatability
-if docutils.__version_info__ < (0, 18, 1):
-    def findall(self, *args, **kwargs):
-        return iter(self.traverse(*args, **kwargs))
-
-    nodes.Node.findall = findall
 
 
 entry.formatRFC2822 = feed.formatRFC2822 = _format_rfc_2822

--- a/generate_rss.py
+++ b/generate_rss.py
@@ -7,7 +7,7 @@ import email.utils
 from pathlib import Path
 import re
 
-import docutils
+import docutils.frontend
 from docutils import nodes
 from docutils import utils
 from docutils.parsers import rst

--- a/generate_rss.py
+++ b/generate_rss.py
@@ -131,7 +131,7 @@ def pep_creation(full_path: Path) -> datetime.datetime:
 
 def parse_rst(full_path: Path) -> nodes.document:
     text = full_path.read_text(encoding="utf-8")
-    settings = frontend.OptionParser((rst.Parser,)).get_default_values()
+    settings = docutils.frontend.get_default_settings(rst.Parser)
     document = utils.new_document(f'<{full_path}>', settings=settings)
     rst.Parser(rfc2822=True).parse(text, document)
     return document

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Requirements for building PEPs with Sphinx
 Pygments >= 2.9.0
 Sphinx >= 4.0.2
-docutils >= 0.17.1
+docutils >= 0.19.0
 
 # For RSS
 feedgen >= 0.9.0  # For RSS feed


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fix these warnings:

```
.venv/bin/python3 generate_rss.py
/home/runner/work/peps/peps/generate_rss.py:134: DeprecationWarning: The frontend.OptionParser class will be replaced by a subclass of argparse.ArgumentParser in Docutils 0.21 or later.
  settings = frontend.OptionParser((rst.Parser,)).get_default_values()
/home/runner/work/peps/peps/generate_rss.py:134: DeprecationWarning: The frontend.OptionParser class will be replaced by a subclass of argparse.ArgumentParser in Docutils 0.21 or later.
  settings = frontend.OptionParser((rst.Parser,)).get_default_values()
/home/runner/work/peps/peps/generate_rss.py:134: DeprecationWarning: The frontend.OptionParser class will be replaced by a subclass of argparse.ArgumentParser in Docutils 0.21 or later.
  settings = frontend.OptionParser((rst.Parser,)).get_default_values()
/home/runner/work/peps/peps/generate_rss.py:134: DeprecationWarning: The frontend.OptionParser class will be replaced by a subclass of argparse.ArgumentParser in Docutils 0.21 or later.
  settings = frontend.OptionParser((rst.Parser,)).get_default_values()
/home/runner/work/peps/peps/generate_rss.py:134: DeprecationWarning: The frontend.OptionParser class will be replaced by a subclass of argparse.ArgumentParser in Docutils 0.21 or later.
  settings = frontend.OptionParser((rst.Parser,)).get_default_values()
/home/runner/work/peps/peps/generate_rss.py:134: DeprecationWarning: The frontend.OptionParser class will be replaced by a subclass of argparse.ArgumentParser in Docutils 0.21 or later.
  settings = frontend.OptionParser((rst.Parser,)).get_default_values()
/home/runner/work/peps/peps/generate_rss.py:134: DeprecationWarning: The frontend.OptionParser class will be replaced by a subclass of argparse.ArgumentParser in Docutils 0.21 or later.
  settings = frontend.OptionParser((rst.Parser,)).get_default_values()
</home/runner/work/peps/peps/pep-0692.rst>:288: (ERROR/3) Unknown interpreted text role "ref".
/home/runner/work/peps/peps/generate_rss.py:134: DeprecationWarning: The frontend.OptionParser class will be replaced by a subclass of argparse.ArgumentParser in Docutils 0.21 or later.
  settings = frontend.OptionParser((rst.Parser,)).get_default_values()
/home/runner/work/peps/peps/generate_rss.py:134: DeprecationWarning: The frontend.OptionParser class will be replaced by a subclass of argparse.ArgumentParser in Docutils 0.21 or later.
  settings = frontend.OptionParser((rst.Parser,)).get_default_values()
/home/runner/work/peps/peps/generate_rss.py:134: DeprecationWarning: The frontend.OptionParser class will be replaced by a subclass of argparse.ArgumentParser in Docutils 0.21 or later.
  settings = frontend.OptionParser((rst.Parser,)).get_default_values()
```

https://github.com/python/peps/runs/7516254257?check_suite_focus=true#step:5:98


By requiring docutils 0.19.0+ and replacing:

```diff
-    settings = frontend.OptionParser((rst.Parser,)).get_default_values()
+    settings = docutils.frontend.get_default_settings(rst.Parser)
```

We can also remove this monkey patch:

```python
# Monkeypatch nodes.Node.findall for forwards compatability
if docutils.__version_info__ < (0, 18, 1):
    def findall(self, *args, **kwargs):
        return iter(self.traverse(*args, **kwargs))

    nodes.Node.findall = findall
```