### PR TITLE
Infra: Don't generate broken source link for topic pages

### DIFF
--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -44,7 +44,7 @@
             <h2>Contents</h2>
             {{ toc }}
             <br>
-            {%- if not sourcename.startswith("pep-0000") %}
+            {%- if not (sourcename.startswith("pep-0000") or sourcename.startswith("topic")) %}
             <a id="source" href="https://github.com/python/peps/blob/main/{{sourcename}}">Page Source (GitHub)</a>
             {%- endif %}
         </nav>


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

To reproduce:

1. Go to a topic index page:
   * https://peps.python.org/topic/
   * https://peps.python.org/topic/packaging/
   * https://peps.python.org/topic/release/
   * https://peps.python.org/topic/typing/
2. Click "Page Source (GitHub)" in the left menu

Actual result:

404 this is not the page you are looking for, because these pages are generated at build time and don't exist in the Git repo.

Expected result:

Either no 404, or no link in the first place.

Fix:

Let's not generate the link.

Preview:

   * https://pep-previews--2843.org.readthedocs.build/topic/
   * https://pep-previews--2843.org.readthedocs.build/topic/packaging/
   * https://pep-previews--2843.org.readthedocs.build/topic/release/
   * https://pep-previews--2843.org.readthedocs.build/topic/typing/
