### PR TITLE
Style: Fix zebra stripes and improve table & code presentation

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -158,6 +158,7 @@ code.literal {
     background-color: var(--colour-inline-code-bg);
     color: var(--colour-inline-code-text);
     font-size: .8em;
+    padding: 1px 2px 1px;
 }
 pre {
     overflow-x: auto;

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -41,7 +41,10 @@
     --colour-scrollbar: var(--light, #ccc) var(--dark, #333);
     --colour-rule-strong: var(--light, #888) var(--dark, #777);
     --colour-rule-light: var(--light, #ddd) var(--dark, #222);
-    --colour-inline-code: var(--light, #f8f8f8) var(--dark, #333);
+    --colour-inline-code-bg: var(--light, #eee) var(--dark, #333);
+    --colour-inline-code-text: var(--light, #222) var(--dark, #ccc);
+    --colour-inline-code-accent-bg: var(--light, #ddd) var(--dark, #444);
+    --colour-inline-code-accent-text: var(--light, #111) var(--dark, #ccc);
     --colour-error: var(--light, #faa) var(--dark, #800);
     --colour-warning: var(--light, #fca) var(--dark, #840);
     --colour-caution: var(--light, #ffa) var(--dark, #550);
@@ -152,8 +155,9 @@ code {
     overflow-wrap: anywhere;
 }
 code.literal {
+    background-color: var(--colour-inline-code-bg);
+    color: var(--colour-inline-code-text);
     font-size: .8em;
-    background-color: var(--colour-inline-code);
 }
 pre {
     overflow-x: auto;
@@ -234,6 +238,10 @@ table caption {
 }
 table tbody tr:nth-of-type(odd) {
     background-color: var(--colour-background-accent-light);
+}
+table tbody tr:nth-of-type(odd) code.literal {
+    background-color: var(--colour-inline-code-accent-bg);
+    color: var(--colour-inline-code-accent-text);
 }
 table th,
 table td {

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -33,9 +33,10 @@
 /* Set master colours */
 :root {
     --colour-background: var(--light, white) var(--dark, #011);
-    --colour-background-accent-strong: var(--light, #ccc) var(--dark, #333);
+    --colour-background-accent-strong: var(--light, #ccc) var(--dark, #444);
     --colour-background-accent-light: var(--light, #eee) var(--dark, #222);
     --colour-text: var(--light, #333) var(--dark, #ccc);
+    --colour-text-strong: var(--light, #222) var(--dark, #ddd);
     --colour-links: var(--light, #069) var(--dark, #8bf);
     --colour-links-light: var(--light, #057) var(--dark, #acf);
     --colour-scrollbar: var(--light, #ccc) var(--dark, #333);
@@ -45,6 +46,7 @@
     --colour-inline-code-text: var(--light, #222) var(--dark, #ccc);
     --colour-inline-code-accent-bg: var(--light, #ddd) var(--dark, #444);
     --colour-inline-code-accent-text: var(--light, #111) var(--dark, #ccc);
+    --colour-admonition: var(--light, #ddd) var(--dark, #333);
     --colour-error: var(--light, #faa) var(--dark, #800);
     --colour-warning: var(--light, #fca) var(--dark, #840);
     --colour-caution: var(--light, #ffa) var(--dark, #550);
@@ -231,16 +233,22 @@ div.table-wrapper {
 table {
     width: 100%;
     border-collapse: collapse;
-    border-top: 1px solid var(--colour-background-accent-light);
-    border-bottom: 1px solid var(--colour-background-accent-light);
+    border: 1px solid var(--colour-background-accent-strong);
 }
 table caption {
     margin: 1rem 0 .75rem;
 }
-table tbody tr:nth-of-type(odd) {
+table thead tr {
+    background-color: var(--colour-background-accent-strong);
+    color: var(--colour-text-strong);
+}
+table tbody tr {
+    border-top: 1px solid var(--colour-background-accent-strong);
+}
+table tbody tr:nth-of-type(even) {
     background-color: var(--colour-background-accent-light);
 }
-table tbody tr:nth-of-type(odd) code.literal {
+table tbody tr:nth-of-type(even) code.literal {
     background-color: var(--colour-inline-code-accent-bg);
     color: var(--colour-inline-code-accent-text);
 }
@@ -253,7 +261,7 @@ table.pep-zero-table tr td:nth-child(2) {
     white-space: nowrap;
 }
 table td + td {
-    border-left: 1px solid var(--colour-rule-light);
+    border-left: 1px solid var(--colour-background-accent-strong);
 }
 
 /* Breadcrumbs rules */
@@ -304,7 +312,7 @@ ul.breadcrumbs a {
 
 /* Admonitions rules */
 div.admonition {
-    background-color: var(--colour-background-accent-strong);
+    background-color: var(--colour-admonition);
     margin-bottom: 1rem;
     margin-top: 1rem;
     padding: 0.5rem 0.75rem;

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -34,7 +34,7 @@
 :root {
     --colour-background: var(--light, white) var(--dark, #011);
     --colour-background-accent-strong: var(--light, #ccc) var(--dark, #333);
-    --colour-background-accent-light: var(--light, #ddd) var(--dark, #222);
+    --colour-background-accent-light: var(--light, #eee) var(--dark, #222);
     --colour-text: var(--light, #333) var(--dark, #ccc);
     --colour-links: var(--light, #069) var(--dark, #8bf);
     --colour-links-light: var(--light, #057) var(--dark, #acf);

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -44,8 +44,6 @@
     --colour-rule-light: var(--light, #ddd) var(--dark, #222);
     --colour-inline-code-bg: var(--light, #eee) var(--dark, #333);
     --colour-inline-code-text: var(--light, #222) var(--dark, #ccc);
-    --colour-inline-code-accent-bg: var(--light, #ddd) var(--dark, #444);
-    --colour-inline-code-accent-text: var(--light, #111) var(--dark, #ccc);
     --colour-admonition: var(--light, #ddd) var(--dark, #333);
     --colour-error: var(--light, #faa) var(--dark, #800);
     --colour-warning: var(--light, #fca) var(--dark, #840);
@@ -239,18 +237,11 @@ table caption {
     margin: 1rem 0 .75rem;
 }
 table thead tr {
-    background-color: var(--colour-background-accent-strong);
+    background-color: var(--colour-admonition);
     color: var(--colour-text-strong);
 }
 table tbody tr {
     border-top: 1px solid var(--colour-background-accent-strong);
-}
-table tbody tr:nth-of-type(even) {
-    background-color: var(--colour-background-accent-light);
-}
-table tbody tr:nth-of-type(even) code.literal {
-    background-color: var(--colour-inline-code-accent-bg);
-    color: var(--colour-inline-code-accent-text);
 }
 table th,
 table td {
@@ -260,6 +251,7 @@ table td {
 table.pep-zero-table tr td:nth-child(2) {
     white-space: nowrap;
 }
+table th + th,
 table td + td {
     border-left: 1px solid var(--colour-background-accent-strong);
 }

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -34,6 +34,7 @@
 :root {
     --colour-background: var(--light, white) var(--dark, #011);
     --colour-background-accent-strong: var(--light, #ccc) var(--dark, #444);
+    --colour-background-accent-medium: var(--light, #ddd) var(--dark, #333);
     --colour-background-accent-light: var(--light, #eee) var(--dark, #222);
     --colour-text: var(--light, #333) var(--dark, #ccc);
     --colour-text-strong: var(--light, #222) var(--dark, #ddd);
@@ -44,7 +45,6 @@
     --colour-rule-light: var(--light, #ddd) var(--dark, #222);
     --colour-inline-code-bg: var(--light, #eee) var(--dark, #333);
     --colour-inline-code-text: var(--light, #222) var(--dark, #ccc);
-    --colour-admonition: var(--light, #ddd) var(--dark, #333);
     --colour-error: var(--light, #faa) var(--dark, #800);
     --colour-warning: var(--light, #fca) var(--dark, #840);
     --colour-caution: var(--light, #ffa) var(--dark, #550);
@@ -237,7 +237,7 @@ table caption {
     margin: 1rem 0 .75rem;
 }
 table thead tr {
-    background-color: var(--colour-admonition);
+    background-color: var(--colour-background-accent-medium);
     color: var(--colour-text-strong);
 }
 table tbody tr {
@@ -304,7 +304,7 @@ ul.breadcrumbs a {
 
 /* Admonitions rules */
 div.admonition {
-    background-color: var(--colour-admonition);
+    background-color: var(--colour-background-accent-medium);
     margin-bottom: 1rem;
     margin-top: 1rem;
     padding: 0.5rem 0.75rem;


### PR DESCRIPTION
Followup to #2740 and #2734 

After further discussion with @gvanrossum and a lot of experimentation, tweaking and testing, I've resolved the remaining outstanding issues with styling for tables, and (I believe) substantially improved their presentation overall, along with related fixes. Initially, this PR further lightened the zebra stripes in tables and fixed the relative contrast issues with the code literal backgrounds and the table stripes. However, after adding the horizontal/vertical rules and darker header to maintain sufficient contrast and readability, in the end all the shades of grey ended up being unnecessarily distracting and overcomplicated, so I removed the zebra stripes altogether, with the end product being very similar to a slightly contrast-refined version of the tables in the CPython docs (that others mentioned they favored).

In addition, I also addressed a couple small related issues, namely ensuring readable and consistent contrast for inline code backgrounds and text for the dark and the light themes, plus adding a bit of needed padding for such, and separating the default admonition color from the background accent and improving its own contrast, and a bit of related refactoring.

<details>

<summary>Before/after screenshots</summary>

![image](https://user-images.githubusercontent.com/17051931/192690819-c3a82fc1-ffe6-4859-9c8e-8f8371faf0f5.png)

![image](https://user-images.githubusercontent.com/17051931/192690848-450c86f3-5e9e-4c0c-a720-cfc575b3e5e1.png)

</details>

Fixes #2749 (finally)