### PR TITLE
Meta: Clarify scope of Packaging topic and rm ensurepip PEPs (453/477)

### DIFF
--- a/pep-0453.txt
+++ b/pep-0453.txt
@@ -5,7 +5,6 @@ Author: Donald Stufft <donald@stufft.io>,
 BDFL-Delegate: Martin von Löwis
 Status: Final
 Type: Standards Track
-Topic: Packaging
 Content-Type: text/x-rst
 Created: 10-Aug-2013
 Post-History: 30-Aug-2013, 15-Sep-2013, 18-Sep-2013, 19-Sep-2013,

--- a/pep-0477.txt
+++ b/pep-0477.txt
@@ -1,13 +1,10 @@
 PEP: 477
 Title: Backport ensurepip (PEP 453) to Python 2.7
-Version: $Revision$
-Last-Modified: $Date$
 Author: Donald Stufft <donald@stufft.io>,
         Nick Coghlan <ncoghlan@gmail.com>
 BDFL-Delegate: Benjamin Peterson <benjamin@python.org>
 Status: Final
 Type: Standards Track
-Topic: Packaging
 Content-Type: text/x-rst
 Created: 26-Aug-2014
 Post-History: 01-Sep-2014
@@ -128,14 +125,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep_sphinx_extensions/pep_zero_generator/constants.py
+++ b/pep_sphinx_extensions/pep_zero_generator/constants.py
@@ -36,10 +36,10 @@ ACTIVE_ALLOWED = {TYPE_PROCESS, TYPE_INFO}
 # map of topic -> additional description
 SUBINDICES_BY_TOPIC = {
     "packaging": """\
-The canonical, up-to-date packaging specifications can be found on the
-`Python Packaging Authority`_ (PyPA) `specifications`_ page.
 Packaging PEPs follow the `PyPA specification update process`_.
 They are used to propose major additions or changes to the PyPA specifications.
+The canonical, up-to-date packaging specifications can be found on the
+`Python Packaging Authority`_ (PyPA) `specifications`_ page.
 
 .. _Python Packaging Authority: https://www.pypa.io/
 .. _specifications: https://packaging.python.org/en/latest/specifications/


### PR DESCRIPTION
As discussed on #2696 , tweaks the packaging page description text to clarify scope to be PyPA only and removes PEP 453/477 (ensurepip) accordingly.

Closes #2696