### PR TITLE
PEP 585: clarify removal as "no sooner than"

### DIFF
--- a/pep-0585.rst
+++ b/pep-0585.rst
@@ -123,9 +123,9 @@ about such deprecated usage when the target version of the checked
 program is signalled to be Python 3.9 or newer.  It's recommended to
 allow for those warnings to be silenced on a project-wide basis.
 
-The deprecated functionality will be removed from the ``typing`` module
-in the first Python version released 5 years after the release of
-Python 3.9.0.
+The deprecated functionality will eventually be removed from the ``typing``
+module. Removal will occur no sooner than Python 3.9's end of life,
+scheduled in October 2025.
 
 
 Parameters to generics are available at runtime

--- a/pep-0585.rst
+++ b/pep-0585.rst
@@ -125,7 +125,7 @@ allow for those warnings to be silenced on a project-wide basis.
 
 The deprecated functionality will eventually be removed from the ``typing``
 module. Removal will occur no sooner than Python 3.9's end of life,
-scheduled in October 2025.
+scheduled for October 2025.
 
 
 Parameters to generics are available at runtime

--- a/pep-0585.rst
+++ b/pep-0585.rst
@@ -123,7 +123,7 @@ about such deprecated usage when the target version of the checked
 program is signalled to be Python 3.9 or newer.  It's recommended to
 allow for those warnings to be silenced on a project-wide basis.
 
-The deprecated functionality will eventually be removed from the ``typing``
+The deprecated functionality may eventually be removed from the ``typing``
 module. Removal will occur no sooner than Python 3.9's end of life,
 scheduled for October 2025.
 


### PR DESCRIPTION
See https://discuss.python.org/t/concern-about-pep-585-removals

I mentioned the date explicitly so people not familiar with Python
release schedule have less arithmetic to do.

I also change the phrasing of the date to Python 3.9's EOL. The date
remains the same. Again, this is to help ease fear of writing 3.8 bridging
code for people who don't know Python version lifespan.
This should also be in line with ambv's (original author) intentions;
see bolded part of his message at
https://discuss.python.org/t/concern-about-pep-585-removals/15901/14