### PR TITLE
Infra: Link status and type headers to descriptions

### DIFF
--- a/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
@@ -109,6 +109,12 @@ class PEPHeaders(transforms.Transform):
                         ]
                 if new_body:
                     para[:] = new_body[:-1]  # Drop trailing space/comma
+            elif name == "status":
+                target = self.document.settings.pep_url.format(1) + "#pep-review-resolution"
+                para[:] = [nodes.reference("", body.astext(), internal=True, refuri=target)]
+            elif name == "type":
+                target = self.document.settings.pep_url.format(1) + "#pep-types"
+                para[:] = [nodes.reference("", body.astext(), internal=True, refuri=target)]
             elif name in {"last-modified", "content-type", "version"}:
                 # Mark unneeded fields
                 fields_to_remove.append(field)

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
@@ -23,6 +23,26 @@ from pep_sphinx_extensions.pep_zero_generator.constants import (
     TYPE_STANDARDS,
 )
 
+ABBREVIATED_STATUSES = {
+    STATUS_DRAFT: "Proposal under active discussion and revision",
+    STATUS_DEFERRED: "Inactive draft that may be taken up again at a later time",
+    STATUS_ACCEPTED: "Normative proposal accepted for implementation",
+    STATUS_ACTIVE: "Currently valid/in-use guidance or process",
+    STATUS_FINAL: "Accepted and implementation complete, or no longer active",
+    STATUS_WITHDRAWN: "Removed from consideration by author(s)/sponsor",
+    STATUS_REJECTED: "Formally declined and will not be accepted",
+    STATUS_SUPERSEDED: "Replaced by another succeeding PEP",
+    STATUS_PROVISIONAL: "Provisionally accepted but additional feedback needed",
+}
+
+ABBREVIATED_TYPES = {
+    TYPE_STANDARDS: "Normative PEP with a new feature for Python, implementation "
+    "change for CPython or interoperability standard for the ecosystem",
+    TYPE_INFO: "Non-normative PEP containing background, guidelines or other "
+    "information relevant to the Python ecosystem",
+    TYPE_PROCESS: "Normative PEP describing or proposing a change to a Python "
+    "community process, workflow or governance",
+}
 
 class PEPParsingError(errors.SphinxError):
     pass
@@ -260,41 +280,14 @@ def _abbreviate_status(status: str) -> str:
     if status in SPECIAL_STATUSES:
         status = SPECIAL_STATUSES[status]
 
-    if status == STATUS_DRAFT:
-        return "Proposal under active discussion and revision"
-    if status == STATUS_DEFERRED:
-        return "Inactive draft that may be taken up again at a later time"
-    if status == STATUS_ACCEPTED:
-        return "Normative proposal accepted for implementation"
-    if status == STATUS_ACTIVE:
-        return "Currently valid/in-use guidance or process"
-    if status == STATUS_FINAL:
-        return "Accepted and implementation complete, or no longer active"
-    if status == STATUS_WITHDRAWN:
-        return "Removed from consideration by author(s)/sponsor"
-    if status == STATUS_REJECTED:
-        return "Formally declined and will not be accepted"
-    if status == STATUS_SUPERSEDED:
-        return "Replaced by another succeeding PEP"
-    if status == STATUS_PROVISIONAL:
-        return "Provisionally accepted but additional feedback needed"
-    raise PEPParsingError(f"Unknown status: {status}")
+    try:
+        return ABBREVIATED_STATUSES[status]
+    except KeyError:
+        raise PEPParsingError(f"Unknown status: {status}")
 
 
 def _abbreviate_type(type_: str) -> str:
