### PR TITLE
PEP 649: Fix nested list formatting

### DIFF
--- a/pep-0649.rst
+++ b/pep-0649.rst
@@ -199,9 +199,11 @@ them to their actual Python values.  This has several drawbacks:
   implementation.
 * It requires that all annotations be evaluated at module-level
   scope.  Annotations under :pep:`563` can no longer refer to
+
   * class variables,
   * local variables in the current function, or
   * local variables in enclosing functions.
+
 * It requires a code change every time existing code uses an
   annotation, to handle converting the stringized
   annotation back into a useful value.
@@ -224,10 +226,12 @@ This PEP also solves the forward reference problem outlined in
 * Python implementations would generate annotations as code
   objects.  This is simpler than stringizing, and is something
   Python implementations are already quite good at.  This means:
+
   - alternate implementations would need to write less code to
-  implement this feature, and
+    implement this feature, and
   - the implementation would be simpler overall, which should
-  reduce its ongoing maintenance cost.
+    reduce its ongoing maintenance cost.
+
 * Existing annotations would not need to be changed to only
   use global scope.  Actually, annotations would become much
   easier to use, as they would now also handle forward


### PR DESCRIPTION
This fixes the formatting of a couple of nested lists so that they render correctly (i.e: as lists rather than paragraphs).