### PR TITLE
PEP 582: Updates the rejected ideas list

### DIFF
--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -333,6 +333,8 @@ Rejected Ideas
 
 * Additional features of virtual environments. This proposal is not a replacement for virtual environments, and such features are therefore out of scope.
 
+* We will not scan any parent directory to find ``__pypackages__``. If we want to execute scripts inside of the ``~/bin/`` directory, then the ``__pypackages__`` directory must be inside of the ``~/bin/`` directory. Doing any such scan for ``__pypackages__`` (for the interpreter or a script) will have security implications and also increase startup time.
+
 * Raise an error if unexpected files or directories are present in ``__pypackages__``. This is considered too strict, particularly as transitional approaches like ``pip install --prefix`` can create additional files in ``__pypackages__``.
 
 * Using a different ``sysconfig`` scheme, or a dedicated ``pypackages`` scheme. While this is attractive in theory, it makes transition harder, as there will be no readily-available way of installing to ``__pypackages__`` until tools implement explicit support. And while the PEP authors hope and assume that such support would be added, having the proposal dependent on such support in order to be usable seems like an unacceptable risk.


### PR DESCRIPTION
Brings back the rejected idea of parent directory scanning.