### PR TITLE
PEP 668: Change to Standards Track

### DIFF
--- a/pep-0668.rst
+++ b/pep-0668.rst
@@ -11,7 +11,7 @@ Author: Geoffrey Thomas <geofft@ldpreload.com>,
 PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/10302
 Status: Accepted
-Type: Informational
+Type: Standards Track
 Topic: Packaging
 Content-Type: text/x-rst
 Created: 18-May-2021


### PR DESCRIPTION
This PEP describes a new feature for Python Packaging interoperability,
which is better classified under this type.
