### PR TITLE
Infra: Use consistent 'make html' and 'make dirhtml'

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -28,7 +28,7 @@ jobs:
           python -m pip install --upgrade pip
 
       - name: 🔧 Render PEPs
-        run: make pages JOBS=$(nproc)
+        run: make dirhtml JOBS=$(nproc)
 
         # remove the .doctrees folder when building for deployment as it takes two thirds of disk space
       - name: 🔥 Clean up files

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@ JOBS=8
 OUTPUT_DIR=build
 RENDER_COMMAND=$(VENVDIR)/bin/python3 build.py -j $(JOBS) -o $(OUTPUT_DIR)
 
-## render         to render PEPs to "pep-NNNN.html" files
-.PHONY: render
-render: venv
+## html           to render PEPs to "pep-NNNN.html" files
+.PHONY: html
+html: venv
 	$(RENDER_COMMAND)
 
-## pages          to render PEPs to "index.html" files within "pep-NNNN" directories
-.PHONY: pages
-pages: venv rss
+## dirhtml        to render PEPs to "index.html" files within "pep-NNNN" directories
+.PHONY: dirhtml
+dirhtml: venv rss
 	$(RENDER_COMMAND) --build-dirs
 
 ## fail-warning   to render PEPs to "pep-NNNN.html" files and fail the Sphinx build on any warning
@@ -70,6 +70,16 @@ test: venv
 spellcheck: venv
 	$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit
 	$(VENVDIR)/bin/python3 -m pre_commit run --all-files --hook-stage manual codespell
+
+## render         (deprecated: use 'make html' alias instead)
+.PHONY: render
+render: html
+	@echo "\033[0;33mWarning:\033[0;31m 'make render' \033[0;33mis deprecated, use\033[0;32m 'make html' \033[0;33malias instead\033[0m"
+
+## pages          (deprecated: use 'make dirhtml' alias instead)
+.PHONY: pages
+pages: dirhtml
+	@echo "\033[0;33mWarning:\033[0;31m 'make pages' \033[0;33mis deprecated, use\033[0;32m 'make dirhtml' \033[0;33malias instead\033[0m"
 
 .PHONY: help
 help : Makefile

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     python: "3.10"
 
   commands:
-    - make pages JOBS=$(nproc) OUTPUT_DIR=_readthedocs/html
+    - make dirhtml JOBS=$(nproc) OUTPUT_DIR=_readthedocs/html
 
 sphinx:
   builder: dirhtml


### PR DESCRIPTION
<!--

*Please* read our Contributing Guidelines (CONTRIBUTING.rst)
before submitting an issue or pull request to this repository,
to make sure this repo is the appropriate venue for your proposed change.

Prefix the pull request title with the PEP number; for example:

PEP NNN: Summary of the changes made

-->

I keep forgetting what `make render` and `make pages` actually do, and to be sure need to check how the `Makefile` calls `build.py` and how that calls `sphinx-build`.

Let's add `make html` and `make dirhtml` aliases.

These are the actual Sphinx builder names, and the same `Makefile` targets are used by other Sphinx/Python projects, including CPython docs and the devguide, so we can use muscle memory.

(They're also the default for new Sphinx projects.)

And then I don't think we need the old `make render` and `make pages` and can mark them as deprecated?