### PR TITLE
Infra: Fix Replaces/Superseded-By/Requires links for dirhtml

### DIFF
--- a/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
@@ -131,6 +131,8 @@ class PEPHeaders(transforms.Transform):
                 new_body = []
                 for pep_str in re.split(r",?\s+", body.astext()):
                     target = self.document.settings.pep_url.format(int(pep_str))
+                    if self.document.settings.builder == "dirhtml":
+                        target = f"../{target}"
                     new_body += [nodes.reference("", pep_str, refuri=target), nodes.Text(", ")]
                 para[:] = new_body[:-1]  # drop trailing space
             elif name == "topic":


### PR DESCRIPTION
<!--

*Please* read our Contributing Guidelines (CONTRIBUTING.rst)
before submitting an issue or pull request to this repository,
to make sure this repo is the appropriate venue for your proposed change.

Prefix the pull request title with the PEP number; for example:

PEP NNN: Summary of the changes made

-->

Fixes #2980.

After https://github.com/python/peps/pull/2972, when building `dirhtml`, we need to re-add the initial `/` for the links to PEPs in the Replaces/Superseded-By/Requires headers.

# Demo

https://pep-previews--2981.org.readthedocs.build/pep-0509/ <--> https://pep-previews--2981.org.readthedocs.build/pep-0699/

