### PR TITLE
PEP 619: Add 3.10.7 release

### DIFF
--- a/pep-0619.rst
+++ b/pep-0619.rst
@@ -69,23 +69,24 @@ Actual:
 - 3.10.4: Thursday, 2022-03-24
 - 3.10.5: Monday, 2022-06-06
 - 3.10.6: Tuesday, 2022-08-02
+- 3.10.7: Tuesday, 2022-09-06
 
 Expected:
 
-- 3.10.7: Monday, 2022-10-03
-- 3.10.8: Monday, 2022-12-05
-- 3.10.9: Monday, 2023-02-06
+- 3.10.8: Monday, 2022-10-03
+- 3.10.9: Monday, 2022-12-05
+- 3.10.10: Monday, 2023-02-06
 
 Final regular bugfix release with binary installers:
 
-- 3.10.10: Monday, 2023-04-03
+- 3.10.11: Monday, 2023-04-03
 
 3.10 Lifespan
 -------------
 
 3.10 will receive bugfix updates approximately every 2 months for
 approximately 18 months.  Some time after the release of 3.11.0 final,
-the ninth and final 3.10 bugfix update will be released.  After that,
+the 11th and final 3.10 bugfix update will be released.  After that,
 it is expected that security updates (source only) will be released
 until 5 years after the release of 3.10 final, so until approximately
 October 2026.


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3107/

As as unscheduled release, I inserted this and kept the four remaining binary releases, bumping their patch version.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
