### PR TITLE
PEP 695: Incorporate feedback on draft PEP

### DIFF
--- a/pep-0695.rst
+++ b/pep-0695.rst
@@ -384,9 +384,9 @@ no use for this capability, it preserves the ability in the future to support
 upper bound expressions or type argument defaults that depend on earlier
 type parameters.
 
-A compiler error or runtime exception if the definition of an earlier type
-parameter references a later type parameter even if name is defined in an
-outer scope.
+A compiler error or runtime exception is generated if the definition of an
+earlier type parameter references a later type parameter even if name is
+defined in an outer scope.
 
 ::
 

--- a/pep-0695.rst
+++ b/pep-0695.rst
@@ -2,7 +2,7 @@ PEP: 695
 Title: Type Parameter Syntax
 Author: Eric Traut <erictr at microsoft.com>
 Sponsor: Guido van Rossum <guido@python.org>
-Discussions-To: typing-sig@python.org
+Discussions-To: https://mail.python.org/archives/list/typing-sig@python.org/thread/BB2BGYJY2YG5IWESKGTAPUQL3N27ZKVW/
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
@@ -30,13 +30,12 @@ syntax for specifying type parameters still feels "bolted on" to Python.
 This is a source of confusion among Python developers.
 
 There is consensus within the Python static typing community that it is time
-to provide a formal syntax and bring Python in alignment with other modern
-programming languages that support generic types.
+to provide a formal syntax that is similar to other modern programming
+languages that support generic types.
 
 An analysis of 25 popular typed Python libraries revealed that type
 variables (in particular, the ``typing.TypeVar`` symbol) were used in
-14% of modules. This percentage is likely to increase if type parameters
-become less cumbersome to use.
+14% of modules.
 
 
 Points of Confusion
@@ -50,11 +49,11 @@ confusion.
 The scoping rules for type variables are difficult to understand. Type
 variables are typically allocated within the global scope, but their semantic
 meaning is valid only when used within the context of a generic class,
-function or or type alias. A single runtime instance of a type variable may be
+function, or or type alias. A single runtime instance of a type variable may be
 reused in multiple generic contexts, and it has a different semantic meaning
 in each of these contexts. This PEP proposes to eliminate this source of
 confusion by declaring type parameters at a natural place within a class,
-function or type alias declaration statement.
+function, or type alias declaration statement.
 
 Generic type aliases are often misused because it is not clear to developers
 that a type argument must be supplied when the type alias is used. This leads
@@ -66,8 +65,8 @@ clear.
 variable used within a generic class. Type variables can be invariant,
 covariant, or contravariant. The concept of variance is an advanced detail
 of type theory that is not well understood by most Python developers, yet
-they are immediately confronted with the concept today when defining their
-first generic class. This PEP largely eliminates the need for most developers
+they must confront this concept today when defining their first generic
+class. This PEP largely eliminates the need for most developers
 to understand the concept of variance when defining generic classes.
 
 When more than one type parameter is used with a generic class or type alias,
@@ -115,7 +114,8 @@ Defining a generic class prior to this PEP looks something like this.
     _T_co = TypeVar("_T_co", covariant=True, bound=str)
 
     class ClassA(Generic[_T_co]):
-        ...
+        def method1(self) -> _T_co:
+            ...
 
 
 With the new syntax, it looks like this.
@@ -123,28 +123,26 @@ With the new syntax, it looks like this.
 ::
 
     class ClassA[T: str]:
-        ...
+        def method1(self) -> T:
+            ...
 
 
 Here is an example of a generic function today.
 
 ::
 
-    from typing import ParamSpec, TypeVar, Callable
+    from typing import TypeVar
 
-    _P = ParamSpec("_P")
-    _R = TypeVar("_R")
+    _T = TypeVar("_T")
 
-    def func(cb: Callable[_P, _R], *args: _P.args, **kwargs: _P.kwargs) -> _R:
+    def func(a: _T, b: _T) -> _T:
         ...
 
 And the new syntax.
 
 ::
 
