### PR TITLE
PEP 3141: Fixes typo Number.Complex.imag() #2880

### DIFF
--- a/pep-3141.txt
+++ b/pep-3141.txt
@@ -85,7 +85,7 @@ numbers are supported by this hierarchy. ::
 
         @abstractproperty
         def imag(self):
-            """Retrieve the real component of this number.
+            """Retrieve the imaginary component of this number.
 
             This should subclass Real.
             """


### PR DESCRIPTION
Resubmit typo error fix. 
