### PR TITLE
PEP 699: Make the spelling consistent

### DIFF
--- a/pep-0699.rst
+++ b/pep-0699.rst
@@ -33,7 +33,7 @@ guard for optimizations.
 
 Since CPython 3.11, this field has become unused by internal optimization
 efforts. :pep:`659`-specialized instructions use other methods of verifying
-that certain optimisations are safe.
+that certain optimizations are safe.
 
 To enable further optimizations in CPython, this PEP proposes that the
 ``ma_version_tag`` field no longer conform to the :pep:`509` specification.


### PR DESCRIPTION
Accidentally mixed British and American English :).