### PR TITLE
PEP 8104: Nominations and Voter Roll

### DIFF
--- a/pep-8104.rst
+++ b/pep-8104.rst
@@ -31,7 +31,7 @@ Schedule
 There will be a two-week nomination period, followed by a two-week
 vote.
 
-The nomination period shall be: November 14, 2022 through `November 28, 2022 AoE
+The nomination period was: November 14, 2022 through `November 28, 2022 AoE
 <https://www.timeanddate.com/worldclock/fixedtime.html?msg=Python+Steering+Council+nominations+close&iso=20221129T00&p1=3399>`_ [#note-aoe]_.
 
 The voting period shall be: December 1, 2022 through `December 14, 2022 AoE
@@ -46,7 +46,14 @@ is a core team member, they may nominate themselves.
 
 Nominees (in alphabetical order):
 
-- TBD
+- `Brett Cannon <https://discuss.python.org/t/steering-council-nomination-brett-cannon-2023-term/21078>`_
+- `Emily Morehouse <https://discuss.python.org/t/steering-council-nomination-emily-morehouse-2023-term/21329>`_
+- `Dong-hee Na <https://discuss.python.org/t/steering-council-nomination-dong-hee-na-2023-term/21424/1>`_
+- `Pablo Galindo Salgado <https://discuss.python.org/t/steering-council-nomination-pablo-galindo-salgado-2023-term/21307>`_
+- `Gregory P. Smith <https://discuss.python.org/t/steering-council-nomination-gregory-p-smith-2023-term/21332/1>`_
+- `Victor Stinner <https://discuss.python.org/t/steering-council-nomination-victor-stinner-2023-term/21407/1>`_
+- `Petr Viktorin <https://discuss.python.org/t/steering-council-nomination-petr-viktorin-2023-term/21478>`_
+- `Thomas Wouters <https://discuss.python.org/t/steering-council-nomination-thomas-wouters-2023-term/21147>`_
 
 Withdrawn nominations:
 
@@ -139,7 +146,89 @@ Active Python core developers
 
 .. code-block:: text
 
-    TBD
+    Alex Gaynor
+    Alex Waygood
+    Ammar Askar
+    Andrew Svetlov
+    Antoine Pitrou
+    Barry Warsaw
+    Batuhan Taskaya
+    Benjamin Peterson
+    Berker Peksağ
+    Brandt Bucher
+    Brett Cannon
+    Brian Curtin
+    Brian Quinlan
+    Carol Willing
+    Cheryl Sabella
+    Chris Jerdonek
+    Chris Withers
+    Christian Heimes
+    Dennis Sweeney
+    Dino Viehland
+    Dong-hee Na
+    Emily Morehouse
+    Éric Araujo
+    Eric Snow
+    Eric V. Smith
+    Erlend Egeberg Aasland
+    Ethan Furman
+    Ezio Melotti
+    Facundo Batista
+    Filipe Laíns
+    Fred Drake
+    Georg Brandl
+    Giampaolo Rodolà
+    Gregory P. Smith
+    Guido van Rossum
+    Hugo van Kemenade
+    Hynek Schlawack
+    Inada Naoki
+    Irit Katriel
+    Ivan Levkivskyi
+    Jason R. Coombs
+    Jelle Zijlstra
+    Jeremy Kloth
+    Jesús Cea
+    Joannah Nanjekye
+    Julien Palard
+    Karthikeyan Singaravelan
+    Ken Jin
+    Kumar Aditya
+    Kurt B. Kaiser
+    Kushal Das
+    Larry Hastings
+    Łukasz Langa
+    Lysandros Nikolaou
+    Marc-André Lemburg
+    Mariatta
+    Mark Dickinson
+    Mark Shannon
+    Nathaniel J. Smith
+    Ned Deily
+    Neil Schemenauer
+    Nick Coghlan
+    Pablo Galindo
+    Paul Ganssle
+    Paul Moore
+    Petr Viktorin
+    R. David Murray
+    Raymond Hettinger
+    Ronald Oussoren
+    Senthil Kumaran
+    Serhiy Storchaka
+    Stefan Behnel
+    Stéphane Wirtel
+    Steve Dower
+    Tal Einat
+    Terry Jan Reedy
+    Thomas Wouters
+    Tim Golden
+    Tim Peters
+    Victor Stinner
+    Vinay Sajip
+    Yury Selivanov
+    Zachary Ware
 
 
 .. [#note-voters] This repository is private and accessible only to Python Core


### PR DESCRIPTION
Steering Council nominations for 2023 term election have closed, this updates with those results and the current voter roll.