### PR TITLE
PEP 692: Add changing the meaning of **kwargs annotations to rejected ideas

### DIFF
--- a/pep-0692.rst
+++ b/pep-0692.rst
@@ -589,6 +589,21 @@ overloaded::
     @overload
     def foo(**kwargs: **Book): ...
 
+Changing the meaning of ``*kwargs`` annotations
+-----------------------------------------------
+
+One way to achieve the purpose of this PEP without any grammar
+change would be to change the meaning of ``*kwargs`` annotations,
+so that the annotations would apply to the entire ``**kwargs`` dict,
+not to individual elements. For consistency, we would have to make an
+analogous change to ``*args`` annotations.
+
+This idea was discussed in a meeting of the typing community, and the
+consensus was that the change would not be worth the cost. There is no
+clear migration path, the current meaning of ``*args`` and ``**kwargs``
+annotations is well-established in the ecosystem, and type checkers
+would have to introduce new errors for code that is currently legal.
+
 
 References
 ==========


### PR DESCRIPTION
cc @franekmagiera

This was discussed in last month's typing-sig meeting, where I agreed
to add this to the Rejected Ideas section of PEP 692 (sorry for the
delay). @gvanrossum @erictraut @sobolevn @pradeep90 does this new
section represent well what you said in the meeting?