### PR TITLE
PEP 698: reword the disadvantages section

### DIFF
--- a/pep-0698.rst
+++ b/pep-0698.rst
@@ -167,12 +167,7 @@ Providing support for ``@override`` in static checks would add value because
 Disadvantages
 -------------
 
-The two disadvantages we are aware of to using ``@override`` are that
-
-- The code becomes more verbose - overriding methods require one additional
-  line.
-- Adding or removing base class methods that impact overrides will require
-  updating subclass code.
+Using ``@override`` will make code more verbose.
 
 
 Specification


### PR DESCRIPTION
We claimed that there are two disadvantages to overrides: it makes code more verbose, and requires developers to update subclasses when possibly-breaking changes happen to base classes.

In discussion, it was pointed out that the second disadvantage is kind of strange - it is exactly the same as the advantage of using @override in the first place because the whole point is that it is not usually safe to assume subclasses can be unchanged when a method they override is removed from a base class.

I think just pointing out verbosity is good enough, I think it's understood that more verbose code potentially requires more edits to change, and in reality I think the case when it was safe to ignore invalidated overrides is pretty rare so making that a big focus seems a little weird.

An earlier draft tried to still make both points:
```
The main disadvantage we are aware of to using ``@override`` are that it makes
the code more verbose. In the special case of a code change removing a base
class method where subclass implementations can safely remain unchanged, overrides
will require editing subclass code.
```
but I felt like all the extra words added almost no value. I'm happy to consider other wording, or just abandon this
change and leave as-is.