-    from typing import Callable
-
-    def func[**P, R](cb: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+    def func[T](a: T, b: T) -> T:
         ...
 
 
@@ -172,14 +170,14 @@ Specification
 Type Parameter Declarations
 ---------------------------
 
-We propose to add new syntax for declaring type parameters for generic
+Here is a new syntax for declaring type parameters for generic
 classes, functions, and type aliases. The syntax adds support for
 a comma-delimited list of type parameters in square brackets after
 the name of the class, function, or type alias.
 
 Simple (non-variadic) type variables are declared with an unadorned name.
-Variadic type variables are preceded by ``*``. Parameter specifications are
-preceded by ``**``.
+Variadic type variables are preceded by ``*`` (see :pep:`646` for details).
+Parameter specifications are preceded by ``**`` (see :pep:`612` for details).
 
 ::
 
@@ -189,7 +187,7 @@ preceded by ``**``.
 
 There is no need to include ``Generic`` as a base class. Its inclusion as
 a base class is implied by the presence of type parameters, and it will
-automatically be included in the ``__mro__`` and ``__orig_bases`` attributes
+automatically be included in the ``__mro__`` and ``__orig_bases__`` attributes
 for the class. The explicit use of a ``Generic`` base class will result in a
 runtime error.
 
@@ -198,8 +196,8 @@ runtime error.
     class ClassA[T](Generic[T]): ...  # Runtime error
 
 
-A ``Protocol`` base class with type arguments will not generate a runtime
-error, but type checkers should generate an error in this case because
+A ``Protocol`` base class with type arguments may generate a runtime
+error. Type checkers should generate an error in this case because
 the use of type arguments is not needed, and the order of type parameters
 for the class are no longer dictated by their order in the ``Protocol``
 base class.
@@ -211,10 +209,10 @@ base class.
     class ClassB[S, T](Protocol[S, T]): ... # Recommended type checker error
 
 
-Type parameter names within a generic class, function, or type alias must
-be unique. Type parameters for a generic function cannot overlap the name
-of a function parameter. A duplicate name generates a syntax error at compile
-time.
+Type parameter names within a generic class, function, or type alias must be
+unique within that same class, function, or type alias. A duplicate name
+generates a syntax error at compile time. This is consistent with the
+requirement that parameter names within a function signature must be unique.
 
 ::
 
@@ -222,59 +220,11 @@ time.
 
     def func1[T, **T](): ... # Syntax Error
 
-    def func2[T](T): ... # Syntax Error
-
 
 Class type parameter names are not mangled if they begin with a double
 underscore. Mangling would not make sense because type parameters, unlike other
 class-scoped variables, cannot be accessed through the class dictionary, and
-the notion of a "private" type parameter doesn't make sense. Other class-scoped
-variables are mangled if they begin with a double underscore, so the mangled
-name is used to determine whether there is a name collision with type parameters.
-
-::
-
-    class ClassA[__T, _ClassA__S]:
-        __T = 0  # OK
-        __S = 0  # Syntax Error (because mangled name is _ClassA__S)
-
-
-Type Parameter Scopes
----------------------
-
-A type parameter declared as part of a generic class is valid within the
-class body and inner scopes contained therein. Type parameters are also
-accessible when evaluating the argument list (base classes and any keyword
-arguments) that comprise the class definition. This allows base classes
-to be parameterized by these type parameters. Type parameters are not
-accessible outside of the class body, including in any class decorators.
-
-::
-
-    class ClassA[T](BaseClass[T], param = Foo[T]): ...  # OK
-
-    print(T)  # Runtime error: 'T' is not defined
-
-    @dec(Foo[T])  # Runtime error: 'T' is not defined
-    class ClassA[T]: ...
-
-A type parameter declared as part of a generic function is valid within
-the function body and any scopes contained therein. It is also valid within
-parameter and return type annotations. Default argument values for function
-parameters are evaluated outside of this scope, so type parameters are
-not accessible in default value expressions. Likewise, type parameters are not
-in scope for function decorators.
-
-::
-
-    def func1[T](a: T) -> T: ...  # OK
-
-    print(T)  # Runtime error: 'T' is not defined
-
-    def func2[T](a = list[T]): ...  # Runtime error: 'T' is not defined
-
-    @dec(list[T])  # Runtime error: 'T' is not defined
-    def func3[T](): ...
+the notion of a "private" type parameter doesn't make sense.
 
 
 Upper Bound Specification
@@ -290,34 +240,37 @@ not specified, the upper bound is assumed to be ``object``.
 
 The specified upper bound type must use an expression form that is allowed in
 type annotations. More complex expression forms should be flagged
-as an error by a type checker. Quoted forward declarations are allowed.
+as an error by a type checker. Quoted forward references are allowed.
 
 The specified upper bound type must be concrete. An attempt to use a generic
-type should be flagged as an error by a type checker.
+type should be flagged as an error by a type checker. This is consistent with
+the existing rules enforced by type checkers for a ``TypeVar`` constructor call.
 
 ::
 
     class ClassA[T: dict[str, int]]: ...  # OK
 
-    class ClassB[T: "ForwardDeclaration"]: ...  # OK
+    class ClassB[T: "ForwardReference"]: ...  # OK
 
-    class ClassC[T: dict[str, V]]: ...  # Type checker error: generic type
+    class ClassC[V]:
+        class ClassD[T: dict[str, V]]: ...  # Type checker error: generic type
 
-    class ClassD[T: [str, int]]: ...  # Type checker error: illegal expression form
+    class ClassE[T: [str, int]]: ...  # Type checker error: illegal expression form
 
 
 Constrained Type Specification
 ------------------------------
 
-For a non-variadic type parameter, a set of two or more "constrained types"
-can be specified through the use of a literal tuple expression that contains
+:pep:`484` introduced the concept of a "constrained type variable" which is
+constrained to a set of two or more types. The new syntax supports this type
+of constraint through the use of a literal tuple expression that contains
 two or more types.
 
 ::
 
     class ClassA[AnyStr: (str, bytes)]: ...  # OK
 
-    class ClassB[T: ("ForwardDeclaration", bytes)]: ...  # OK
+    class ClassB[T: ("ForwardReference", bytes)]: ...  # OK
 
     class ClassC[T: ()]: ...  # Type checker error: two or more types required
 
@@ -329,7 +282,7 @@ two or more types.
 
 If the specified type is not a tuple expression or the tuple expression includes
 complex expression forms that are not allowed in a type annotation, a type
-checker should generate an error. Quoted forward declarations are allowed.
+checker should generate an error. Quoted forward references are allowed.
 
 ::
 
@@ -366,7 +319,7 @@ Type aliases can refer to themselves without the use of quotes.
 
 ::
 
-    # A type alias that refers to a forward-declared type
+    # A type alias that includes a forward reference
     type AnimalOrVegetable = Animal | "Vegetable"
 
     # A generic self-referential type alias
@@ -386,8 +339,9 @@ The use of more complex expression forms (call expressions, ternary operators,
 arithmetic operators, comparison operators, etc.) should be flagged as an
 error.
 
-Type alias expressions are not allowed to use traditional type variables.
-Type checkers should generate an error in this case.
+Type alias expressions are not allowed to use traditional type variables (i.e.
+those allocated with an explicit ``TypeVar`` constructor call). Type checkers
+should generate an error in this case.
 
 ::
 
@@ -407,8 +361,7 @@ At runtime, a ``type`` statement will generate an instance of
 include:
 
 * ``__name__`` is a str representing the name of the type alias
-* ``__parameters__`` is a tuple of ``TypeVar``, ``TypeVarTuple``, or
-    ``ParamSpec`` objects that parameterize the type alias if it is generic
+* ``__parameters__`` is a tuple of ``TypeVar``, ``TypeVarTuple``, or ``ParamSpec`` objects that parameterize the type alias if it is generic
 * ``__value__`` is the evaluated value of the type alias
 
 The ``__value__`` attribute initially has a value of ``None`` while the type
@@ -416,21 +369,230 @@ alias expression is evaluated. It is then updated after a successful evaluation.
 This allows for self-referential type aliases.
 
 
+Type Parameter Scopes
+---------------------
+
+When the new syntax is used, a new lexical scope is introduced, and this scope
+includes the type parameters. Type parameters can be accessed by name
+within inner scopes. As with other symbols in Python, an inner scope can
+define its own symbol that overrides an outer-scope symbol of the same name.
+
+Type parameters declared earlier in a type parameter list are visible to
+type parameters declared later in the list. This allows later type parameters
+to use earlier type parameters within their definition. While there is currently
+no use for this capability, it preserves the ability in the future to support
+upper bound expressions or type argument defaults that depend on earlier
+type parameters.
+
+A compiler error or runtime exception if the definition of an earlier type
+parameter references a later type parameter even if name is defined in an
+outer scope.
+
+::
+
+    # The following generates no compiler error, but a type checker
+    # should generate an error because an upper bound type must be concrete,
+    # and ``Sequence[S]`` is generic. Future extensions to the typing system may
+    # eliminate this limitation.
+    class ClassA[S, T: Sequence[S]]: ...
+
+    # The following generates a compiler error or runtime exception because T
+    # is referenced before it is defined. This occurs even though T is defined
+    # in the outer scope.
+    T = 0
+    class ClassB[S: Sequence[T], T]: ...  # Compiler error: T is not defined
+
+
+A type parameter declared as part of a generic class is valid within the
+class body and inner scopes contained therein. Type parameters are also
+accessible when evaluating the argument list (base classes and any keyword
+arguments) that comprise the class definition. This allows base classes
+to be parameterized by these type parameters. Type parameters are not
+accessible outside of the class body, including class decorators.
+
+::
+
+    class ClassA[T](BaseClass[T], param = Foo[T]): ...  # OK
+
+    print(T)  # Runtime error: 'T' is not defined
+
+    @dec(Foo[T])  # Runtime error: 'T' is not defined
+    class ClassA[T]: ...
+
+
+A type parameter declared as part of a generic function is valid within
+the function body and any scopes contained therein. It is also valid within
+parameter and return type annotations. Default argument values for function
+parameters are evaluated outside of this scope, so type parameters are
+not accessible in default value expressions. Likewise, type parameters are not
+in scope for function decorators.
+
+::
+
+    def func1[T](a: T) -> T: ...  # OK
+
+    print(T)  # Runtime error: 'T' is not defined
+
+    def func2[T](a = list[T]): ...  # Runtime error: 'T' is not defined
+
+    @dec(list[T])  # Runtime error: 'T' is not defined
+    def func3[T](): ...
+
+A type parameter declared as part of a generic type alias is valid within
+the type alias expression.
+
+::
+
+    type Alias1[K, V] = Mapping[K, V] | Sequence[K]
+
+
+Type parameter symbols defined in outer scopes cannot be bound with
+``nonlocal`` statements in inner scopes.
+
+::
+
+    S = 0
+
+    def outer1[S]():
+        S = 1
+        T = 1
+
+        def outer2[T]():
+            
+            def inner1():
+                nonlocal S  # OK because it binds variable S from outer1
+                nonlocal T  # Syntax error: nonlocal binding not allowed for type parameter
+
+            def inner2():
+                global S  # OK because it binds variable S from global scope
+
+
+The lexical scope introduced by the new type parameter syntax is unlike
+traditional scopes introduced by a ``def`` or ``class`` statement. A type
+parameter scope acts more like a temporary "overlay" to the containing scope.
+It does not capture variables from outer scopes, and the only symbols contained
+within its symbol table are the type parameters defined using the new syntax.
+References to all other symbols are treated as though they were found within
+the containing scope. This allows base class lists (in class definitions) and
+type annotation expressions (in function definitions) to reference symbols
+defined in the containing scope.
+
+::
+
+    class Outer:
+        class Private:
+            pass
+
+        # If the type parameter scope was like a traditional scope,
+        # the base class 'Private' would not be accessible here.
+        class Inner[T](Private, Sequence[T]):
+            pass
+
+        # Likewise, 'Inner' would not be available in these type annotations.
+        def method1[T](self, a: Inner[T]) -> Inner[T]:
+            return a
+
+
+The compiler allows inner scopes to define a local symbol that overrides an
+outer-scoped type parameter.
+
+Consistent with the scoping rules defined in :pep:`484`, type checkers should
+generate an error if inner-scoped generic classes, functions, or type aliases
+reuse the same type parameter name as an outer scope.
+
+::
+
+    T = 0
+
+    @decorator(T)  # Argument expression `T` evaluates to 0
+    class ClassA[T](Sequence[T]):
+        T = 1
+
+        # All methods below should result in a type checker error
+        # "type parameter 'T' already in use" because they are using the
+        # type parameter 'T', which is already in use by the outer scope
+        # 'ClassA'.
+        def method1[T](self):
+            ...
+
+        def method2[T](self, x = T):  # Parameter 'x' gets default value of 1
+            ...
+
+        def method3[T](self, x: T):  # Parameter 'x' has type T (scoped to method3)
+            ...
+
+
+Symbols referenced in inner scopes are resolved using existing rules except
+that type parameter scopes are also considered during name resolution.
+
+::
+    T = 0
+
+    # T refers to the global variable
+    print(T)  # Prints 0
+
+    class Outer[T]:
+        T = 1
+
+        # T refers to the local variable scoped to class 'Outer'
+        print(T)  # Prints 1
+
+        class Inner1:
+            T = 2
+
+            # T refers to the local type variable within 'Inner1'
+            print(T)  # Prints 2
+
+            def inner_method(self):
+                # T refers to the type parameter scoped to class 'Outer';
+                # If 'Outer' did not use the new type parameter syntax,
+                # this would instead refer to the global variable 'T'
+                print(T)  # Prints 'T'
+
+        def outer_method(self):
+            T = 3
+
+            # T refers to the local variable within 'outer_method'
+            print(T)  # Prints 3
+
+            def inner_func():
+                # T refers to the variable captured from 'outer_method'
+                print(T)  # Prints 3
+
+
+When the new type parameter syntax is used for a generic class, assignment
+expressions are not allowed within the argument list for the class definition.
+Likewise, with functions that use the new type parameter syntax, assignment
+expressions are not allowed within parameter or return type annotations, nor
+are they allowed within the expression that defines a type alias.
+
+This restriction is necessary because expressions evaluated within the
+new lexical scope should not introduce symbols within that scope other than
+the defined type parameters.
+
+::
+
+    class ClassA[T]((x := Sequence[T])): ...  # Syntax error: assignment expression not allowed
+
+    def func1[T](val: (x := int)): ...  # Syntax error: assignment expression not allowed
+
+    def func2[T]() -> (x := Sequence[T]): ...  # Syntax error: assignment expression not allowed
+
+    type Alias1[T] = (x := list[T])  # Syntax error: assignment expression not allowed
+
+
 Variance Inference
 ------------------
 
-We propose to eliminate the need for variance to be specified for type
+This PEP eliminates the need for variance to be specified for type
 parameters. Instead, type checkers will infer the variance of type parameters
-based on their usage within a class. Type parameters can be invariant,
-covariant, or contravariant depending on how they are used.
+based on their usage within a class. Type parameters are inferred to be
+invariant, covariant, or contravariant depending on how they are used.
 
 Python type checkers already include the ability to determine the variance of
 type parameters for the purpose of validating variance within a generic
 protocol class. This capability can be used for all classes (whether or not
-they are protocols) to calculate the variance of each type parameter. This
-eliminates the need for most developers to understand the concept of variance.
-It also eliminates the need to introduce a dedicated syntax for specifying
-variance.
+they are protocols) to calculate the variance of each type parameter.
 
 The algorithm for computing the variance of a type parameter is as follows.
 
