### PR TITLE
PEP 654: Add missing Python-Version header

### DIFF
--- a/pep-0654.rst
+++ b/pep-0654.rst
@@ -7,6 +7,7 @@ Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 22-Feb-2021
+Python-Version: 3.11
 Post-History: 22-Feb-2021, 20-Mar-2021
 
 


### PR DESCRIPTION
PEP 654 was [implemented in Python 3.11](https://docs.python.org/3.12/whatsnew/3.11.html#exceptions-can-be-enriched-with-notes-pep-678) but is missing a Python-Version header, which resulted in it not showing up in my search for 3.11 PEPs while helping with the What's New. This adds it.