### PR TITLE
Many PEPs: 'Author' must be list of 'Name <email@example.com>, ...'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,7 +129,7 @@ repos:
         language: pygrep
         entry: '(?<=\n)Author:(?:(?!((( +|\n {1,8})[^!#$%&()*+,/:;<=>?@\[\\\]\^_`{|}~]+( <[\w!#$%&''*+\-/=?^_{|}~.]+(@| at )[\w\-.]+\.[A-Za-z0-9]+>)?)(,|(?=\n[^ ])))+\n(?=[A-Z])))'
         args: [--multiline]
-        files: '^pep-\d+\.rst$'
+        files: '^pep-\d+\.(rst|txt)$'
         types: [text]
 
       - id: validate-author-legacy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,14 +132,6 @@ repos:
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]
 
-      - id: validate-author-legacy
-        name: "Legacy 'Author' must be a list of names/emails"
-        language: pygrep
-        entry: '(?<=\n)Author:(?:(?!((((( +|\n {1,8})[^!#$%&()*+,/:;<=>?@\[\\\]\^_`{|}~]+( <[\w!#$%&''*+\-/=?^_{|}~.]+(@| at )[\w\-.]+\.[A-Za-z0-9]+>)?)(,|(?=\n[^ ])))+)|(((( +|\n {1,8})[\w!#$%&''*+\-/=?^_{|}~.]+(@| at )[\w\-.]+\.[A-Za-z0-9]+) \(([^!#$%&()*+,/:;<=>?@\[\\\]\^_`{|}~]+)\)(,|(?=\n[^ ])))+))\n(?=[A-Z])))'
-        args: [--multiline]
-        files: '^pep-\d+\.(rst|txt)$'
-        types: [text]
-
       - id: validate-sponsor
         name: "'Sponsor' must have format 'Name <email@example.com>'"
         language: pygrep

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -629,10 +629,7 @@ if the email address is included, and just:
 
     Random J. User
 
-if the address is not given.  For historical reasons the format
-``random@example.com (Random J. User)`` may appear in a PEP;
-however, new PEPs must use the mandated format above, and it is acceptable to
-change to this format when PEPs are updated.
+if the address is not given.
 
 If there are multiple authors, each should be on a separate line
 following :rfc:`2822` continuation line conventions.  Note that personal

--- a/pep-0003.txt
+++ b/pep-0003.txt
@@ -69,4 +69,4 @@ Original Guidelines
 References
 ==========
 
-.. [1] http://bugs.python.org/
+* https://bugs.python.org

--- a/pep-0003.txt
+++ b/pep-0003.txt
@@ -2,7 +2,7 @@ PEP: 3
 Title: Guidelines for Handling Bug Reports
 Version: $Revision$
 Last-Modified: $Date$
-Author: jeremy@alum.mit.edu (Jeremy Hylton)
+Author: Jeremy Hylton <jeremy@alum.mit.edu>
 Status: Withdrawn
 Type: Process
 Content-Type: text/x-rst

--- a/pep-0003.txt
+++ b/pep-0003.txt
@@ -1,7 +1,5 @@
 PEP: 3
 Title: Guidelines for Handling Bug Reports
-Version: $Revision$
-Last-Modified: $Date$
 Author: Jeremy Hylton <jeremy@alum.mit.edu>
 Status: Withdrawn
 Type: Process

--- a/pep-0005.txt
+++ b/pep-0005.txt
@@ -1,7 +1,5 @@
 PEP: 5
 Title: Guidelines for Language Evolution
-Version: $Revision$
-Last-Modified: $Date$
 Author: Paul Prescod <paul@prescod.net>
 Status: Active
 Type: Process

--- a/pep-0005.txt
+++ b/pep-0005.txt
@@ -2,7 +2,7 @@ PEP: 5
 Title: Guidelines for Language Evolution
 Version: $Revision$
 Last-Modified: $Date$
-Author: paul@prescod.net (Paul Prescod)
+Author: Paul Prescod <paul@prescod.net>
 Status: Active
 Type: Process
 Content-Type: text/x-rst

--- a/pep-0005.txt
+++ b/pep-0005.txt
@@ -75,9 +75,3 @@ Steps For Introducing Backwards-Incompatible Features
    the backwards incompatible version.  Users will have at least a
    year to test their programs and migrate them from use of the
    deprecated construct to the alternative one.
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   End:

--- a/pep-0006.txt
+++ b/pep-0006.txt
@@ -217,10 +217,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   End:

--- a/pep-0006.txt
+++ b/pep-0006.txt
@@ -1,7 +1,5 @@
 PEP: 6
 Title: Bug Fix Releases
-Version: $Revision$
-Last-Modified: $Date$
 Author: Aahz <aahz@pythoncraft.com>, Anthony Baxter <anthony@interlink.com.au>
 Status: Active
 Type: Process

--- a/pep-0006.txt
+++ b/pep-0006.txt
@@ -2,7 +2,7 @@ PEP: 6
 Title: Bug Fix Releases
 Version: $Revision$
 Last-Modified: $Date$
-Author: aahz@pythoncraft.com (Aahz), anthony@interlink.com.au (Anthony Baxter)
+Author: Aahz <aahz@pythoncraft.com>, Anthony Baxter <anthony@interlink.com.au>
 Status: Active
 Type: Process
 Content-Type: text/x-rst

--- a/pep-0010.txt
+++ b/pep-0010.txt
@@ -1,7 +1,5 @@
 PEP: 10
 Title: Voting Guidelines
-Version: $Revision$
-Last-Modified: $Date$
 Author: Barry Warsaw <barry@python.org>
 Status: Active
 Type: Process

--- a/pep-0010.txt
+++ b/pep-0010.txt
@@ -2,7 +2,7 @@ PEP: 10
 Title: Voting Guidelines
 Version: $Revision$
 Last-Modified: $Date$
-Author: barry@python.org (Barry Warsaw)
+Author: Barry Warsaw <barry@python.org>
 Status: Active
 Type: Process
 Content-Type: text/x-rst

--- a/pep-0010.txt
+++ b/pep-0010.txt
@@ -71,11 +71,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   fill-column: 70
-   End:

--- a/pep-0100.txt
+++ b/pep-0100.txt
@@ -2,7 +2,7 @@ PEP: 100
 Title: Python Unicode Integration
 Version: $Revision$
 Last-Modified: $Date$
-Author: mal@lemburg.com (Marc-André Lemburg)
+Author: Marc-André Lemburg <mal@lemburg.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0100.txt
+++ b/pep-0100.txt
@@ -1246,10 +1246,3 @@ file.]
 ---
 
 * first version
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   End:

--- a/pep-0100.txt
+++ b/pep-0100.txt
@@ -1,7 +1,5 @@
 PEP: 100
 Title: Python Unicode Integration
-Version: $Revision$
-Last-Modified: $Date$
 Author: Marc-André Lemburg <mal@lemburg.com>
 Status: Final
 Type: Standards Track

--- a/pep-0102.txt
+++ b/pep-0102.txt
@@ -512,10 +512,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   End:

--- a/pep-0102.txt
+++ b/pep-0102.txt
@@ -2,9 +2,9 @@ PEP: 102
 Title: Doing Python Micro Releases
 Version: $Revision$
 Last-Modified: $Date$
-Author: anthony@interlink.com.au (Anthony Baxter),
-        barry@python.org (Barry Warsaw),
-        guido@python.org (Guido van Rossum)
+Author: Anthony Baxter <anthony@interlink.com.au>,
+        Barry Warsaw <barry@python.org>,
+        Guido van Rossum <guido@python.org>
 Status: Superseded
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0102.txt
+++ b/pep-0102.txt
@@ -1,7 +1,5 @@
 PEP: 102
 Title: Doing Python Micro Releases
-Version: $Revision$
-Last-Modified: $Date$
 Author: Anthony Baxter <anthony@interlink.com.au>,
         Barry Warsaw <barry@python.org>,
         Guido van Rossum <guido@python.org>

--- a/pep-0201.txt
+++ b/pep-0201.txt
@@ -1,7 +1,5 @@
 PEP: 201
 Title: Lockstep Iteration
-Version: $Revision$
-Last-Modified: $Date$
 Author: Barry Warsaw <barry@python.org>
 Status: Final
 Type: Standards Track

--- a/pep-0201.txt
+++ b/pep-0201.txt
@@ -289,11 +289,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0201.txt
+++ b/pep-0201.txt
@@ -2,7 +2,7 @@ PEP: 201
 Title: Lockstep Iteration
 Version: $Revision$
 Last-Modified: $Date$
