### PR TITLE
Lint: Add a new check for consistent PEP header order

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,6 +116,14 @@ repos:
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]
 
+      - id: check-header-order
+        name: "PEP header order must follow PEP 12"
+        language: pygrep
+        entry: '^PEP:[^\n]+\nTitle:[^\n]+\n(Version:[^\n]+\n)?(Last-Modified:[^\n]+\n)?Author:[^\n]+\n( +\S[^\n]+\n)*(Sponsor:[^\n]+\n)?((PEP|BDFL)-Delegate:[^\n]*\n)?(Discussions-To:[^\n]*\n)?Status:[^\n]+\nType:[^\n]+\n(Topic:[^\n]+\n)?Content-Type:[^\n]+\n(Requires:[^\n]+\n)?Created:[^\n]+\n(Python-Version:[^\n]*\n)?(Post-History:[^\n]*\n( +\S[^\n]*\n)*)?(Replaces:[^\n]+\n)?(Superseded-By:[^\n]+\n)?(Resolution:[^\n]*\n)?\n'
+        args: ['--negate', '--multiline']
+        files: '^pep-\d+\.(rst|txt)$'
+        types: [text]
+
       - id: validate-pep-number
         name: "'PEP' header must be a number 1-9999"
         language: pygrep

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,8 +108,8 @@ repos:
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]
 
-      - id: check-required-fields
-        name: "Check PEPs have all required headers"
+      - id: check-required-headers
+        name: "PEPs must have all required headers"
         language: pygrep
         entry: '(?-m:^PEP:(?=[\s\S]*\nTitle:)(?=[\s\S]*\nAuthor:)(?=[\s\S]*\nStatus:)(?=[\s\S]*\nType:)(?=[\s\S]*\nContent-Type:)(?=[\s\S]*\nCreated:))'
         args: ['--negate', '--multiline']

--- a/pep-0440.txt
+++ b/pep-0440.txt
@@ -1,14 +1,12 @@
 PEP: 440
 Title: Version Identification and Dependency Specification
-Version: $Revision$
-Last-Modified: $Date$
 Author: Nick Coghlan <ncoghlan@gmail.com>,
         Donald Stufft <donald@stufft.io>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
 Discussions-To: distutils-sig@python.org
 Status: Final
-Topic: Packaging
 Type: Standards Track
+Topic: Packaging
 Content-Type: text/x-rst
 Created: 18-Mar-2013
 Post-History: 30-Mar-2013, 27-May-2013, 20-Jun-2013,

--- a/pep-0441.txt
+++ b/pep-0441.txt
@@ -1,7 +1,5 @@
 PEP: 441
 Title: Improving Python ZIP Application Support
-Version: $Revision$
-Last-Modified: $Date$
 Author: Daniel Holth <dholth@gmail.com>,
         Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://mail.python.org/pipermail/python-dev/2015-February/138277.html
@@ -9,8 +7,8 @@ Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 30-Mar-2013
-Post-History: 30-Mar-2013, 01-Apr-2013, 16-Feb-2015
 Python-Version: 3.5
+Post-History: 30-Mar-2013, 01-Apr-2013, 16-Feb-2015
 Resolution: https://mail.python.org/pipermail/python-dev/2015-February/138578.html
 
 Improving Python ZIP Application Support
@@ -349,14 +347,3 @@ Copyright
 =========
 
 This document has been placed into the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0523.txt
+++ b/pep-0523.txt
@@ -1,15 +1,13 @@
 PEP: 523
 Title: Adding a frame evaluation API to CPython
-Version: $Revision$
-Last-Modified: $Date$
 Author: Brett Cannon <brett@python.org>,
         Dino Viehland <dinov@microsoft.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 16-May-2016
-Post-History: 16-May-2016
 Python-Version: 3.6
+Post-History: 16-May-2016
 Resolution: https://mail.python.org/pipermail/python-dev/2016-August/145937.html
 
 
@@ -390,14 +388,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0612.rst
+++ b/pep-0612.rst
@@ -12,8 +12,6 @@ Created: 18-Dec-2019
 Python-Version: 3.10
 Post-History: 18-Dec-2019, 13-Jul-2020
 
-Parameter Specification Variables
-=================================
 
 Abstract
 --------
@@ -578,7 +576,7 @@ Reference Implementation
 The `Pyre <https://pyre-check.org/>`_ type checker supports all of the behavior
 described above.  A reference implementation of the runtime components needed
 for those uses is provided in the ``pyre_extensions`` module.  A reference
-implementation for CPython can be found 
+implementation for CPython can be found
 `here <https://github.com/python/cpython/pull/23702>`_.
 
 Rejected Alternatives


### PR DESCRIPTION
As suggested by @stroxler in https://github.com/python/peps/pull/2834#discussion_r994449405 , we don't currently have any automated checks for the standard PEP header order. This adds such a check, and fixes the three remaining PEPs that didn't conform (and one other related problem spotted in the process).