### PR TITLE
Fix typos in PEP 698

### DIFF
--- a/pep-0698.rst
+++ b/pep-0698.rst
@@ -334,8 +334,8 @@ insufficient for several reasons:
 Runtime enforcement
 -------------------
 
-We considered having ``@typing.overrride`` enforce override safety at runtime,
-similarly to how ``@overrides.overrrides``
+We considered having ``@typing.override`` enforce override safety at runtime,
+similarly to how ``@overrides.overrides``
 `does today <https://pypi.org/project/overrides/>`_.
 
 We rejected this for three reasons:
@@ -343,7 +343,7 @@ We rejected this for three reasons:
 - For users of static type checking, it is not clear this brings any benefits.
 - There would be at least some performance overhead, leading to projects
   importing slower with runtime enforcement. We estimate the
-  ``@overrides.overrrides`` implementation takes around 100 microseconds, which
+  ``@overrides.overrides`` implementation takes around 100 microseconds, which
   is fast but could still add up to a second or more of extra initialization
   time in million-plus line codebases, which is exactly where we think
   ``@typing.override`` will be most useful.
@@ -359,7 +359,7 @@ We rejected this for three reasons:
 Marking overrides at runtime with an ``__override__`` attribute
 ---------------------------------------------------------------
 
-The ``@overrides.overrrides`` decorator marks methods it decorates with an
+The ``@overrides.overrides`` decorator marks methods it decorates with an
 ``__override__`` attribute.
 
 We considered having ``@typing.override`` do the same, since many typing


### PR DESCRIPTION
Fix some typos. Would like to give some comments to the PEP as the maintainer of overrides package, but I'll do it on reddit for example.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
