### PR TITLE
Infra: Only emit a category table when it has entries

### DIFF
--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -143,12 +143,13 @@ class PEPZeroWriter:
         for (category, peps_in_category) in pep_categories:
             # For sub-indices, only emit categories with entries.
             # For PEP 0, emit every category, but only with a table when it has entries.
-            if is_pep0 and len(peps_in_category) == 0:
+            if len(peps_in_category) > 0:
+                self.emit_pep_category(category, peps_in_category)
+            elif is_pep0:
+                # emit the category with no table
                 self.emit_subtitle(category)
                 self.emit_text("None.")
                 self.emit_newline()
-            elif len(peps_in_category) > 0:
-                self.emit_pep_category(category, peps_in_category)
 
         self.emit_newline()
 

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -142,8 +142,12 @@ class PEPZeroWriter:
         ]
         for (category, peps_in_category) in pep_categories:
             # For sub-indices, only emit categories with entries.
-            # For PEP 0, emit every category
-            if is_pep0 or len(peps_in_category) > 0:
+            # For PEP 0, emit every category, but only with a table when it has entries.
+            if is_pep0 and len(peps_in_category) == 0:
+                self.emit_subtitle(category)
+                self.emit_text("None.")
+                self.emit_newline()
+            elif len(peps_in_category) > 0:
                 self.emit_pep_category(category, peps_in_category)
 
         self.emit_newline()


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

# Before

Currently we have no Provisional PEPs:

<img width="828" alt="image" src="https://user-images.githubusercontent.com/1324225/196910030-cb8ec0c6-d291-4252-ae4e-604f474851ec.png">

https://peps.python.org/#provisional-peps-provisionally-accepted-interface-may-still-change

# After

For PEP 0, we still want the subheading for the table of contents, but instead of an empty table (which looks like an error) let's put some text there:

<img width="805" alt="image" src="https://user-images.githubusercontent.com/1324225/196910686-0104c6d1-223d-4cd2-8e2a-2c91be1f892d.png">

https://pep-previews--2839.org.readthedocs.build/#provisional-peps-provisionally-accepted-interface-may-still-change