-Author: barry@python.org (Barry Warsaw)
+Author: Barry Warsaw <barry@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0202.txt
+++ b/pep-0202.txt
@@ -1,7 +1,5 @@
 PEP: 202
 Title: List Comprehensions
-Version: $Revision$
-Last-Modified: $Date$
 Author: Barry Warsaw <barry@python.org>
 Status: Final
 Type: Standards Track

--- a/pep-0202.txt
+++ b/pep-0202.txt
@@ -2,7 +2,7 @@ PEP: 202
 Title: List Comprehensions
 Version: $Revision$
 Last-Modified: $Date$
-Author: barry@python.org (Barry Warsaw)
+Author: Barry Warsaw <barry@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0202.txt
+++ b/pep-0202.txt
@@ -84,11 +84,3 @@ References
 ==========
 
 .. [1] http://docs.python.org/reference/expressions.html#list-displays
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0203.txt
+++ b/pep-0203.txt
@@ -2,7 +2,7 @@ PEP: 203
 Title: Augmented Assignments
 Version: $Revision$
 Last-Modified: $Date$
-Author: thomas@python.org (Thomas Wouters)
+Author: Thomas Wouters <thomas@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0203.txt
+++ b/pep-0203.txt
@@ -323,10 +323,3 @@ References
 .. [1] http://www.python.org/pipermail/python-list/2000-June/059556.html
 
 .. [2] http://sourceforge.net/patch?func=detailpatch&patch_id=100699&group_id=5470
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0203.txt
+++ b/pep-0203.txt
@@ -1,7 +1,5 @@
 PEP: 203
 Title: Augmented Assignments
-Version: $Revision$
-Last-Modified: $Date$
 Author: Thomas Wouters <thomas@python.org>
 Status: Final
 Type: Standards Track

--- a/pep-0204.txt
+++ b/pep-0204.txt
@@ -1,7 +1,5 @@
 PEP: 204
 Title: Range Literals
-Version: $Revision$
-Last-Modified: $Date$
 Author: Thomas Wouters <thomas@python.org>
 Status: Rejected
 Type: Standards Track

--- a/pep-0204.txt
+++ b/pep-0204.txt
@@ -297,10 +297,3 @@ References
 ==========
 
 .. [1] http://sourceforge.net/patch/?func=detailpatch&patch_id=100902&group_id=5470
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0204.txt
+++ b/pep-0204.txt
@@ -2,7 +2,7 @@ PEP: 204
 Title: Range Literals
 Version: $Revision$
 Last-Modified: $Date$
-Author: thomas@python.org (Thomas Wouters)
+Author: Thomas Wouters <thomas@python.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0207.txt
+++ b/pep-0207.txt
@@ -475,9 +475,3 @@ testing "if a>b:" is massively ambiguous.
 The inlining already present which deals with integer comparisons
 would still apply, resulting in no performance cost for the most
 common cases.
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   End:

--- a/pep-0207.txt
+++ b/pep-0207.txt
@@ -2,7 +2,7 @@ PEP: 207
 Title: Rich Comparisons
 Version: $Revision$
 Last-Modified: $Date$
-Author: guido@python.org (Guido van Rossum), DavidA@ActiveState.com (David Ascher)
+Author: Guido van Rossum <guido@python.org>, David Ascher <DavidA@ActiveState.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0207.txt
+++ b/pep-0207.txt
@@ -1,7 +1,5 @@
 PEP: 207
 Title: Rich Comparisons
-Version: $Revision$
-Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>, David Ascher <DavidA@ActiveState.com>
 Status: Final
 Type: Standards Track

--- a/pep-0208.txt
+++ b/pep-0208.txt
@@ -232,15 +232,3 @@ References
 .. [1] http://www.lemburg.com/files/python/mxDateTime.html
 .. [2] http://sourceforge.net/patch/?func=detailpatch&patch_id=102652&group_id=5470
 .. [3] http://www.lemburg.com/files/python/CoercionProposal.html
-
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 70
-  coding: utf-8
-  End:

--- a/pep-0208.txt
+++ b/pep-0208.txt
@@ -1,7 +1,5 @@
 PEP: 208
 Title: Reworking the Coercion Model
-Version: $Revision$
-Last-Modified: $Date$
 Author: Neil Schemenauer <nas@arctrix.com>, Marc-André Lemburg <mal@lemburg.com>
 Status: Final
 Type: Standards Track

--- a/pep-0208.txt
+++ b/pep-0208.txt
@@ -2,7 +2,7 @@ PEP: 208
 Title: Reworking the Coercion Model
 Version: $Revision$
 Last-Modified: $Date$
-Author: nas@arctrix.com (Neil Schemenauer), mal@lemburg.com (Marc-André Lemburg)
+Author: Neil Schemenauer <nas@arctrix.com>, Marc-André Lemburg <mal@lemburg.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0209.txt
+++ b/pep-0209.txt
@@ -704,10 +704,3 @@ References
 ==========
 
 .. [1] P. Greenfield 2000. private communication.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   End:

--- a/pep-0209.txt
+++ b/pep-0209.txt
@@ -1,7 +1,5 @@
 PEP: 209
 Title: Multi-dimensional Arrays
-Version: $Revision$
-Last-Modified: $Date$
 Author: Paul Barrett <barrett@stsci.edu>, Travis Oliphant <oliphant@ee.byu.edu>
 Status: Withdrawn
 Type: Standards Track

--- a/pep-0209.txt
+++ b/pep-0209.txt
@@ -2,7 +2,7 @@ PEP: 209
 Title: Multi-dimensional Arrays
 Version: $Revision$
 Last-Modified: $Date$
-Author: barrett@stsci.edu (Paul Barrett), oliphant@ee.byu.edu (Travis Oliphant)
+Author: Paul Barrett <barrett@stsci.edu>, Travis Oliphant <oliphant@ee.byu.edu>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0210.txt
+++ b/pep-0210.txt
@@ -1,7 +1,5 @@
 PEP: 210
 Title: Decoupling the Interpreter Loop
-Version: $Revision$
-Last-Modified: $Date$
 Author: David Ascher <davida@activestate.com>
 Status: Rejected
 Type: Standards Track

--- a/pep-0210.txt
+++ b/pep-0210.txt
@@ -2,7 +2,7 @@ PEP: 210
 Title: Decoupling the Interpreter Loop
 Version: $Revision$
 Last-Modified: $Date$
-Author: davida@activestate.com (David Ascher)
+Author: David Ascher <davida@activestate.com>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0211.txt
+++ b/pep-0211.txt
@@ -1,7 +1,5 @@
 PEP: 211
 Title: Adding A New Outer Product Operator
-Version: $Revision$
-Last-Modified: $Date$
 Author: Greg Wilson <gvwilson@ddj.com>
 Status: Rejected
 Type: Standards Track

--- a/pep-0211.txt
+++ b/pep-0211.txt
@@ -2,7 +2,7 @@ PEP: 211
 Title: Adding A New Outer Product Operator
 Version: $Revision$
 Last-Modified: $Date$
-Author: gvwilson@ddj.com (Greg Wilson)
+Author: Greg Wilson <gvwilson@ddj.com>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0211.txt
+++ b/pep-0211.txt
@@ -194,11 +194,3 @@ References
 .. [2] http://www.egroups.com/message/python-numeric/4
 
 .. [3] https://mail.python.org/pipermail/python-dev/2000-July/006427.html
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0212.txt
+++ b/pep-0212.txt
@@ -2,7 +2,7 @@ PEP: 212
 Title: Loop Counter Iteration
 Version: $Revision$
 Last-Modified: $Date$
-Author: nowonder@nowonder.de (Peter Schneider-Kamp)
+Author: Peter Schneider-Kamp <nowonder@nowonder.de>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0212.txt
+++ b/pep-0212.txt
@@ -1,7 +1,5 @@
 PEP: 212
 Title: Loop Counter Iteration
-Version: $Revision$
-Last-Modified: $Date$
 Author: Peter Schneider-Kamp <nowonder@nowonder.de>
 Status: Rejected
 Type: Standards Track

--- a/pep-0212.txt
+++ b/pep-0212.txt
@@ -182,10 +182,3 @@ References
 .. [4] http://sourceforge.net/patch/download.php?id=101129
 
 .. [5] http://sourceforge.net/patch/download.php?id=101178
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0213.txt
+++ b/pep-0213.txt
@@ -2,7 +2,7 @@ PEP: 213
 Title: Attribute Access Handlers
 Version: $Revision$
 Last-Modified: $Date$