-    if type_ == "Standards Track":
-        return (
-            "Normative PEP with a new feature for Python, implementation change for "
-            "CPython or interoperability standard for the ecosystem"
-        )
-    if type_ == "Informational":
-        return (
-            "Non-normative PEP containing background, guidelines or other information "
-            "relevant to the Python ecosystem"
-        )
-    if type_ == "Process":
-        return (
-            "Normative PEP describing or proposing a change to a Python community "
-            "process, workflow or governance"
-        )
-    raise PEPParsingError(f"Unknown type: {type_}")
+    try:
+        return ABBREVIATED_TYPES[type_]
+    except KeyError:
+        raise PEPParsingError(f"Unknown type: {type_}")

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
@@ -29,7 +29,7 @@ ABBREVIATED_STATUSES = {
     STATUS_ACCEPTED: "Normative proposal accepted for implementation",
     STATUS_ACTIVE: "Currently valid informational guidance, or an in-use process",
     STATUS_FINAL: "Accepted and implementation complete, or no longer active",
-    STATUS_WITHDRAWN: "Removed from consideration by author(s)/sponsor",
+    STATUS_WITHDRAWN: "Removed from consideration by sponsor or authors",
     STATUS_REJECTED: "Formally declined and will not be accepted",
     STATUS_SUPERSEDED: "Replaced by another succeeding PEP",
     STATUS_PROVISIONAL: "Provisionally accepted but additional feedback needed",

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
@@ -27,7 +27,7 @@ ABBREVIATED_STATUSES = {
     STATUS_DRAFT: "Proposal under active discussion and revision",
     STATUS_DEFERRED: "Inactive draft that may be taken up again at a later time",
     STATUS_ACCEPTED: "Normative proposal accepted for implementation",
-    STATUS_ACTIVE: "Currently valid/in-use guidance or process",
+    STATUS_ACTIVE: "Currently valid informational guidance, or an in-use process",
     STATUS_FINAL: "Accepted and implementation complete, or no longer active",
     STATUS_WITHDRAWN: "Removed from consideration by author(s)/sponsor",
     STATUS_REJECTED: "Formally declined and will not be accepted",

--- a/pep_sphinx_extensions/pep_zero_generator/constants.py
+++ b/pep_sphinx_extensions/pep_zero_generator/constants.py
@@ -19,8 +19,8 @@ STATUS_VALUES = {
 SPECIAL_STATUSES = {
     "April Fool!": STATUS_REJECTED,  # See PEP 401 :)
 }
-# Draft PEPs have no status displayed, Active shares a key with Accepted
-HIDE_STATUS = {STATUS_DRAFT, STATUS_ACTIVE}
+# Draft PEPs have no status displayed
+HIDE_STATUS = {STATUS_DRAFT}
 # Dead PEP statuses
 DEAD_STATUSES = {STATUS_REJECTED, STATUS_WITHDRAWN, STATUS_SUPERSEDED}
 

--- a/pep_sphinx_extensions/pep_zero_generator/parser.py
+++ b/pep_sphinx_extensions/pep_zero_generator/parser.py
@@ -131,7 +131,7 @@ class PEP:
         """Return reStructuredText tooltip for the PEP type and status."""
         type_code = self.pep_type[0].upper()
         if self.status in HIDE_STATUS:
-            return f":abbr:`{type_code} ({self.pep_type})`"
+            return f":abbr:`{type_code} ({self.pep_type}, {self.status})`"
         status_code = self.status[0].upper()
         return f":abbr:`{type_code}{status_code} ({self.pep_type}, {self.status})`"
 

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -192,7 +192,7 @@ class PEPZeroWriter:
         self.emit_title("PEP Status Key")
         for status in sorted(STATUS_VALUES):
             # Draft PEPs have no status displayed, Active shares a key with Accepted
-            status_code = "<none>" if status == STATUS_DRAFT else status[0]
+            status_code = "<No letter>" if status == STATUS_DRAFT else status[0]
             self.emit_text(
                 f"* **{status_code}** --- *{status}*: {ABBREVIATED_STATUSES[status]}"
             )

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -180,7 +180,7 @@ class PEPZeroWriter:
             self.emit_text(f"* {type_[0]} - {type_} PEP")
             self.emit_newline()
 
-        self.emit_text("More info in :pep:`PEP 1 § PEP Types <1#pep-types>`.")
+        self.emit_text("More info in :pep:`PEP 1 <1#pep-types>`.")
         self.emit_newline()
 
         # PEP status key
@@ -196,9 +196,7 @@ class PEPZeroWriter:
             self.emit_text(msg)
             self.emit_newline()
 
-        self.emit_text(
-            "More info in :pep:`PEP 1 § PEP Review & Resolution <1#pep-review-resolution>`."
-        )
+        self.emit_text("More info in :pep:`PEP 1 <1#pep-review-resolution>`.")
         self.emit_newline()
 
         if is_pep0:

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -177,9 +177,10 @@ class PEPZeroWriter:
         # PEP types key
         self.emit_title("PEP Types Key")
         for type_ in sorted(TYPE_VALUES):
-            self.emit_text(f"    {type_[0]} - {type_} PEP")
+            self.emit_text(f"* {type_[0]} - {type_} PEP")
             self.emit_newline()
 
+        self.emit_text("More info in :pep:`PEP 1 § PEP Types <1#pep-types>`.")
         self.emit_newline()
 
         # PEP status key
@@ -189,12 +190,15 @@ class PEPZeroWriter:
             if status in HIDE_STATUS:
                 continue
             if status == STATUS_ACCEPTED:
-                msg = "    A - Accepted (Standards Track only) or Active proposal"
+                msg = "* A - Accepted (Standards Track only) or Active proposal"
             else:
-                msg = f"    {status[0]} - {status} proposal"
+                msg = f"* {status[0]} - {status} proposal"
             self.emit_text(msg)
             self.emit_newline()
 
+        self.emit_text(
+            "More info in :pep:`PEP 1 § PEP Review & Resolution <1#pep-review-resolution>`."
+        )
         self.emit_newline()
 
         if is_pep0:

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -6,8 +6,11 @@ import datetime
 from typing import TYPE_CHECKING
 import unicodedata
 
+from pep_sphinx_extensions.pep_processor.transforms.pep_headers import (
+    ABBREVIATED_STATUSES,
+    ABBREVIATED_TYPES,
+)
 from pep_sphinx_extensions.pep_zero_generator.constants import DEAD_STATUSES
-from pep_sphinx_extensions.pep_zero_generator.constants import HIDE_STATUS
 from pep_sphinx_extensions.pep_zero_generator.constants import STATUS_ACCEPTED
 from pep_sphinx_extensions.pep_zero_generator.constants import STATUS_ACTIVE
 from pep_sphinx_extensions.pep_zero_generator.constants import STATUS_DEFERRED
@@ -178,7 +181,8 @@ class PEPZeroWriter:
         self.emit_title("PEP Types Key")
         for type_ in sorted(TYPE_VALUES):
             self.emit_text(
-                f"* **{type_[0]}** --- *{type_}*: ABBREVIATED_TYPES[type_]")
+                f"* **{type_[0]}** --- *{type_}*: {ABBREVIATED_TYPES[type_]}"
+            )
             self.emit_newline()
 
         self.emit_text(":pep:`More info in PEP 1 <1#pep-types>`.")
@@ -189,12 +193,9 @@ class PEPZeroWriter:
         for status in sorted(STATUS_VALUES):
             # Draft PEPs have no status displayed, Active shares a key with Accepted
             status_code = "<none>" if status == STATUS_DRAFT else status[0]
-            if status == STATUS_ACCEPTED:
-                msg = "* A - Accepted (Standards Track only) or Active proposal"
-            else:
-                msg = f"* {status[0]} - {status} proposal"
             self.emit_text(
-                f"* **{status_code}** --- *{status}*: ABBREVIATED_STATUSES[status]")
+                f"* **{status_code}** --- *{status}*: {ABBREVIATED_STATUSES[status]}"
+            )
             self.emit_newline()
 
         self.emit_text(":pep:`More info in PEP 1 <1#pep-review-resolution>`.")

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -177,26 +177,27 @@ class PEPZeroWriter:
         # PEP types key
         self.emit_title("PEP Types Key")
         for type_ in sorted(TYPE_VALUES):
-            self.emit_text(f"* {type_[0]} - {type_} PEP")
+            self.emit_text(
+                f"* **{type_[0]}** --- *{type_}*: ABBREVIATED_TYPES[type_]")
             self.emit_newline()
 
-        self.emit_text("More info in :pep:`PEP 1 <1#pep-types>`.")
+        self.emit_text(":pep:`More info in PEP 1 <1#pep-types>`.")
         self.emit_newline()
 
         # PEP status key
         self.emit_title("PEP Status Key")
         for status in sorted(STATUS_VALUES):
             # Draft PEPs have no status displayed, Active shares a key with Accepted
-            if status in HIDE_STATUS:
-                continue
+            status_code = "<none>" if status == STATUS_DRAFT else status[0]
             if status == STATUS_ACCEPTED:
                 msg = "* A - Accepted (Standards Track only) or Active proposal"
             else:
                 msg = f"* {status[0]} - {status} proposal"
-            self.emit_text(msg)
+            self.emit_text(
+                f"* **{status_code}** --- *{status}*: ABBREVIATED_STATUSES[status]")
             self.emit_newline()
 
-        self.emit_text("More info in :pep:`PEP 1 <1#pep-review-resolution>`.")
+        self.emit_text(":pep:`More info in PEP 1 <1#pep-review-resolution>`.")
         self.emit_newline()
 
         if is_pep0:

--- a/pep_sphinx_extensions/tests/pep_processor/transform/test_pep_headers.py
+++ b/pep_sphinx_extensions/tests/pep_processor/transform/test_pep_headers.py
@@ -132,14 +132,14 @@ def test_make_link_pretty(test_input, expected):
     "test_input, expected",
     [
         (STATUS_ACCEPTED, "Normative proposal accepted for implementation"),
-        (STATUS_ACTIVE, "Currently valid/in-use guidance or process"),
+        (STATUS_ACTIVE, "Currently valid informational guidance, or an in-use process"),
         (STATUS_DEFERRED, "Inactive draft that may be taken up again at a later time"),
         (STATUS_DRAFT, "Proposal under active discussion and revision"),
         (STATUS_FINAL, "Accepted and implementation complete, or no longer active"),
         (STATUS_REJECTED, "Formally declined and will not be accepted"),
         ("April Fool!", "Formally declined and will not be accepted"),
         (STATUS_SUPERSEDED, "Replaced by another succeeding PEP"),
-        (STATUS_WITHDRAWN, "Removed from consideration by author(s)/sponsor"),
+        (STATUS_WITHDRAWN, "Removed from consideration by sponsor or authors"),
         (STATUS_PROVISIONAL, "Provisionally accepted but additional feedback needed"),
     ],
 )

