### PR TITLE
Uncap the Sphinx requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for building PEPs with Sphinx
 Pygments >= 2.9.0
-Sphinx >= 5.1.1,<=6.0.0
+Sphinx >= 5.1.1,!=6.1.0,!=6.1.1,<=6.1.2
 docutils >= 0.19.0
 
 # For RSS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 # Requirements for building PEPs with Sphinx
 Pygments >= 2.9.0
-Sphinx >= 5.1.1,!=6.1.0,!=6.1.1,<=6.1.2
+# Sphinx 6.1.0 broke copying images in parallel builds; fixed in 6.1.2
+# See https://github.com/sphinx-doc/sphinx/pull/11100
+Sphinx >= 5.1.1, != 6.1.0, != 6.1.1
 docutils >= 0.19.0
 
 # For RSS


### PR DESCRIPTION
This updates the Sphinx requirement to allow 6.1.2, but blacklists 6.1.0 and 6.1.1 (broken versions) from being installed.

A