-Author: paul@prescod.net (Paul Prescod)
+Author: Paul Prescod <paul@prescod.net>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0213.txt
+++ b/pep-0213.txt
@@ -242,11 +242,3 @@ added to the language making this possible::
 
 Additional syntactic sugar might be added, or a naming convention
 could be recognized.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0213.txt
+++ b/pep-0213.txt
@@ -1,7 +1,5 @@
 PEP: 213
 Title: Attribute Access Handlers
-Version: $Revision$
-Last-Modified: $Date$
 Author: Paul Prescod <paul@prescod.net>
 Status: Deferred
 Type: Standards Track

--- a/pep-0214.txt
+++ b/pep-0214.txt
@@ -381,10 +381,3 @@ References
 
 .. [1] http://docs.python.org/reference/simple_stmts.html#print
 .. [2] http://sourceforge.net/patch/download.php?id=100970
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   End:

--- a/pep-0214.txt
+++ b/pep-0214.txt
@@ -2,7 +2,7 @@ PEP: 214
 Title: Extended Print Statement
 Version: $Revision$
 Last-Modified: $Date$
-Author: barry@python.org (Barry Warsaw)
+Author: Barry Warsaw <barry@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0214.txt
+++ b/pep-0214.txt
@@ -1,7 +1,5 @@
 PEP: 214
 Title: Extended Print Statement
-Version: $Revision$
-Last-Modified: $Date$
 Author: Barry Warsaw <barry@python.org>
 Status: Final
 Type: Standards Track

--- a/pep-0215.txt
+++ b/pep-0215.txt
@@ -149,10 +149,3 @@ References
 ==========
 
 .. [1] http://www.lfw.org/python/Itpl.py
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0215.txt
+++ b/pep-0215.txt
@@ -2,7 +2,7 @@ PEP: 215
 Title: String Interpolation
 Version: $Revision$
 Last-Modified: $Date$
-Author: ping@zesty.ca (Ka-Ping Yee)
+Author: Ka-Ping Yee <ping@zesty.ca>
 Status: Superseded
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0215.txt
+++ b/pep-0215.txt
@@ -1,7 +1,5 @@
 PEP: 215
 Title: String Interpolation
-Version: $Revision$
-Last-Modified: $Date$
 Author: Ka-Ping Yee <ping@zesty.ca>
 Status: Superseded
 Type: Standards Track

--- a/pep-0216.txt
+++ b/pep-0216.txt
@@ -158,11 +158,3 @@ Rejected Suggestions
 ====================
 
 XML -- it's very hard to type, and too cluttered to read it comfortably.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0216.txt
+++ b/pep-0216.txt
@@ -1,7 +1,5 @@
 PEP: 216
 Title: Docstring Format
-Version: $Revision$
-Last-Modified: $Date$
 Author: Moshe Zadka <moshez@zadka.site.co.il>
 Status: Rejected
 Type: Informational

--- a/pep-0216.txt
+++ b/pep-0216.txt
@@ -2,7 +2,7 @@ PEP: 216
 Title: Docstring Format
 Version: $Revision$
 Last-Modified: $Date$
-Author: moshez@zadka.site.co.il (Moshe Zadka)
+Author: Moshe Zadka <moshez@zadka.site.co.il>
 Status: Rejected
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0217.txt
+++ b/pep-0217.txt
@@ -57,10 +57,3 @@ Jython Issues
 =============
 
 The method ``Py.printResult`` will be similarly changed.
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0217.txt
+++ b/pep-0217.txt
@@ -2,7 +2,7 @@ PEP: 217
 Title: Display Hook for Interactive Use
 Version: $Revision$
 Last-Modified: $Date$
-Author: moshez@zadka.site.co.il (Moshe Zadka)
+Author: Moshe Zadka <moshez@zadka.site.co.il>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0217.txt
+++ b/pep-0217.txt
@@ -1,7 +1,5 @@
 PEP: 217
 Title: Display Hook for Interactive Use
-Version: $Revision$
-Last-Modified: $Date$
 Author: Moshe Zadka <moshez@zadka.site.co.il>
 Status: Final
 Type: Standards Track

--- a/pep-0218.txt
+++ b/pep-0218.txt
@@ -1,7 +1,5 @@
 PEP: 218
 Title: Adding a Built-In Set Object Type
-Version: $Revision$
-Last-Modified: $Date$
 Author: Greg Wilson <gvwilson@ddj.com>, Raymond Hettinger <python@rcn.com>
 Status: Final
 Type: Standards Track

--- a/pep-0218.txt
+++ b/pep-0218.txt
@@ -214,11 +214,3 @@ Copyright
 =========
 
 This document has been placed in the Public Domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0218.txt
+++ b/pep-0218.txt
@@ -2,7 +2,7 @@ PEP: 218
 Title: Adding a Built-In Set Object Type
 Version: $Revision$
 Last-Modified: $Date$
-Author: gvwilson@ddj.com (Greg Wilson), python@rcn.com (Raymond Hettinger)
+Author: Greg Wilson <gvwilson@ddj.com>, Raymond Hettinger <python@rcn.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0219.txt
+++ b/pep-0219.txt
@@ -2,7 +2,7 @@ PEP: 219
 Title: Stackless Python
 Version: $Revision$
 Last-Modified: $Date$
-Author: gmcm@hypernet.com (Gordon McMillan)
+Author: Gordon McMillan <gmcm@hypernet.com>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0219.txt
+++ b/pep-0219.txt
@@ -1,7 +1,5 @@
 PEP: 219
 Title: Stackless Python
-Version: $Revision$
-Last-Modified: $Date$
 Author: Gordon McMillan <gmcm@hypernet.com>
 Status: Deferred
 Type: Standards Track

--- a/pep-0219.txt
+++ b/pep-0219.txt
@@ -189,11 +189,3 @@ References
 .. [2] http://web.archive.org/web/20000815070602/http://world.std.com/~wware/uthread.html
 .. [3] Demo/threads/Generator.py in the source distribution
 .. [4] http://www.stackless.com/coroutines.tim.peters.html
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0220.txt
+++ b/pep-0220.txt
@@ -20,11 +20,3 @@ higher level module that makes coroutines and generators easy to
 create is desirable (and being worked on).  The focus of this PEP
 is on showing how coroutines, generators, and green threads can
 simplify common programming problems.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0220.txt
+++ b/pep-0220.txt
@@ -2,7 +2,7 @@ PEP: 220
 Title: Coroutines, Generators, Continuations
 Version: $Revision$
 Last-Modified: $Date$
-Author: gmcm@hypernet.com (Gordon McMillan)
+Author: Gordon McMillan <gmcm@hypernet.com>
 Status: Rejected
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0220.txt
+++ b/pep-0220.txt
@@ -1,7 +1,5 @@
 PEP: 220
 Title: Coroutines, Generators, Continuations
-Version: $Revision$
-Last-Modified: $Date$
 Author: Gordon McMillan <gmcm@hypernet.com>
 Status: Rejected
 Type: Informational

--- a/pep-0221.txt
+++ b/pep-0221.txt
@@ -1,7 +1,5 @@
 PEP: 221
 Title: Import As
-Version: $Revision$
-Last-Modified: $Date$
 Author: Thomas Wouters <thomas@python.org>
 Status: Final
 Type: Standards Track

--- a/pep-0221.txt
+++ b/pep-0221.txt
@@ -114,11 +114,3 @@ References
 .. [1] https://hg.python.org/cpython/rev/18385172fac0
 
 .. [2] http://sourceforge.net/patch/?func=detailpatch&patch_id=101234&group_id=5470
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0221.txt
+++ b/pep-0221.txt
@@ -2,7 +2,7 @@ PEP: 221
 Title: Import As
 Version: $Revision$
 Last-Modified: $Date$
-Author: thomas@python.org (Thomas Wouters)
+Author: Thomas Wouters <thomas@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0223.txt
+++ b/pep-0223.txt
@@ -1,7 +1,5 @@
 PEP: 223
 Title: Change the Meaning of ``\x`` Escapes
-Version: $Revision$
-Last-Modified: $Date$
 Author: Tim Peters <tim.peters@gmail.com>
 Status: Final
 Type: Standards Track

--- a/pep-0223.txt
+++ b/pep-0223.txt
@@ -2,7 +2,7 @@ PEP: 223
 Title: Change the Meaning of ``\x`` Escapes
 Version: $Revision$
 Last-Modified: $Date$
