### PR TITLE
PEP 366, 395, 413, 426, 430, 440, 531, 535, 3150: Fix footnotes

### DIFF
--- a/pep-0366.txt
+++ b/pep-0366.txt
@@ -103,7 +103,7 @@ which stored the main module's real module name in the
 ``__module_name__`` attribute. It was reverted due to the fact
 that 2.5 was already in beta by that time.
 
-Patch 1487 [4] is the proposed implementation for this PEP.
+Patch 1487 [4]_ is the proposed implementation for this PEP.
 
 Alternative Proposals
 =====================
@@ -143,11 +143,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:

--- a/pep-0366.txt
+++ b/pep-0366.txt
@@ -125,7 +125,7 @@ References
 ==========
 
 .. [1] Absolute/relative import not working?
-   (https://bugs.python.org/issue1510172)
+   (https://github.com/python/cpython/issues/43535)
 
 .. [2] c.l.p. question about modules and relative imports
    (http://groups.google.com/group/comp.lang.python/browse_thread/thread/c44c769a72ca69fa/)
@@ -134,7 +134,7 @@ References
    (https://mail.python.org/pipermail/python-3000/2007-April/006793.html)
 
 .. [4] PEP 366 implementation patch
-   (http://bugs.python.org/issue1487)
+   (https://github.com/python/cpython/issues/45828)
 
 .. [5] Acceptance of the PEP
    (https://mail.python.org/pipermail/python-dev/2007-November/075475.html)

--- a/pep-0395.txt
+++ b/pep-0395.txt
@@ -724,18 +724,10 @@ References
 .. [3] Updated PEP 395 (aka "Implicit Relative Imports Must Die!")
    (https://mail.python.org/pipermail/import-sig/2011-November/000397.html)
 
-.. [4] Elaboration of compatibility problems between this PEP and PEP 402
-   (https://mail.python.org/pipermail/import-sig/2011-November/000403.html)
+* `Elaboration of compatibility problems between this PEP and PEP 402
+  <https://mail.python.org/pipermail/import-sig/2011-November/000403.html>`__
 
 Copyright
 =========
 
 This document has been placed in the public domain.
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:

--- a/pep-0395.txt
+++ b/pep-0395.txt
@@ -715,14 +715,14 @@ None as yet.
 References
 ==========
 
-.. [1] Module aliases and/or "real names"
-   (https://mail.python.org/pipermail/python-ideas/2011-January/008983.html)
+.. [1] `Module aliases and/or "real names"
+   <https://mail.python.org/pipermail/python-ideas/2011-January/008983.html>`__
 
-.. [2] PEP 395 (Module aliasing) and the namespace PEPs
-   (https://mail.python.org/pipermail/import-sig/2011-November/000382.html)
+.. [2] `PEP 395 (Module aliasing) and the namespace PEPs
+   <https://mail.python.org/pipermail/import-sig/2011-November/000382.html>`__
 
-.. [3] Updated PEP 395 (aka "Implicit Relative Imports Must Die!")
-   (https://mail.python.org/pipermail/import-sig/2011-November/000397.html)
+.. [3] `Updated PEP 395 (aka "Implicit Relative Imports Must Die!")
+   <https://mail.python.org/pipermail/import-sig/2011-November/000397.html>`__
 
 * `Elaboration of compatibility problems between this PEP and PEP 402
   <https://mail.python.org/pipermail/import-sig/2011-November/000403.html>`__

--- a/pep-0413.txt
+++ b/pep-0413.txt
@@ -593,7 +593,7 @@ resolving this becomes even more critical. While Mercurial phases may
 help to some degree, it would be good to eliminate the problem entirely.
 
 One suggestion from Barry Warsaw is to adopt a non-conflicting
-separate-files-per-change approach, similar to that used by Twisted [2_].
+separate-files-per-change approach, similar to that used by Twisted [2]_.
 
 Given that the current manually updated NEWS file will be used for the 3.3.0
 release, one possible layout for such an approach might look like::
@@ -920,13 +920,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0413.txt
+++ b/pep-0413.txt
@@ -914,7 +914,7 @@ References
 ==========
 
 .. [2] Twisted's "topfiles" approach to NEWS generation
-   http://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles
+   https://web.archive.org/web/20120305142914/http://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles
 
 Copyright
 =========

--- a/pep-0426.txt
+++ b/pep-0426.txt
@@ -443,9 +443,9 @@ in Appendix A.
 Metadata validation
 -------------------
 
-A `jsonschema <https://pypi.python.org/pypi/jsonschema>`__ description of
+A `jsonschema <https://pypi.org/project/jsonschema/>`__ description of
 the distribution metadata is `available
-<http://hg.python.org/peps/file/default/pep-0426/pydist-schema.json>`__.
+<https://hg.python.org/peps/file/default/pep-0426/pydist-schema.json>`__.
 
 This schema does NOT currently handle validation of some of the more complex
 string fields (instead treating them as opaque strings).
@@ -1507,12 +1507,12 @@ Version 1.2 is specified in :pep:`345`.
 The initial attempt at a standardised version scheme, along with the
 justifications for needing such a standard can be found in :pep:`386`.
 
-.. [1] reStructuredText markup:
-   http://docutils.sourceforge.net/
+* `reStructuredText markup
+  <https://docutils.sourceforge.io/>`__
 
-.. _Python Package Index: http://pypi.python.org/pypi/
+.. _Python Package Index: https://pypi.org/
 
-.. _TR39: http://www.unicode.org/reports/tr39/tr39-1.html#Confusable_Detection
+.. _TR39: https://www.unicode.org/reports/tr39/tr39-1.html#Confusable_Detection
 
 
 Copyright

--- a/pep-0426.txt
+++ b/pep-0426.txt
@@ -1519,12 +1519,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:

--- a/pep-0430.txt
+++ b/pep-0430.txt
@@ -28,7 +28,7 @@ Background
 ==========
 
 With the transition of the overall Python ecosystem from Python 2 to Python 3
-still in progress, one question which arises periodically [1_, 2_] is when
+still in progress, one question which arises periodically [1]_, [2]_ is when
 and how to handle the change from providing the Python 2 documentation as
 the default version displayed at the docs.python.org root URL to providing
 the Python 3 documentation.
@@ -77,7 +77,7 @@ the path component.
 Proposal
 ========
 
-This PEP (based on an idea originally put forward back in May [3_]) is to
+This PEP (based on an idea originally put forward back in May [3]_) is to
 *not migrate* the Python 2 specific deep links at all, and instead adopt a
 scheme where all URLs presented to users on docs.python.org are qualified
 appropriately with the relevant release series.

--- a/pep-0440.txt
+++ b/pep-0440.txt
@@ -1559,32 +1559,32 @@ justifications for needing such a standard can be found in :pep:`386`.
 * `Reference Implementation of PEP 440 Versions and Specifiers
   <https://github.com/pypa/packaging/pull/1>`__
 
-.. [2] Version compatibility analysis script:
-   https://github.com/pypa/packaging/blob/master/tasks/check.py
+.. [2] `Version compatibility analysis script
+   <https://github.com/pypa/packaging/blob/master/tasks/check.py>`__
 
 * `Pessimistic version constraint
   <https://web.archive.org/web/20130509214125/http://docs.rubygems.org/read/chapter/16>`__
 
-.. [4] File URIs in Windows
-   https://web.archive.org/web/20130321051043/http://blogs.msdn.com/b/ie/archive/2006/12/06/file-uris-in-windows.aspx
+.. [4] `File URIs in Windows
+   <https://web.archive.org/web/20130321051043/http://blogs.msdn.com/b/ie/archive/2006/12/06/file-uris-in-windows.aspx>`__
 
-.. [5] Proof of Concept: PEP 440 within pip
-    https://github.com/pypa/pip/pull/1894
+.. [5] `Proof of Concept: PEP 440 within pip
+    <https://github.com/pypa/pip/pull/1894>`__
 
-.. [6] PEP440: foo-X.Y.Z does not satisfy "foo>X.Y"
-    https://mail.python.org/pipermail/distutils-sig/2014-December/025451.html
+.. [6] `PEP440: foo-X.Y.Z does not satisfy "foo>X.Y"
+    <https://mail.python.org/pipermail/distutils-sig/2014-December/025451.html>`__
 
-.. [7] PEP440: >1.7 vs >=1.7
-    https://mail.python.org/pipermail/distutils-sig/2014-December/025507.html
+.. [7] `PEP440: >1.7 vs >=1.7
+    <https://mail.python.org/pipermail/distutils-sig/2014-December/025507.html>`__
 
-.. [8] Amend PEP 440 with Wider Feedback on Release Candidates
-   https://mail.python.org/pipermail/distutils-sig/2014-December/025409.html
+.. [8] `Amend PEP 440 with Wider Feedback on Release Candidates
+   <https://mail.python.org/pipermail/distutils-sig/2014-December/025409.html>`__
 
 * `Changing the status of PEP 440 to Provisional
   <https://mail.python.org/pipermail/distutils-sig/2014-December/025412.html>`__
 
-.. [10] PEP 440: regex should not permit Unicode [Nd] characters
-   https://github.com/python/peps/pull/966
+.. [10] `PEP 440: regex should not permit Unicode [Nd] characters
+   <https://github.com/python/peps/pull/966>`__
 
 Appendix A
 ==========

--- a/pep-0440.txt
+++ b/pep-0440.txt
@@ -1556,14 +1556,8 @@ References
 The initial attempt at a standardised version scheme, along with the
 justifications for needing such a standard can be found in :pep:`386`.
 
-* `Reference Implementation of PEP 440 Versions and Specifiers
-  <https://github.com/pypa/packaging/pull/1>`__
-
 .. [2] `Version compatibility analysis script
    <https://github.com/pypa/packaging/blob/master/tasks/check.py>`__
-
-* `Pessimistic version constraint
-  <https://web.archive.org/web/20130509214125/http://docs.rubygems.org/read/chapter/16>`__
 
 .. [4] `File URIs in Windows
    <https://web.archive.org/web/20130321051043/http://blogs.msdn.com/b/ie/archive/2006/12/06/file-uris-in-windows.aspx>`__
@@ -1580,11 +1574,17 @@ justifications for needing such a standard can be found in :pep:`386`.
 .. [8] `Amend PEP 440 with Wider Feedback on Release Candidates
    <https://mail.python.org/pipermail/distutils-sig/2014-December/025409.html>`__
 
-* `Changing the status of PEP 440 to Provisional
-  <https://mail.python.org/pipermail/distutils-sig/2014-December/025412.html>`__
-
 .. [10] `PEP 440: regex should not permit Unicode [Nd] characters
    <https://github.com/python/peps/pull/966>`__
+
+* `Reference Implementation of PEP 440 Versions and Specifiers
+  <https://github.com/pypa/packaging/pull/1>`__
+
+* `Pessimistic version constraint
+  <https://web.archive.org/web/20130509214125/http://docs.rubygems.org/read/chapter/16>`__
+
+* `Changing the status of PEP 440 to Provisional
+  <https://mail.python.org/pipermail/distutils-sig/2014-December/025412.html>`__
 
 Appendix A
 ==========

--- a/pep-0440.txt
+++ b/pep-0440.txt
@@ -39,7 +39,7 @@ document are to be interpreted as described in :rfc:`2119`.
 Projects include Python libraries, frameworks, scripts, plugins,
 applications, collections of data or other resources, and various
 combinations thereof. Public Python projects are typically registered on
-the `Python Package Index <https://pypi.python.org>`__.
+the `Python Package Index <https://pypi.org/>`__.
 
 "Releases" are uniquely identified snapshots of a project.
 
@@ -762,7 +762,7 @@ specify the appropriate version order.
 
 Specific build information may also be included in local version labels.
 
-.. _Semantic versioning: http://semver.org/
+.. _Semantic versioning: https://semver.org/
 
 
 DVCS based version labels
@@ -1556,17 +1556,17 @@ References
 The initial attempt at a standardised version scheme, along with the
 justifications for needing such a standard can be found in :pep:`386`.
 
-.. [1] Reference Implementation of PEP 440 Versions and Specifiers
-   https://github.com/pypa/packaging/pull/1
+* `Reference Implementation of PEP 440 Versions and Specifiers
+  <https://github.com/pypa/packaging/pull/1>`__
 
 .. [2] Version compatibility analysis script:
    https://github.com/pypa/packaging/blob/master/tasks/check.py
 
-.. [3] Pessimistic version constraint
-   http://docs.rubygems.org/read/chapter/16
+* `Pessimistic version constraint
+  <https://web.archive.org/web/20130509214125/http://docs.rubygems.org/read/chapter/16>`__
 
 .. [4] File URIs in Windows
-   http://blogs.msdn.com/b/ie/archive/2006/12/06/file-uris-in-windows.aspx
+   https://web.archive.org/web/20130321051043/http://blogs.msdn.com/b/ie/archive/2006/12/06/file-uris-in-windows.aspx
 
 .. [5] Proof of Concept: PEP 440 within pip
     https://github.com/pypa/pip/pull/1894
@@ -1580,8 +1580,8 @@ justifications for needing such a standard can be found in :pep:`386`.
 .. [8] Amend PEP 440 with Wider Feedback on Release Candidates
    https://mail.python.org/pipermail/distutils-sig/2014-December/025409.html
 
-.. [9] Changing the status of PEP 440 to Provisional
-   https://mail.python.org/pipermail/distutils-sig/2014-December/025412.html
+* `Changing the status of PEP 440 to Provisional
+  <https://mail.python.org/pipermail/distutils-sig/2014-December/025412.html>`__
 
 .. [10] PEP 440: regex should not permit Unicode [Nd] characters
    https://github.com/python/peps/pull/966
@@ -1659,12 +1659,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:

--- a/pep-0531.txt
+++ b/pep-0531.txt
@@ -55,7 +55,7 @@ following characteristics:
 PEP Withdrawal
 ==============
 
-When posting this PEP for discussion on python-ideas [4_], I asked reviewers to
+When posting this PEP for discussion on python-ideas [4]_, I asked reviewers to
 consider 3 high level design questions before moving on to considering the
 specifics of this particular syntactic proposal:
 
@@ -74,7 +74,7 @@ truth-checking "and" and "or" control flow operators were available?
 While the answers to the first question were generally positive, it quickly
 became clear that the answer to the second question is "No".
 
-Steven D'Aprano articulated the counter-argument well in [5_], but the general
+Steven D'Aprano articulated the counter-argument well in [5]_, but the general
 idea is that when checking for "missing data" sentinels, we're almost always
 looking for a *specific* sentinel value, rather than *any* sentinel value.
 
@@ -96,7 +96,7 @@ make sense, and it is accordingly withdrawn.
 
 However, the discussion of the proposal did prompt consideration of a potential
 protocol based approach to make the existing ``and``, ``or`` and ``if-else``
-operators more flexible [6_] without introducing any new syntax, so I'll be
+operators more flexible [6]_ without introducing any new syntax, so I'll be
 writing that up as another possible alternative to :pep:`505`.
 
 
@@ -645,13 +645,3 @@ Copyright
 
 This document has been placed in the public domain under the terms of the
 CC0 1.0 license: https://creativecommons.org/publicdomain/zero/1.0/
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0535.txt
+++ b/pep-0535.txt
@@ -81,7 +81,7 @@ operations would be the same as the existing expansion for ``and``.
 Rationale
 =========
 
-In ultimately rejecting :pep:`335`, Guido van Rossum noted [1_]:
+In ultimately rejecting :pep:`335`, Guido van Rossum noted [1]_:
 
     The NumPy folks brought up a somewhat separate issue: for them,
     the most common use case is chained comparisons (e.g. A < B < C).
@@ -187,13 +187,3 @@ Copyright
 
 This document has been placed in the public domain under the terms of the
 CC0 1.0 license: https://creativecommons.org/publicdomain/zero/1.0/
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-3150.txt
+++ b/pep-3150.txt
@@ -750,8 +750,8 @@ References
 .. [4] Name conflict with NumPy for 'where' keyword choice:
    https://mail.python.org/pipermail/python-ideas/2010-July/007596.html
 
-.. [5] The "Status quo wins a stalemate" design principle:
-   http://www.boredomandlaziness.org/2011/02/status-quo-wins-stalemate.html
+* `The "Status quo wins a stalemate" design principle
+  <https://www.curiousefficiency.org/posts/2011/02/status-quo-wins-stalemate.html>`__
 
 .. [6] Assignments in list/generator expressions:
    https://mail.python.org/pipermail/python-ideas/2011-April/009863.html
@@ -765,21 +765,10 @@ References
 .. [9] Possible PEP 3150 style guidelines (#2):
    https://mail.python.org/pipermail/python-ideas/2011-October/012341.html
 
-.. [10] Multi-line lambdas (again!)
-   https://mail.python.org/pipermail/python-ideas/2013-August/022526.html
+* `Multi-line lambdas (again!)
+  <https://mail.python.org/pipermail/python-ideas/2013-August/022526.html>`__
 
 Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-3150.txt
+++ b/pep-3150.txt
@@ -738,32 +738,32 @@ TO-DO
 References
 ==========
 
-.. [1] Explicitation lines in Python:
-   https://mail.python.org/pipermail/python-ideas/2010-June/007476.html
+.. [1] `Explicitation lines in Python
+   <https://mail.python.org/pipermail/python-ideas/2010-June/007476.html>`__
 
-.. [2] 'where' statement in Python:
-   https://mail.python.org/pipermail/python-ideas/2010-July/007584.html
+.. [2] `'where' statement in Python
+   <https://mail.python.org/pipermail/python-ideas/2010-July/007584.html>`__
 
-.. [3] Where-statement (Proposal for function expressions):
-   https://mail.python.org/pipermail/python-ideas/2009-July/005132.html
+.. [3] `Where-statement (Proposal for function expressions)
+   <https://mail.python.org/pipermail/python-ideas/2009-July/005132.html>`__
 
-.. [4] Name conflict with NumPy for 'where' keyword choice:
-   https://mail.python.org/pipermail/python-ideas/2010-July/007596.html
+.. [4] `Name conflict with NumPy for 'where' keyword choice
+   <https://mail.python.org/pipermail/python-ideas/2010-July/007596.html>`__
 
 * `The "Status quo wins a stalemate" design principle
   <https://www.curiousefficiency.org/posts/2011/02/status-quo-wins-stalemate.html>`__
 
-.. [6] Assignments in list/generator expressions:
-   https://mail.python.org/pipermail/python-ideas/2011-April/009863.html
+.. [6] `Assignments in list/generator expressions
+   <https://mail.python.org/pipermail/python-ideas/2011-April/009863.html>`__
 
-.. [7] Possible PEP 3150 style guidelines (#1):
-   https://mail.python.org/pipermail/python-ideas/2011-April/009869.html
+.. [7] `Possible PEP 3150 style guidelines (#1)
+   <https://mail.python.org/pipermail/python-ideas/2011-April/009869.html>`__
 
-.. [8] Discussion of PEP 403 (statement local function definition):
-   https://mail.python.org/pipermail/python-ideas/2011-October/012276.html
+.. [8] `Discussion of PEP 403 (statement local function definition)
+   <https://mail.python.org/pipermail/python-ideas/2011-October/012276.html>`__
 
-.. [9] Possible PEP 3150 style guidelines (#2):
-   https://mail.python.org/pipermail/python-ideas/2011-October/012341.html
+.. [9] `Possible PEP 3150 style guidelines (#2)
+   <https://mail.python.org/pipermail/python-ideas/2011-October/012341.html>`__
 
 * `Multi-line lambdas (again!)
   <https://mail.python.org/pipermail/python-ideas/2013-August/022526.html>`__

--- a/pep-3150.txt
+++ b/pep-3150.txt
@@ -750,9 +750,6 @@ References
 .. [4] `Name conflict with NumPy for 'where' keyword choice
    <https://mail.python.org/pipermail/python-ideas/2010-July/007596.html>`__
 
-* `The "Status quo wins a stalemate" design principle
-  <https://www.curiousefficiency.org/posts/2011/02/status-quo-wins-stalemate.html>`__
-
 .. [6] `Assignments in list/generator expressions
    <https://mail.python.org/pipermail/python-ideas/2011-April/009863.html>`__
 
@@ -764,6 +761,9 @@ References
 
 .. [9] `Possible PEP 3150 style guidelines (#2)
    <https://mail.python.org/pipermail/python-ideas/2011-October/012341.html>`__
+
+* `The "Status quo wins a stalemate" design principle
+  <https://www.curiousefficiency.org/posts/2011/02/status-quo-wins-stalemate.html>`__
 
 * `Multi-line lambdas (again!)
   <https://mail.python.org/pipermail/python-ideas/2013-August/022526.html>`__


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fix these warnings:

```
pep-0366.txt:136: WARNING: Footnote [4] is not referenced.
pep-0395.txt:727: WARNING: Footnote [4] is not referenced.
pep-0413.txt:916: WARNING: Footnote [2] is not referenced.
pep-0426.txt:1510: WARNING: Footnote [1] is not referenced.
pep-0430.txt:208: WARNING: Footnote [1] is not referenced.
pep-0430.txt:211: WARNING: Footnote [2] is not referenced.
pep-0430.txt:214: WARNING: Footnote [3] is not referenced.
pep-0440.txt:1559: WARNING: Footnote [1] is not referenced.
pep-0440.txt:1565: WARNING: Footnote [3] is not referenced.
pep-0440.txt:1583: WARNING: Footnote [9] is not referenced.
pep-0531.txt:634: WARNING: Footnote [4] is not referenced.
pep-0531.txt:637: WARNING: Footnote [5] is not referenced.
pep-0531.txt:640: WARNING: Footnote [6] is not referenced.
pep-0535.txt:182: WARNING: Footnote [1] is not referenced.
pep-3150.txt:753: WARNING: Footnote [5] is not referenced.
pep-3150.txt:768: WARNING: Footnote [10] is not referenced.
```

# Details

PEP 366: 

* Fix footnotes references
* Remove redundant emacs metadata
* Update BPO redirects to GH

PEP 395: 

* Convert unused footnote to bullets
* Convert footnotes into inline links
* Remove redundant emacs metadata

PEP 413: 

* Fix footnote reference
* Remove redundant emacs metadata
* Replace broken link with contemporary Wayback Machine link

PEP 426:

* Convert unused footnote to bullets
* Update link redirects
* Remove redundant emacs metadata

PEP 430:

* Fix footnote references

PEP 440:

* Convert unused footnote to bullets
* Convert footnotes into inline links
* Fix links
* Remove redundant emacs metadata

PEP 531:

* Fix footnote references
* Remove redundant emacs metadata

PEP 535:

* Fix footnote references
* Remove redundant emacs metadata

PEP 3150:

* Convert unused footnote to bullets
* Convert footnotes into inline links
* Update link redirects
* Remove redundant emacs metadata

# Previews

- https://pep-previews--2794.org.readthedocs.build/pep-0366/#references
- https://pep-previews--2794.org.readthedocs.build/pep-0395/#references
- https://pep-previews--2794.org.readthedocs.build/pep-0413/#references
- https://pep-previews--2794.org.readthedocs.build/pep-0426/#references
- https://pep-previews--2794.org.readthedocs.build/pep-0430/#references
- https://pep-previews--2794.org.readthedocs.build/pep-0440/#references
- https://pep-previews--2794.org.readthedocs.build/pep-0531/#references
- https://pep-previews--2794.org.readthedocs.build/pep-0535/#references
- https://pep-previews--2794.org.readthedocs.build/pep-3150/#references
