### PR TITLE
Infra: Add 'make help'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,6 @@ JOBS=8
 OUTPUT_DIR=build
 RENDER_COMMAND=$(VENVDIR)/bin/python3 build.py -j $(JOBS) -o $(OUTPUT_DIR)
 
-.PHONY: help
-help : Makefile
-	@echo "Please use \`make <target>' where <target> is one of"
-	@sed -n 's/^##//p' $<
-
 ## render         to render PEPs to "pep-NNNN.html" files
 .PHONY: render
 render: venv
@@ -75,3 +70,8 @@ test: venv
 spellcheck: venv
 	$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit
 	$(VENVDIR)/bin/python3 -m pre_commit run --all-files --hook-stage manual codespell
+
+.PHONY: help
+help : Makefile
+	@echo "Please use \`make <target>' where <target> is one of"
+	@sed -n 's/^##//p' $<

--- a/Makefile
+++ b/Makefile
@@ -11,42 +11,42 @@ help : Makefile
 	@echo "Please use \`make <target>' where <target> is one of"
 	@sed -n 's/^##//p' $<
 
-## render		to render PEPs to "pep-NNNN.html" files
+## render         to render PEPs to "pep-NNNN.html" files
 .PHONY: render
 render: venv
 	$(RENDER_COMMAND)
 
-## pages		to render PEPs to "index.html" files within "pep-NNNN" directories
+## pages          to render PEPs to "index.html" files within "pep-NNNN" directories
 .PHONY: pages
 pages: venv rss
 	$(RENDER_COMMAND) --build-dirs
 
-## fail-warning	to render PEPs to "pep-NNNN.html" files and fail the Sphinx build on any warning
+## fail-warning   to render PEPs to "pep-NNNN.html" files and fail the Sphinx build on any warning
 .PHONY: fail-warning
 fail-warning: venv
 	$(RENDER_COMMAND) --fail-on-warning
 
-## check-links	to check validity of links within PEP sources
+## check-links    to check validity of links within PEP sources
 .PHONY: check-links
 check-links: venv
 	$(RENDER_COMMAND) --check-links
 
-## rss		to generate the peps.rss file
+## rss            to generate the peps.rss file
 .PHONY: rss
 rss: venv
 	$(VENVDIR)/bin/python3 generate_rss.py
 
-## clean		to remove the venv and build files
+## clean          to remove the venv and build files
 .PHONY: clean
 clean: clean-venv
 	-rm -rf build topic
 
-## clean-venv	to remove the venv
+## clean-venv     to remove the venv
 .PHONY: clean-venv
 clean-venv:
 	rm -rf $(VENVDIR)
 
-## venv		to create a venv with necessary tools
+## venv           to create a venv with necessary tools
 .PHONY: venv
 venv:
 	@if [ -d $(VENVDIR) ] ; then \
@@ -59,18 +59,18 @@ venv:
 		echo "The venv has been created in the $(VENVDIR) directory"; \
 	fi
 
-## lint		to lint all the files
+## lint           to lint all the files
 .PHONY: lint
 lint: venv
 	$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit
 	$(VENVDIR)/bin/python3 -m pre_commit run --all-files
 
-## test		to test the Sphinx extensions for PEPs
+## test           to test the Sphinx extensions for PEPs
 .PHONY: test
 test: venv
 	$(VENVDIR)/bin/python3 -bb -X dev -W error -m pytest
 
-## spellcheck	to check spelling
+## spellcheck     to check spelling
 .PHONY: spellcheck
 spellcheck: venv
 	$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit

--- a/Makefile
+++ b/Makefile
@@ -6,34 +6,47 @@ JOBS=8
 OUTPUT_DIR=build
 RENDER_COMMAND=$(VENVDIR)/bin/python3 build.py -j $(JOBS) -o $(OUTPUT_DIR)
 
+.PHONY: help
+help : Makefile
+	@echo "Please use \`make <target>' where <target> is one of"
+	@sed -n 's/^##//p' $<
+
+## render		to render PEPs to "pep-NNNN.html" files
 .PHONY: render
 render: venv
 	$(RENDER_COMMAND)
 
+## pages		to render PEPs to "index.html" files within "pep-NNNN" directories
 .PHONY: pages
 pages: venv rss
 	$(RENDER_COMMAND) --build-dirs
 
+## fail-warning	to render PEPs to "pep-NNNN.html" files and fail the Sphinx build on any warning
 .PHONY: fail-warning
 fail-warning: venv
 	$(RENDER_COMMAND) --fail-on-warning
 
