### PR TITLE
PEP 11: Clarify Fixed vs. Modern lifecycle & non-support of ESU

### DIFF
--- a/pep-0011.txt
+++ b/pep-0011.txt
@@ -157,15 +157,16 @@ Microsoft has established a policy called `product support lifecycle
 Each product's lifecycle has a mainstream support phase, where
 the product is generally commercially available, and an extended
 support phase, where paid support is still available, and certain bug
-fixes are released. Sometimes this is then followed by a third phase
-called "ESU", for "extended security updates".
+fixes are released. This is distinct from `ESU (Extended Security Updates)
+<https://learn.microsoft.com/en-us/lifecycle/faq/extended-security-updates>`_,
+a specialized, paid program available to high-volume enterprise customers
+as a "last resort" option after the end of extended support.
 
 CPython's Windows support now follows this lifecycle. A new feature
 release X.Y.0 will support all Windows releases whose extended support
-phase is not yet expired. (We don't consider the ESU phase for this
-purpose; only the "extended support" phase.) Subsequent bug fix releases
-will support the same Windows releases as the original feature release
-(even if the extended support phase has ended).
+phase is not yet expired (ESU is not considered supported).
+Subsequent bug fix releases will support the same Windows releases
+as the original feature release (even if the extended support phase has ended).
 
 Each feature release is built by a specific version of Microsoft
 Visual Studio. That version should have mainstream support when the

--- a/pep-0011.txt
+++ b/pep-0011.txt
@@ -152,17 +152,19 @@ Notes
 Microsoft Windows
 '''''''''''''''''
 
-Windows versions prior to Windows 10 follow Microsoft's `Fixed Lifecycle Policy <https://learn.microsoft.com/en-us/lifecycle/policies/fixed>`__,
+Windows versions prior to Windows 10 follow Microsoft's `Fixed Lifecycle Policy
+<https://learn.microsoft.com/en-us/lifecycle/policies/fixed>`__,
 with a mainstream support phase for 5 years after release,
 where the product is generally commercially available,
 and an additional 5 year extended support phase,
 where paid support is still available and certain bug fixes are released.
-Extended support is distinct from `ESU (Extended Security Updates)
-<https://learn.microsoft.com/en-us/lifecycle/faq/extended-security-updates>`_,
-a specialized, paid program available to high-volume enterprise customers
-as a "last resort" option after extended support ends.
+`Extended Security Updates (ESU)
+<https://learn.microsoft.com/en-us/lifecycle/faq/extended-security-updates>`_
+is a paid program available to high-volume enterprise customers
+as a "last resort" option to receive certain security updates after extended support ends.
+ESU is considered a distinct phase that follows the expiration of extended support.
 
-Windows 10 and up follow Microsoft's `Modern Lifecycle Policy
+Windows 10 and later follow Microsoft's `Modern Lifecycle Policy
 <https://learn.microsoft.com/en-us/lifecycle/policies/modern>`__,
 which varies per-product, per-version, per-edition and per-channel.
 Generally, feature updates (1709, 22H2) occur every 6-12 months
@@ -176,10 +178,11 @@ has more specific and up-to-date guidance.
 
 CPython's Windows support currently follows Microsoft's lifecycles.
 A new feature release X.Y.0 will support all Windows versions
-whose extended support phase is not yet expired
-(ESU is not considered supported).
+whose *extended support* phase has not yet expired.
 Subsequent bug fix releases will support the same Windows versions
 as the original feature release, even if no longer supported by Microsoft.
+New versions of Windows released while CPython is in maintenance mode
+may be supported at the discretion of the core team and release manager.
 
 Each feature release is built by a specific version of Microsoft
 Visual Studio. That version should have mainstream support when the

--- a/pep-0011.txt
+++ b/pep-0011.txt
@@ -1,7 +1,5 @@
 PEP: 11
 Title: CPython platform support
-Version: $Revision$
-Last-Modified: $Date$
 Author: Martin von Löwis <martin@v.loewis.de>,
         Brett Cannon <brett@python.org>
 Status: Active
@@ -370,14 +368,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0011.txt
+++ b/pep-0011.txt
@@ -152,21 +152,34 @@ Notes
 Microsoft Windows
 '''''''''''''''''
 
