### PR TITLE
PEP 698: Change the wording for strict mode section

### DIFF
--- a/pep-0698.rst
+++ b/pep-0698.rst
@@ -228,8 +228,10 @@ principle.
 Strict Enforcement Per-Project
 ==============================
 
-We plan to make the use of  ``@override`` required in Pyre’s strict mode. This
-is a feature we believe most type checkers would benefit from.
+We believe that ``@override`` is most useful if checkers also allow developers
+to opt into a strict mode where methods that override a parent class are
+required to use the decorator. Strict enforcement should be opt-in for backward
+compatibility.
 
 
 Motivation


### PR DESCRIPTION
At this time, Pyre still does not have strict override enforcement.

This (and supporting codemod tools) are still something we want, but given that we have not yet delivered this and do not have a firm ETA we should not make claims about specific plans in the PEP text.