### PR TITLE
Infra: Include PEP number in API

### DIFF
--- a/pep_sphinx_extensions/pep_zero_generator/parser.py
+++ b/pep_sphinx_extensions/pep_zero_generator/parser.py
@@ -148,9 +148,10 @@ class PEP:
         }
 
     @property
-    def full_details(self) -> dict[str, str]:
+    def full_details(self) -> dict[str, str | int]:
         """Returns all headers of the PEP as a dict."""
         return {
+            "number": self.number,
             "title": self.title,
             "authors": ", ".join(author.nick for author in self.authors),
             "discussions_to": self.discussions_to,


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

Fixes https://github.com/python/peps/issues/2878.

Add `"number": int` to the body in the API.

# Before

```json
{
"1": {
    "title": "PEP Purpose and Guidelines",
    "authors": "Warsaw, Hylton, Goodger, Coghlan",
    "discussions_to": null,
    "status": "Active",
    "type": "Process",
    "topic": "",
    "created": "13-Jun-2000",
    "python_version": null,
    "post_history": "21-Mar-2001, 29-Jul-2002, 03-May-2003, 05-May-2012, 07-Apr-2013",
    "resolution": null,
    "requires": null,
    "replaces": null,
    "superseded_by": null,
    "url": "https://peps.python.org/pep-0001/"
  },
...
```
https://peps.python.org/api/peps.json

# After

```json
{
  "1": {
    "number": 1,
    "title": "PEP Purpose and Guidelines",
    "authors": "Warsaw, Hylton, Goodger, Coghlan",
    "discussions_to": null,
    "status": "Active",
    "type": "Process",
    "topic": "",
    "created": "13-Jun-2000",
    "python_version": null,
    "post_history": "21-Mar-2001, 29-Jul-2002, 03-May-2003, 05-May-2012, 07-Apr-2013",
    "resolution": null,
    "requires": null,
    "replaces": null,
    "superseded_by": null,
    "url": "https://peps.python.org/pep-0001/"
  },
...
```

# Preview

https://pep-previews--2879.org.readthedocs.build/api/peps.json
