### PR TITLE
PEP 561: Clarify 4th step in Module Resolution Order

### DIFF
--- a/pep-0561.rst
+++ b/pep-0561.rst
@@ -182,6 +182,7 @@ laid out as follows::
         └── hexagon
             └── __init__.pyi
 
+.. _mro:
 
 Type Checker Module Resolution Order
 ------------------------------------
@@ -200,8 +201,10 @@ resolve modules containing type information:
 3. Stub packages - these packages SHOULD supersede any installed inline
    package. They can be found at ``foopkg-stubs`` for package ``foopkg``.
 
-4. Inline packages - if there is nothing overriding the installed
-   package, *and* it opts into type checking, inline types SHOULD be used.
+4. Packages with a ``py.typed`` marker file - if there is nothing overriding
+   the installed package, *and* it opts into type checking, the types
+   bundled with the package SHOULD be used (be they in ``.pyi`` type
+   stub files or inline in ``.py`` files).
 
 5. Typeshed (if used) - Provides the stdlib types and several third party
    libraries.
@@ -273,6 +276,12 @@ Vlasovskikh, Nathaniel Smith, and Guido van Rossum.
 
 Version History
 ===============
+
+* 2023-01-13
+
+    * Clarify that the 4th step of the :ref:`Module Resolution Order <mro>` applies
+      to any package with a ``py.typed`` marker file (and not just
+      inline packages).
 
 * 2021-09-20
 


### PR DESCRIPTION
Fixes https://github.com/python/typing/issues/1334.

\cc @ethanhs as PEP author.