@@ -441,16 +603,19 @@ specification (``ParamSpec``), it is always considered invariant. No further
 inference is needed.
 
 2. If the type parameter comes from a traditional ``TypeVar`` declaration and
-is not specified as ``autovariance`` (see below), its variance is specified
+is not specified as ``infer_variance`` (see below), its variance is specified
 by the ``TypeVar`` constructor call. No further inference is needed.
 
 3. Create two specialized versions of the class. We'll refer to these as
 ``upper`` and ``lower`` specializations. In both of these specializations,
 replace all type parameters other than the one being inferred by a dummy type
-instance. In the ``upper`` specialized class, specialize the target type
-parameter with an ``object`` instance. In the ``lower`` specialized class,
-specialize the target type parameter with itself. This specialization
-ignores the type parameter's upper bound or constraints.
+instance (a concrete anonymous class that is type compatible with itself and
+assumed to meet the bounds or constraints of the type parameter). In
+the ``upper`` specialized class, specialize the target type parameter with
+an ``object`` instance. This specialization ignores the type parameter's
+upper bound or constraints. In the ``lower`` specialized class, specialize
+the target type parameter with itself (i.e. the corresponding type argument
+is the type parameter itself).
 
 4. Determine whether ``lower`` can be assigned to ``upper`` using normal type
 compatibility rules. If so, the target type parameter is covariant. If not,
