### PR TITLE
Infra: Add index by topic to PEP 0

### DIFF
--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -129,7 +129,7 @@ class PEPZeroWriter:
         self.emit_newline()
 
         # PEPs by topic
-        self.emit_title("Index by Topic")
+        self.emit_title("Topics")
         self.emit_text("PEPs for specialist subjects are :doc:`indexed by topic <topic/index>`.")
         self.emit_newline()
         for subindex in SUBINDICES_BY_TOPIC:

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -42,8 +42,7 @@ This PEP contains the index of all Python Enhancement Proposals,
 known as PEPs.  PEP numbers are :pep:`assigned <1#pep-editors>`
 by the PEP editors, and once assigned are never changed.  The
 `version control history <https://github.com/python/peps>`_ of
-the PEP texts represent their historical record.  The PEPs are
-:doc:`indexed by topic <topic/index>` for specialist subjects.
+the PEP texts represent their historical record.
 """
 
 
@@ -131,6 +130,8 @@ class PEPZeroWriter:
 
         # PEPs by topic
         self.emit_title("Index by Topic")
+        self.emit_text("PEPs for specialist subjects are :doc:`indexed by topic <topic/index>`.")
+        self.emit_newline()
         for subindex in SUBINDICES_BY_TOPIC:
             self.emit_text(f"* `{subindex.title()} PEPs <topic/{subindex}>`_")
             self.emit_newline()

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -17,6 +17,7 @@ from pep_sphinx_extensions.pep_zero_generator.constants import STATUS_PROVISIONA
 from pep_sphinx_extensions.pep_zero_generator.constants import STATUS_REJECTED
 from pep_sphinx_extensions.pep_zero_generator.constants import STATUS_VALUES
 from pep_sphinx_extensions.pep_zero_generator.constants import STATUS_WITHDRAWN
+from pep_sphinx_extensions.pep_zero_generator.constants import SUBINDICES_BY_TOPIC
 from pep_sphinx_extensions.pep_zero_generator.constants import TYPE_INFO
 from pep_sphinx_extensions.pep_zero_generator.constants import TYPE_PROCESS
 from pep_sphinx_extensions.pep_zero_generator.constants import TYPE_VALUES
@@ -126,6 +127,13 @@ class PEPZeroWriter:
         # Introduction
         self.emit_title("Introduction")
         self.emit_text(intro)
+        self.emit_newline()
+
+        # PEPs by topic
+        self.emit_title("Index by Topic")
+        for subindex in SUBINDICES_BY_TOPIC:
+            self.emit_text(f"* `{subindex.title()} PEPs <topic/{subindex}>`_")
+            self.emit_newline()
         self.emit_newline()
 
         # PEPs by category


### PR DESCRIPTION
<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->

As suggested by @malemburg at https://discuss.python.org/t/proposal-peps-should-be-change-proposals/21068/19?u=hugovk, make the topic listing more prominent on the first page by putting it right before the category listing:

![image](https://user-images.githubusercontent.com/1324225/202412030-55ccd3a9-131d-4294-aa24-8642796fed91.png)

# Preview

![image](https://user-images.githubusercontent.com/1324225/202412243-268a50cf-152b-426d-b59c-668bbd003637.png)

https://pep-previews--2892.org.readthedocs.build/

# Question

Shall we move the "The PEPs are [indexed by topic](https://github.com/python/peps/compare/topic/) for specialist subjects." text into this new section? For example:

![image](https://user-images.githubusercontent.com/1324225/202412835-eb1d8a4a-8abe-4d4a-a462-1f9a40ca0bdb.png)


