### PR TITLE
PEP 689: Mark as Accepted

### DIFF
--- a/pep-0689.rst
+++ b/pep-0689.rst
@@ -2,7 +2,7 @@ PEP: 689
 Title: Unstable C API tier
 Author: Petr Viktorin <encukou@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-689-unstable-c-api-tier/20452
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
 Requires: 523
@@ -11,6 +11,7 @@ Python-Version: 3.12
 Post-History: `27-Apr-2022 <https://mail.python.org/archives/list/python-dev@python.org/thread/PQXSP7E2B6KNXTJ2AERWMKKX42YP5D6O/>`__,
               `25-Aug-2022 <https://discuss.python.org/t/c-api-what-should-the-leading-underscore-py-mean/18486>`__,
               `27-Oct-2022 <https://discuss.python.org/t/pep-689-unstable-c-api-tier/20452>`__,
+Resolution: https://discuss.python.org/t/pep-689-unstable-c-api-tier/20452/13
 
 
 Abstract


### PR DESCRIPTION

* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread (https://discuss.python.org/t/pep-689-unstable-c-api-tier/20452/13)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` link points directly to SC/PEP Delegate official acceptance/rejected post
* [x] (N/A) Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date

On to the implementation :)