### PR TITLE
PEP 582: Updates to internal directory structure

### DIFF
--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -10,7 +10,7 @@ Type: Standards Track
 Topic: Packaging
 Content-Type: text/x-rst
 Created: 16-May-2018
-Python-Version: 3.8
+Python-Version: 3.12
 
 
 Abstract

--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -89,14 +89,15 @@ the Python executable and any script will behave.
 
     foo
         __pypackages__
-            3.8
-                lib
-                    bottle
+            lib
+                python3.10
+                           site-packages
+                                         bottle
         myscript.py
 
     /> python foo/myscript.py
     sys.path[0] == 'foo'
-    sys.path[1] == 'foo/__pypackages__/3.8/lib'
+    sys.path[1] == 'foo/__pypackages__/lib/python3.10/site-packages/'
 
 
     cd foo
@@ -109,15 +110,17 @@ the Python executable and any script will behave.
 
     foo> python
     sys.path[0] == '.'
-    sys.path[1] == './__pypackages__/3.8/lib'
+    sys.path[1] == './__pypackages__/lib/python3.10/site-packages'
 
     foo> python -m bottle
 
 We have a project directory called ``foo`` and it has a ``__pypackages__``
 inside of it. We have ``bottle`` installed in that
-``__pypackages__/3.8/lib``, and have a ``myscript.py`` file inside of the
-project directory. We have used whatever tool we generally use to install ``bottle``
-in that location.
+``__pypackages__/lib/python3.10/stie-packages/``, and have a ``myscript.py``
+file inside of the project directory. We have used whatever tool we generally
+use to install ``bottle`` in that location. This actual internal path will
+depend on the Python implementation name, as mentioned in the
+``sysconfig._INSTALL_SCHEMES['posix_prefix']`` dictionary.
 
 For invoking a script, Python will try to find a ``__pypackages__`` inside of
 the directory that the script resides[1]_, ``/usr/bin``.  The same will happen
@@ -180,8 +183,8 @@ adding it the ``sys.path`` just before site packages, if it is present.
 Reference Implementation
 ========================
 
-`Here <https://github.com/kushaldas/cpython/tree/pypackages>`_ is a PoC
-implementation (in the ``pypackages`` branch).
+`Here <https://github.com/kushaldas/pep582>`_ is a small script which will
+enable the implementation for ``Cpython`` & in ``PyPy``.
 
 
 Rejected Ideas


### PR DESCRIPTION
Includes the latest update in the internal structure of `__pypackages__` directory. Also points to a working example to enable the same in both `Cpython` & in `PyPy`.
