### PR TITLE
PEP 1: Update main PEP discussion venue from Python-Dev to Discourse

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -285,21 +285,17 @@ Some specialized topics have specific venues, such as
 Discourse for packaging PEPs. If the PEP authors are unsure of the best venue,
 the PEP Sponsor and PEP editors can advise them accordingly.
 
-If the chosen venue is not a Discourse category,
-a brief announcement thread should be posted in ``PEPs``
-when the draft PEP is committed to the repository,
-which should include a link to the rendered PEP
-and to the canonical ``Discussions-To`` thread.
-
 If a PEP undergoes a significant re-write or other major, substantive
 changes to its proposed specification, a new thread should typically be created
 in the chosen venue to solicit additional feedback. If this occurs, the
 ``Discussions-To`` link must be updated and a new ``Post-History`` entry added
 pointing to this new thread.
-Also, if Discourse is not the discussion venue,
-a further announcement should be posted in the `PEPs category`_
-containing the same information as above
-and at least briefly summarizing the major changes.
+
+If it is not chosen as the discussion venue,
+a brief announcement post should be made to the `PEPs category`_
+with at least a link to the rendered PEP and the `Discussions-To` thread
+when the draft PEP is committed to the repository
+and if a major-enough change is made to trigger a new thread.
 
 PEP authors are responsible for collecting community feedback on a PEP
 before submitting it for review. However, to avoid long-winded and
@@ -435,7 +431,7 @@ accepted that a competing proposal is a better alternative.
 When a PEP is Accepted, Rejected or Withdrawn, the PEP should be updated
 accordingly. In addition to updating the Status field, at the very least
 the Resolution header should be added with a direct link
-to the relevant SC post officially accepting or rejecting the PEP.
+to the relevant post making a decision on the PEP.
 
 PEPs can also be superseded by a different PEP, rendering the original
 obsolete.  This is intended for Informational PEPs, where version 2 of

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -278,24 +278,28 @@ for the discussion, so long as the the following criteria are met:
 * A direct link to the current discussion thread is provided in the PEP
   under the ``Discussions-To`` header.
 
-Typically, the `Python-Dev`_ mailing list and the
-`PEPs category`_ of the `Python Discourse`_ are good choices for most PEPs,
-while some specialized topics have specific venues, such as
+Typically, the `PEPs category`_ of the `Python Discourse`_
+is a good choice for most new PEPs,
+whereas historically the `Python-Dev`_ mailing list was commonly used.
+Some specialized topics have specific venues, such as
 `Typing-SIG`_ for typing PEPs or the `Packaging category`_ on the Python
 Discourse for packaging PEPs. If the PEP authors are unsure of the best venue,
 the PEP Sponsor and PEP editors can advise them accordingly.
 
-If the chosen venue is not the `Python-Dev`_ mailing list,
-a brief announcement should be posted there when the draft PEP is
-committed to the repository, which should include a link to the rendered PEP
+If the chosen venue is not a Discourse category,
+a brief announcement thread should be posted in ``PEPs``
+when the draft PEP is committed to the repository,
+which should include a link to the rendered PEP
 and to the canonical ``Discussions-To`` thread.
 
 If a PEP undergoes a significant re-write or other major, substantive
 changes to its proposed specification, a new thread should typically be created
 in the chosen venue to solicit additional feedback. If this occurs, the
 ``Discussions-To`` link must be updated and a new ``Post-History`` entry added
-pointing to this new thread, and (if not the discussion venue) a further
-announcement sent to `Python-Dev`_ containing the same information as above
+pointing to this new thread, and (if Discourse is not the discussion venue)
+a further announcement thread should generally posted
+in the ``PEPs`` Discourse category
+containing the same information as above
 and at least briefly summarizing the major changes.
 
 PEP authors are responsible for collecting community feedback on a PEP
@@ -395,8 +399,10 @@ the interpreter unduly.  Finally, a proposed enhancement must be
 the Steering Council.  This logic is intentionally circular.)  See :pep:`2`
 for standard library module acceptance criteria.
 
-Except where otherwise approved by the Steering Council, pronouncements
-of PEP resolution will be posted to the `Python-Dev`_ mailing list.
+Except where otherwise approved by the Steering Council,
+pronouncements of PEP resolution will be posted to the
+`PEPs category`_ on the `Python Discourse`_
+and the PEP's most recent ``Discussions-To`` thread.
 
 Once a PEP has been accepted, the reference implementation must be
 completed.  When the reference implementation is complete and incorporated
