### PR TITLE
PEP 692: Explicitly describe the change to Unpack.__repr__ behavior

### DIFF
--- a/pep-0692.rst
+++ b/pep-0692.rst
@@ -491,7 +491,20 @@ special method on an object it was used on. This means that at runtime,
 ``def foo(**kwargs: **T): ...`` is equivalent to
 ``def foo(**kwargs: type(T).__typing_unpack__(T)): ...``.
 ``TypedDict`` is the only type in the standard library that is expected to
-implement ``__typing_unpack__``, which should return ``Unpack[self]``.
+implement ``__typing_unpack__``, which should return ``Unpack[self]``. The
+motivation for reusing :pep:`646`'s ``Unpack`` is described in the
+:ref:`Backwards Compatibility <pep-692-backwards-compatibility>` section.
+
+It is worth pointing out that currently using ``Unpack`` in the context of
+typing is interchangeable with using the asterisk syntax::
+
+    >>> Unpack[Movie]
+    *<class '__main__.Movie'>
+
+Therefore, in order to be compatible with the new usecase, ``Unpack``'s
+``repr`` should be changed to simply ``Unpack[T]``.
+
+.. _pep-692-backwards-compatibility:
 
 Backwards Compatibility
 -----------------------


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Explicitly state that `Unpack`'s repr should be changed to `Unpack[T]`. 
