### PR TITLE
PEP 585: Mark as Final

### DIFF
--- a/pep-0585.rst
+++ b/pep-0585.rst
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Łukasz Langa <lukasz@python.org>
 Discussions-To: typing-sig@python.org
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
 Content-Type: text/x-rst


### PR DESCRIPTION
[PEP 585](https://peps.python.org/pep-0585/) should be marked Final, as indicated by @hauntsaninja [here](https://discuss.python.org/t/multiple-released-peps-have-status-accepted-not-final/20776/5).