### PR TITLE
PEP 630: superseded by a HOWTO in the docs

### DIFF
--- a/pep-0630.rst
+++ b/pep-0630.rst
@@ -2,7 +2,7 @@ PEP: 630
 Title: Isolating Extension Modules
 Author: Petr Viktorin <encukou@gmail.com>
 Discussions-To: capi-sig@python.org
-Status: Active
+Status: Final
 Type: Informational
 Content-Type: text/x-rst
 Created: 25-Aug-2020
@@ -10,6 +10,8 @@ Post-History: 16-Jul-2020
 
 
 .. highlight:: c
+
+.. canonical-doc:: `Isolating Extension Modules HOWTO <https://docs.python.org/3.11/howto/isolating-extensions.html>`_
 
 Abstract
 ========


### PR DESCRIPTION
I'd welcome some PEP editor guidance:
- If an informational PEP is moved to a HOWTO, what should its status become?
- What's the best way to reference Python's dev (3.11) docs?

Here are my guesses.