### PR TITLE
Infra: Use dark grey instead of dark green for dark theme background

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -32,7 +32,7 @@
 
 /* Set master colours */
 :root {
-    --colour-background: var(--light, white) var(--dark, #011);
+    --colour-background: var(--light, white) var(--dark, #121212);
     --colour-background-accent-strong: var(--light, #ccc) var(--dark, #444);
     --colour-background-accent-medium: var(--light, #ddd) var(--dark, #333);
     --colour-background-accent-light: var(--light, #eee) var(--dark, #222);

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -32,7 +32,7 @@
 
 /* Set master colours */
 :root {
-    --colour-background: var(--light, white) var(--dark, #121212);
+    --colour-background: var(--light, white) var(--dark, #111);
     --colour-background-accent-strong: var(--light, #ccc) var(--dark, #444);
     --colour-background-accent-medium: var(--light, #ddd) var(--dark, #333);
     --colour-background-accent-light: var(--light, #eee) var(--dark, #222);


### PR DESCRIPTION
<!--

*Please* read our Contributing Guidelines (CONTRIBUTING.rst)
before submitting an issue or pull request to this repository,
to make sure this repo is the appropriate venue for your proposed change.

Prefix the pull request title with the PEP number; for example:

PEP NNN: Summary of the changes made

-->

Without wanting to bikeshed too much!

The dark theme's current background colour has a bit of a greenish tint: `#001111` (labelled "Dark Green" on [some sites](https://www.htmlcsscolor.com/hex/001111)) which looks a bit off.

The background shouldn't be pure black, the contrast is too high. Here's what a few other sites use:

* `#0d1117` [GitHub](https://github.com/)
* `#121212` [Google's Material Design](https://m2.material.io/design/color/dark-theme.html#properties)
* `#202020` [Furo](https://pradyunsg.me/furo/)
* `#202124` [Google](https://www.google.com/)
* `#2d2d2d` [Stack Overflow](https://stackoverflow.com/)

Previews:

<table>
<tr>
	<th><pre>#001111</pre>
	<th><pre>#121212</pre>
	<th><pre>#202020</pre>
	<th><pre>#202124</pre>
    <th><pre>#2d2d2d</pre>
<tr>
	<td><img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/213933156-fef4397a-5eed-4587-83b6-3f533f8377f2.png">
	<td><img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/213933230-b402653c-3eef-497a-a4a9-926225c1a0ee.png">
	<td><img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/213933238-f815e237-4395-4ed5-8067-45b8858bc168.png">
	<td><img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/213933271-d510a5b8-7034-454c-8c9d-df960068d355.png">
	<td><img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/213933292-57f034d3-43bc-41cd-a3b3-514139cf379e.png">
</table>

Material Design's `#121212` is often suggested ([1](https://uxplanet.org/8-tips-for-dark-theme-design-8dfc2f8f7ab6), [2](https://www.dev.kitchen/blog/how-to-design-a-dark-theme-user-interface), [3](https://compilezero.medium.com/dark-mode-ui-design-the-definitive-guide-part-1-color-53dcfaea5129), [4](https://www.editorx.com/shaping-design/article/designing-for-dark-mode)) so I've gone for that.

No contrast errors at https://wave.webaim.org/report#/https://hugovk-peps.readthedocs.io/en/dark-bgcolor/ or https://wave.webaim.org/report#/https://hugovk-peps.readthedocs.io/en/dark-bgcolor/pep-0008.

# Demo

https://pep-previews--2977.org.readthedocs.build/