@@ -476,9 +641,9 @@ To determine the variance of ``T1``, we specialize ``ClassA`` as follows:
     upper = ClassA[object, Dummy, Dummy]
     lower = ClassA[T1, Dummy, Dummy]
 
-We find that ``upper`` is not assignable to ``lower`` nor is ``lower``
-assignable to ``upper`` using standard type compatibility checks, so we
-can conclude that ``T1`` is invariant.
+We find that ``upper`` is not assignable to ``lower`` using normal type
+compatibility rules defined in :pep:`484`. Likewise, ``lower`` is not assignable
+to ``upper``, so we conclude that ``T1`` is invariant.
 
 To determine the variance of ``T2``, we specialize ``ClassA`` as follows:
 
@@ -505,17 +670,19 @@ Auto Variance For TypeVar
 The existing ``TypeVar`` class constructor accepts keyword parameters named
 ``covariant`` and ``contravariant``. If both of these are ``False``, the
 type variable is assumed to be invariant. We propose to add another keyword
-parameter named ``autovariance``. A corresponding instance variable
-``__autovariance__`` can be accessed at runtime to determine whether the
-variance is inferred. Type variables that are implicitly allocated using the
-new syntax will always have ``__autovariance__`` set to ``True``.
+parameter named ``infer_variance`` indicating that a type checker should use
+inference to determine whether the type variable is invariant, covariant or
+contravariant. A corresponding instance variable ``__infer_variance__`` can be
+accessed at runtime to determine whether the variance is inferred. Type
+variables that are implicitly allocated using the new syntax will always
+have ``__infer_variance__`` set to ``True``.
 
 A generic class that uses the traditional syntax may include combinations of
 type variables with explicit and inferred variance.
 
 ::
 
