### PR TITLE
PEP 3333: bug, remove extra placeholder

### DIFF
--- a/pep-3333.txt
+++ b/pep-3333.txt
@@ -318,7 +318,7 @@ server.
                  status, response_headers = headers_sent[:] = headers_set
                  out.write(wsgi_to_bytes('Status: %s\r\n' % status))
                  for header in response_headers:
-                     out.write(wsgi_to_bytes('%s: %s\r\n' % header))
+                     out.write(wsgi_to_bytes('%s: \r\n' % header))
                  out.write(wsgi_to_bytes('\r\n'))
 
             out.write(data)


### PR DESCRIPTION
Remove extra string placeholder, otherwise it will give an error when this line will be called.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