-Author: tim.peters@gmail.com (Tim Peters)
+Author: Tim Peters <tim.peters@gmail.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0223.txt
+++ b/pep-0223.txt
@@ -224,11 +224,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0224.txt
+++ b/pep-0224.txt
@@ -1,7 +1,5 @@
 PEP: 224
 Title: Attribute Docstrings
-Version: $Revision$
-Last-Modified: $Date$
 Author: Marc-André Lemburg <mal@lemburg.com>
 Status: Rejected
 Type: Standards Track

--- a/pep-0224.txt
+++ b/pep-0224.txt
@@ -2,7 +2,7 @@ PEP: 224
 Title: Attribute Docstrings
 Version: $Revision$
 Last-Modified: $Date$
-Author: mal@lemburg.com (Marc-André Lemburg)
+Author: Marc-André Lemburg <mal@lemburg.com>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0224.txt
+++ b/pep-0224.txt
@@ -266,11 +266,3 @@ References
 ==========
 
 .. [1] http://sourceforge.net/patch/?func=detailpatch&patch_id=101264&group_id=5470
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0225.txt
+++ b/pep-0225.txt
@@ -771,11 +771,3 @@ Additional References
 =====================
 
 .. [1] http://MatPy.sourceforge.net/Misc/index.html
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0225.txt
+++ b/pep-0225.txt
@@ -2,8 +2,8 @@ PEP: 225
 Title: Elementwise/Objectwise Operators
 Version: $Revision$
 Last-Modified: $Date$
-Author: hzhu@users.sourceforge.net (Huaiyu Zhu),
-        gregory.lielens@fft.be (Gregory Lielens)
+Author: Huaiyu Zhu <hzhu@users.sourceforge.net>,
+        Gregory Lielens <gregory.lielens@fft.be>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0225.txt
+++ b/pep-0225.txt
@@ -1,7 +1,5 @@
 PEP: 225
 Title: Elementwise/Objectwise Operators
-Version: $Revision$
-Last-Modified: $Date$
 Author: Huaiyu Zhu <hzhu@users.sourceforge.net>,
         Gregory Lielens <gregory.lielens@fft.be>
 Status: Rejected

--- a/pep-0227.txt
+++ b/pep-0227.txt
@@ -1,7 +1,5 @@
 PEP: 227
 Title: Statically Nested Scopes
-Version: $Revision$
-Last-Modified: $Date$
 Author: Jeremy Hylton <jeremy@alum.mit.edu>
 Status: Final
 Type: Standards Track

--- a/pep-0227.txt
+++ b/pep-0227.txt
@@ -2,7 +2,7 @@ PEP: 227
 Title: Statically Nested Scopes
 Version: $Revision$
 Last-Modified: $Date$
-Author: jeremy@alum.mit.edu (Jeremy Hylton)
+Author: Jeremy Hylton <jeremy@alum.mit.edu>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0227.txt
+++ b/pep-0227.txt
@@ -506,10 +506,3 @@ References
 
 Copyright
 =========
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   End:

--- a/pep-0228.txt
+++ b/pep-0228.txt
@@ -1,7 +1,5 @@
 PEP: 228
 Title: Reworking Python's Numeric Model
-Version: $Revision$
-Last-Modified: $Date$
 Author: Moshe Zadka <moshez@zadka.site.co.il>, Guido van Rossum <guido@python.org>
 Status: Withdrawn
 Type: Standards Track

--- a/pep-0228.txt
+++ b/pep-0228.txt
@@ -146,11 +146,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0228.txt
+++ b/pep-0228.txt
@@ -2,7 +2,7 @@ PEP: 228
 Title: Reworking Python's Numeric Model
 Version: $Revision$
 Last-Modified: $Date$
-Author: moshez@zadka.site.co.il (Moshe Zadka), guido@python.org (Guido van Rossum)
+Author: Moshe Zadka <moshez@zadka.site.co.il>, Guido van Rossum <guido@python.org>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0230.txt
+++ b/pep-0230.txt
@@ -1,7 +1,5 @@
 PEP: 230
 Title: Warning Framework
-Version: $Revision$
-Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>
 Status: Final
 Type: Standards Track

--- a/pep-0230.txt
+++ b/pep-0230.txt
@@ -2,7 +2,7 @@ PEP: 230
 Title: Warning Framework
 Version: $Revision$
 Last-Modified: $Date$
-Author: guido@python.org (Guido van Rossum)
+Author: Guido van Rossum <guido@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0230.txt
+++ b/pep-0230.txt
@@ -410,8 +410,3 @@ Implementation
 Here's a prototype implementation:
 http://sourceforge.net/patch/?func=detailpatch&patch_id=102715&group_id=5470
 
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   End:

--- a/pep-0231.txt
+++ b/pep-0231.txt
@@ -1,7 +1,5 @@
 PEP: 231
 Title: __findattr__()
-Version: $Revision$
-Last-Modified: $Date$
 Author: Barry Warsaw <barry@python.org>
 Status: Rejected
 Type: Standards Track

--- a/pep-0231.txt
+++ b/pep-0231.txt
@@ -613,7 +613,8 @@ References
 .. [5] http://www.digicool.com/releases/ExtensionClass
 .. [6] http://www.python.org/doc/essays/metaclasses/
 .. [7] http://www.foretec.com/python/workshops/1998-11/dd-ascher-sum.html
-.. [8] http://docs.python.org/howto/regex.html
+
+* http://docs.python.org/howto/regex.html
 
 
 Rejection

--- a/pep-0231.txt
+++ b/pep-0231.txt
@@ -641,10 +641,3 @@ Copyright
 =========
 
 This document has been placed in the Public Domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   End:

--- a/pep-0231.txt
+++ b/pep-0231.txt
@@ -2,7 +2,7 @@ PEP: 231
 Title: __findattr__()
 Version: $Revision$
 Last-Modified: $Date$
-Author: barry@python.org (Barry Warsaw)
+Author: Barry Warsaw <barry@python.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0233.txt
+++ b/pep-0233.txt
@@ -108,11 +108,3 @@ Security Issues
 This module will attempt to import modules with the same names as
 requested topics.  Don't use the modules if you are not confident
 that everything in your ``PYTHONPATH`` is from a trusted source.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0233.txt
+++ b/pep-0233.txt
@@ -2,7 +2,7 @@ PEP: 233
 Title: Python Online Help
 Version: $Revision$
 Last-Modified: $Date$
-Author: paul@prescod.net (Paul Prescod)
+Author: Paul Prescod <paul@prescod.net>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0233.txt
+++ b/pep-0233.txt
@@ -1,7 +1,5 @@
 PEP: 233
 Title: Python Online Help
-Version: $Revision$
-Last-Modified: $Date$
 Author: Paul Prescod <paul@prescod.net>
 Status: Deferred
 Type: Standards Track

--- a/pep-0234.txt
+++ b/pep-0234.txt
@@ -483,11 +483,3 @@ Copyright
 =========
 
 This document is in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0234.txt
+++ b/pep-0234.txt
@@ -2,7 +2,7 @@ PEP: 234
 Title: Iterators
 Version: $Revision$
 Last-Modified: $Date$
-Author: ping@zesty.ca (Ka-Ping Yee), guido@python.org (Guido van Rossum)
+Author: Ka-Ping Yee <ping@zesty.ca>, Guido van Rossum <guido@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0234.txt
+++ b/pep-0234.txt
@@ -1,7 +1,5 @@
 PEP: 234
 Title: Iterators
-Version: $Revision$
-Last-Modified: $Date$
 Author: Ka-Ping Yee <ping@zesty.ca>, Guido van Rossum <guido@python.org>
 Status: Final
 Type: Standards Track

--- a/pep-0238.txt
+++ b/pep-0238.txt
@@ -2,8 +2,8 @@ PEP: 238
 Title: Changing the Division Operator
 Version: $Revision$
 Last-Modified: $Date$
-Author: moshez@zadka.site.co.il (Moshe Zadka),
-        guido@python.org (Guido van Rossum)
+Author: Moshe Zadka <moshez@zadka.site.co.il>,
+        Guido van Rossum <guido@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0238.txt
+++ b/pep-0238.txt
@@ -480,11 +480,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0238.txt
+++ b/pep-0238.txt
@@ -1,7 +1,5 @@
 PEP: 238
 Title: Changing the Division Operator
-Version: $Revision$
-Last-Modified: $Date$
 Author: Moshe Zadka <moshez@zadka.site.co.il>,
         Guido van Rossum <guido@python.org>
 Status: Final