--- a/pep_sphinx_extensions/tests/pep_processor/transform/test_pep_headers.py
+++ b/pep_sphinx_extensions/tests/pep_processor/transform/test_pep_headers.py
@@ -1,6 +1,20 @@
 import pytest
 
 from pep_sphinx_extensions.pep_processor.transforms import pep_headers
+from pep_sphinx_extensions.pep_zero_generator.constants import (
+    STATUS_ACCEPTED,
+    STATUS_ACTIVE,
+    STATUS_DEFERRED,
+    STATUS_DRAFT,
+    STATUS_FINAL,
+    STATUS_PROVISIONAL,
+    STATUS_REJECTED,
+    STATUS_SUPERSEDED,
+    STATUS_WITHDRAWN,
+    TYPE_INFO,
+    TYPE_PROCESS,
+    TYPE_STANDARDS,
+)
 
 
 @pytest.mark.parametrize(
@@ -112,3 +126,60 @@ def test_make_link_pretty(test_input, expected):
     out = pep_headers._make_link_pretty(test_input)
 
     assert out == expected
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [
+        (STATUS_ACCEPTED, "Normative proposal accepted for implementation"),
+        (STATUS_ACTIVE, "Currently valid/in-use guidance or process"),
+        (STATUS_DEFERRED, "Inactive draft that may be taken up again at a later time"),
+        (STATUS_DRAFT, "Proposal under active discussion and revision"),
+        (STATUS_FINAL, "Accepted and implementation complete, or no longer active"),
+        (STATUS_REJECTED, "Formally declined and will not be accepted"),
+        ("April Fool!", "Formally declined and will not be accepted"),
+        (STATUS_SUPERSEDED, "Replaced by another succeeding PEP"),
+        (STATUS_WITHDRAWN, "Removed from consideration by author(s)/sponsor"),
+        (STATUS_PROVISIONAL, "Provisionally accepted but additional feedback needed"),
+    ],
+)
+def test_abbreviate_status(test_input, expected):
+    out = pep_headers._abbreviate_status(test_input)
+
+    assert out == expected
+
+
+def test_abbreviate_status_unknown():
+    with pytest.raises(pep_headers.PEPParsingError):
+        pep_headers._abbreviate_status("an unknown status")
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [
+        (
+            TYPE_INFO,
+            "Non-normative PEP containing background, guidelines or other information "
+            "relevant to the Python ecosystem",
+        ),
+        (
+            TYPE_PROCESS,
+            "Normative PEP describing or proposing a change to a Python community "
+            "process, workflow or governance",
+        ),
+        (
+            TYPE_STANDARDS,
+            "Normative PEP with a new feature for Python, implementation change for "
+            "CPython or interoperability standard for the ecosystem",
+        ),
+    ],
+)
+def test_abbreviate_type(test_input, expected):
+    out = pep_headers._abbreviate_type(test_input)
+
+    assert out == expected
+
+
+def test_abbreviate_type_unknown():
+    with pytest.raises(pep_headers.PEPParsingError):
+        pep_headers._abbreviate_type("an unknown type")

