### PR TITLE
Infra: Declare Makefile targets as phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,27 +6,35 @@ JOBS=8
 OUTPUT_DIR=build
 RENDER_COMMAND=$(VENVDIR)/bin/python3 build.py -j $(JOBS) -o $(OUTPUT_DIR)
 
+.PHONY: render
 render: venv
 	$(RENDER_COMMAND)
 
+.PHONY: pages
 pages: venv rss
 	$(RENDER_COMMAND) --build-dirs
 
+.PHONY: fail-warning
 fail-warning: venv
 	$(RENDER_COMMAND) --fail-on-warning
 
+.PHONY: check-links
 check-links: venv
 	$(RENDER_COMMAND) --check-links
 
+.PHONY: rss
 rss: venv
 	$(VENVDIR)/bin/python3 generate_rss.py
 
+.PHONY: clean
 clean: clean-venv
 	-rm -rf build topic
 
+.PHONY: clean-venv
 clean-venv:
 	rm -rf $(VENVDIR)
 
+.PHONY: venv
 venv:
 	@if [ -d $(VENVDIR) ] ; then \
 		echo "venv already exists."; \
@@ -38,13 +46,16 @@ venv:
 		echo "The venv has been created in the $(VENVDIR) directory"; \
 	fi
 
+.PHONY: lint
 lint: venv
 	$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit
 	$(VENVDIR)/bin/python3 -m pre_commit run --all-files
 
+.PHONY: test
 test: venv
 	$(VENVDIR)/bin/python3 -bb -X dev -W error -m pytest
 
+.PHONY: spellcheck
 spellcheck: venv
 	$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit
 	$(VENVDIR)/bin/python3 -m pre_commit run --all-files --hook-stage manual codespell


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

We were missing the `.PHONY` declarations in the Makefile, let's add them next to each target.

Docs: https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html

(Related: https://github.com/python/devguide/pull/972, https://github.com/python/cpython/pull/98266.)