--- a/pep-0242.txt
+++ b/pep-0242.txt
@@ -2,7 +2,7 @@ PEP: 242
 Title: Numeric Kinds
 Version: $Revision$
 Last-Modified: $Date$
-Author: paul@pfdubois.com (Paul F. Dubois)
+Author: Paul F. Dubois <paul@pfdubois.com>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0242.txt
+++ b/pep-0242.txt
@@ -237,10 +237,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   End:

--- a/pep-0242.txt
+++ b/pep-0242.txt
@@ -1,7 +1,5 @@
 PEP: 242
 Title: Numeric Kinds
-Version: $Revision$
-Last-Modified: $Date$
 Author: Paul F. Dubois <paul@pfdubois.com>
 Status: Rejected
 Type: Standards Track

--- a/pep-0243.txt
+++ b/pep-0243.txt
@@ -1,7 +1,5 @@
 PEP: 243
 Title: Module Repository Upload Mechanism
-Version: $Revision$
-Last-Modified: $Date$
 Author: Sean Reifschneider <jafo-pep@tummy.com>
 Discussions-To: distutils-sig@python.org
 Status: Withdrawn

--- a/pep-0243.txt
+++ b/pep-0243.txt
@@ -172,11 +172,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0243.txt
+++ b/pep-0243.txt
@@ -2,7 +2,7 @@ PEP: 243
 Title: Module Repository Upload Mechanism
 Version: $Revision$
 Last-Modified: $Date$
-Author: jafo-pep@tummy.com (Sean Reifschneider)
+Author: Sean Reifschneider <jafo-pep@tummy.com>
 Discussions-To: distutils-sig@python.org
 Status: Withdrawn
 Type: Standards Track

--- a/pep-0244.txt
+++ b/pep-0244.txt
@@ -162,11 +162,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0244.txt
+++ b/pep-0244.txt
@@ -1,7 +1,5 @@
 PEP: 244
 Title: The ``directive`` statement
-Version: $Revision$
-Last-Modified: $Date$
 Author: Martin von Löwis <martin@v.loewis.de>
 Status: Rejected
 Type: Standards Track

--- a/pep-0244.txt
+++ b/pep-0244.txt
@@ -2,7 +2,7 @@ PEP: 244
 Title: The ``directive`` statement
 Version: $Revision$
 Last-Modified: $Date$
-Author: martin@v.loewis.de (Martin von Löwis)
+Author: Martin von Löwis <martin@v.loewis.de>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0246.txt
+++ b/pep-0246.txt
@@ -2,8 +2,8 @@ PEP: 246
 Title: Object Adaptation
 Version: $Revision$
 Last-Modified: $Date$
-Author: aleaxit@gmail.com (Alex Martelli),
-        cce@clarkevans.com (Clark C. Evans)
+Author: Alex Martelli <aleaxit@gmail.com>,
+        Clark C. Evans <cce@clarkevans.com>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0246.txt
+++ b/pep-0246.txt
@@ -1,7 +1,5 @@
 PEP: 246
 Title: Object Adaptation
-Version: $Revision$
-Last-Modified: $Date$
 Author: Alex Martelli <aleaxit@gmail.com>,
         Clark C. Evans <cce@clarkevans.com>
 Status: Rejected

--- a/pep-0246.txt
+++ b/pep-0246.txt
@@ -750,12 +750,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:

--- a/pep-0248.txt
+++ b/pep-0248.txt
@@ -1,7 +1,5 @@
 PEP: 248
 Title: Python Database API Specification v1.0
-Version: $Revision$
-Last-Modified: $Date$
 Author: Marc-André Lemburg <mal@lemburg.com>
 Discussions-To: db-sig@python.org
 Status: Final

--- a/pep-0248.txt
+++ b/pep-0248.txt
@@ -303,11 +303,3 @@ Copyright
 =========
 
 This document has been placed in the Public Domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0248.txt
+++ b/pep-0248.txt
@@ -2,7 +2,7 @@ PEP: 248
 Title: Python Database API Specification v1.0
 Version: $Revision$
 Last-Modified: $Date$
-Author: mal@lemburg.com (Marc-André Lemburg)
+Author: Marc-André Lemburg <mal@lemburg.com>
 Discussions-To: db-sig@python.org
 Status: Final
 Type: Informational

--- a/pep-0249.txt
+++ b/pep-0249.txt
@@ -1,7 +1,5 @@
 PEP: 249
 Title: Python Database API Specification v2.0
-Version: $Revision$
-Last-Modified: $Date$
 Author: Marc-André Lemburg <mal@lemburg.com>
 Discussions-To: db-sig@python.org
 Status: Final

--- a/pep-0249.txt
+++ b/pep-0249.txt
@@ -2,7 +2,7 @@ PEP: 249
 Title: Python Database API Specification v2.0
 Version: $Revision$
 Last-Modified: $Date$
-Author: mal@lemburg.com (Marc-André Lemburg)
+Author: Marc-André Lemburg <mal@lemburg.com>
 Discussions-To: db-sig@python.org
 Status: Final
 Type: Informational

--- a/pep-0250.txt
+++ b/pep-0250.txt
@@ -1,7 +1,5 @@
 PEP: 250
 Title: Using site-packages on Windows
-Version: $Revision$
-Last-Modified: $Date$
 Author: Paul Moore <p.f.moore@gmail.com>
 Status: Final
 Type: Standards Track

--- a/pep-0250.txt
+++ b/pep-0250.txt
@@ -136,11 +136,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0250.txt
+++ b/pep-0250.txt
@@ -2,7 +2,7 @@ PEP: 250
 Title: Using site-packages on Windows
 Version: $Revision$
 Last-Modified: $Date$
-Author: p.f.moore@gmail.com (Paul Moore)
+Author: Paul Moore <p.f.moore@gmail.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0251.txt
+++ b/pep-0251.txt
@@ -1,7 +1,5 @@
 PEP: 251
 Title: Python 2.2 Release Schedule
-Version: $Revision$
-Last-Modified: $Date$
 Author: Barry Warsaw <barry@python.org>, Guido van Rossum <guido@python.org>
 Status: Final
 Type: Informational

--- a/pep-0251.txt
+++ b/pep-0251.txt
@@ -86,11 +86,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0251.txt
+++ b/pep-0251.txt
@@ -2,7 +2,7 @@ PEP: 251
 Title: Python 2.2 Release Schedule
 Version: $Revision$
 Last-Modified: $Date$
-Author: barry@python.org (Barry Warsaw), guido@python.org (Guido van Rossum)
+Author: Barry Warsaw <barry@python.org>, Guido van Rossum <guido@python.org>
 Status: Final
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0252.txt
+++ b/pep-0252.txt
@@ -724,9 +724,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   End:

--- a/pep-0252.txt
+++ b/pep-0252.txt
@@ -1,7 +1,5 @@
 PEP: 252
 Title: Making Types Look More Like Classes
-Version: $Revision$
-Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>
 Status: Final
 Type: Standards Track

--- a/pep-0252.txt
+++ b/pep-0252.txt
@@ -2,7 +2,7 @@ PEP: 252
 Title: Making Types Look More Like Classes
 Version: $Revision$
 Last-Modified: $Date$
-Author: guido@python.org (Guido van Rossum)
+Author: Guido van Rossum <guido@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0253.txt
+++ b/pep-0253.txt
@@ -1,7 +1,5 @@
 PEP: 253
 Title: Subtyping Built-in Types
-Version: $Revision$
-Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>
 Status: Final
 Type: Standards Track

--- a/pep-0253.txt
+++ b/pep-0253.txt
@@ -2,7 +2,7 @@ PEP: 253
 Title: Subtyping Built-in Types
 Version: $Revision$
 Last-Modified: $Date$
-Author: guido@python.org (Guido van Rossum)
+Author: Guido van Rossum <guido@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0253.txt
+++ b/pep-0253.txt
@@ -961,9 +961,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   End:

--- a/pep-0254.txt
+++ b/pep-0254.txt
@@ -29,10 +29,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0254.txt
+++ b/pep-0254.txt
@@ -2,7 +2,7 @@ PEP: 254
 Title: Making Classes Look More Like Types
 Version: $Revision$
 Last-Modified: $Date$
-Author: guido@python.org (Guido van Rossum)
+Author: Guido van Rossum <guido@python.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0254.txt
+++ b/pep-0254.txt
@@ -1,7 +1,5 @@
 PEP: 254
 Title: Making Classes Look More Like Types
-Version: $Revision$
-Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>
 Status: Rejected
 Type: Standards Track

