### PR TITLE
Meta: Update Contrib Guide & PR template for new CLA bot

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 <!--
 
-Please include the PEP number in the pull request title, example:
+*Please* read our Contributing Guidelines (CONTRIBUTING.rst)
+before submitting an issue or pull request to this repository,
+to make sure this repo is the appropriate venue for your proposed change.
+
+Prefix the pull request title with the PEP number; for example:
 
 PEP NNN: Summary of the changes made
-
-In addition, please sign the CLA.
-
-For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)
 
 -->

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -53,16 +53,18 @@ alterations with ``Lint:`` and other non-PEP meta changes, such as updates to
 the Readme/Contributing Guide, issue/PR template, etc., with ``Meta:``.
 
 
-Sign the CLA
-------------
+Sign the Contributor License Agreement
+--------------------------------------
 
-Before you hit "Create pull request", please take a moment to ensure that this
-project can legally accept your contribution by verifying you have signed the
+All contributors need to sign the 
 `PSF Contributor Agreement <https://www.python.org/psf/contrib/contrib-form/>`_.
+to ensure we legally accept your work.
 
-If you haven't signed the CLA before, please follow the
-`steps outlined in the CPython devguide
-<https://devguide.python.org/pullrequest/#licensing>`_ to do so.
+If you haven't signed the CLA before,
+simply submit your Pull Request and the CLA bot will reply with instructions.
+`See the CPython devguide
+<https://devguide.python.org/pullrequest/#licensing>`__
+for more information.
 
 
 Code of Conduct

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -60,8 +60,9 @@ All contributors need to sign the
 `PSF Contributor Agreement <https://www.python.org/psf/contrib/contrib-form/>`_.
 to ensure we legally accept your work.
 
-If you haven't signed the CLA before,
-simply submit your Pull Request and the CLA bot will reply with instructions.
+You don't need to do anything beforehand;
+go ahead and create your pull request,
+and our bot will ping you to sign the CLA if needed.
 `See the CPython devguide
 <https://devguide.python.org/pullrequest/#licensing>`__
 for more information.


### PR DESCRIPTION
As originally brought up in #2898 ; the Contributing Guide and the PR template both state that the CLA should be signed _prior_ to submitting a PR, but in fact the current workflow with the bot is to sign the CLA _after_. This clarifies that in both places, and also takes the opportunity to further stress reading the Contributing Guide before opening a PR to ensure this repo is the appropriate place for it.