### PR TITLE
PEP 404: Add Python 2.8 to Release PEPs topic

### DIFF
--- a/pep-0404.txt
+++ b/pep-0404.txt
@@ -1,10 +1,9 @@
 PEP: 404
 Title: Python 2.8 Un-release Schedule
-Version: $Revision$
-Last-Modified: $Date$
 Author: Barry Warsaw <barry@python.org>
 Status: Final
 Type: Informational
+Topic: Release
 Content-Type: text/x-rst
 Created: 09-Nov-2011
 Python-Version: 2.8
@@ -182,13 +181,3 @@ This document has been placed in the public domain.
 .. _differences: http://docs.python.org/release/3.0.1/whatsnew/3.0.html
 .. _porting: http://python3porting.com/
 
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 70
-  coding: utf-8
-  End:

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -253,7 +253,7 @@ def _classify_peps(peps: list[PEP]) -> tuple[list[PEP], ...]:
             # Hack until the conflict between the use of "Final"
             # for both API definition PEPs and other (actually
             # obsolete) PEPs is addressed
-            if pep.status == STATUS_ACTIVE or "Release Schedule" not in pep.title:
+            if pep.status == STATUS_ACTIVE or "release schedule" not in pep.title.lower():
                 info.append(pep)
             else:
                 historical.append(pep)


### PR DESCRIPTION
<!--

*Please* read our Contributing Guidelines (CONTRIBUTING.rst)
before submitting an issue or pull request to this repository,
to make sure this repo is the appropriate venue for your proposed change.

Prefix the pull request title with the PEP number; for example:

PEP NNN: Summary of the changes made

-->

Follow on to https://github.com/python/peps/pull/2669.

Add [PEP 404 ("Python 2.8 Un-release Schedule")](https://peps.python.org/pep-0404/) to the Release topic.

It's an un-release schedule for a 404 version-not-found :) but probably belongs in the topic.