### PR TITLE
PEP 569, 596, 619: Add release dates for 2022-10-11 release

### DIFF
--- a/pep-0569.rst
+++ b/pep-0569.rst
@@ -1,7 +1,5 @@
 PEP: 569
 Title: Python 3.8 Release Schedule
-Version: $Revision$
-Last-Modified: $Date$
 Author: Łukasz Langa <lukasz@python.org>
 Status: Active
 Type: Informational
@@ -95,6 +93,7 @@ Provided irregularly on an "as-needed" basis until October 2024.
 - 3.8.12: Monday, 2021-08-30
 - 3.8.13: Wednesday, 2022-03-16
 - 3.8.14: Tuesday, 2022-09-06
+- 3.8.15: Tuesday, 2022-10-11
 
 
 Features for 3.8
@@ -132,13 +131,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 72
-  coding: utf-8
-  End:

--- a/pep-0596.rst
+++ b/pep-0596.rst
@@ -1,7 +1,5 @@
 PEP: 596
 Title: Python 3.9 Release Schedule
-Version: $Revision$
-Last-Modified: $Date$
 Author: Łukasz Langa <lukasz@python.org>
 Discussions-To: https://discuss.python.org/t/pep-596-python-3-9-release-schedule-doubling-the-release-cadence/1828
 Status: Active
@@ -92,6 +90,8 @@ Source-only security fix releases
 Provided irregularly on an "as-needed" basis until October 2025.
 
 - 3.9.14: Tuesday, 2022-09-06
+- 3.9.15: Tuesday, 2022-10-11
+
 
 
 3.9 Lifespan
@@ -124,13 +124,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 72
-  coding: utf-8
-  End:

--- a/pep-0619.rst
+++ b/pep-0619.rst
@@ -1,7 +1,5 @@
 PEP: 619
 Title: Python 3.10 Release Schedule
-Version: $Revision$
-Last-Modified: $Date$
 Author: Pablo Galindo Salgado <pablogsal@python.org>
 Status: Active
 Type: Informational
@@ -71,10 +69,10 @@ Actual:
 - 3.10.5: Monday, 2022-06-06
 - 3.10.6: Tuesday, 2022-08-02
 - 3.10.7: Tuesday, 2022-09-06
+- 3.10.8: Tuesday, 2022-10-11
 
 Expected:
 
-- 3.10.8: Monday, 2022-10-03
 - 3.10.9: Monday, 2022-12-05
 - 3.10.10: Monday, 2023-02-06
 
@@ -113,13 +111,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 72
-  coding: utf-8
-  End:


### PR DESCRIPTION
This updates the release PEPs with the recent announcements of the Python 3.8.15, 3.9.15 and 3.10.8 ~quintuple~ *I can't count* quadruple release (with 3.7.15, which was already updated in #2829 ) on Tuesday, 2022-10-11, per the [announcement](https://discuss.python.org/t/python-versions-3-10-8-3-9-15-3-8-15-3-7-15-now-available/19889).

Also, cleans out the old clutter while we're touching these anyway.