### PR TITLE
PEP 698: Mark as Accepted

### DIFF
--- a/pep-0698.rst
+++ b/pep-0698.rst
@@ -15,7 +15,7 @@ Post-History: `20-May-2022 <https://mail.python.org/archives/list/typing-sig@pyt
               `17-Aug-2022 <https://mail.python.org/archives/list/typing-sig@python.org/thread/7JDW2PKGF6YTERUJGWM3BRP3GDHRFP4O/>`__,
               `11-Oct-2022 <https://mail.python.org/archives/list/typing-sig@python.org/thread/TOIYZ3SNPBJZDBRU3ZSBREXV2NNHF4KW/>`__,
               `07-Nov-2022 <https://discuss.python.org/t/pep-698-a-typing-override-decorator/20839>`__,
-
+Resolution: https://discuss.python.org/t/pep-698-a-typing-override-decorator/20839/11
 
 Abstract
 ========

--- a/pep-0698.rst
+++ b/pep-0698.rst
@@ -5,7 +5,7 @@ Author: Steven Troxler <steven.troxler@gmail.com>,
         Shannon Zhu <szhu@fb.com>
 Sponsor: Jelle Zijlstra <jelle.zijlstra at gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-698-a-typing-override-decorator/20839
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Topic: Typing
 Content-Type: text/x-rst


### PR DESCRIPTION
See https://github.com/python/steering-council/issues/160#issuecomment-1409208844

@JelleZijlstra the other things I'm aware of that I / we need to do:
- announce this to typing-sig
- make PRs for cpython and typeshed to update the typing module; this will involve a bit of a learning curve for me
- I'm guessing make a PR on typing_extensions to import from typing in future versions of Python?

Are all those steps needed / is there anything I missed?
