### PR TITLE
PEP 3141: Fix typo in Number.Complex.imag() docstring

### DIFF
--- a/pep-3141.txt
+++ b/pep-3141.txt
@@ -85,7 +85,7 @@ numbers are supported by this hierarchy. ::
 
         @abstractproperty
         def imag(self):
-            """Retrieve the complex component of this number.
+            """Retrieve the imaginary component of this number.
 
             This should subclass Real.
             """

--- a/pep-3141.txt
+++ b/pep-3141.txt
@@ -85,7 +85,7 @@ numbers are supported by this hierarchy. ::
 
         @abstractproperty
         def imag(self):
-            """Retrieve the real component of this number.
+            """Retrieve the complex component of this number.
 
             This should subclass Real.
             """


### PR DESCRIPTION
Made small typo changes per discussion in #2880. Scope of changes limited to reduce burden on historical PEP. 