### PR TITLE
Infra: link directly to RSS feed at peps.python.org

### DIFF
--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="{{ pathto('_static/mq.css', resource=True) }}" type="text/css">
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', resource=True) }}" type="text/css" media="(prefers-color-scheme: light)" id="pyg-light">
     <link rel="stylesheet" href="{{ pathto('_static/pygments_dark.css', resource=True) }}" type="text/css" media="(prefers-color-scheme: dark)" id="pyg-dark">
-    <link rel="alternate" type="application/rss+xml" title="Latest PEPs" href="https://www.python.org/dev/peps/peps.rss">
+    <link rel="alternate" type="application/rss+xml" title="Latest PEPs" href="https://peps.python.org/peps.rss">
     <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <meta name="description" content="Python Enhancement Proposals (PEPs)">
 </head>


### PR DESCRIPTION
<!--

*Please* read our Contributing Guidelines (CONTRIBUTING.rst)
before submitting an issue or pull request to this repository,
to make sure this repo is the appropriate venue for your proposed change.

Prefix the pull request title with the PEP number; for example:

PEP NNN: Summary of the changes made

-->

The PEP HTML headers have a link to the RSS feed:

* https://www.python.org/dev/peps/peps.rss

This is the old location, and there's a redirect in place to the new location, but let's link directly to the new one:

* https://peps.python.org/peps.rss



