### PR TITLE
Infra: Only invert image brightness, not hue

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -53,7 +53,7 @@
 }
 
 img.invert-in-dark-mode {
-    filter: var(--dark, invert(1));
+    filter: var(--dark, invert(1) hue-rotate(.5turn));
 }
 
 /* Set master rules */


### PR DESCRIPTION
In #2409, CSS was added to invert images that would otherwise be hard to see on dark background.

Since inversion doesn’t just affect brightness, but also hue, there’s a problem: Some background colors have perceptually less contrast with their text when hue rotated.

This PR rotates their hue back, fixing this. Also I prefer the less vaporware aesthetic of the original colors. E.g. the white-on-red is much more readable than white-on-cyan in [PEP 458](https://peps.python.org/pep-0458/):

<table>
<thead>
<tr>
	<th>Without this PR
	<th>With this PR
<tbody>
<tr>
	<td width="50%"><img src="https://user-images.githubusercontent.com/291575/211005055-35d02d00-936e-49ef-9492-cf45951aa2f7.png" alt="without">
	<td width="50%"><img src="https://user-images.githubusercontent.com/291575/211005019-3fa68378-141f-4e98-b2a7-ab0e19406824.png" alt="with">
</table>