@@ -430,9 +436,8 @@ accepted that a competing proposal is a better alternative.
 
 When a PEP is Accepted, Rejected or Withdrawn, the PEP should be updated
 accordingly. In addition to updating the Status field, at the very least
-the Resolution header should be added with a link to the relevant post
-in the `Python-Dev`_ mailing list
-`archives <https://mail.python.org/archives/list/python-dev@python.org/>`_.
+the Resolution header should be added with a direct link
+to the relevant SC post officially accepting or rejecting the PEP.
 
 PEPs can also be superseded by a different PEP, rendering the original
 obsolete.  This is intended for Informational PEPs, where version 2 of
@@ -807,7 +812,7 @@ Once the PEP is ready for the repository, a PEP editor will:
 * Merge the new (or updated) PEP.
 
 * Inform the author of the next steps (open a discussion thread and
-  update the PEP with it, post an announcement to Python-Dev, etc).
+  update the PEP with it, post an announcement, etc).
 
 Updates to existing PEPs should be submitted as a `GitHub pull request`_.
 

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -134,8 +134,7 @@ Each PEP must have a champion -- someone who writes the PEP using the style
 and format described below, shepherds the discussions in the appropriate
 forums, and attempts to build community consensus around the idea.  The PEP
 champion (a.k.a. Author) should first attempt to ascertain whether the idea is
-PEP-able.  Posting to the `Python-Ideas`_ mailing list or the
-`Ideas category`_ of the `Python Discourse`_ is usually
+PEP-able.  Posting to the `Ideas category`_ of the `Python Discourse`_ is usually
 the best way to go about this, unless a more specialized venue is appropriate,
 such as `Typing-SIG`_ for static typing or the `Packaging category`_ of the
 Python Discourse for packaging issues.
@@ -278,8 +277,8 @@ for the discussion, so long as the the following criteria are met:
 * A direct link to the current discussion thread is provided in the PEP
   under the ``Discussions-To`` header.
 
-Typically, the `PEPs category`_ of the `Python Discourse`_
-is a good choice for most new PEPs,
+The `PEPs category`_ of the `Python Discourse`_
+is the preferred choice for most new PEPs,
 whereas historically the `Python-Dev`_ mailing list was commonly used.
 Some specialized topics have specific venues, such as
 `Typing-SIG`_ for typing PEPs or the `Packaging category`_ on the Python
@@ -296,9 +295,9 @@ If a PEP undergoes a significant re-write or other major, substantive
 changes to its proposed specification, a new thread should typically be created
 in the chosen venue to solicit additional feedback. If this occurs, the
 ``Discussions-To`` link must be updated and a new ``Post-History`` entry added
-pointing to this new thread, and (if Discourse is not the discussion venue)
-a further announcement thread should generally posted
-in the ``PEPs`` Discourse category
+pointing to this new thread.
+Also, if Discourse is not the discussion venue,
+a further announcement should be posted in the `PEPs category`_
 containing the same information as above
 and at least briefly summarizing the major changes.
 
@@ -401,8 +400,7 @@ for standard library module acceptance criteria.
 
 Except where otherwise approved by the Steering Council,
 pronouncements of PEP resolution will be posted to the
-`PEPs category`_ on the `Python Discourse`_
-and the PEP's most recent ``Discussions-To`` thread.
+`PEPs category`_ on the `Python Discourse`_.
 
 Once a PEP has been accepted, the reference implementation must be
 completed.  When the reference implementation is complete and incorporated
@@ -852,8 +850,6 @@ Footnotes
 .. _GitHub issue: https://github.com/python/peps/issues
 
 .. _Steering Council issue: https://github.com/python/steering-council/issues/new/choose
-
-.. _Python-Ideas: https://mail.python.org/mailman3/lists/python-ideas.python.org/
 
 .. _Python-Dev: https://mail.python.org/mailman3/lists/python-dev.python.org/
 


### PR DESCRIPTION
The Steering Council [recently changed the canonical PEP announcement venue from Python-Dev to Discourse](https://mail.python.org/archives/list/python-dev@python.org/thread/VHFLDK43DSSLHACT67X4QA3UZU73WYYJ/). Therefore, we should update PEP 1 to reflect this.