### PR TITLE
PEP 101: Remove reference to Zulip

### DIFF
--- a/pep-0101.txt
+++ b/pep-0101.txt
@@ -931,7 +931,7 @@ else does them.  Some of those tasks include:
 
     * mailing lists (python-committers, python-dev, python-list, python-announcements)
 
-    * discuss.python.org and Zulip
+    * discuss.python.org
 
     * Python Dev blog
 


### PR DESCRIPTION
<!--

*Please* read our Contributing Guidelines (CONTRIBUTING.rst)
before submitting an issue or pull request to this repository,
to make sure this repo is the appropriate venue for your proposed change.

Prefix the pull request title with the PEP number; for example:

PEP NNN: Summary of the changes made

-->


For the second point of https://github.com/python/core-workflow/issues/457.

Zulip is no longer used and there's very little activity:

![image](https://user-images.githubusercontent.com/1324225/206199178-b61f2877-aa3d-4867-b7c6-36bbe0dcc88a.png)

The little activity that remains is unanswered questions, such as:

![image](https://user-images.githubusercontent.com/1324225/206199375-8368742f-49d2-422e-b817-7edff0210d5b.png)

There are better places to ask for help, let's remove this Zulip reference, it's not been followed for a long time.
