### PR TITLE
PEP 517: add clarifying sentence about duplicate keys in config-settings

### DIFF
--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -374,12 +374,14 @@ dictionary provided as an "escape hatch" for users to pass ad-hoc
 configuration into individual package builds. Build backends MAY
 assign any semantics they like to this dictionary. Build frontends
 SHOULD provide some mechanism for users to specify arbitrary
-string-key/string-value pairs to be placed in this dictionary. For
-example, they might support some syntax like ``--package-config
-CC=gcc``. Build frontends MAY also provide arbitrary other mechanisms
-for users to place entries in this dictionary. For example, ``pip``
-might choose to map a mix of modern and legacy command line arguments
-like::
+string-key/string-value pairs to be placed in this dictionary.
+In case a user provides duplicate string-key’s, build frontends
+SHOULD combine the corresponding string-value’s into a list of
+string-values. For example, they might support some syntax like
+``--package-config CC=gcc``. Build frontends MAY also provide
+arbitrary other mechanisms for users to place entries in this
+dictionary. For example, ``pip`` might choose to map a mix of
+modern and legacy command line arguments like::
 
   pip install                                           \
     --package-config CC=gcc                             \

--- a/pep-0517.txt
+++ b/pep-0517.txt
@@ -375,13 +375,13 @@ configuration into individual package builds. Build backends MAY
 assign any semantics they like to this dictionary. Build frontends
 SHOULD provide some mechanism for users to specify arbitrary
 string-key/string-value pairs to be placed in this dictionary.
-In case a user provides duplicate string-key’s, build frontends
-SHOULD combine the corresponding string-value’s into a list of
-string-values. For example, they might support some syntax like
-``--package-config CC=gcc``. Build frontends MAY also provide
-arbitrary other mechanisms for users to place entries in this
-dictionary. For example, ``pip`` might choose to map a mix of
-modern and legacy command line arguments like::
+For example, they might support some syntax like ``--package-config CC=gcc``. 
+In case a user provides duplicate string-keys, build frontends SHOULD
+combine the corresponding string-values into a list of strings.
+Build frontends MAY also provide arbitrary other mechanisms
+for users to place entries in this dictionary. For example, ``pip``
+might choose to map a mix of modern and legacy command line arguments
+like::
 
   pip install                                           \
     --package-config CC=gcc                             \


### PR DESCRIPTION
As discussed on Discourse:
https://discuss.python.org/t/amending-pep-517-with-a-sentence-on-handling-duplicate-config-settings-keys/23222.