-    T1 = TypeVar("T1", autovariance=True)  # Inferred variance
+    T1 = TypeVar("T1", infer_variance=True)  # Inferred variance
     T2 = TypeVar("T2")  # Invariant
     T3 = TypeVar("T3", covariant=True)  # Covariant
 
@@ -557,8 +724,8 @@ new-style type parameters must come from an outer scope in this case.
         # should generate an error in this case because this method uses the
         # new syntax for type parameters, and all type parameters associated
         # with the method must be explicitly declared. In this case, ``K``
-        # is not declared by "method2", nor is it supplied defined an outer
-        # scope.
+        # is not declared by "method2", nor is it supplied by a new-style
+        # type parameter defined in an outer scope.
         def method2[M](self, a: M, b: K) -> M | K: ...
 
 
@@ -586,14 +753,20 @@ in the following ways:
 
     type_param_bound: ":" e=expression
 
+    # Grammar definitions for class_def_raw and function_def_raw are modified
+    # to reference type_params as an optional syntax element. The definitions
+    # of class_def_raw and function_def_raw are simplified here for brevity.
+
+    class_def_raw: 'class' n=NAME t=[type_params] ...
+
+    function_def_raw: a=[ASYNC] 'def' n=NAME t=[type_params] ...
+
 
 2. Addition of new ``type`` statement for defining type aliases.
 
 ::
 