--- a/pep-0255.txt
+++ b/pep-0255.txt
@@ -503,11 +503,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0255.txt
+++ b/pep-0255.txt
@@ -1,7 +1,5 @@
 PEP: 255
 Title: Simple Generators
-Version: $Revision$
-Last-Modified: $Date$
 Author: Neil Schemenauer <nas@arctrix.com>,
         Tim Peters <tim.peters@gmail.com>,
         Magnus Lie Hetland <magnus@hetland.org>

--- a/pep-0255.txt
+++ b/pep-0255.txt
@@ -2,9 +2,9 @@ PEP: 255
 Title: Simple Generators
 Version: $Revision$
 Last-Modified: $Date$
-Author: nas@arctrix.com (Neil Schemenauer),
-        tim.peters@gmail.com (Tim Peters),
-        magnus@hetland.org (Magnus Lie Hetland)
+Author: Neil Schemenauer <nas@arctrix.com>,
+        Tim Peters <tim.peters@gmail.com>,
+        Magnus Lie Hetland <magnus@hetland.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0259.txt
+++ b/pep-0259.txt
@@ -1,7 +1,5 @@
 PEP: 259
 Title: Omit printing newline after newline
-Version: $Revision$
-Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>
 Status: Rejected
 Type: Standards Track

--- a/pep-0259.txt
+++ b/pep-0259.txt
@@ -135,10 +135,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0259.txt
+++ b/pep-0259.txt
@@ -2,7 +2,7 @@ PEP: 259
 Title: Omit printing newline after newline
 Version: $Revision$
 Last-Modified: $Date$
-Author: guido@python.org (Guido van Rossum)
+Author: Guido van Rossum <guido@python.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0260.txt
+++ b/pep-0260.txt
@@ -86,10 +86,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0260.txt
+++ b/pep-0260.txt
@@ -2,7 +2,7 @@ PEP: 260
 Title: Simplify xrange()
 Version: $Revision$
 Last-Modified: $Date$
-Author: guido@python.org (Guido van Rossum)
+Author: Guido van Rossum <guido@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0260.txt
+++ b/pep-0260.txt
@@ -1,7 +1,5 @@
 PEP: 260
 Title: Simplify xrange()
-Version: $Revision$
-Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>
 Status: Final
 Type: Standards Track

--- a/pep-0263.txt
+++ b/pep-0263.txt
@@ -2,8 +2,8 @@ PEP: 263
 Title: Defining Python Source Code Encodings
 Version: $Revision$
 Last-Modified: $Date$
-Author: mal@lemburg.com (Marc-André Lemburg),
-        martin@v.loewis.de (Martin von Löwis)
+Author: Marc-André Lemburg <mal@lemburg.com>,
+        Martin von Löwis <martin@v.loewis.de>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0263.txt
+++ b/pep-0263.txt
@@ -1,7 +1,5 @@
 PEP: 263
 Title: Defining Python Source Code Encodings
-Version: $Revision$
-Last-Modified: $Date$
 Author: Marc-André Lemburg <mal@lemburg.com>,
         Martin von Löwis <martin@v.loewis.de>
 Status: Final

--- a/pep-0263.txt
+++ b/pep-0263.txt
@@ -282,13 +282,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 70
-  coding: utf-8
-  End:

--- a/pep-0265.txt
+++ b/pep-0265.txt
@@ -1,7 +1,5 @@
 PEP: 265
 Title: Sorting Dictionaries by Value
-Version: $Revision$
-Last-Modified: $Date$
 Author: Grant Griffin <g2@iowegian.com>
 Status: Rejected
 Type: Standards Track

--- a/pep-0265.txt
+++ b/pep-0265.txt
@@ -2,7 +2,7 @@ PEP: 265
 Title: Sorting Dictionaries by Value
 Version: $Revision$
 Last-Modified: $Date$
-Author: g2@iowegian.com (Grant Griffin)
+Author: Grant Griffin <g2@iowegian.com>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0265.txt
+++ b/pep-0265.txt
@@ -207,11 +207,3 @@ Copyright
 
 This document has been placed in the public domain.
 
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:
-

--- a/pep-0266.txt
+++ b/pep-0266.txt
@@ -2,7 +2,7 @@ PEP: 266
 Title: Optimizing Global Variable/Attribute Access
 Version: $Revision$
 Last-Modified: $Date$
-Author: skip@pobox.com (Skip Montanaro)
+Author: Skip Montanaro <skip@pobox.com>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0266.txt
+++ b/pep-0266.txt
@@ -433,12 +433,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  fill-column: 70
-  End:

--- a/pep-0266.txt
+++ b/pep-0266.txt
@@ -1,7 +1,5 @@
 PEP: 266
 Title: Optimizing Global Variable/Attribute Access
-Version: $Revision$
-Last-Modified: $Date$
 Author: Skip Montanaro <skip@pobox.com>
 Status: Withdrawn
 Type: Standards Track

--- a/pep-0267.txt
+++ b/pep-0267.txt
@@ -1,7 +1,5 @@
 PEP: 267
 Title: Optimized Access to Module Namespaces
-Version: $Revision$
-Last-Modified: $Date$
 Author: Jeremy Hylton <jeremy@alum.mit.edu>
 Status: Deferred
 Type: Standards Track

--- a/pep-0267.txt
+++ b/pep-0267.txt
@@ -286,11 +286,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0267.txt
+++ b/pep-0267.txt
@@ -2,7 +2,7 @@ PEP: 267
 Title: Optimized Access to Module Namespaces
 Version: $Revision$
 Last-Modified: $Date$
-Author: jeremy@alum.mit.edu (Jeremy Hylton)
+Author: Jeremy Hylton <jeremy@alum.mit.edu>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0268.txt
+++ b/pep-0268.txt
@@ -2,7 +2,7 @@ PEP: 268
 Title: Extended HTTP functionality and WebDAV
 Version: $Revision$
 Last-Modified: $Date$
-Author: gstein@lyra.org (Greg Stein)
+Author: Greg Stein <gstein@lyra.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0268.txt
+++ b/pep-0268.txt
@@ -207,13 +207,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   fill-column: 70
-   sentence-end-double-space: t
-   End:

--- a/pep-0268.txt
+++ b/pep-0268.txt
@@ -1,7 +1,5 @@
 PEP: 268
 Title: Extended HTTP functionality and WebDAV
-Version: $Revision$
-Last-Modified: $Date$
 Author: Greg Stein <gstein@lyra.org>
 Status: Rejected
 Type: Standards Track

--- a/pep-0269.txt
+++ b/pep-0269.txt
@@ -208,12 +208,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  fill-column: 70
-  End:

--- a/pep-0269.txt
+++ b/pep-0269.txt
@@ -2,7 +2,7 @@ PEP: 269
 Title: Pgen Module for Python
 Version: $Revision$
 Last-Modified: $Date$
-Author: jriehl@spaceship.com (Jonathan Riehl)
+Author: Jonathan Riehl <jriehl@spaceship.com>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0269.txt
+++ b/pep-0269.txt
@@ -1,7 +1,5 @@
 PEP: 269
 Title: Pgen Module for Python
-Version: $Revision$
-Last-Modified: $Date$
 Author: Jonathan Riehl <jriehl@spaceship.com>
 Status: Deferred
 Type: Standards Track

--- a/pep-0270.txt
+++ b/pep-0270.txt
@@ -81,12 +81,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  fill-column: 70
-  End:

--- a/pep-0270.txt
+++ b/pep-0270.txt
@@ -2,7 +2,7 @@ PEP: 270
 Title: uniq method for list objects
 Version: $Revision$
 Last-Modified: $Date$
-Author: jp@demonseed.net (Jason Petrone)
+Author: Jason Petrone <jp@demonseed.net>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0270.txt
+++ b/pep-0270.txt
@@ -1,7 +1,5 @@
 PEP: 270
 Title: uniq method for list objects
-Version: $Revision$
-Last-Modified: $Date$
 Author: Jason Petrone <jp@demonseed.net>
 Status: Rejected
 Type: Standards Track

--- a/pep-0271.txt
+++ b/pep-0271.txt
@@ -72,14 +72,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 70
-  coding: utf-8
-  End:

--- a/pep-0271.txt
+++ b/pep-0271.txt
@@ -1,7 +1,5 @@
 PEP: 271
 Title: Prefixing sys.path by command line option
-Version: $Revision$
-Last-Modified: $Date$
 Author: Frédéric B. Giacometti <fred@arakne.com>
 Status: Rejected
 Type: Standards Track

