### PR TITLE
PEP 11: Clarify Windows support phases

### DIFF
--- a/pep-0011.txt
+++ b/pep-0011.txt
@@ -158,13 +158,15 @@ Microsoft has established a policy called product support lifecycle
 [1]_. Each product's lifecycle has a mainstream support phase, where
 the product is generally commercially available, and an extended
 support phase, where paid support is still available, and certain bug
-fixes are released (in particular security fixes).
+fixes are released. Sometimes this is then followed by a third phase
+called "ESU", for "extended security updates".
 
 CPython's Windows support now follows this lifecycle. A new feature
 release X.Y.0 will support all Windows releases whose extended support
-phase is not yet expired. Subsequent bug fix releases will support
-the same Windows releases as the original feature release (even if
-the extended support phase has ended).
+phase is not yet expired. (We don't consider the ESU phase for this
+purpose; only the "extended support" phase.) Subsequent bug fix releases
+will support the same Windows releases as the original feature release
+(even if the extended support phase has ended).
 
 Each feature release is built by a specific version of Microsoft
 Visual Studio. That version should have mainstream support when the


### PR DESCRIPTION
This isn't a semantic change, but I just got "extended support" and "extended security updates" confused and Steve Dower had to correct me. So make it even more obvious in the text that we mean "extended support", and not "extended security updates".

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
