### PR TITLE
PEP 572: Mark as Final

### DIFF
--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -2,7 +2,7 @@ PEP: 572
 Title: Assignment Expressions
 Author: Chris Angelico <rosuav@gmail.com>, Tim Peters <tim.peters@gmail.com>,
         Guido van Rossum <guido@python.org>
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 28-Feb-2018


### PR DESCRIPTION
[PEP 572](https://peps.python.org/pep-0572/) should be marked Final, as indicated by @ericvsmith [here](https://discuss.python.org/t/multiple-released-peps-have-status-accepted-not-final/20776/4).