-    type_alias[stmt_ty]:
-        | "type" n=NAME t=[type_params] '=' b=expression {
-            CHECK_VERSION(stmt_ty, 12, "Type statement is", _PyAST_TypeAlias(n->v.Name.id, t, b, EXTRA)) }
+    type_alias: "type" n=NAME t=[type_params] '=' b=expression
 
 
 AST Changes
@@ -605,7 +778,7 @@ This PEP introduces a new AST node type called ``TypeAlias``.
 
     TypeAlias(identifier name, typeparam* typeparams, expr value)
 
-It also adds an AST node that represents a type parameter.
+It also adds an AST node type that represents a type parameter.
 
 ::
 
@@ -613,105 +786,10 @@ It also adds an AST node that represents a type parameter.
         | ParamSpec(identifier name)
         | TypeVarTuple(identifier name)
 
-It also modifies existing AST nodes ``FunctionDef``, ``AsyncFunctionDef`` and
-``ClassDef`` to include an additional optional attribute called ``typeparam*``
-that includes a list of type parameters associated with the function or class.
-
-
-Compiler Changes
-----------------
-
-The compiler maintains a list of "active type variables" as it recursively
-generates byte codes for the program. Consider the following example.
-
-::
-
-    class Outer[K, V]:
-        # Active type variables are K and V
-
-        class Inner[T]:
-            # Active type variables are K, V, and T
-
-            def method[M](self, a: M) -> M:
-                # Active type variables are K, V, T, and M
-                ...
-
-An active type variable symbol cannot be used for other purposes within
-these scopes. This includes local parameters, local variables, variables
-bound from other scopes (nonlocal or global), or other type parameters. An
-attempt to reuse a type variable name in one of these manners results in
-a syntax error.
-
-::
-
-    class ClassA[K, V]:
-        class Inner[K]: # Syntax error: K already in use as type variable
-            ...
-
-    class ClassB[K, V]:
-        def method(self, K): # Syntax error: K already in use as type variable
-            ...
-
-    class ClassC[T, T]: # Syntax error: T already in use as type variable
-        ...
-
-    def func1[T]():
-        ...
-
-
-A type variable is considered "active" when compiling the arguments for
-a class declaration, the type annotations for a function declaration, and
-the right-hand expression in a type alias declaration. Type variable are
-not considered "active" when compiling the default argument expressions for
-a function declaration or decorator expressions for classes or functions.
-
-::
-
-    T = list
-
-    @decorator(T) # T in decorator refers to outer variable
-    class ClassA[T](Base[T], metaclass=Meta[T]) # T refers to type variable
-        ...
-
-    @decorator(T) # T in decorator refers to outer variable
-    def func1[T](a: list[T]) -> T: # T refers to type variable
-        ...
-
-    def func2[T](a = T): # T in default refers to outer variable
-        ...
-
-
-When a ``class``, ``def``, or ``type`` statement includes one or more type
-parameters, the compiler emits byte codes to construct the corresponding
-``typing.TypeVar``, ``typing.TypeVarTuple``, or ``typing.ParamSpec`` instances.
-It then builds a new tuple that includes all active type variables and stores
-this new tuple in a local variable. Active type variables include all type
-parameters declared by outer ``class`` and ``def`` scopes plus those declared
-by the ``class``, ``def``, or ``type`` statement itself. (In the reference
-implementation, the local variable happens to have the name
-``__type_variables__``, but this is an implementation detail. Other Python
-compilers or future versions of the CPython compiler may choose a different
-name or an entirely anonymous local variable slot for this purpose.)
-
-When a type variable is referenced, the compiler generates opcodes that
-load the active type variable tuple from either the local variable or (if
-there are no local type variables) through the use of a new opcode called
-``LOAD_TYPEVARS`` that loads the tuple of active type variables from the
-current function object. It then emits opcodes to index into this tuple to
-fetch the desired type variable.
-
-When a new function is created, the "active type variables" tuple is copied
-to the C struct field ``func_typevars`` of the function object, making the type
-variables from outer scopes available to inner scopes of the function or class.
-
-A new read-only attribute called ``__type_variables__`` is available on class,
-function, and type alias objects. This attribute is a tuple of the active
-type variables that are visible within the scope of that class, function,
-or type alias. This attribute is used for runtime evaluation of stringified
-(forward referenced) type annotations that include references to type
-parameters. Functions like ``typing.get_type_hints`` can use this attribute
-to populate the ``locals`` dictionary with values for type parameters that
-are in scope when calling ``eval`` to evaluate the stringified expression.
+It also modifies existing AST node types ``FunctionDef``, ``AsyncFunctionDef``
+and ``ClassDef`` to include an additional optional attribute called
+``typeparam*`` that includes a list of type parameters associated with the
+function or class.
 
 
 Library Changes
