### PR TITLE
PEP 550: Fix footnotes

### DIFF
--- a/pep-0550.rst
+++ b/pep-0550.rst
@@ -1699,7 +1699,7 @@ References
 
 .. [1] https://go.dev/blog/context
 
-.. [2] https://docs.microsoft.com/en-us/dotnet/api/system.threading.executioncontext?redirectedfrom=MSDN&view=net-6.0
+.. [2] https://docs.microsoft.com/en-us/dotnet/api/system.threading.executioncontext
 
 .. [3] https://github.com/numpy/numpy/issues/9444
 

--- a/pep-0550.rst
+++ b/pep-0550.rst
@@ -1701,8 +1701,6 @@ References
 
 .. [3] https://github.com/numpy/numpy/issues/9444
 
-.. [4] http://bugs.python.org/issue31179
-
 .. [5] https://en.wikipedia.org/wiki/Hash_array_mapped_trie
 
 .. [6] http://blog.higher-order.net/2010/08/16/assoc-and-clojures-persistenthashmap-part-ii.html
@@ -1714,16 +1712,6 @@ References
 .. [9] https://gist.github.com/1st1/9004813d5576c96529527d44c5457dcd
 
 .. [10] https://gist.github.com/1st1/dbe27f2e14c30cce6f0b5fddfc8c437e
-
-.. [11] https://github.com/1st1/cpython/tree/pep550
-
-.. [13] https://github.com/MagicStack/uvloop/blob/master/examples/bench/echoserver.py
-
-.. [14] https://github.com/MagicStack/pgbench
-
-.. [15] https://github.com/python/performance
-
-.. [16] https://gist.github.com/1st1/6b7a614643f91ead3edf37c4451a6b4c
 
 .. [17] https://mail.python.org/pipermail/python-ideas/2017-August/046752.html
 

--- a/pep-0550.rst
+++ b/pep-0550.rst
@@ -1697,15 +1697,15 @@ Version History
 References
 ==========
 
-.. [1] https://blog.golang.org/context
+.. [1] https://go.dev/blog/context
 
-.. [2] https://msdn.microsoft.com/en-us/library/system.threading.executioncontext.aspx
+.. [2] https://docs.microsoft.com/en-us/dotnet/api/system.threading.executioncontext?redirectedfrom=MSDN&view=net-6.0
 
 .. [3] https://github.com/numpy/numpy/issues/9444
 
 .. [5] https://en.wikipedia.org/wiki/Hash_array_mapped_trie
 
-.. [6] http://blog.higher-order.net/2010/08/16/assoc-and-clojures-persistenthashmap-part-ii.html
+.. [6] https://blog.higher-order.net/2010/08/16/assoc-and-clojures-persistenthashmap-part-ii.html
 
 .. [7] https://github.com/1st1/cpython/tree/hamt
 
@@ -1739,7 +1739,7 @@ References
 
 .. [28] https://docs.python.org/3/library/decimal.html#decimal.Context.abs
 
-.. [29] https://curio.readthedocs.io/en/latest/reference.html#task-local-storage
+.. [29] https://web.archive.org/web/20170706074739/https://curio.readthedocs.io/en/latest/reference.html#task-local-storage
 
 .. [30] https://docs.atlassian.com/aiolocals/latest/usage.html
 

--- a/pep-0550.rst
+++ b/pep-0550.rst
@@ -818,7 +818,9 @@ Implementation
 Execution context is implemented as an immutable linked list of
 logical contexts, where each logical context is an immutable weak key
 mapping.  A pointer to the currently active execution context is
-stored in the OS thread state::
+stored in the OS thread state:
+
+.. code-block:: text
 
                       +-----------------+
                       |                 |     ec

--- a/pep-0550.rst
+++ b/pep-0550.rst
@@ -1752,13 +1752,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fix these warnings by removing the orphaned references:

```
pep-0550.rst:1704: WARNING: Footnote [4] is not referenced.
pep-0550.rst:1718: WARNING: Footnote [11] is not referenced.
pep-0550.rst:1720: WARNING: Footnote [13] is not referenced.
pep-0550.rst:1722: WARNING: Footnote [14] is not referenced.
pep-0550.rst:1724: WARNING: Footnote [15] is not referenced.
pep-0550.rst:1726: WARNING: Footnote [16] is not referenced.
```

[4] was removed in https://github.com/python/peps/commit/1b8728ded7cde9df0f9a24268574907fafec6d5e ("PEP-0550 V4" #375)

And the others were removed in https://github.com/python/peps/commit/09c05c8740785fb1987d6b2162b927cccea58818 ("pep-550: Full rewrite: v2." #344)

---

Also:

* Remove redundant emacs metadata
* Use plaintext literal block for ASCII diagram
* Update link redirects/https

# Preview

https://pep-previews--2751.org.readthedocs.build/pep-0550/
