### PR TITLE
Revert "PEP 517: add missing def for the mandatory hook build_wheel signature"

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -211,7 +211,7 @@ build_wheel
 
 ::
 
-    def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
         ...
 
 Must build a .whl file, and place it in the specified ``wheel_directory``. It
@@ -341,7 +341,7 @@ get_requires_for_build_sdist
 ::
 
   def get_requires_for_build_sdist(config_settings=None):
-      ...
+    ...
 
 This hook MUST return an additional list of strings containing :pep:`508`
 dependency specifications, above and beyond those specified in the


### PR DESCRIPTION
Reverts python/peps#2535