### PR TITLE
PEP 681: Clarifications about classes decorated with `dataclass_transform`

### DIFF
--- a/pep-0681.rst
+++ b/pep-0681.rst
@@ -109,8 +109,10 @@ than one, of the overloads. When applied to an overload, the
 function.
 
 If ``dataclass_transform`` is applied to a class, dataclass-like
-semantics will be assumed for any class that derives from the
-decorated class or uses the decorated class as a metaclass.
+semantics will be assumed for any class that directly or indirectly
+derives from the decorated class or uses the decorated class as a
+metaclass. Attributes on the decorated class and its base classes
+are not considered to be fields.
 
 Examples of each approach are shown in the following sections. Each
 example creates a ``CustomerModel`` class with dataclass-like semantics.
@@ -568,8 +570,11 @@ This includes, but is not limited to, the following semantics:
   keyword-only parameters are used for ``__init__``, so the rule is
   not enforced if ``kw_only`` semantics are in effect.
 
-* As with dataclass, method synthesis is skipped if it would
+* As with ``dataclass``, method synthesis is skipped if it would
   overwrite a method that is explicitly declared within the class.
+  Method declarations on base classes do not cause method synthesis to
+  be skipped.
+
   For example, if a class declares an ``__init__`` method explicitly,
   an ``__init__`` method will not be synthesized for that class.
 


### PR DESCRIPTION
Clarified the following behaviors around classes decorated with `dataclass_transform`:

1. Attributes on such a class or its base classes are not considered to be fields.
2. Classes that are indirectly derived from such a class are still assumed to have dataclass-like semantics.
3. Method synthesis on a class is not impacted by the presence of explicit method declarations on that class's base classes. For example, the presence of an explicit `__init__` method on a base class, will not cause `__init__` synthesis to be skipped on a derived class. This is true when using functions decorated with `dataclass_transform` as well as with classes/metaclasses decorated with `dataclass_transform`.

These clarifications address questions from users in https://github.com/microsoft/pyright/issues/3907 and https://github.com/microsoft/pylance-release/issues/3304.

cc: @erictraut 