### PR TITLE
Lint: Add missing Python-Version header in PEPs

### DIFF
--- a/pep-0229.txt
+++ b/pep-0229.txt
@@ -7,6 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 16-Nov-2000
+Python-Version: 2.1
 Post-History:
 
 

--- a/pep-0305.txt
+++ b/pep-0305.txt
@@ -12,6 +12,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 26-Jan-2003
+Python-Version: 2.3
 Post-History: 31-Jan-2003, 13-Feb-2003
 
 

--- a/pep-0307.txt
+++ b/pep-0307.txt
@@ -7,6 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 31-Jan-2003
+Python-Version: 2.3
 Post-History: 07-Feb-2003
 
 Introduction

--- a/pep-0308.txt
+++ b/pep-0308.txt
@@ -7,6 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 07-Feb-2003
+Python-Version: 2.5
 Post-History: 07-Feb-2003, 11-Feb-2003
 
 

--- a/pep-0311.txt
+++ b/pep-0311.txt
@@ -7,6 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 05-Feb-2003
+Python-Version: 2.3
 Post-History: 05-Feb-2003, 14-Feb-2003, 19-Apr-2003
 
 

--- a/pep-0341.txt
+++ b/pep-0341.txt
@@ -7,6 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 04-May-2005
+Python-Version: 2.5
 Post-History:
 
 

--- a/pep-0352.txt
+++ b/pep-0352.txt
@@ -7,6 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 27-Oct-2005
+Python-Version: 2.5
 Post-History:
 
 

--- a/pep-0353.txt
+++ b/pep-0353.txt
@@ -7,6 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 18-Dec-2005
+Python-Version: 2.5
 Post-History:
 
 

--- a/pep-0397.txt
+++ b/pep-0397.txt
@@ -8,6 +8,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 15-Mar-2011
+Python-Version: 3.3
 Post-History: 21-Jul-2011, 17-May-2011, 15-Mar-2011
 Resolution: https://mail.python.org/pipermail/python-dev/2012-June/120505.html
 

--- a/pep-0409.txt
+++ b/pep-0409.txt
@@ -7,6 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 26-Jan-2012
+Python-Version: 3.3
 Post-History: 30-Aug-2002, 01-Feb-2012, 03-Feb-2012
 Superseded-By: 415
 Resolution: https://mail.python.org/pipermail/python-dev/2012-February/116136.html

--- a/pep-0414.txt
+++ b/pep-0414.txt
@@ -8,6 +8,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 15-Feb-2012
+Python-Version: 3.3
 Post-History: 28-Feb-2012, 04-Mar-2012
 Resolution: https://mail.python.org/pipermail/python-dev/2012-February/116995.html
 

--- a/pep-0421.txt
+++ b/pep-0421.txt
@@ -8,6 +8,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 26-Apr-2012
+Python-Version: 3.3
 Post-History: 26-Apr-2012
 Resolution: https://mail.python.org/pipermail/python-dev/2012-May/119683.html
 

--- a/pep-0436.txt
+++ b/pep-0436.txt
@@ -8,6 +8,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 22-Feb-2013
+Python-Version: 3.4
 
 
 Abstract

--- a/pep-0441.txt
+++ b/pep-0441.txt
@@ -10,6 +10,7 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 30-Mar-2013
 Post-History: 30-Mar-2013, 01-Apr-2013, 16-Feb-2015
+Python-Version: 3.5
 Resolution: https://mail.python.org/pipermail/python-dev/2015-February/138578.html
 
 Improving Python ZIP Application Support

--- a/pep-0443.txt
+++ b/pep-0443.txt
@@ -8,6 +8,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 22-May-2013
+Python-Version: 3.4
 Post-History: 22-May-2013, 25-May-2013, 31-May-2013
 Replaces: 245, 246, 3124
 

--- a/pep-0476.txt
+++ b/pep-0476.txt
@@ -7,6 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 28-Aug-2014
+Python-Version: 2.7.9, 3.4.3, 3.5
 Resolution: https://mail.python.org/pipermail/python-dev/2014-October/136676.html
 
 Abstract

--- a/pep-0523.txt
+++ b/pep-0523.txt
@@ -9,6 +9,7 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 16-May-2016
 Post-History: 16-May-2016
+Python-Version: 3.6
 Resolution: https://mail.python.org/pipermail/python-dev/2016-August/145937.html
 
 

--- a/pep-3106.txt
+++ b/pep-3106.txt
@@ -7,6 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 19-Dec-2006
+Python-Version: 3.0
 Post-History:
 
 

--- a/pep-3119.txt
+++ b/pep-3119.txt
@@ -7,6 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 18-Apr-2007
+Python-Version: 3.0
 Post-History: 26-Apr-2007, 11-May-2007
 
 

--- a/pep-3138.txt
+++ b/pep-3138.txt
@@ -7,6 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 05-May-2008
+Python-Version: 3.0
 Post-History: 05-May-2008, 05-Jun-2008
 
 

--- a/pep-3141.txt
+++ b/pep-3141.txt
@@ -7,6 +7,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 23-Apr-2007
+Python-Version: 3.0
 Post-History: 25-Apr-2007, 16-May-2007, 02-Aug-2007
 
 

--- a/pep-3156.txt
+++ b/pep-3156.txt
@@ -9,6 +9,7 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 12-Dec-2012
+Python-Version: 3.3
 Post-History: 21-Dec-2012
 Replaces: 3153
 Resolution: https://mail.python.org/pipermail/python-dev/2013-November/130419.html


### PR DESCRIPTION
As originally discussed in #2755 , a number of older non-Packaging Accepted/Final Standards Track PEPs are missing Python-Version headers even though they were implemented. I've added those missing them via cross-referencing the What's New in Python documents, as well as the CPython commit history and the PEPs themselves.