--- a/pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py
+++ b/pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py
@@ -48,7 +48,7 @@ def test_pep_details(monkeypatch):
     assert pep8.details == {
         "authors": "GvR, Warsaw, Coghlan",
         "number": 8,
-        "shorthand": ":abbr:`P (Process)`",
+        "shorthand": ":abbr:`PA (Process, Active)`",
         "title": "Style Guide for Python Code",
     }
 
@@ -97,12 +97,12 @@ def test_parse_authors_invalid():
 @pytest.mark.parametrize(
     "test_type, test_status, expected",
     [
-        (TYPE_INFO, STATUS_DRAFT, ":abbr:`I (Informational)`"),
-        (TYPE_INFO, STATUS_ACTIVE, ":abbr:`I (Informational)`"),
+        (TYPE_INFO, STATUS_DRAFT, ":abbr:`I (Informational, Draft)`"),
+        (TYPE_INFO, STATUS_ACTIVE, ":abbr:`IA (Informational, Active)`"),
         (TYPE_INFO, STATUS_ACCEPTED, ":abbr:`IA (Informational, Accepted)`"),
         (TYPE_INFO, STATUS_DEFERRED, ":abbr:`ID (Informational, Deferred)`"),
         (TYPE_PROCESS, STATUS_ACCEPTED, ":abbr:`PA (Process, Accepted)`"),
-        (TYPE_PROCESS, STATUS_ACTIVE, ":abbr:`P (Process)`"),
+        (TYPE_PROCESS, STATUS_ACTIVE, ":abbr:`PA (Process, Active)`"),
         (TYPE_PROCESS, STATUS_FINAL, ":abbr:`PF (Process, Final)`"),
         (TYPE_PROCESS, STATUS_SUPERSEDED, ":abbr:`PS (Process, Superseded)`"),
         (TYPE_PROCESS, STATUS_WITHDRAWN, ":abbr:`PW (Process, Withdrawn)`"),


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

#  Link status and type headers to descriptions

This helps people look up what the PEP status and type really mean by linking to their descriptions in PEP 1.

## Before

<img width="719" alt="image" src="https://user-images.githubusercontent.com/1324225/197347214-0c0f7a2a-0a5d-4540-9884-7fb735e3852b.png">

https://peps.python.org/pep-0700/

## After

<img width="718" alt="image" src="https://user-images.githubusercontent.com/1324225/197347244-ee688d43-8a44-4899-a59c-c165121dacde.png">

https://pep-previews--2842.org.readthedocs.build/pep-0700/

# Link PEP 0 type/status keys to more info in PEP 1

And on PEP 0, we have a list of types and statuses, let's also link these to the same places in PEP 1.

Plus turn them from quoted text to bullet points.

## Before

<img width="421" alt="image" src="https://user-images.githubusercontent.com/1324225/197347398-6030e418-4a46-4ddf-abbb-543c76e5a55b.png">

https://peps.python.org/pep-0000/#pep-types-key

## After

<img width="415" alt="image" src="https://user-images.githubusercontent.com/1324225/197347364-c16316a4-e1c9-4374-9466-baa6eb7e1beb.png">

https://pep-previews--2842.org.readthedocs.build/#pep-types-key

## Question

I'm not too sure about using the "§" symbol in "PEP 1 § PEP Types", but it's in the tooltip. Perhaps "PEP 1 > PEP Types" or "PEP Types" is clearer?