@@ -719,8 +797,9 @@ Library Changes
 
 Several classes in the ``typing`` module that are currently implemented in
 Python must be reimplemented in C. This includes: ``TypeVar``,
-``TypeVarTuple``, ``ParamSpec``, and ``Generic``. The new class
-``TypeAliasType`` (described above) also must be implemented in C.
+``TypeVarTuple``, ``ParamSpec``, ``Generic``, and ``Union``. The new class
+``TypeAliasType`` (described above) also must be implemented in C. The
+documented behaviors of these classes should not change.
 
 The ``typing.get_type_hints`` must be updated to use the new
 ``__type_variables__`` attribute.
@@ -729,7 +808,7 @@ The ``typing.get_type_hints`` must be updated to use the new
 Reference Implementation
 ========================
 
-This proposal is prototyped in the CPython code base in
+This proposal is partially prototyped in the CPython code base in
 `this fork <https://github.com/erictraut/cpython/tree/type_param_syntax2>`_.
 
 The Pyright type checker supports the behavior described in this PEP.
@@ -962,8 +1041,7 @@ combined with other type operators such as ``keyof``.
 TypeScript uses declaration-site variance. Variance is inferred from
 usage, not specified explicitly. TypeScript 4.7 introduced the ability
 to specify variance using ``in`` and ``out`` keywords. This was added to handle
-extremely complex types where inference of variance was expensive,
-yet the maintainers state that is useful for increasing readability.
+extremely complex types where inference of variance was expensive.
 
 A default type argument can be specified using the ``=`` operator.
 

