### PR TITLE
PEP 485: Fix relative difference formula

### DIFF
--- a/pep-0485.txt
+++ b/pep-0485.txt
@@ -230,7 +230,7 @@ consideration, for instance:
 
 4) The absolute value of the arithmetic mean of the two
 
-These leads to the following possibilities for determining if two
+These lead to the following possibilities for determining if two
 values, a and b, are close to each other.
 
 1) ``abs(a-b) <= tol*abs(a)``

--- a/pep-0485.txt
+++ b/pep-0485.txt
@@ -239,7 +239,7 @@ values, a and b, are close to each other.
 
 3) ``abs(a-b) <= tol * min( abs(a), abs(b) )``
 
-4) ``abs(a-b) <= tol * (a + b)/2``
+4) ``abs(a-b) <= tol * abs(a + b)/2``
 
 NOTE: (2) and (3) can also be written as:
 


### PR DESCRIPTION
The alternative formula ``abs(a-b) <= tol * (a + b)/2`` does not work correctly for values ``a + b < 0``.

<!--

*Please* read our Contributing Guidelines (CONTRIBUTING.rst)
before submitting an issue or pull request to this repository,
to make sure this repo is the appropriate venue for your proposed change.

Prefix the pull request title with the PEP number; for example:

PEP NNN: Summary of the changes made

-->
