### PR TITLE
PEP 13: Update current SC members for 2023 term

### DIFF
--- a/pep-0013.rst
+++ b/pep-0013.rst
@@ -22,12 +22,12 @@ Current steering council
 The current steering council consists of:
 
 * Brett Cannon
+* Emily Morehouse
 * Gregory P. Smith
 * Pablo Galindo Salgado
-* Petr Viktorin
 * Thomas Wouters
 
-Per the results of the vote tracked in :pep:`8103`.
+Per the results of the vote tracked in :pep:`8104`.
 
 The core team consists of those listed in the private
 https://github.com/python/voters/ repository which is publicly
@@ -287,7 +287,7 @@ active privileges like voting or nominating for the steering council,
 and commit access.
 
 The initial active core team members will consist of everyone
-currently listed in the `"Python core" team on Github
+currently listed in the `"Python core" team on GitHub
 <https://github.com/orgs/python/teams/python-core/members>`__ (access
 granted for core members only), and the
 initial inactive members will consist of everyone else who has been a
@@ -357,14 +357,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
<!--

*Please* read our Contributing Guidelines (CONTRIBUTING.rst)
before submitting an issue or pull request to this repository,
to make sure this repo is the appropriate venue for your proposed change.

Prefix the pull request title with the PEP number; for example:

PEP NNN: Summary of the changes made

-->

Update PEP 13 with the results of the latest steering council election: [PEP 8104](https://peps.python.org/pep-8104/).