--- a/pep-0695.rst
+++ b/pep-0695.rst
@@ -594,6 +594,7 @@ or type alias. This attribute is needed for runtime evaluation of stringified
 parameters. Functions like ``typing.get_type_hints`` can use this attribute
 to populate the ``locals`` dictionary with values for type parameters that
 are in scope when calling ``eval`` to evaluate the stringified expression.
+The tuple contains ``TypeVar`` instances.
 
 Type parameters declared using the new syntax will not appear within the
 dictionary returned by ``globals()`` or ``locals()``.

--- a/pep-0695.rst
+++ b/pep-0695.rst
@@ -385,7 +385,7 @@ upper bound expressions or type argument defaults that depend on earlier
 type parameters.
 
 A compiler error or runtime exception is generated if the definition of an
-earlier type parameter references a later type parameter even if name is
+earlier type parameter references a later type parameter even if the name is
 defined in an outer scope.
 
 ::
@@ -579,6 +579,22 @@ the defined type parameters.
     def func2[T]() -> (x := Sequence[T]): ...  # Syntax error: assignment expression not allowed
 
     type Alias1[T] = (x := list[T])  # Syntax error: assignment expression not allowed
+
+
+Accessing Type Parameters at Runtime
+------------------------------------
+
+A new read-only attribute called ``__type_variables__`` is available on class,
+function, and type alias objects. This attribute is a tuple of the active
+type variables that are visible within the scope of that class, function,
+or type alias. This attribute is needed for runtime evaluation of stringified
+(forward referenced) type annotations that include references to type
+parameters. Functions like ``typing.get_type_hints`` can use this attribute
+to populate the ``locals`` dictionary with values for type parameters that
+are in scope when calling ``eval`` to evaluate the stringified expression.
+
+Type parameters declared using the new syntax will not appear within the
+dictionary returned by ``globals()`` or ``locals()``.
 
 
 Variance Inference

--- a/pep-0695.rst
+++ b/pep-0695.rst
@@ -49,7 +49,7 @@ confusion.
 The scoping rules for type variables are difficult to understand. Type
 variables are typically allocated within the global scope, but their semantic
 meaning is valid only when used within the context of a generic class,
-function, or or type alias. A single runtime instance of a type variable may be
+function, or type alias. A single runtime instance of a type variable may be
 reused in multiple generic contexts, and it has a different semantic meaning
 in each of these contexts. This PEP proposes to eliminate this source of
 confusion by declaring type parameters at a natural place within a class,
@@ -361,7 +361,8 @@ At runtime, a ``type`` statement will generate an instance of
 include:
 
 * ``__name__`` is a str representing the name of the type alias
-* ``__parameters__`` is a tuple of ``TypeVar``, ``TypeVarTuple``, or ``ParamSpec`` objects that parameterize the type alias if it is generic
+* ``__parameters__`` is a tuple of ``TypeVar``, ``TypeVarTuple``, or
+  ``ParamSpec`` objects that parameterize the type alias if it is generic
 * ``__value__`` is the evaluated value of the type alias
 
 The ``__value__`` attribute initially has a value of ``None`` while the type
@@ -392,7 +393,7 @@ defined in an outer scope.
 
     # The following generates no compiler error, but a type checker
     # should generate an error because an upper bound type must be concrete,
-    # and ``Sequence[S]`` is generic. Future extensions to the typing system may
+    # and ``Sequence[S]`` is generic. Future extensions to the type system may
     # eliminate this limitation.
     class ClassA[S, T: Sequence[S]]: ...
 

--- a/pep-0695.rst
+++ b/pep-0695.rst
@@ -8,6 +8,7 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 15-Jun-2022
 Python-Version: 3.12
+Post-History: `20-Jun-2022 <https://mail.python.org/archives/list/typing-sig@python.org/thread/BB2BGYJY2YG5IWESKGTAPUQL3N27ZKVW/>`__
 
 
 Abstract


### PR DESCRIPTION
Changes include:
* Updated link to typing-sig discussion
* Made clarifications to some terminology
* Made improvements to some code samples based on input from Guido
* Fixed a few formatting bugs
* Changed scoping rules for type parameters based on input from Guido and other reviewers
* Changed "autovariance" to "infer_variance" based in input that the former was confusing
* Removed detailed "compiler changes" section since it's an implementation detail and not normative