### PR TITLE
PEP 249: Replace StandardError with Exception

### DIFF
--- a/pep-0249.txt
+++ b/pep-0249.txt
@@ -1295,17 +1295,16 @@ Footnotes
     ``WHERE`` clause, or clearly document a different interpretation
     of the ``.rowcount`` attribute.
 
-.. [10] In Python 2 and earlier versions of this PEP,
-    ``exceptions.StandardError`` was used as the base class for all
-    DB-API exceptions. Since ``StandardError`` was removed in Python 3,
-    database modules targeting Python 3 should use
-    ``exception.Exception`` as base class instead. Both
-    ``StandardError`` and ``Exception`` are available as builtin
-    objects, so it is not necessary to import the ``exceptions`` module
-    for this. The PEP was updated to use ``Exception`` throughout the
-    text, to avoid confusion. The change should not affect existing
-    modules or uses of those modules, since all DB-API error exception
-    classes are still rooted at the ``Error`` or ``Warning`` classes.
+.. [10] In Python 2 and earlier versions of this PEP, ``StandardError``
+    was used as the base class for all DB-API exceptions. Since
+    ``StandardError`` was removed in Python 3, database modules
+    targeting Python 3 should use ``Exception`` as base class instead.
+    Both ``StandardError`` and ``Exception`` are available as builtin
+    exception objects. The PEP was updated to use ``Exception``
+    throughout the text, to avoid confusion. The change should not
+    affect existing modules or uses of those modules, since all DB-API
+    error exception classes are still rooted at the ``Error`` or
+    ``Warning`` classes.
 
 .. [11] In a future revision of the DB-API, the base class for
     ``Warning`` will likely change to the builtin ``Warning`` class. At

--- a/pep-0249.txt
+++ b/pep-0249.txt
@@ -118,7 +118,7 @@ exceptions or subclasses thereof:
 `Warning`_
     Exception raised for important warnings like data truncations
     while inserting, etc. It must be a subclass of the Python
-    ``StandardError`` (defined in the module exceptions).
+    ``Exception`` [10]_ [11]_.
 
 
 .. _Error:
@@ -128,7 +128,7 @@ exceptions or subclasses thereof:
     exceptions. You can use this to catch all errors with one single
     ``except`` statement. Warnings are not considered errors and thus
     should not use this class as base. It must be a subclass of the
-    Python ``StandardError`` (defined in the module exceptions).
+    Python ``Exception`` [10]_.
 
 
 .. _InterfaceError:
@@ -201,8 +201,8 @@ exceptions or subclasses thereof:
 
 This is the exception inheritance layout::
 
-    StandardError
-    |__Warning
+    Exception [10]_
+    |__Warning [11]_
     |__Error
        |__InterfaceError
        |__DatabaseError
@@ -731,14 +731,12 @@ Implementation Hints for Module Authors
   constructor.
 
 * Here is a snippet of Python code that implements the exception
-  hierarchy defined above::
+  hierarchy defined above [10]_::
 
-        import exceptions
-
-        class Error(exceptions.StandardError):
+        class Error(Exception):
             pass
 
-        class Warning(exceptions.StandardError):
+        class Warning(Exception):
             pass
 
         class InterfaceError(Error):
@@ -1296,6 +1294,23 @@ Footnotes
     interpretation of returning the total number of rows found by the
     ``WHERE`` clause, or clearly document a different interpretation
     of the ``.rowcount`` attribute.
+
+.. [10] In Python 2 and earlier versions of this PEP,
+    ``exceptions.StandardError`` was used as the base class for all
+    DB-API exceptions. Since ``StandardError`` was removed in Python 3,
+    database modules targeting Python 3 should use
+    ``exception.Exception`` as base class instead. Both
+    ``StandardError`` and ``Exception`` are available as builtin
+    objects, so it is not necessary to import the ``exceptions`` module
+    for this. The PEP was updated to use ``Exception`` throughout the
+    text, to avoid confusion. The change should not affect existing
+    modules or uses of those modules, since all DB-API error exception
+    classes are still rooted at the ``Error`` or ``Warning`` classes.
+
+.. [11] In a future revision of the DB-API, the base class for
+    ``Warning`` will likely change to the builtin ``Warning`` class. At
+    the time of writing of The DB-API 2.0, the warning framework in
+    Python had not yet existed.
 
 
 Acknowledgements

--- a/pep-0249.txt
+++ b/pep-0249.txt
@@ -1307,7 +1307,7 @@ Footnotes
 .. [11] In a future revision of the DB-API, the base class for
     ``Warning`` will likely change to the builtin ``Warning`` class. At
     the time of writing of the DB-API 2.0 in 1999, the warning framework
-    in Python had not yet existed.
+    in Python did not yet exist.
 
 
 Acknowledgements

--- a/pep-0249.txt
+++ b/pep-0249.txt
@@ -1299,12 +1299,10 @@ Footnotes
     was used as the base class for all DB-API exceptions. Since
     ``StandardError`` was removed in Python 3, database modules
     targeting Python 3 should use ``Exception`` as base class instead.
-    Both ``StandardError`` and ``Exception`` are available as builtin
-    exception objects. The PEP was updated to use ``Exception``
-    throughout the text, to avoid confusion. The change should not
-    affect existing modules or uses of those modules, since all DB-API
-    error exception classes are still rooted at the ``Error`` or
-    ``Warning`` classes.
+    The PEP was updated to use ``Exception`` throughout the text, to
+    avoid confusion. The change should not affect existing modules or
+    uses of those modules, since all DB-API error exception classes are
+    still rooted at the ``Error`` or ``Warning`` classes.
 
 .. [11] In a future revision of the DB-API, the base class for
     ``Warning`` will likely change to the builtin ``Warning`` class. At

--- a/pep-0249.txt
+++ b/pep-0249.txt
@@ -118,7 +118,7 @@ exceptions or subclasses thereof:
 `Warning`_
     Exception raised for important warnings like data truncations
     while inserting, etc. It must be a subclass of the Python
-    ``Exception`` [10]_ [11]_.
+    ``Exception`` class [10]_ [11]_.
 
 
 .. _Error:
@@ -128,7 +128,7 @@ exceptions or subclasses thereof:
     exceptions. You can use this to catch all errors with one single
     ``except`` statement. Warnings are not considered errors and thus
     should not use this class as base. It must be a subclass of the
-    Python ``Exception`` [10]_.
+    Python ``Exception`` class [10]_.
 
 
 .. _InterfaceError:
@@ -199,10 +199,12 @@ exceptions or subclasses thereof:
     or has transactions turned off.  It must be a subclass of
     DatabaseError_.
 
-This is the exception inheritance layout::
+This is the exception inheritance layout [10]_ [11]_:
 
-    Exception [10]_
-    |__Warning [11]_
+.. code-block:: text
+
+    Exception
+    |__Warning
     |__Error
        |__InterfaceError
        |__DatabaseError

--- a/pep-0249.txt
+++ b/pep-0249.txt
@@ -1309,8 +1309,8 @@ Footnotes
 
 .. [11] In a future revision of the DB-API, the base class for
     ``Warning`` will likely change to the builtin ``Warning`` class. At
-    the time of writing of The DB-API 2.0, the warning framework in
-    Python had not yet existed.
+    the time of writing of the DB-API 2.0 in 1999, the warning framework
+    in Python had not yet existed.
 
 
 Acknowledgements


### PR DESCRIPTION
To avoid confusion when using the DB-API 2.0 in the context of Python 3.

Add a note about a future upgrade to the Warning base class.

Fixes #2776.