--- a/pep-0271.txt
+++ b/pep-0271.txt
@@ -2,7 +2,7 @@ PEP: 271
 Title: Prefixing sys.path by command line option
 Version: $Revision$
 Last-Modified: $Date$
-Author: fred@arakne.com (Frédéric B. Giacometti)
+Author: Frédéric B. Giacometti <fred@arakne.com>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0273.txt
+++ b/pep-0273.txt
@@ -233,12 +233,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  fill-column: 70
-  End:

--- a/pep-0273.txt
+++ b/pep-0273.txt
@@ -1,7 +1,5 @@
 PEP: 273
 Title: Import Modules from Zip Archives
-Version: $Revision$
-Last-Modified: $Date$
 Author: James C. Ahlstrom <jim@interet.com>
 Status: Final
 Type: Standards Track

--- a/pep-0273.txt
+++ b/pep-0273.txt
@@ -2,7 +2,7 @@ PEP: 273
 Title: Import Modules from Zip Archives
 Version: $Revision$
 Last-Modified: $Date$
-Author: jim@interet.com (James C. Ahlstrom)
+Author: James C. Ahlstrom <jim@interet.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0275.txt
+++ b/pep-0275.txt
@@ -2,7 +2,7 @@ PEP: 275
 Title: Switching on Multiple Values
 Version: $Revision$
 Last-Modified: $Date$
-Author: mal@lemburg.com (Marc-André Lemburg)
+Author: Marc-André Lemburg <mal@lemburg.com>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0275.txt
+++ b/pep-0275.txt
@@ -1,7 +1,5 @@
 PEP: 275
 Title: Switching on Multiple Values
-Version: $Revision$
-Last-Modified: $Date$
 Author: Marc-André Lemburg <mal@lemburg.com>
 Status: Rejected
 Type: Standards Track

--- a/pep-0275.txt
+++ b/pep-0275.txt
@@ -358,12 +358,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0276.txt
+++ b/pep-0276.txt
@@ -2,7 +2,7 @@ PEP: 276
 Title: Simple Iterator for ints
 Version: $Revision$
 Last-Modified: $Date$
-Author: james_althoff@i2.com (Jim Althoff)
+Author: Jim Althoff <james_althoff@i2.com>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0276.txt
+++ b/pep-0276.txt
@@ -426,11 +426,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   fill-column: 70
-   End:

--- a/pep-0276.txt
+++ b/pep-0276.txt
@@ -1,7 +1,5 @@
 PEP: 276
 Title: Simple Iterator for ints
-Version: $Revision$
-Last-Modified: $Date$
 Author: Jim Althoff <james_althoff@i2.com>
 Status: Rejected
 Type: Standards Track

--- a/pep-0277.txt
+++ b/pep-0277.txt
@@ -2,7 +2,7 @@ PEP: 277
 Title: Unicode file name support for Windows NT
 Version: $Revision$
 Last-Modified: $Date$
-Author: neilh@scintilla.org (Neil Hodgson)
+Author: Neil Hodgson <neilh@scintilla.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0277.txt
+++ b/pep-0277.txt
@@ -113,13 +113,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  fill-column: 70
-  End:
-

--- a/pep-0277.txt
+++ b/pep-0277.txt
@@ -1,7 +1,5 @@
 PEP: 277
 Title: Unicode file name support for Windows NT
-Version: $Revision$
-Last-Modified: $Date$
 Author: Neil Hodgson <neilh@scintilla.org>
 Status: Final
 Type: Standards Track

--- a/pep-0278.txt
+++ b/pep-0278.txt
@@ -2,7 +2,7 @@ PEP: 278
 Title: Universal Newline Support
 Version: $Revision$
 Last-Modified: $Date$
-Author: jack@cwi.nl (Jack Jansen)
+Author: Jack Jansen <jack@cwi.nl>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0278.txt
+++ b/pep-0278.txt
@@ -1,7 +1,5 @@
 PEP: 278
 Title: Universal Newline Support
-Version: $Revision$
-Last-Modified: $Date$
 Author: Jack Jansen <jack@cwi.nl>
 Status: Final
 Type: Standards Track

--- a/pep-0278.txt
+++ b/pep-0278.txt
@@ -205,12 +205,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  fill-column: 70
-  End:

--- a/pep-0279.txt
+++ b/pep-0279.txt
@@ -1,7 +1,5 @@
 PEP: 279
 Title: The enumerate() built-in function
-Version: $Revision$
-Last-Modified: $Date$
 Author: Raymond Hettinger <python@rcn.com>
 Status: Final
 Type: Standards Track

--- a/pep-0279.txt
+++ b/pep-0279.txt
@@ -201,14 +201,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  fill-column: 70
-  End:
-
-

--- a/pep-0279.txt
+++ b/pep-0279.txt
@@ -2,7 +2,7 @@ PEP: 279
 Title: The enumerate() built-in function
 Version: $Revision$
 Last-Modified: $Date$
-Author: python@rcn.com (Raymond Hettinger)
+Author: Raymond Hettinger <python@rcn.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0280.txt
+++ b/pep-0280.txt
@@ -1,7 +1,5 @@
 PEP: 280
 Title: Optimizing access to globals
-Version: $Revision$
-Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>
 Status: Deferred
 Type: Standards Track

--- a/pep-0280.txt
+++ b/pep-0280.txt
@@ -2,7 +2,7 @@ PEP: 280
 Title: Optimizing access to globals
 Version: $Revision$
 Last-Modified: $Date$
-Author: guido@python.org (Guido van Rossum)
+Author: Guido van Rossum <guido@python.org>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0280.txt
+++ b/pep-0280.txt
@@ -529,10 +529,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   End:

--- a/pep-0281.txt
+++ b/pep-0281.txt
@@ -140,12 +140,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  fill-column: 70
-  End:

--- a/pep-0281.txt
+++ b/pep-0281.txt
@@ -2,7 +2,7 @@ PEP: 281
 Title: Loop Counter Iteration with range and xrange
 Version: $Revision$
 Last-Modified: $Date$
-Author: magnus@hetland.org (Magnus Lie Hetland)
+Author: Magnus Lie Hetland <magnus@hetland.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0281.txt
+++ b/pep-0281.txt
@@ -1,7 +1,5 @@
 PEP: 281
 Title: Loop Counter Iteration with range and xrange
-Version: $Revision$
-Last-Modified: $Date$
 Author: Magnus Lie Hetland <magnus@hetland.org>
 Status: Rejected
 Type: Standards Track

--- a/pep-0282.txt
+++ b/pep-0282.txt
@@ -1,7 +1,5 @@
 PEP: 282
 Title: A Logging System
-Version: $Revision$
-Last-Modified: $Date$
 Author: Vinay Sajip <vinay_sajip at red-dove.com>,
         Trent Mick <trentm@activestate.com>
 Status: Final

--- a/pep-0282.txt
+++ b/pep-0282.txt
@@ -2,8 +2,8 @@ PEP: 282
 Title: A Logging System
 Version: $Revision$
 Last-Modified: $Date$
-Author: vinay_sajip at red-dove.com (Vinay Sajip),
-        trentm@activestate.com (Trent Mick)
+Author: Vinay Sajip <vinay_sajip at red-dove.com>,
+        Trent Mick <trentm@activestate.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0282.txt
+++ b/pep-0282.txt
@@ -635,12 +635,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:

--- a/pep-0285.txt
+++ b/pep-0285.txt
@@ -2,7 +2,7 @@ PEP: 285
 Title: Adding a bool type
 Version: $Revision$
 Last-Modified: $Date$
-Author: guido@python.org (Guido van Rossum)
+Author: Guido van Rossum <guido@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0285.txt
+++ b/pep-0285.txt
@@ -447,11 +447,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   fill-column: 70
-   End:

--- a/pep-0285.txt
+++ b/pep-0285.txt
@@ -1,7 +1,5 @@
 PEP: 285
 Title: Adding a bool type
-Version: $Revision$
-Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>
 Status: Final
 Type: Standards Track

--- a/pep-0286.txt
+++ b/pep-0286.txt
@@ -124,11 +124,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  fill-column: 70
-  End:

--- a/pep-0286.txt
+++ b/pep-0286.txt
@@ -1,7 +1,5 @@
 PEP: 286
 Title: Enhanced Argument Tuples
-Version: $Revision$
-Last-Modified: $Date$
 Author: Martin von Löwis <martin@v.loewis.de>
 Status: Deferred
 Type: Standards Track

