### PR TITLE
PEP 693: Set to active with 3.12.0a1 release

### DIFF
--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -1,7 +1,7 @@
 PEP: 693
 Title: Python 3.12 Release Schedule
 Author: Thomas Wouters <thomas@python.org>
-Status: Draft
+Status: Active
 Type: Informational
 Topic: Release
 Content-Type: text/x-rst
@@ -43,10 +43,10 @@ in a 12-month release cadence between major versions, as defined by
 Actual:
 
 - 3.12 development begins: Monday, 2022-05-08
+- 3.12.0 alpha 1: Tuesday, 2022-10-25
 
 Expected:
 
-- 3.12.0 alpha 1: Monday, 2022-10-24
 - 3.12.0 alpha 2: Monday, 2022-11-14
 - 3.12.0 alpha 3: Monday, 2022-12-05
 - 3.12.0 alpha 4: Monday, 2023-01-09

--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -43,7 +43,7 @@ in a 12-month release cadence between major versions, as defined by
 Actual:
 
 - 3.12 development begins: Monday, 2022-05-08
-- 3.12.0 alpha 1: Tuesday, 2022-10-24
+- 3.12.0 alpha 1: Monday, 2022-10-24
 
 Expected:
 

--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -43,7 +43,7 @@ in a 12-month release cadence between major versions, as defined by
 Actual:
 
 - 3.12 development begins: Monday, 2022-05-08
-- 3.12.0 alpha 1: Tuesday, 2022-10-25
+- 3.12.0 alpha 1: Tuesday, 2022-10-24
 
 Expected:
 


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Python 3.12.0 alpha 1 has been released, let's set this PEP to active. 

* https://discuss.python.org/t/python-3-12-0-alpha-1-released/20298 


I put the 25th as the release date, as that's what I see on the download page:

* https://www.python.org/downloads/release/python-3120a1/ 