### PR TITLE
PEP 467: Fix footnotes

### DIFF
--- a/pep-0467.txt
+++ b/pep-0467.txt
@@ -238,8 +238,8 @@ References
 
 * `Initial March 2014 discussion thread on python-ideas <https://mail.python.org/pipermail/python-ideas/2014-March/027295.html>`_
 * `Guido's initial feedback in that thread <https://mail.python.org/pipermail/python-ideas/2014-March/027376.html>`_
-* `Issue proposing moving zero-initialised sequences to a dedicated API <http://bugs.python.org/issue20895>`_
-* `Issue proposing to use calloc() for zero-initialised binary sequences <http://bugs.python.org/issue21644>`_
+* `Issue proposing moving zero-initialised sequences to a dedicated API <https://github.com/python/cpython/issues/65094>`_
+* `Issue proposing to use calloc() for zero-initialised binary sequences <https://github.com/python/cpython/issues/65843>`_
 * `August 2014 discussion thread on python-dev <https://mail.python.org/pipermail/python-ideas/2014-March/027295.html>`_
 * `June 2016 discussion thread on python-dev <https://mail.python.org/pipermail/python-dev/2016-June/144875.html>`_
 

--- a/pep-0467.txt
+++ b/pep-0467.txt
@@ -128,7 +128,7 @@ Python 2 ``str``) was as simple as::
 
    >>> str(123)
    '123'
-   
+
 With Python 3 that became the more verbose::
 
    >>> b'%d' % 123
@@ -236,18 +236,12 @@ of this PEP.
 References
 ==========
 
-.. [1] Initial March 2014 discussion thread on python-ideas
-   (https://mail.python.org/pipermail/python-ideas/2014-March/027295.html)
-.. [2] Guido's initial feedback in that thread
-   (https://mail.python.org/pipermail/python-ideas/2014-March/027376.html)
-.. [3] Issue proposing moving zero-initialised sequences to a dedicated API
-   (http://bugs.python.org/issue20895)
-.. [4] Issue proposing to use calloc() for zero-initialised binary sequences
-   (http://bugs.python.org/issue21644)
-.. [5] August 2014 discussion thread on python-dev
-   (https://mail.python.org/pipermail/python-ideas/2014-March/027295.html)
-.. [6] June 2016 discussion thread on python-dev
-   (https://mail.python.org/pipermail/python-dev/2016-June/144875.html)
+* `Initial March 2014 discussion thread on python-ideas <https://mail.python.org/pipermail/python-ideas/2014-March/027295.html>`_
+* `Guido's initial feedback in that thread <https://mail.python.org/pipermail/python-ideas/2014-March/027376.html>`_
+* `Issue proposing moving zero-initialised sequences to a dedicated API <http://bugs.python.org/issue20895>`_
+* `Issue proposing to use calloc() for zero-initialised binary sequences <http://bugs.python.org/issue21644>`_
+* `August 2014 discussion thread on python-dev <https://mail.python.org/pipermail/python-ideas/2014-March/027295.html>`_
+* `June 2016 discussion thread on python-dev <https://mail.python.org/pipermail/python-dev/2016-June/144875.html>`_
 
 
 Copyright


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fix these warnings:

```
pep-0467.txt:239: WARNING: Footnote [1] is not referenced.
pep-0467.txt:241: WARNING: Footnote [2] is not referenced.
pep-0467.txt:243: WARNING: Footnote [3] is not referenced.
pep-0467.txt:245: WARNING: Footnote [4] is not referenced.
pep-0467.txt:247: WARNING: Footnote [5] is not referenced.
pep-0467.txt:249: WARNING: Footnote [6] is not referenced.
```

They're not really footnotes, so like in https://github.com/python/peps/pull/2644 and others, let's convert them to regular links.

Plus update a couple of redirects.

# Preview

https://pep-previews--2752.org.readthedocs.build/pep-0467/