-Microsoft has established a policy called `product support lifecycle
-<https://learn.microsoft.com/en-us/lifecycle/>`__.
-Each product's lifecycle has a mainstream support phase, where
-the product is generally commercially available, and an extended
-support phase, where paid support is still available, and certain bug
-fixes are released. This is distinct from `ESU (Extended Security Updates)
+Windows versions prior to Windows 10 follow Microsoft's `Fixed Lifecycle Policy <https://learn.microsoft.com/en-us/lifecycle/policies/fixed>`__,
+with a mainstream support phase for 5 years after release,
+where the product is generally commercially available,
+and an additional 5 year extended support phase,
+where paid support is still available and certain bug fixes are released.
+Extended support is distinct from `ESU (Extended Security Updates)
 <https://learn.microsoft.com/en-us/lifecycle/faq/extended-security-updates>`_,
 a specialized, paid program available to high-volume enterprise customers
-as a "last resort" option after the end of extended support.
+as a "last resort" option after extended support ends.
 
-CPython's Windows support now follows this lifecycle. A new feature
-release X.Y.0 will support all Windows releases whose extended support
-phase is not yet expired (ESU is not considered supported).
-Subsequent bug fix releases will support the same Windows releases
-as the original feature release (even if the extended support phase has ended).
+Windows 10 and up follow Microsoft's `Modern Lifecycle Policy
+<https://learn.microsoft.com/en-us/lifecycle/policies/modern>`__,
+which varies per-product, per-version, per-edition and per-channel.
+Generally, feature updates (1709, 22H2) occur every 6-12 months
+and are supported for 18-36 months;
+Server and IoT editions, and LTSC channel releases are supported for 5-10 years,
+and the latest feature release of a major version (Windows 10, Windows 11)
+generally receives new updates for at least 10 years following release.
+Microsoft's `Windows Lifecycle FAQ
+<https://learn.microsoft.com/en-us/lifecycle/faq/windows>`_
+has more specific and up-to-date guidance.
+
+CPython's Windows support currently follows Microsoft's lifecycles.
+A new feature release X.Y.0 will support all Windows versions
+whose extended support phase is not yet expired
+(ESU is not considered supported).
+Subsequent bug fix releases will support the same Windows versions
+as the original feature release, even if no longer supported by Microsoft.
 
 Each feature release is built by a specific version of Microsoft
 Visual Studio. That version should have mainstream support when the

--- a/pep-0011.txt
+++ b/pep-0011.txt
@@ -152,8 +152,9 @@ Notes
 Microsoft Windows
 '''''''''''''''''
 
-Microsoft has established a policy called product support lifecycle
-[1]_. Each product's lifecycle has a mainstream support phase, where
+Microsoft has established a policy called `product support lifecycle
+<https://learn.microsoft.com/en-us/lifecycle/>`__.
+Each product's lifecycle has a mainstream support phase, where
 the product is generally commercially available, and an extended
 support phase, where paid support is still available, and certain bug
 fixes are released. Sometimes this is then followed by a third phase
@@ -357,11 +358,6 @@ Discussions
   <https://mail.python.org/archives/list/python-dev@python.org/thread/DSSGXU5LBCMKYMZBRVB6RF3YAB6ST5AV/>`_
   (Skip Montanaro)
 
-
-References
-==========
-
-.. [1] http://support.microsoft.com/lifecycle/
 
 Copyright
 =========


### PR DESCRIPTION
As a followup to #2801 , this PR:

* Adds and updates background, clarifications and links to clearly reflect the current status quo situation with Windows support policies, specifically that the lifecycle refereed to is the Fixed lifecycle policy, clarifying the distinction with the newer "Modern" lifecycle policy introduced since the PEP's last revision in this area, and prepares for a future decision on the policy to adopt toward Windows 10+ releases which follow the latter (without intending to make a substantive policy change itself, just clarifying the present status quo until a more specific policy is discussed, decided and adopted).
* Further clarifies the situation with ESU updates, and improves the text and terminology used therein.
* Makes several minor technical fixes to PEP 11, removing the obsolete headers and footer and updating and inlining the last remaining footnote-style link.

@zooba My intent here is to avoid any substantive change to the existing CPython policy or declaration of a new policy for Windows 10+ in this PR, and only update and clarify the existing status quo on Microsoft's current lifecycles. To that end, I've kept the same wording wrt CPython's support policy, aside from a few very minor textual clarifications. If you prefer, I could add an explicit statement that the support policy for Windows 10+ is yet to be conclusively decided, with perhaps some reasonable lower and upper bounds, or other tweaks if you think them prudent.