### PR TITLE
Lint: Update outdated Python-Version on still-Draft PEPs

### DIFF
--- a/pep-0467.txt
+++ b/pep-0467.txt
@@ -7,7 +7,7 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 30-Mar-2014
-Python-Version: 3.11
+Python-Version: 3.12
 Post-History: 30-Mar-2014, 15-Aug-2014, 16-Aug-2014, 07-Jun-2016, 01-Sep-2016,
               13-Apr-2021, 03-Nov-2021
 

--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -6,7 +6,7 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 05-Sep-2017
-Python-Version: 3.10
+Python-Version: 3.12
 Post-History: 07-Sep-2017, 08-Sep-2017, 13-Sep-2017, 05-Dec-2017,
               09-May-2018, 20-Apr-2020, 04-May-2020
 

--- a/pep-0558.rst
+++ b/pep-0558.rst
@@ -7,7 +7,7 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 08-Sep-2017
-Python-Version: 3.11
+Python-Version: 3.12
 Post-History: 08-Sep-2017, 22-May-2019, 30-May-2019, 30-Dec-2019, 18-Jul-2021,
               26-Aug-2021
 

--- a/pep-0603.rst
+++ b/pep-0603.rst
@@ -3,11 +3,11 @@ Title: Adding a frozenmap type to collections
 Version: $Revision$
 Last-Modified: $Date$
 Author: Yury Selivanov <yury@edgedb.com>
+Discussions-To: https://discuss.python.org/t/pep-603-adding-a-frozenmap-type-to-collections/2318/
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 12-Sep-2019
-Python-Version: 3.9
 Post-History: 12-Sep-2019
 
 

--- a/pep-0619.rst
+++ b/pep-0619.rst
@@ -3,7 +3,7 @@ Title: Python 3.10 Release Schedule
 Version: $Revision$
 Last-Modified: $Date$
 Author: Pablo Galindo Salgado <pablogsal@python.org>
-Status: Draft
+Status: Active
 Type: Informational
 Content-Type: text/x-rst
 Created: 25-May-2020

--- a/pep-0620.rst
+++ b/pep-0620.rst
@@ -5,7 +5,7 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 19-Jun-2020
-Python-Version: 3.10
+Python-Version: 3.12
 
 Abstract
 ========

--- a/pep-0664.rst
+++ b/pep-0664.rst
@@ -3,7 +3,7 @@ Title: Python 3.11 Release Schedule
 Version: $Revision$
 Last-Modified: $Date$
 Author: Pablo Galindo Salgado <pablogsal@python.org>
-Status: Draft
+Status: Active
 Type: Informational
 Content-Type: text/x-rst
 Created: 12-Jul-2021

--- a/pep-0671.rst
+++ b/pep-0671.rst
@@ -6,7 +6,7 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 24-Oct-2021
-Python-Version: 3.11
+Python-Version: 3.12
 Post-History: `24-Oct-2021 <https://mail.python.org/archives/list/python-ideas@python.org/thread/KR2TMLPFR7NHDZCDOS6VTNWDKZQQJN3V/>`__,
               `01-Dec-2021 <https://mail.python.org/archives/list/python-ideas@python.org/thread/UVOQEK7IRFSCBOH734T5GFJOEJXFCR6A/>`__
 

--- a/pep-0674.rst
+++ b/pep-0674.rst
@@ -5,7 +5,7 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 30-Nov-2021
-Python-Version: 3.11
+
 
 Abstract
 ========

--- a/pep-0679.rst
+++ b/pep-0679.rst
@@ -6,7 +6,7 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 07-Jan-2022
-Python-Version: 3.11
+Python-Version: 3.12
 
 
 Abstract

--- a/pep-0684.rst
+++ b/pep-0684.rst
@@ -6,7 +6,7 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 08-Mar-2022
-Python-Version: 3.11
+Python-Version: 3.12
 Post-History: `08-Mar-2022 <https://mail.python.org/archives/list/python-dev@python.org/thread/CF7B7FMACFYDAHU6NPBEVEY6TOSGICXU/>`__
 Resolution:
 

--- a/pep-0689.rst
+++ b/pep-0689.rst
@@ -2,7 +2,7 @@ PEP: 689
 Title: Unstable C API tier
 Author: Petr Viktorin <encukou@gmail.com>
 Discussions-To: https://mail.python.org/archives/list/python-dev@python.org/thread/PQXSP7E2B6KNXTJ2AERWMKKX42YP5D6O/
-Status: Draft
+Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst
 Requires: 523

--- a/pep-0689.rst
+++ b/pep-0689.rst
@@ -1,12 +1,13 @@
 PEP: 689
 Title: Unstable C API tier
 Author: Petr Viktorin <encukou@gmail.com>
+Discussions-To: https://mail.python.org/archives/list/python-dev@python.org/thread/PQXSP7E2B6KNXTJ2AERWMKKX42YP5D6O/
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Requires: 523
 Created: 22-Apr-2022
-Python-Version: 3.11
+Python-Version: 3.12
 Post-History: `27-Apr-2022 <https://mail.python.org/archives/list/python-dev@python.org/thread/PQXSP7E2B6KNXTJ2AERWMKKX42YP5D6O/>`__,
 
 


### PR DESCRIPTION
Now that Python 3.11 is in its RC phase, the still-Draft PEPs targeting it or an earlier version can't make the cut, so I've checked each PEP carefully, as well as their associated discussion threads and the Steering Council repo, and bumped/dropped their `Python-Version`s accordingly.

Authors, please either let us know that a version bump is okay, or otherwise let us know what you'd like to do about your PEP (e.g. a later target version, removing the version entirely and Deferring/Withdrawing it, etc.); I'll leave this open for ≈two weeks, unless we hear from everyone before then, to ensure everyone has a chance to see this. Thanks!

Two PEPs were exceptions to just bumping the version:

* ~~PEP 603 (PEP-603) appears to be inactive, as there haven't been meaningful changes or much discussion activity for several years. @1st1 , I haven't done that here (I just dropped the outdated `Python-Version` header for now, which still read `3.9`), but do you mind if we at least mark it Deferred, would you like to formally Withdraw it, or would you rather it be updated to retarget 3.12?~~ 
  
  @1st1 [responded on the PEP's discussion thread](https://discuss.python.org/t/pep-603-adding-a-frozenmap-type-to-collections/2318/66?u=cam-gerlach); I'll just leave things as they are for now (just dropping the version), unless @pablogsal wants to take over and updates the PEP, in which case I can drop the changes here.

* PEP 674 (PEP-674) appears to have been [not accepted in its current form](https://mail.python.org/archives/list/python-dev@python.org/thread/CV6KWDRHV5WP6TIDK3Z46PW7HNSHYOWG/), with changes requested. @vstinner how would you like to move forward here? Target it on 3.12? 3.14? Mark it as Deferred? Something else? For now I just dropped the outdated header and left everything else as it is.

Also, I marked the two latest release PEPs as Active rather than Draft, since they are Informational PEPs and each of their formal release cycles has been going on for quite some time now, and opportunistically added a few missing `Discussions-To` that I found in the course of my research on each PR.

Originally discussed in https://github.com/python/peps/pull/2755#issuecomment-1209904231