### PR TITLE
PEP 541: Additional clarifications on invalid projects

### DIFF
--- a/pep-0541.txt
+++ b/pep-0541.txt
@@ -206,12 +206,15 @@ A project published on the Package Index meeting ANY of the following
 is considered invalid and will be removed from the Index:
 
 * project does not conform to Terms of Use;
-* project is malware (designed to exploit or harm systems or users);
+* project is malware (designed to exploit or harm systems or users directly, to
+  facilitate command-and-control attacks, or perform data exfiltration);
+* project is spam (designed to advertise or solicit goods or services);
 * project contains illegal content;
 * project violates copyright, trademarks, patents, or licenses;
 * project is name squatting (package has no functionality or is
   empty);
 * project name, description, or content violates the Code of Conduct;
+* project uses obfuscation to hide or mask functionality;
   or
 * project is abusing the Package Index for purposes it was not
   intended.


### PR DESCRIPTION
This PR adds some clarification to additional things that PyPI maintainers consider to be 'invalid projects' and adds some additional clarification to existing items.

(CC @ambv as the original author)