+## check-links	to check validity of links within PEP sources
 .PHONY: check-links
 check-links: venv
 	$(RENDER_COMMAND) --check-links
 
+## rss		to generate the peps.rss file
 .PHONY: rss
 rss: venv
 	$(VENVDIR)/bin/python3 generate_rss.py
 
+## clean		to remove the venv and build files
 .PHONY: clean
 clean: clean-venv
 	-rm -rf build topic
 
+## clean-venv	to remove the venv
 .PHONY: clean-venv
 clean-venv:
 	rm -rf $(VENVDIR)
 
+## venv		to create a venv with necessary tools
 .PHONY: venv
 venv:
 	@if [ -d $(VENVDIR) ] ; then \
@@ -46,15 +59,18 @@ venv:
 		echo "The venv has been created in the $(VENVDIR) directory"; \
 	fi
 
+## lint		to lint all the files
 .PHONY: lint
 lint: venv
 	$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit
 	$(VENVDIR)/bin/python3 -m pre_commit run --all-files
 
+## test		to test the Sphinx extensions for PEPs
 .PHONY: test
 test: venv
 	$(VENVDIR)/bin/python3 -bb -X dev -W error -m pytest
 
+## spellcheck	to check spelling
 .PHONY: spellcheck
 spellcheck: venv
 	$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Normally you can run `make help` or just `make` on Sphinx projects and get help listing the available commands.

For example, [CPython docs](https://github.com/python/cpython/blob/main/Doc/Makefile#L28-L45):

```console
$  make -C Doc help
Please use `make <target>' where <target> is one of
  clean      to remove build files
  venv       to create a venv with necessary tools
  html       to make standalone HTML files
  htmlview   to open the index page built by the html target in your browser
  htmlhelp   to make HTML files and a HTML help project
  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter
  text       to make plain text files
  texinfo    to make Texinfo file
  epub       to make EPUB files
  changes    to make an overview over all changed/added/deprecated items
  linkcheck  to check all external links for integrity
  coverage   to check documentation coverage for library and C API
  doctest    to run doctests in the documentation
  pydoc-topics  to regenerate the pydoc topics file
  dist       to create a "dist" directory with archived docs for download
  check      to run a check for frequent markup errors
```

And the [Devguide](https://github.com/python/devguide/blob/main/make.bat#L35-L53):

```console
$ make help
Please use `make <target>' where <target> is one of
  venv       to create a venv with necessary tools
  html       to make standalone HTML files
  htmlview   to open the index page built by the html target in your browser
  clean      to remove the venv and build files
  dirhtml    to make HTML files named index.html in directories
  singlehtml to make a single large HTML file
  pickle     to make pickle files
  json       to make JSON files
  htmlhelp   to make HTML files and a HTML help project
  qthelp     to make HTML files and a qthelp project
  devhelp    to make HTML files and a Devhelp project
  epub       to make an epub
  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter
  latexpdf   to make LaTeX files and run them through pdflatex
  text       to make text files
  man        to make manual pages
  changes    to make an overview of all changed/added/deprecated items
  linkcheck  to check all external links for integrity
  doctest    to run all doctests embedded in the documentation (if enabled)
  check      to run a check for frequent markup errors
```

Let's add it here, too:

```console
$  make help
Please use `make <target>' where <target> is one of
 render		to render PEPs to "pep-NNNN.html" files
 pages		to render PEPs to "index.html" files within "pep-NNNN" directories
 fail-warning	to render PEPs to "pep-NNNN.html" files and fail the Sphinx build on any warning
 check-links	to check validity of links within PEP sources
 rss		to generate the peps.rss file
 clean		to remove the venv and build files
 clean-venv	to remove the venv
 venv		to create a venv with necessary tools
 lint		to lint all the files
 test		to test the Sphinx extensions for PEPs
 spellcheck	to check spelling
```

Unlike the docs and devguide, I used tabs rather than spaces, and they do line up on my terminal (see below). But shall I switch to spaces too?

<img width="682" alt="image" src="https://user-images.githubusercontent.com/1324225/198894826-7ba31608-fc14-49d5-a20b-4eb85020aed7.png">

Also unlike the docs and devguide, I put each help line inline with each target, instead of grouping them all at the top. This makes it easier to remember to add help when copying/pasting another target.

Finally, we could previously just type `make` and it would do `make render`. Now plain `make` gives the help -- and this now matches the CPython docs, Devguide and other Sphinx projects. This can be changed back, but I think it's better like this.