### PR TITLE
PEP 458: Clarify sequence of PyPI and pip integration

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -329,7 +329,11 @@ Integrating PyPI with TUF
 =========================
 
 A software update system must complete two main tasks to integrate with TUF.
-First, it must add the framework to the client side of the update system. For
+First, the repository on the server side MUST be modified to provide signed
+TUF metadata. This PEP is concerned with the first part of the integration,
+and the changes on PyPI required to support software updates with TUF.
+
+Second, it must add the framework to the client side of the update system. For
 example, TUF MAY be integrated with the pip package manager. Thus, new versions
 of pip going forward SHOULD use TUF by default to download and verify distributions
 from PyPI before installing them. However, there may be unforeseen issues that
@@ -340,9 +344,6 @@ until they are resolved. Note, the proposed option name is purposefully long,
 because a user must be helped to understand that the action is unsafe and not
 generally recommended.
 
-Second, the repository on the server side MUST be modified to provide signed
-TUF metadata. This PEP is concerned with the second part of the integration,
-and the changes on PyPI required to support software updates with TUF.
 We assume that pip would use TUF to verify distributions downloaded only from PyPI.
 pip MAY support TAP 4__ in order use TUF to also verify distributions downloaded
 from :pep:`elsewhere <470>`.


### PR DESCRIPTION
OK'd by coauthors in [Discourse conversation](https://discuss.python.org/t/pep-458-secure-pypi-downloads-with-package-signing/2648/132).