### PR TITLE
PEP 698: fix typo enumerating runtime enforcement rejections

### DIFF
--- a/pep-0698.rst
+++ b/pep-0698.rst
@@ -379,7 +379,7 @@ We considered having ``@typing.override`` enforce override safety at runtime,
 similarly to how ``@overrides.overrides``
 `does today <https://pypi.org/project/overrides/>`_.
 
-We rejected this for three reasons:
+We rejected this for four reasons:
 
 - For users of static type checking, it is not clear this brings any benefits.
 - There would be at least some performance overhead, leading to projects


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

# Details

This changes the count of reasons for rejecting runtime enforcement to match the actual number of reasons given.