### PR TITLE
PEP 693: Note the release of 3.12.0a2

### DIFF
--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -44,10 +44,10 @@ Actual:
 
 - 3.12 development begins: Monday, 2022-05-08
 - 3.12.0 alpha 1: Monday, 2022-10-24
+- 3.12.0 alpha 2: Monday, 2022-11-14
 
 Expected:
 
-- 3.12.0 alpha 2: Monday, 2022-11-14
 - 3.12.0 alpha 3: Monday, 2022-12-05
 - 3.12.0 alpha 4: Monday, 2023-01-09
 - 3.12.0 alpha 5: Monday, 2023-02-06


### PR DESCRIPTION
Note the release of 3.12.0a2 (dated yesterday because that is when the release branch was cut).