--- a/pep-0286.txt
+++ b/pep-0286.txt
@@ -2,7 +2,7 @@ PEP: 286
 Title: Enhanced Argument Tuples
 Version: $Revision$
 Last-Modified: $Date$
-Author: martin@v.loewis.de (Martin von Löwis)
+Author: Martin von Löwis <martin@v.loewis.de>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0288.txt
+++ b/pep-0288.txt
@@ -2,7 +2,7 @@ PEP: 288
 Title: Generators Attributes and Exceptions
 Version: $Revision$
 Last-Modified: $Date$
-Author: python@rcn.com (Raymond Hettinger)
+Author: Raymond Hettinger <python@rcn.com>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0288.txt
+++ b/pep-0288.txt
@@ -1,7 +1,5 @@
 PEP: 288
 Title: Generators Attributes and Exceptions
-Version: $Revision$
-Last-Modified: $Date$
 Author: Raymond Hettinger <python@rcn.com>
 Status: Withdrawn
 Type: Standards Track

--- a/pep-0288.txt
+++ b/pep-0288.txt
@@ -155,12 +155,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  fill-column: 70
-  End:

--- a/pep-0289.txt
+++ b/pep-0289.txt
@@ -1,7 +1,5 @@
 PEP: 289
 Title: Generator Expressions
-Version: $Revision$
-Last-Modified: $Date$
 Author: Raymond Hettinger <python@rcn.com>
 Status: Final
 Type: Standards Track

--- a/pep-0289.txt
+++ b/pep-0289.txt
@@ -298,12 +298,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:

--- a/pep-0289.txt
+++ b/pep-0289.txt
@@ -2,7 +2,7 @@ PEP: 289
 Title: Generator Expressions
 Version: $Revision$
 Last-Modified: $Date$
-Author: python@rcn.com (Raymond Hettinger)
+Author: Raymond Hettinger <python@rcn.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0291.txt
+++ b/pep-0291.txt
@@ -153,13 +153,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 70
-  End:

--- a/pep-0291.txt
+++ b/pep-0291.txt
@@ -2,7 +2,7 @@ PEP: 291
 Title: Backward Compatibility for the Python 2 Standard Library
 Version: $Revision$
 Last-Modified: $Date$
-Author: nnorwitz@gmail.com (Neal Norwitz)
+Author: Neal Norwitz <nnorwitz@gmail.com>
 Status: Final
 Type: Informational
 Content-Type: text/x-rst

--- a/pep-0291.txt
+++ b/pep-0291.txt
@@ -1,7 +1,5 @@
 PEP: 291
 Title: Backward Compatibility for the Python 2 Standard Library
-Version: $Revision$
-Last-Modified: $Date$
 Author: Neal Norwitz <nnorwitz@gmail.com>
 Status: Final
 Type: Informational

--- a/pep-0292.txt
+++ b/pep-0292.txt
@@ -1,7 +1,5 @@
 PEP: 292
 Title: Simpler String Substitutions
-Version: $Revision$
-Last-Modified: $Date$
 Author: Barry Warsaw <barry@python.org>
 Status: Final
 Type: Standards Track

--- a/pep-0292.txt
+++ b/pep-0292.txt
@@ -210,13 +210,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 70
-  End:

--- a/pep-0292.txt
+++ b/pep-0292.txt
@@ -2,7 +2,7 @@ PEP: 292
 Title: Simpler String Substitutions
 Version: $Revision$
 Last-Modified: $Date$
-Author: barry@python.org (Barry Warsaw)
+Author: Barry Warsaw <barry@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0294.txt
+++ b/pep-0294.txt
@@ -2,7 +2,7 @@ PEP: 294
 Title: Type Names in the types Module
 Version: $Revision$
 Last-Modified: $Date$
-Author: oren at hishome.net (Oren Tirosh)
+Author: Oren Tirosh <oren at hishome.net>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0294.txt
+++ b/pep-0294.txt
@@ -100,11 +100,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:

--- a/pep-0294.txt
+++ b/pep-0294.txt
@@ -1,7 +1,5 @@
 PEP: 294
 Title: Type Names in the types Module
-Version: $Revision$
-Last-Modified: $Date$
 Author: Oren Tirosh <oren at hishome.net>
 Status: Rejected
 Type: Standards Track

--- a/pep-0295.txt
+++ b/pep-0295.txt
@@ -2,7 +2,7 @@ PEP: 295
 Title: Interpretation of multiline string constants
 Version: $Revision$
 Last-Modified: $Date$
-Author: yozh@mx1.ru (Stepan Koltsov)
+Author: Stepan Koltsov <yozh@mx1.ru>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0295.txt
+++ b/pep-0295.txt
@@ -119,13 +119,3 @@ Copyright
 =========
 
 This document has been placed in the Public Domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 70
-  End:

--- a/pep-0295.txt
+++ b/pep-0295.txt
@@ -1,7 +1,5 @@
 PEP: 295
 Title: Interpretation of multiline string constants
-Version: $Revision$
-Last-Modified: $Date$
 Author: Stepan Koltsov <yozh@mx1.ru>
 Status: Rejected
 Type: Standards Track

--- a/pep-0296.txt
+++ b/pep-0296.txt
@@ -1,7 +1,5 @@
 PEP: 296
 Title: Adding a bytes Object Type
-Version: $Revision$
-Last-Modified: $Date$
 Author: Scott Gilbert <xscottg at yahoo.com>
 Status: Withdrawn
 Type: Standards Track

--- a/pep-0296.txt
+++ b/pep-0296.txt
@@ -357,12 +357,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:

--- a/pep-0296.txt
+++ b/pep-0296.txt
@@ -2,7 +2,7 @@ PEP: 296
 Title: Adding a bytes Object Type
 Version: $Revision$
 Last-Modified: $Date$
-Author: xscottg at yahoo.com (Scott Gilbert)
+Author: Scott Gilbert <xscottg at yahoo.com>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0297.txt
+++ b/pep-0297.txt
@@ -2,7 +2,7 @@ PEP: 297
 Title: Support for System Upgrades
 Version: $Revision$
 Last-Modified: $Date$
-Author: mal@lemburg.com (Marc-André Lemburg)
+Author: Marc-André Lemburg <mal@lemburg.com>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0297.txt
+++ b/pep-0297.txt
@@ -116,14 +116,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 70
-  coding: utf-8
-  End:

--- a/pep-0297.txt
+++ b/pep-0297.txt
@@ -1,7 +1,5 @@
 PEP: 297
 Title: Support for System Upgrades
-Version: $Revision$
-Last-Modified: $Date$
 Author: Marc-André Lemburg <mal@lemburg.com>
 Status: Rejected
 Type: Standards Track

--- a/pep-0666.txt
+++ b/pep-0666.txt
@@ -2,7 +2,7 @@ PEP: 666
 Title: Reject Foolish Indentation
 Version: $Revision$
 Last-Modified: $Date$
-Author: lac@strakt.com (Laura Creighton)
+Author: Laura Creighton <lac@strakt.com>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0666.txt
+++ b/pep-0666.txt
@@ -1,7 +1,5 @@
 PEP: 666
 Title: Reject Foolish Indentation
-Version: $Revision$
-Last-Modified: $Date$
 Author: Laura Creighton <lac@strakt.com>
 Status: Rejected
 Type: Standards Track

--- a/pep-0666.txt
+++ b/pep-0666.txt
@@ -96,12 +96,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  fill-column: 70
-  End:

--- a/pep-3103.txt
+++ b/pep-3103.txt
@@ -2,7 +2,7 @@ PEP: 3103
 Title: A Switch/Case Statement
 Version: $Revision$
 Last-Modified: $Date$
-Author: guido@python.org (Guido van Rossum)
+Author: Guido van Rossum <guido@python.org>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-3103.txt
+++ b/pep-3103.txt
@@ -624,14 +624,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-3103.txt
+++ b/pep-3103.txt
@@ -1,7 +1,5 @@
 PEP: 3103
 Title: A Switch/Case Statement
-Version: $Revision$
-Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>
 Status: Rejected
 Type: Standards Track


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Prep for https://github.com/python/peps/pull/2672.

* Enable the `validate-author` check for .txt PEPs
* Reformat the old `email@example.com (Name)` headers to `Name <email@example.com>`
* Whilst editing those files, also remove the redundant emacs metadata
* And fix the couple of footnote warnings in PEPs 3 and 231:

```
pep-0003.txt:72: WARNING: Footnote [1] is not referenced.
pep-0231.txt:616: WARNING: Footnote [8] is not referenced.
```
