### PR TITLE
PEP 699: Follow standard deprecation policy

### DIFF
--- a/pep-0699.rst
+++ b/pep-0699.rst
@@ -64,10 +64,11 @@ Certain extensions use ``ma_version_tag`` for fast dictionary or globals
 lookups. For example,
 `Cython uses the field for fast dynamic module variable lookups <https://github.com/cython/cython/blob/169876872f3cb6198971a1db07e5b8a9d12b3dac/Cython/Utility/ObjectHandling.c#L1556>`_.
 
-Since this field is private and makes no guarantees on backwards compatibility,
-this PEP proposes to repeal :pep:`509` immediately within the next CPython
-version. A function for fast cached dictionary lookups may be provided as an
-alternative feature to replace directly accessing ``ma_version_tag``.
+This PEP proposes to emit a compiler warning when accessing ``ma_version_tag``.
+After two consecutive version releases of warnings, :pep:`509` will be fully
+repealed, in line with :pep:`387`. A function for fast cached dictionary
+lookups may be provided as an alternative feature to replace directly
+accessing ``ma_version_tag``.
 
 The biggest user the author could find for this field was Cython.
 Discussions with a Cython maintainer indicated that

--- a/pep-0699.rst
+++ b/pep-0699.rst
@@ -65,8 +65,9 @@ lookups. For example,
 `Cython uses the field for fast dynamic module variable lookups <https://github.com/cython/cython/blob/169876872f3cb6198971a1db07e5b8a9d12b3dac/Cython/Utility/ObjectHandling.c#L1556>`_.
 
 This PEP proposes to emit a compiler warning when accessing ``ma_version_tag``.
-After two consecutive version releases with warnings, :pep:`509` will be fully
-repealed, in line with :pep:`387`. A function for fast cached dictionary
+After two consecutive version releases with warnings, ``ma_version_tag``
+may be changed or removed, in line with :pep:`387`.
+A function for fast cached dictionary
 lookups may be provided as an alternative feature to replace directly
 accessing ``ma_version_tag``.
 

--- a/pep-0699.rst
+++ b/pep-0699.rst
@@ -97,7 +97,8 @@ Special Thanks
 ==============
 
 Thanks to C.A.M. Gerlach for edits and wording changes to this document.
-
+Thanks also to Mark Shannon and Kumar Aditya for providing possible
+implementations.
 
 Copyright
 =========

--- a/pep-0699.rst
+++ b/pep-0699.rst
@@ -66,10 +66,7 @@ lookups. For example,
 
 This PEP proposes to emit a compiler warning when accessing ``ma_version_tag``.
 After two consecutive version releases with warnings, ``ma_version_tag``
-may be changed or removed, in line with :pep:`387`.
-A function for fast cached dictionary
-lookups may be provided as an alternative feature to replace directly
-accessing ``ma_version_tag``.
+will be removed, in line with :pep:`387`.
 
 The biggest user the author could find for this field was Cython.
 Discussions with a Cython maintainer indicated that

--- a/pep-0699.rst
+++ b/pep-0699.rst
@@ -65,7 +65,7 @@ lookups. For example,
 `Cython uses the field for fast dynamic module variable lookups <https://github.com/cython/cython/blob/169876872f3cb6198971a1db07e5b8a9d12b3dac/Cython/Utility/ObjectHandling.c#L1556>`_.
 
 This PEP proposes to emit a compiler warning when accessing ``ma_version_tag``.
-After two consecutive version releases of warnings, :pep:`509` will be fully
+After two consecutive version releases with warnings, :pep:`509` will be fully
 repealed, in line with :pep:`387`. A function for fast cached dictionary
 lookups may be provided as an alternative feature to replace directly
 accessing ``ma_version_tag``.


### PR DESCRIPTION
This PR amends the PEP to follow the standard deprecation policy, in line with the SC's feedback on the Discourse thread https://discuss.python.org/t/pep-699-remove-private-dict-version-field-added-in-pep-509/19724/10?u=kj0.