### PR TITLE
Infra: replace feedgen/lxml dependency to test Python 3.12-dev

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.x", "3.11-dev"]
+        python-version: ["3.x", "3.12-dev"]
 
     steps:
       - name: 🛎️ Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11-dev"]
+        python-version: ["3.9", "3.10", "3.11", "3.12-dev"]
         os: [windows-latest, macos-latest, ubuntu-latest]
-        # lxml doesn't yet install for 3.11 on Windows
-        exclude:
-        - { python-version: "3.11-dev", os: windows-latest }
 
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ check-links: venv
 ## rss            to generate the peps.rss file
 .PHONY: rss
 rss: venv
-	$(VENVDIR)/bin/python3 generate_rss.py
+	$(VENVDIR)/bin/python3 generate_rss.py -o $(OUTPUT_DIR)
 
 ## clean          to remove the venv and build files
 .PHONY: clean

--- a/generate_rss.py
+++ b/generate_rss.py
@@ -2,6 +2,7 @@
 # This file is placed in the public domain or under the
 # CC0-1.0-Universal license, whichever is more permissive.
 
+import argparse
 import datetime
 import email.utils
 from html import escape
@@ -135,6 +136,15 @@ def pep_abstract(full_path: Path) -> str:
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Generate RSS feed")
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        default="build",  # synchronise with render.yaml -> deploy step
+        help="Output directory, relative to root. Default 'build'.",
+    )
+    args = parser.parse_args()
+
     # get list of peps with creation time (from "Created:" string in pep source)
     peps_with_dt = sorted((pep_creation(path), path) for path in PEP_ROOT.glob("pep-????.???"))
 
@@ -191,8 +201,8 @@ def main():
 """
 
     # output directory for target HTML files
-    out_dir = PEP_ROOT / "build"
-    out_dir.mkdir(exist_ok=True)
+    out_dir = PEP_ROOT / args.output_dir
+    out_dir.mkdir(exist_ok=True, parents=True)
     out_dir.joinpath("peps.rss").write_text(output)
 
 

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
   commands:
     - make dirhtml JOBS=$(nproc) OUTPUT_DIR=_readthedocs/html

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,6 @@ Pygments >= 2.9.0
 Sphinx >= 5.1.1, != 6.1.0, != 6.1.1
 docutils >= 0.19.0
 
-# For RSS
-feedgen >= 0.9.0  # For RSS feed
-
 # For tests
 pytest
 pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{311, 310, 39}
+    py{312, 311, 310, 39}
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
<!--

*Please* read our Contributing Guidelines (CONTRIBUTING.rst)
before submitting an issue or pull request to this repository,
to make sure this repo is the appropriate venue for your proposed change.

Prefix the pull request title with the PEP number; for example:

PEP NNN: Summary of the changes made

-->

I wanted to bump `3.11-dev` to `3.12-dev` on the CI, but https://github.com/lkiesow/python-feedgen depends on https://lxml.de/, which is difficult to build from source, even for Ubuntu.

We're writing out fairly simple RSS, so we can remove the feedgen/lxml dependencies, and it takes less code to do so.

In addition to testing `3.12-dev` on all operating systems, this means we can also now test 3.11/Windows.

---

I also updated the `generate_rss.py` script to take an optional output directory (like `build.py` does), so we can also generate RSS on the Read the Docs previews.

---

And let's bump RTD to use 3.11 instead of 3.10 for build previews.


