### PR TITLE
PEP 699 & 509: Accept 699 and replace 509

### DIFF
--- a/pep-0509.txt
+++ b/pep-0509.txt
@@ -3,11 +3,12 @@ Title: Add a private version to dict
 Version: $Revision$
 Last-Modified: $Date$
 Author: Victor Stinner <vstinner@python.org>
-Status: Final
+Status: Replaced
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 04-Jan-2016
 Python-Version: 3.6
+Superseded-By: 699
 
 
 Abstract

--- a/pep-0509.txt
+++ b/pep-0509.txt
@@ -1,14 +1,17 @@
 PEP: 509
 Title: Add a private version to dict
-Version: $Revision$
-Last-Modified: $Date$
 Author: Victor Stinner <vstinner@python.org>
-Status: Replaced
+Status: Superseded
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 04-Jan-2016
 Python-Version: 3.6
+Post-History: `08-Jan-2016 <https://mail.python.org/archives/list/python-ideas@python.org/thread/FPB7MLWMRSCYQVOUYN2SUV4NR47TPPG3/>`__,
+              `11-Jan-2016 <https://mail.python.org/archives/list/python-dev@python.org/thread/AY42HER5DFKA7DJV25AL7YX5DQPF6RMV/>`__,
+              `14-Apr-2016 <https://mail.python.org/archives/list/python-dev@python.org/thread/UXEQIDSTVLAHJVDQJMJPCU2QZGYMBV2H/>`__,
+              `19-Apr-2016 <https://mail.python.org/archives/list/python-dev@python.org/thread/2S562SVRK5S2QKP3SFONG357Z72I6KLE/>`__
 Superseded-By: 699
+Resolution: https://mail.python.org/archives/list/python-dev@python.org/message/QFVJV6YQOUSWIYY4FBORY647YCBSCIMQ/
 
 
 Abstract

--- a/pep-0699.rst
+++ b/pep-0699.rst
@@ -2,7 +2,7 @@ PEP: 699
 Title: Remove private dict version field added in PEP 509
 Author: Ken Jin <kenjin@python.org>
 Discussions-To: https://discuss.python.org/t/pep-699-remove-private-dict-version-field-added-in-pep-509/19724
-Status: Draft
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 03-Oct-2022

--- a/pep-0699.rst
+++ b/pep-0699.rst
@@ -2,7 +2,7 @@ PEP: 699
 Title: Remove private dict version field added in PEP 509
 Author: Ken Jin <kenjin@python.org>
 Discussions-To: https://discuss.python.org/t/pep-699-remove-private-dict-version-field-added-in-pep-509/19724
-Status: Final
+Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 03-Oct-2022

--- a/pep-0699.rst
+++ b/pep-0699.rst
@@ -9,7 +9,7 @@ Created: 03-Oct-2022
 Python-Version: 3.12
 Post-History: `05-Oct-2022 <https://discuss.python.org/t/pep-699-remove-private-dict-version-field-added-in-pep-509/19724>`__
 Replaces: 509
-Resolution:
+Resolution: https://discuss.python.org/t/pep-699-remove-private-dict-version-field-added-in-pep-509/19724/13
 
 
 


### PR DESCRIPTION
See SC decision at https://discuss.python.org/t/pep-699-remove-private-dict-version-field-added-in-pep-509/19724/13.