### PR TITLE
Lint: Upgrade linters, enable backtick check & fix new errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,9 +71,7 @@ repos:
     hooks:
       - id: sphinx-lint
         name: "Sphinx lint"
-        # Temporarily disable "role-with-double-backticks" due to false positive:
-        # https://github.com/sphinx-contrib/sphinx-lint/issues/34
-        args: ["--disable=role-with-double-backticks,trailing-whitespace"]
+        args: ["--disable=trailing-whitespace"]
 
   # RST checks
   - repo: https://github.com/pre-commit/pygrep-hooks
@@ -81,6 +79,8 @@ repos:
     hooks:
       - id: rst-backticks
         name: "Check RST: No single backticks"
+        files: '^pep-\d\.txt|\.rst$'
+        types: [text]
       - id: rst-inline-touching-normal
         name: "Check RST: No backticks touching text"
         files: '^pep-\d+\.txt|\.rst$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         name: "Check YAML"
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         name: "Format with Black"
@@ -67,7 +67,7 @@ repos:
         name: "Format tox.ini"
 
   - repo: https://github.com/sphinx-contrib/sphinx-lint
-    rev: v0.6.1
+    rev: v0.6.6
     hooks:
       - id: sphinx-lint
         name: "Sphinx lint"
@@ -92,7 +92,7 @@ repos:
 
   # Manual codespell check
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.1
     hooks:
       - id: codespell
         name: "Check for common misspellings in text files"

--- a/pep-0240.txt
+++ b/pep-0240.txt
@@ -1,7 +1,5 @@
 PEP: 240
 Title: Adding a Rational Literal to Python
-Version: $Revision$
-Last-Modified: $Date$
 Author: Christopher A. Craig <python-pep@ccraig.org>, Moshe Zadka <moshez@zadka.site.co.il>
 Status: Rejected
 Type: Standards Track
@@ -61,7 +59,7 @@ mentioned above.  The following migration is suggested:
    to cause all such literals to be treated as rational numbers.
 
 2. Python 3.0 will have a warning, turned on by default, about
-   such literals in the absence of a `` __future__`` statement.  The
+   such literals in the absence of a ``__future__`` statement.  The
    warning message will contain information about the ``__future__``
    statement, and indicate that to get floating point literals,
    they should be suffixed with "e0".
@@ -97,11 +95,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:

--- a/pep-0357.txt
+++ b/pep-0357.txt
@@ -1,7 +1,5 @@
 PEP: 357
 Title: Allowing Any Object to be Used for Slicing
-Version: $Revision$
-Last-Modified: $Date$
 Author: Travis Oliphant <oliphant@ee.byu.edu>
 Status: Final
 Type: Standards Track
@@ -237,13 +235,3 @@ Copyright
 =========
 
 This document is placed in the public domain.
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 70
-  coding: utf-8
-  End:

--- a/pep-0447.txt
+++ b/pep-0447.txt
@@ -1,7 +1,5 @@
 PEP: 447
 Title: Add __getdescriptor__ method to metaclass
-Version: $Revision$
-Last-Modified: $Date$
 Author: Ronald Oussoren <ronaldoussoren@mac.com>
 Status: Deferred
 Type: Standards Track
@@ -117,7 +115,7 @@ Aside: Attribute resolution algorithm in Python
 -----------------------------------------------
 
 The attribute resolution process as implemented by ``object.__getattribute__``
-(or PyObject_GenericGetAttr`` in CPython's implementation) is fairly
+(or ``PyObject_GenericGetAttr`` in CPython's implementation) is fairly
 straightforward, but not entirely so without reading C code.
 
 The current CPython implementation of object.__getattribute__ is basically

--- a/pep-0461.txt
+++ b/pep-0461.txt
@@ -1,7 +1,5 @@
 PEP: 461
 Title: Adding % formatting to bytes and bytearray
-Version: $Revision$
-Last-Modified: $Date$
 Author: Ethan Furman <ethan@stoneleaf.us>
 Status: Final
 Type: Standards Track
@@ -55,7 +53,7 @@ All the numeric formatting codes (``d``, ``i``, ``o``, ``u``, ``x``, ``X``,
 ``e``, ``E``, ``f``, ``F``, ``g``, ``G``, and any that are subsequently added
 to Python 3) will be supported, and will work as they do for str, including
 the padding, justification and other related modifiers (currently ``#``, ``0``,
-``-``, `` `` (space), and ``+`` (plus any added to Python 3)).  The only
+``-``, space, and ``+`` (plus any added to Python 3)).  The only
 non-numeric codes allowed are ``c``, ``b``, ``a``, and ``s`` (which is a
 synonym for b).
 
@@ -243,13 +241,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
* Upgrade check versions to latest (particularly Sphinx-Lint, fixing several false positives and false negatives)
* Enable single-backtick default role checks for txt and rst now that all false positives and true positives are fixed on both ( sphinx-contrib/sphinx-lint#34 )
* Fix several outstanding syntax errors detected on PEPs 240, 357, 447 and 461, and clean up a few additional things