### PR TITLE
PEP 617: Fix typo `out` -> `our`

### DIFF
--- a/pep-0617.rst
+++ b/pep-0617.rst
@@ -743,7 +743,7 @@ parser due to encoding issues, sometimes intentional.)
 
 - Compiling and throwing away the internal AST took 2.141 seconds.
   That's 350,040 lines/sec, or 12,899,367 bytes/sec. The max RSS was
-  74 MiB (the largest file in the stdlib is much smaller than out
+  74 MiB (the largest file in the stdlib is much smaller than our
   canonical test file).
 
 - Compiling to bytecode took 3.290 seconds. That's 227,861 lines/sec,


### PR DESCRIPTION
Fix typo `out` -> `our`
