### PR TITLE
PEP 248: Fix Author and Created date headers

### DIFF
--- a/pep-0248.txt
+++ b/pep-0248.txt
@@ -1,6 +1,6 @@
 PEP: 248
 Title: Python Database API Specification v1.0
-Author: Greg Stein <gstein@lyra.org>, Marc-André Lemburg (editor) <mal@lemburg.com>
+Author: Greg Stein <gstein@lyra.org>, Marc-André Lemburg as Editor <mal@lemburg.com>
 Discussions-To: db-sig@python.org
 Status: Final
 Type: Informational

--- a/pep-0248.txt
+++ b/pep-0248.txt
@@ -5,7 +5,7 @@ Discussions-To: db-sig@python.org
 Status: Final
 Type: Informational
 Content-Type: text/x-rst
-Created: 8-May-1996
+Created: 08-May-1996
 Post-History:
 Superseded-By: 249
 

--- a/pep-0248.txt
+++ b/pep-0248.txt
@@ -1,6 +1,6 @@
 PEP: 248
 Title: Python Database API Specification v1.0
-Author: Greg Stein <gstein@lyra.org>, Editor: Marc-André Lemburg <mal@lemburg.com>
+Author: Greg Stein <gstein@lyra.org>, Marc-André Lemburg (editor) <mal@lemburg.com>
 Discussions-To: db-sig@python.org
 Status: Final
 Type: Informational

--- a/pep-0248.txt
+++ b/pep-0248.txt
@@ -1,6 +1,6 @@
 PEP: 248
 Title: Python Database API Specification v1.0
-Author: Greg Stein <gstein@lyra.org>, Marc-André Lemburg as Editor <mal@lemburg.com>
+Author: Greg Stein <gstein@lyra.org>, Marc-André Lemburg <mal@lemburg.com>
 Discussions-To: db-sig@python.org
 Status: Final
 Type: Informational
@@ -294,8 +294,11 @@ Acknowledgements
 
 Many thanks go to Andrew Kuchling who converted the Python
 Database API Specification 1.0 from the original HTML format into
-the PEP format.
+the PEP format in 2001.
 
+Greg Stein is the original author of the Python Database API
+Specification 1.0. Marc-André later continued maintenance of the API as
+an editor.
 
 Copyright
 =========

--- a/pep-0248.txt
+++ b/pep-0248.txt
@@ -1,11 +1,11 @@
 PEP: 248
 Title: Python Database API Specification v1.0
-Author: Marc-André Lemburg <mal@lemburg.com>
+Author: Greg Stein <gstein@lyra.org>, Editor: Marc-André Lemburg <mal@lemburg.com>
 Discussions-To: db-sig@python.org
 Status: Final
 Type: Informational
 Content-Type: text/x-rst
-Created: 29-Mar-2001
+Created: 8-May-1996
 Post-History:
 Superseded-By: 249
 


### PR DESCRIPTION
The headers did not include the original author (Greg Stein) and listed a wrong create date.