### PR TITLE
PEP-8104: Correct links for nomination/vote deadlines

### DIFF
--- a/pep-8104.rst
+++ b/pep-8104.rst
@@ -32,10 +32,10 @@ There will be a two-week nomination period, followed by a two-week
 vote.
 
 The nomination period shall be: November 14, 2022 through `November 28, 2022 AoE
-<https://www.timeanddate.com/worldclock/fixedtime.html?msg=Python+Steering+Council+nominations+close&iso=20221129T00>`_ [#note-aoe]_.
+<https://www.timeanddate.com/worldclock/fixedtime.html?msg=Python+Steering+Council+nominations+close&iso=20221129T00&p1=3399>`_ [#note-aoe]_.
 
 The voting period shall be: December 1, 2022 through `December 14, 2022 AoE
-<https://www.timeanddate.com/worldclock/fixedtime.html?msg=Python+Steering+Council+voting+closes&iso=20221215T00>`_ [#note-aoe]_.
+<https://www.timeanddate.com/worldclock/fixedtime.html?msg=Python+Steering+Council+voting+closes&iso=20221215T00&p1=3399>`_ [#note-aoe]_.
 
 
 Candidates


### PR DESCRIPTION
As noted on [discuss.python.org](https://discuss.python.org/t/steering-council-nominations-are-now-open-2023-term/21062/3) the links were incorrect