### PR TITLE
Lint: Allow per-message Post-History links w/trailing slash

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -223,7 +223,7 @@ repos:
       - id: validate-post-history
         name: "'Post-History' must be '`DD-mmm-YYYY <Thread URL>`__, ...'"
         language: pygrep
-        entry: '(?<=\n)Post-History:(?:(?! ?\n|((( +|\n {1,14})(([0-2][0-9]|(3[01]))-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(199[0-9]|20[0-9][0-9])|`([0-2][0-9]|(3[01]))-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(199[0-9]|20[0-9][0-9]) <https://((discuss\.python\.org/t/([\w\-]+/)?\d+/?)|(mail\.python\.org/pipermail/[\w\-]+/\d{4}-[A-Za-z]+/[A-Za-z0-9]+\.html)|(mail\.python\.org/archives/list/[\w\-]+@python\.org/thread/[A-Za-z0-9]+/?(#[A-Za-z0-9]+)?))>`__)(,|(?=\n[^ ])))+\n(?=[A-Z\n]))))'
+        entry: '(?<=\n)Post-History:(?:(?! ?\n|((( +|\n {1,14})(([0-2][0-9]|(3[01]))-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(199[0-9]|20[0-9][0-9])|`([0-2][0-9]|(3[01]))-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(199[0-9]|20[0-9][0-9]) <https://((discuss\.python\.org/t/([\w\-]+/)?\d+(?:/\d+/|/?))|(mail\.python\.org/pipermail/[\w\-]+/\d{4}-[A-Za-z]+/[A-Za-z0-9]+\.html)|(mail\.python\.org/archives/list/[\w\-]+@python\.org/thread/[A-Za-z0-9]+/?(#[A-Za-z0-9]+)?))>`__)(,|(?=\n[^ ])))+\n(?=[A-Z\n]))))'
         args: [--multiline]
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -223,7 +223,7 @@ repos:
       - id: validate-post-history
         name: "'Post-History' must be '`DD-mmm-YYYY <Thread URL>`__, ...'"
         language: pygrep
-        entry: '(?<=\n)Post-History:(?:(?! ?\n|((( +|\n {1,14})(([0-2][0-9]|(3[01]))-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(199[0-9]|20[0-9][0-9])|`([0-2][0-9]|(3[01]))-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(199[0-9]|20[0-9][0-9]) <https://((discuss\.python\.org/t/([\w\-]+/)?\d+(?:/\d+)?/?)|(mail\.python\.org/pipermail/[\w\-]+/\d{4}-[A-Za-z]+/[A-Za-z0-9]+\.html)|(mail\.python\.org/archives/list/[\w\-]+@python\.org/thread/[A-Za-z0-9]+/?(#[A-Za-z0-9]+)?))>`__)(,|(?=\n[^ ])))+\n(?=[A-Z\n]))))'
+        entry: '(?<=\n)Post-History:(?:(?! ?\n|((( +|\n {1,14})(([0-2][0-9]|(3[01]))-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(199[0-9]|20[0-9][0-9])|`([0-2][0-9]|(3[01]))-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(199[0-9]|20[0-9][0-9]) <https://((discuss\.python\.org/t/([\w\-]+/)?\d+/?)|(mail\.python\.org/pipermail/[\w\-]+/\d{4}-[A-Za-z]+/[A-Za-z0-9]+\.html)|(mail\.python\.org/archives/list/[\w\-]+@python\.org/thread/[A-Za-z0-9]+/?(#[A-Za-z0-9]+)?))>`__)(,|(?=\n[^ ])))+\n(?=[A-Z\n]))))'
         args: [--multiline]
         files: '^pep-\d+\.(rst|txt)$'
         types: [text]

--- a/pep-0684.rst
+++ b/pep-0684.rst
@@ -10,7 +10,6 @@ Created: 08-Mar-2022
 Python-Version: 3.12
 Post-History: `08-Mar-2022 <https://mail.python.org/archives/list/python-dev@python.org/thread/CF7B7FMACFYDAHU6NPBEVEY6TOSGICXU/>`__,
               `29-Sep-2022 <https://discuss.python.org/t/pep-684-a-per-interpreter-gil/19583>`__,
-              `28-Oct-2022 <https://discuss.python.org/t/pep-684-a-per-interpreter-gil/19583/19>`__,
 Resolution:
 
 

--- a/pep-0684.rst
+++ b/pep-0684.rst
@@ -10,6 +10,7 @@ Created: 08-Mar-2022
 Python-Version: 3.12
 Post-History: `08-Mar-2022 <https://mail.python.org/archives/list/python-dev@python.org/thread/CF7B7FMACFYDAHU6NPBEVEY6TOSGICXU/>`__,
               `29-Sep-2022 <https://discuss.python.org/t/pep-684-a-per-interpreter-gil/19583>`__,
+              `28-Oct-2022 <https://discuss.python.org/t/pep-684-a-per-interpreter-gil/19583/19/>`__,
 Resolution:
 
 

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
@@ -250,7 +250,7 @@ def _process_discourse_url(parts: list[str]) -> tuple[str, str]:
     has_title = not first_subpart.isnumeric()
 
     if "t" in parts:
-        item_type = "post" if len(parts) > (5 + has_title) else "thread"
+        item_type = "message" if len(parts) > (5 + has_title) else "thread"
     elif "c" in parts:
         item_type = "category"
         if has_title:


### PR DESCRIPTION
<!--
This template is for an infra or meta change not belonging to another category.
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

In PR #3004 , a regression was introduced in the linter, bypassing the check that Discourse links are to the thread rather than to an individual message (as the modern link form of `Post-History` is for keeping a history of the `Discussions-To` threads, rather than links to individual messages about the PEP, which can go in the PEP body if desired).

This is also a pretty easy mistake to make by accident, as if you've scrolled past the first message, the message number will be appended to the URL, leaving readers unintentionally stuck in the middle of the thread rather than at the start (which also messes with Discourse's bookmarking of where you left off reading a thread).

Finally, as the headers are intended to be structured data in an easily-machine-parsable format, consumed by a number of tools in this repo and many more through the PEP API, including PEP-o-tron, the Python Discord bot, and others, it's best if they are as consistent as possible.