### PR TITLE
Infra: Use relative links to ease development

### DIFF
--- a/pep_sphinx_extensions/__init__.py
+++ b/pep_sphinx_extensions/__init__.py
@@ -25,8 +25,9 @@ def _depart_maths():
 
 def _update_config_for_builder(app: Sphinx) -> None:
     app.env.document_ids = {}  # For PEPReferenceRoleTitleText
+    app.env.settings["builder"] = app.builder.name
     if app.builder.name == "dirhtml":
-        app.env.settings["pep_url"] = "/pep-{:0>4}"
+        app.env.settings["pep_url"] = "pep-{:0>4}"
 
     # internal_builder exists if Sphinx is run by build.py
     if "internal_builder" not in app.tags:
@@ -46,7 +47,7 @@ def _post_build(app: Sphinx, exception: Exception | None) -> None:
 def setup(app: Sphinx) -> dict[str, bool]:
     """Initialize Sphinx extension."""
 
-    environment.default_settings["pep_url"] = "/pep-{:0>4}.html"
+    environment.default_settings["pep_url"] = "pep-{:0>4}.html"
     environment.default_settings["halt_level"] = 2  # Fail on Docutils warning
 
     # Register plugin logic

--- a/pep_sphinx_extensions/pep_processor/parsing/pep_role.py
+++ b/pep_sphinx_extensions/pep_processor/parsing/pep_role.py
@@ -15,6 +15,10 @@ class PEPRole(roles.ReferenceRole):
             prb = self.inliner.problematic(self.rawtext, self.rawtext, msg)
             return [prb], [msg]
         pep_base = self.inliner.document.settings.pep_url.format(pep_num)
+        if self.inliner.document.settings.builder == "dirhtml":
+            pep_base = "../" + pep_base
+        if "topic" in self.get_location():
+            pep_base = "../" + pep_base
         if fragment:
             ref_uri = f"{pep_base}#{fragment}"
         else:

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
@@ -137,7 +137,11 @@ class PEPHeaders(transforms.Transform):
                 new_body = []
                 for topic_name in body.astext().split(","):
                     if topic_name:
-                        target = f"/topic/{topic_name.lower().strip()}/"
+                        target = f"topic/{topic_name.lower().strip()}"
+                        if self.document.settings.builder == "html":
+                            target = f"{target}.html"
+                        else:
+                            target = f"../{target}/"
                         new_body += [
                             nodes.reference("", topic_name, refuri=target),
                             nodes.Text(", "),


### PR DESCRIPTION
<!--

*Please* read our Contributing Guidelines (CONTRIBUTING.rst)
before submitting an issue or pull request to this repository,
to make sure this repo is the appropriate venue for your proposed change.

Prefix the pull request title with the PEP number; for example:

PEP NNN: Summary of the changes made

-->

Another dev papercut:

Most of the internal links are ["root-relative"](https://mor10.com/html-basics-hyperlink-syntax-absolute-relative-and-root-relative/), that is, they begin with `/`.

For example, https://peps.python.org/ links to `/pep-0008`:

```html
<a class="pep reference internal" href="/pep-0008" title="PEP 8 – Style Guide for Python Code">8</a>
```

This is fine on https://peps.python.org/ and the PR preview builds (e.g. https://pep-previews--2956.org.readthedocs.build/) which are served at the root of the domain, and when serving locally with something like `python -m http.server --directory build` (that `--directory build` being important).

However, for a static site, opening local html files directly in the browser should be enough: `open build/index.html`. But the root relative links mean we encounter 404s when navigating.

For example, from `file:///Users/hugo/github/peps/build/index.html` we go to the 404 `file:///pep-0008.html`.

And it's also a problem for RTD builds for forks, for example https://hugovk-peps.readthedocs.io/en/my-branch/ goes to the 404 https://hugovk-peps.readthedocs.io/pep-0008

So instead of using root relative links (beginning `/`) let's use "plain" relative links like `pep-0008.html`. This works for:

* domain deploys like https://peps.python.org/ and https://pep-previews--2956.org.readthedocs.build/
* local server root `python -m http.server --directory build` at http://[::]:8000/index.html
* local server `python -m http.server` at http://[::]:8000/build/index.html
* local static files at `file:///Users/hugo/github/peps/build/index.html`
* subdirectory deploys like https://hugovk-peps.readthedocs.io/en/infra-relative-links/

Some things to test:

* Links to PEPs from PEP 0 (`index.html`)
* Links to PEPs from PEP 0 (`pep-0000.html` / `pep-0000/`)
* Links to PEPs from other PEPs
* Links to PEP 0 from PEP Index in the header breadcrumbs
* Links to PEPs, and back via the "Topic: xxx" link in the PEP header 
