### PR TITLE
PEP 562: Fix example by adding repr in an error message

### DIFF
--- a/pep-0562.rst
+++ b/pep-0562.rst
@@ -43,7 +43,7 @@ on module *instances*. For example::
       if name in deprecated_names:
           warn(f"{name} is deprecated", DeprecationWarning)
           return globals()[f"_deprecated_{name}"]
-      raise AttributeError(f"module {__name__} has no attribute {name}")
+      raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
   # main.py
 


### PR DESCRIPTION
The first example in the PEP doesn't use `!r` while formatting the name of the module and the attribute.  The following example does.  This PR fixes the first example so that it matches the second and the regular behavior of Python while trying to access a non-existing module variable.
