### PR TITLE
PEP 706: Filter for tarfile.extractall

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -585,6 +585,8 @@ pep-0701.rst  @pablogsal @isidentical @lysnikolaou
 pep-0702.rst  @jellezijlstra
 pep-0703.rst  @ambv
 pep-0704.rst  @brettcannon @pradyunsg
+# pep-0705.rst
+pep-0706.rst  @encukou
 # ...
 # pep-0754.txt
 # ...

--- a/conf.py
+++ b/conf.py
@@ -49,6 +49,7 @@ exclude_patterns = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'packaging': ('https://packaging.python.org/en/latest/', None),
+    'py3.11': ('https://docs.python.org/3.11/', None),
 }
 intersphinx_disabled_reftypes = []
 

--- a/pep-0706.rst
+++ b/pep-0706.rst
@@ -207,8 +207,8 @@ keyword-only parameter, which takes a function with the signature::
 
     filter(/, member: TarInfo, path: str) -> TarInfo|None
 
-where `member` is the member to be extracted, and `path` is the path to where
-the archive is extracted (i.e., it'll be the same for every member).
+where ``member`` is the member to be extracted, and ``path`` is the path to
+where the archive is extracted (i.e., it'll be the same for every member).
 
 When used it will be called on each member as it is extracted,
 and extraction will work with the result.
@@ -257,9 +257,9 @@ of the following strings:
 
      * Set the owner read and write permissions (``S_IRUSR|S_IWUSR``).
      * Remove the group & other *executable* permission (``S_IXGRP|S_IXOTH``)
-      if the owner doesn't have it (``S_IXUSR``).
+       if the owner doesn't have it (``S_IXUSR``).
      * Remove the group & other *read* permission (``S_IRGRP|S_IROTH``)
-      if the owner doesn't have it (``S_IRUSR``).
+       if the owner doesn't have it (``S_IRUSR``).
 
   * For other files (directories), ignore mode entirely (set it to ``None``).
   * Ignore user and group info (set ``uid``, ``gid``, ``uname``, ``gname``

--- a/pep-0706.rst
+++ b/pep-0706.rst
@@ -269,7 +269,7 @@ The corresponding filter functions will be available as
 ``tarfile.fully_trusted_filter()``, ``tarfile.tar_filter()``, etc., so
 they can be easily used in custom policies.
 
-Note that these filters never return `None`.
+Note that these filters never return ``None``.
 Skipping members this way is a feature for user-defined filters.
 
 Defaults and their configuration

--- a/pep-0706.rst
+++ b/pep-0706.rst
@@ -5,7 +5,7 @@ Discussions-To:
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
-Created: 2023-01-30
+Created: 09-Feb-2023
 Python-Version: 3.12
 Post-History: `25-Jan-2023 <https://discuss.python.org/t/23149>`__,
 

--- a/pep-0706.rst
+++ b/pep-0706.rst
@@ -13,7 +13,7 @@ Post-History: `25-Jan-2023 <https://discuss.python.org/t/23149>`__,
 Abstract
 ========
 
-The extraction methods in ``tarfile`` gain a ``filter`` argument,
+The extraction methods in :external+py3.11:mod:`tarfile` gain a ``filter`` argument,
 which allows rejecting files or modifying metadata as the archive is extracted.
 Three built-in named filters are provided, aimed at limiting features that
 might be surprising or dangerous.
@@ -40,21 +40,22 @@ In many cases, it's best to ignore or disallow some of them when extracting
 an archive.
 
 Python allows extracting ``tar`` archives using
-``tarfile.TarFile.extractall()``, whose docs warn to
+:external+py3.11:meth:`tarfile.TarFile.extractall`, whose docs warn to
 *never extract archives from untrusted sources without prior inspection*.
 However, it’s not clear what kind of inspection should be done.
 Indeed, it’s quite tricky to do such an inspection correctly.
 As a result, many people don’t bother, or do the check incorrectly, resulting in
 security issues such as `CVE-2007-4559`_.
 
-Since :mod:`tarfile` was first written, it's become more accepted that warnings
-in documentation are not enough.
+Since :external+py3.11:mod:`tarfile` was first written, it's become more
+accepted that warnings in documentation are not enough.
 Whenever possible, an unsafe operation should be *explicitly requested*;
 potentially dangerous operations should *look* dangerous.
 However, ``TarFile.extractall`` looks benign in a code review.
 
-Tarfile extraction is also exposed via ``shutil.unpack_archive``, which allows
-the user to not care about the kind of archive they're dealing with.
+Tarfile extraction is also exposed via :external+py3.11:func:`shutil.unpack_archive`,
+which allows the user to not care about the kind of archive they're
+dealing with.
 The API is very inviting for extracting archives without prior inspection,
 even though the docs again warn against it.
 
@@ -69,8 +70,9 @@ Rationale
 
 How do we improve things?
 Unfortunately, we will need to change the defaults, which implies
-breaking backwards compatibility. ``TarFile.extractall()`` is what people reach
-for when they need to extract a tarball. Its default behaviour needs to change.
+breaking backwards compatibility. :external+py3.11:meth:`TarFile.extractall <tarfile.TarFile.extractall>`
+is what people reach for when they need to extract a tarball.
+Its default behaviour needs to change.
 
 What would be the best behaviour? That depends on the use case.
 So, we'll add several general “policies” to control extraction.
@@ -82,7 +84,8 @@ security implications:
   made yourself.
 - Unpacking a UNIX archive: roughly following GNU ``tar``, e.g. stripping
   leading ``/`` from filenames.
-- Unpacking a general data archive: the ``shutil.unpack_archive`` use case,
+- Unpacking a general data archive: the :external+py3.11:func:`shutil.unpack_archive`
+  use case,
   where it's not important to preserve details specific to ``tar`` or
   Unix-like filesystems.
 
@@ -93,8 +96,8 @@ Even with better general defaults, users should still verify the archives
 they extract, and perhaps modify some of the metadata.
 Superficially, the following looks like a reasonable way to do this today:
 
-* Call ``TarFile.getmembers()``
-* Verify or modify each member's ``TarInfo``
+* Call :external+py3.11:meth:`TarFile.getmembers <tarfile.TarFile.getmembers>`
+* Verify or modify each member's :external+py3.11:class:`~tarfile.TarInfo`
 * Pass the result to ``extractall``'s ``members``
 
 However, there are some issues with this approach:
@@ -112,8 +115,8 @@ However, there are some issues with this approach:
 To solve these issues we'll:
 
 - Provide a supported way to “clone” and modify ``TarInfo`` objects.
-  A ``replace`` method, similar to :func:`dataclasses.replace`
-  or :func:`namedtuple._replace <collections.namedtuple._replace>`
+  A ``replace`` method, similar to :external+py3.11:func:`dataclasses.replace`
+  or :external+py3.11:meth:`namedtuple._replace <collections.somenamedtuple._replace>`
   should do the trick.
 - Provide a “filter” hook in ``extractall``'s loop that can modify or discard
   members before they are processed.
@@ -123,7 +126,7 @@ To solve these issues we'll:
   at the cost of not being able to do a precise “dry run”.
 
 The hook API will be very similar to the existing ``filter`` argument
-for :meth:`tarfile.TarFile.add`.
+for :external+py3.11:meth:`TarFile.add <tarfile.TarFile.add>`.
 We'll also name it ``filter``.
 (In some cases “policy” would be a more fitting name,
 but the API can be used for more than security policies.)
@@ -135,16 +138,16 @@ public filter API, so they can be used as building blocks or examples.
 Setting a precedent
 -------------------
 
-If and when other libraries for archive extraction, such as ``zipfile``,
+If and when other libraries for archive extraction, such as :external+py3.11:mod:`zipfile`,
 gain similar functionality, they should mimic this API as much as it's
 reasonable.
 
 To enable this for simple cases, the built-in filters will have string names;
 e.g. users can pass ``filter='data'`` instead of a specific function that deals
-with ``TarInfo`` objects.
+with :external+py3.11:class:`~tarfile.TarInfo` objects.
 
-The ``shutil.extract_archive()`` function will get a ``filter`` argument,
-which it will pass to ``extractall``.
+The :external+py3.11:func:`shutil.unpack_archive` function will get a
+``filter`` argument, which it will pass to ``extractall``.
 
 Adding function-based API that would work across archive formats is
 out of scope of this PEP.
@@ -170,8 +173,8 @@ Specification
 Modifying and forgetting member metadata
 ----------------------------------------
 
-The ``TarInfo`` class will gain a new method, ``replace()``,
-which will work similarly to ``dataclasses.replace``.
+The :external+py3.11:class:`~tarfile.TarInfo` class will gain a new method,
+``replace()``, which will work similarly to ``dataclasses.replace``.
 It will return a copy of the ``TarInfo`` object with attributes
 replaced as specified by keyword-only arguments:
 
@@ -195,15 +198,18 @@ When ``addfile`` or ``tobuf`` encounters such a ``None``, it will raise a
 When ``list`` encounters such a ``None``, it will print a placeholder string.
 
 The documentation will mention why the method is there:
-``TarInfo`` objects retrieved from ``TarFile.getmembers()`` are “live”;
-modifying them directly will affect subsequent unrelated operations.
+``TarInfo`` objects retrieved from :external+py3.11:meth:`TarFile.getmembers <tarfile.TarFile.getmembers>`
+are “live”; modifying them directly will affect subsequent unrelated
+operations.
 
 
 Filters
 -------
 
-``TarFile.extract`` and ``TarFile.extractall`` methods will grow a ``filter``
-keyword-only parameter, which takes a function with the signature::
+:external+py3.11:meth:`TarFile.extract <tarfile.TarFile.extract>` and
+:external+py3.11:meth:`TarFile.extractall <tarfile.TarFile.extractall>` methods
+will grow a ``filter`` keyword-only parameter,
+which takes a function with the signature::
 
     filter(/, member: TarInfo, path: str) -> TarInfo|None
 
@@ -215,8 +221,8 @@ and extraction will work with the result.
 If it returns ``None``, the member will be skipped.
 
 The function can also raise an exception.
-This can, depending on ``Tarfile.errorlevel``, abort the extraction or cause
-the member to be skipped.
+This can, depending on ``TarFile.errorlevel``,
+abort the extraction or cause the member to be skipped.
 
 We will also provide a set of defaults for common use cases.
 In addition to a function, the ``filter`` argument can be one
@@ -235,9 +241,9 @@ of the following strings:
     would end up outside the destination.
     (Note that GNU ``tar`` instead delays creating some links.)
   * Clear high mode bits (setuid, setgid, sticky) and group/other write bits
-    (``S_IWGRP|S_IWOTH``).
-    (This is an approximation of ``tar``'s default, which limits the mode by
-    the current ``umask`` setting.)
+    (:external+py3.11:data:`S_IWGRP|S_IWOTH <stat.S_IWGRP>`).
+    (This is an approximation of GNU ``tar``'s default, which limits the mode
+    by the current ``umask`` setting.)
 
 * ``'data'``:  Extract a "data" archive, disallowing common attack vectors
   but limiting functionality.
@@ -255,11 +261,11 @@ of the following strings:
   * Refuse to extract device files (including pipes).
   * For regular files and hard links:
 
-     * Set the owner read and write permissions (``S_IRUSR|S_IWUSR``).
-     * Remove the group & other *executable* permission (``S_IXGRP|S_IXOTH``)
-       if the owner doesn't have it (``S_IXUSR``).
-     * Remove the group & other *read* permission (``S_IRGRP|S_IROTH``)
-       if the owner doesn't have it (``S_IRUSR``).
+    * Set the owner read and write permissions (:external+py3.11:data:`S_IRUSR|S_IWUSR <stat.S_IRUSR>`).
+    * Remove the group & other *executable* permission (:external+py3.11:data:`S_IXGRP|S_IXOTH <stat.S_IXGRP>`)
+      if the owner doesn't have it (:external+py3.11:data:`~stat.S_IXUSR`).
+    * Remove the group & other *read* permission (:external+py3.11:data:`S_IRGRP|S_IROTH <stat.S_IRGRP>`)
+      if the owner doesn't have it (:external+py3.11:data:`~stat.S_IRUSR`).
 
   * For other files (directories), ignore mode entirely (set it to ``None``).
   * Ignore user and group info (set ``uid``, ``gid``, ``uname``, ``gname``
@@ -275,8 +281,8 @@ Skipping members this way is a feature for user-defined filters.
 Defaults and their configuration
 --------------------------------
 
-``TarFile`` will gain a new attribute, ``extraction_filter``, to allow
-configuring the default filter.
+:external+py3.11:class:`~tarfile.TarFile` will gain a new attribute,
+``extraction_filter``, to allow configuring the default filter.
 By default it will be ``None``, but users can set it to a callable
 that will be used if the ``filter`` argument is missing or ``None``.
 
@@ -304,15 +310,16 @@ Subclasses of ``TarFile`` can also override ``extraction_filter``.
 FilterError
 -----------
 
-A new exception, ``FilterError``, will be added to the ``tarfile`` module.
+A new exception, ``FilterError``, will be added to the :external+py3.11:mod:`tarfile`
+module.
 It'll have several new subclasses, one for each of the refusal reasons above.
 ``FilterError``'s ``member`` attribute will contain the relevant ``TarInfo``.
 
 In the lists above, “refusing" to extract a file means that a ``FilterError``
 will be raised.
-As with other extraction errors, if the ``TarFile.errorlevel`` is 1 or more,
-this will abort the extraction; with ``errorlevel=0`` the error will be
-logged and the member will be ignored, but extraction will continue.
+As with other extraction errors, if the ``TarFile.errorlevel``
+is 1 or more, this will abort the extraction; with ``errorlevel=0`` the error
+will be logged and the member will be ignored, but extraction will continue.
 Note that ``extractall()`` may leave the archive partially extracted;
 it is the user's responsibility to clean up.
 
@@ -320,8 +327,8 @@ it is the user's responsibility to clean up.
 Hints for further verification
 ------------------------------
 
-Even with the proposed changes, ``tarfile`` will not be suited for extracting
-untrusted files without prior inspection.
+Even with the proposed changes, :external+py3.11:mod:`tarfile` will not be
+suited for extracting untrusted files without prior inspection.
 Among other issues, the proposed policies don't prevent denial-of-service
 attacks.
 Users should do additional checks.
@@ -351,8 +358,8 @@ Also, the docs will note that:
 This list is not comprehensive, but the documentation is a good place to
 collect such general tips.
 It can be moved into a separate document if grows too long or if it needs to
-be consolidated with ``zipfile`` or ``shutil`` (which is out of scope for
-this proposal).
+be consolidated with :external+py3.11:mod:`zipfile` or :external+py3.11:mod:`shutil`
+(which is out of scope for this proposal).
 
 
 .. _706-offset:
@@ -390,11 +397,11 @@ the filename option of GNU ``tar``.)
 Other archive libraries
 -----------------------
 
-If and when other archive libraries, such as ``zipfile``, grow similar
-functionality, their extraction functions should use a ``filter`` argument
-that takes, at least, the strings ``'fully_trusted'`` (which should disable
-any security precautions) and ``'data'`` (which should avoid features that
-might surprise users).
+If and when other archive libraries, such as :external+py3.11:mod:`zipfile`,
+grow similar functionality, their extraction functions should use a ``filter``
+argument that takes, at least, the strings ``'fully_trusted'`` (which should
+disable any security precautions) and ``'data'`` (which should avoid features
+that might surprise users).
 
 Standardizing a function-based filter API is out of scope of this PEP.
 
@@ -402,10 +409,10 @@ Standardizing a function-based filter API is out of scope of this PEP.
 Shutil
 ------
 
-``shutil.unpack_archive`` will gain a ``filter`` argument.
+:external+py3.11:func:`shutil.unpack_archive` will gain a ``filter`` argument.
 If it's given, it will be passed to the underlying extraction function.
-Passing it for a ``zip`` archive will fail for now (until ``zipfile`` gains a
-``filter`` argument, if it ever does).
+Passing it for a ``zip`` archive will fail for now (until :external+py3.11:mod:`zipfile`
+gains a ``filter`` argument, if it ever does).
 
 If ``filter`` is not specified (or left as ``None``), it won't be passed
 on, so extracting a tarball will use the default filter
@@ -429,13 +436,14 @@ A simple ``StatefulFilter`` example will be added to the docs.
 Backwards Compatibility
 =======================
 
-The default behavior of ``TarFile.extract`` and ``TarFile.extactall``
+The default behavior of :external+py3.11:meth:`TarFile.extract <tarfile.TarFile.extract>`
+and :external+py3.11:meth:`TarFile.extractall <tarfile.TarFile.extractall>`
 will change, after raising ``DeprecationWarning`` for 2 releases
 (shortest deprecation period allowed in Python's
 :pep:`backwards compatibility policy <387>`).
 
-Additionally, code that relies on ``TarInfo`` object identity may break,
-see :ref:`706-offset`.
+Additionally, code that relies on :external+py3.11:class:`tarfile.TarInfo`
+object identity may break, see :ref:`706-offset`.
 
 
 Backporting & Forward Compatibility
@@ -517,7 +525,7 @@ not with the specifics of UNIX filesystems nor the related security issues.
 Reference Implementation
 ========================
 
-Draft implementation: https://github.com/python/cpython/compare/main...encukou:cpython:tarfile-dir-traversal-sq
+A draft implementation is `on GitHub <https://github.com/python/cpython/compare/main...encukou:cpython:tarfile-dir-traversal-sq>`_.
 
 
 Rejected Ideas

--- a/pep-0706.rst
+++ b/pep-0706.rst
@@ -21,9 +21,6 @@ These can be used as-is, or serve as a base for custom filters.
 
 After a deprecation period, a strict (but safer) filter will become the default.
 
-The API is meant to set a precedent for other archive libraries, such as
-``zipfile``.
-
 
 Motivation
 ==========
@@ -102,8 +99,10 @@ Superficially, the following looks like a reasonable way to do this today:
 
 However, there are some issues with this approach:
 
-- ``TarInfo`` does not officially allow modification. You can modify it, but you
-  can get surprising results since ``TarInfo`` objects are cached/shared.
+- It's possible to modify ``TarInfo`` objects, but the changes to them
+  affect all subsequent operations on the same ``TarFile`` object.
+  This behavior is fine for most uses, but despite that, it would be very
+  surprising if ``TarFile.extractall`` did this by default.
 - Calling ``getmembers`` can be expensive and it 
   `requires a seekable archive <https://github.com/python/cpython/issues/45385#issuecomment-1255615199>`__.
 - When verifying members in advance, it may be necessary to track how each
@@ -112,8 +111,7 @@ However, there are some issues with this approach:
 
 To solve these issues we'll:
 
-- Provide a supported way to modify ``TarInfo`` when needed,
-  without unnecessary work when not.
+- Provide a supported way to “clone” and modify ``TarInfo`` objects.
   A ``replace`` method, similar to :func:`dataclasses.replace`
   or :func:`namedtuple._replace <collections.namedtuple._replace>`
   should do the trick.
@@ -174,7 +172,7 @@ Modifying and forgetting member metadata
 
 The ``TarInfo`` class will gain a new method, ``replace()``,
 which will work similarly to ``dataclasses.replace``.
-It will return a *deep* copy of the ``TarInfo`` object with attributes
+It will return a copy of the ``TarInfo`` object with attributes
 replaced as specified by keyword-only arguments:
 
 * ``name``
@@ -189,10 +187,12 @@ replaced as specified by keyword-only arguments:
 Any of these, except ``name`` and ``linkname``, will be allowed to be set
 to ``None``.
 When ``extract`` or ``extractall`` encounters such a ``None``, it will not
-set that piece of metadata, leaving it as if the file was created by ``open()``.
-When ``addfile`` encounters such a ``None``, it will raise an error.
-(It could also not store the attribute, if the format allows it,
-but that's a possible future enhancement.)
+set that piece of metadata.
+(If ``uname`` or ``gname`` is ``None``, it will fall back to ``uid`` or ``gid``
+as if the name wasn't found.)
+When ``addfile`` or ``tobuf`` encounters such a ``None``, it will raise a
+``ValueError``.
+When ``list`` encounters such a ``None``, it will print a placeholder string.
 
 The documentation will mention why the method is there:
 ``TarInfo`` objects retrieved from ``TarFile.getmembers()`` are “live”;
@@ -203,9 +203,12 @@ Filters
 -------
 
 ``TarFile.extract`` and ``TarFile.extractall`` methods will grow a ``filter``
-parameter, which takes a function with the signature::
+keyword-only parameter, which takes a function with the signature::
 
-    filter(member: TarInfo) -> TarInfo|None
+    filter(/, member: TarInfo, path: str) -> TarInfo|None
+
+where `member` is the member to be extracted, and `path` is the path to where
+the archive is extracted (i.e., it'll be the same for every member).
 
 When used it will be called on each member as it is extracted,
 and extraction will work with the result.
@@ -225,8 +228,9 @@ of the following strings:
 * ``'tar'``: Roughly follow defaults of the GNU ``tar`` command
   (when run as a normal user):
 
-  * Strip leading ``/`` from filenames
-  * Refuse to extract files with a ``..`` component in the filename
+  * Strip leading ``'/'`` and ``os.sep`` from filenames
+  * Refuse to extract files with absolute paths (after the ``/`` stripping
+    above, e.g. ``C:/foo`` on Windows).
   * Refuse to extract files whose absolute path (after following symlinks)
     would end up outside the destination.
     (Note that GNU ``tar`` instead delays creating some links.)
@@ -242,6 +246,7 @@ of the following strings:
   filter for cross-platform archives.
   In addition to ``tar``:
 
+  * Refuse to extract links (hard or soft) that link to absolute paths.
   * Refuse to extract links (hard or soft) which end up linking to a path
     outside of the destination.
     (On systems that don't support links, ``tarfile`` will, in most cases,
@@ -250,27 +255,56 @@ of the following strings:
   * Refuse to extract device files (including pipes).
   * For regular files and hard links:
 
-    * Set the owner read and write permissions (``S_IRUSR|S_IWUSR``).
-      (By now only the *executable* bits depend on information in the archive.)
-    * Remove the group & other *executable* permission (``S_IXGRP|S_IXOTH``)
-      if the user doesn't have it (``S_IXUSR``).
+     * Set the owner read and write permissions (``S_IRUSR|S_IWUSR``).
+     * Remove the group & other *executable* permission (``S_IXGRP|S_IXOTH``)
+      if the owner doesn't have it (``S_IXUSR``).
+     * Remove the group & other *read* permission (``S_IRGRP|S_IROTH``)
+      if the owner doesn't have it (``S_IRUSR``).
 
   * For other files (directories), ignore mode entirely (set it to ``None``).
   * Ignore user and group info (set ``uid``, ``gid``, ``uname``, ``gname``
     to ``None``).
 
-* ``'legacy_warning'``: Like ``'fully_trusted'``, but emit a 
-  ``DeprecationWarning`` for each member that would be changed or removed under
-  ``'data'``.
-
 The corresponding filter functions will be available as
 ``tarfile.fully_trusted_filter()``, ``tarfile.tar_filter()``, etc., so
 they can be easily used in custom policies.
 
+Note that these filters never return `None`.
+Skipping members this way is a feature for user-defined filters.
+
+Defaults and their configuration
+--------------------------------
+
+``TarFile`` will gain a new attribute, ``extraction_filter``, to allow
+configuring the default filter.
+By default it will be ``None``, but users can set it to a callable
+that will be used if the ``filter`` argument is missing or ``None``.
+
+.. note::
+
+  String names won't be accepted here. That would encourage code like
+  ``my_tarfile.extraction_filter = 'data'``.
+  On Python versions without this feature, this would do nothing,
+  silently ignoring a security-related request.
+
+If both the argument and attribute are ``None``:
+
+  * In Python 3.12-3.13, a ``DeprecationWarning`` will be emitted and
+    extraction will use the ``'fully_trusted'`` filter.
+  * In Python 3.14+, it will use the ``'data'`` filter.
+
+Applications and system integrators may wish to change ``extraction_filter``
+of the ``TarFile`` class itself to set a global default.
+When using a function, they will generally want to wrap it in ``staticmethod()``
+to prevent injection of a ``self`` argument.
+
+Subclasses of ``TarFile`` can also override ``extraction_filter``.
+
+
 FilterError
 -----------
 
-A new exception, ``FilterError``, will be added.
+A new exception, ``FilterError``, will be added to the ``tarfile`` module.
 It'll have several new subclasses, one for each of the refusal reasons above.
 ``FilterError``'s ``member`` attribute will contain the relevant ``TarInfo``.
 
@@ -281,28 +315,6 @@ this will abort the extraction; with ``errorlevel=0`` the error will be
 logged and the member will be ignored, but extraction will continue.
 Note that ``extractall()`` may leave the archive partially extracted;
 it is the user's responsibility to clean up.
-
-
-Defaults and their configuration
---------------------------------
-
-``TarFile`` will get a new class member ``extraction_filter``, with the
-default filter.
-This will be ``tarfile.legacy_warning_filter`` in Python 3.12 and 3.13,
-and ``tarfile.data_filter`` from Python 3.14 on.
-
-Applications and system integrators may wish to change ``extraction_filter``
-to suit their requirements.
-Users may also assign the ``extraction_filter`` attribute of an individual
-``TarFile`` instance to specify the default filter.
-Note that the attribute should be set to a filter function, not a string name.
-
-.. note::
-
-  Allowing strings would encourage code like
-  ``my_tarfile.extraction_filter = 'data'``.
-  On Python versions without this feature, this would do nothing,
-  silently ignoring a security-related request.
 
 
 Hints for further verification
@@ -317,13 +329,14 @@ Users should do additional checks.
 New docs will tell users to consider:
 
 * extracting to a new empty directory,
+* using external (e.g. OS-level) limits on disk, memory and CPU usage,
 * checking filenames against an allow-list of characters (to filter out control
   characters, confusables, etc.),
 * checking that filenames have expected extensions (discouraging files that
   execute when you “click on them”, or extension-less files like Windows
   special device names),
-* limiting the total size of extracted data, size of individual files,
-  and number of files,
+* limiting the number of extracted, files total size of extracted data,
+  and size of individual files,
 * checking for files that would be shadowed on case-insensitive filesystems.
 
 Also, the docs will note that:
@@ -342,15 +355,46 @@ be consolidated with ``zipfile`` or ``shutil`` (which is out of scope for
 this proposal).
 
 
+.. _706-offset:
+
+TarInfo identity, and ``offset``
+--------------------------------
+
+With filters that use ``replace()``, the ``TarInfo`` objects handled
+by the extraction machinery will not necessarily be the same objects
+as those present in ``members``.
+This may affect ``TarInfo`` subclasses that override methods like
+``makelink`` and rely on object identity.
+
+Such code can switch to comparing ``offset``, the position of the member
+header inside the file.
+
+Note that both the overridable methods and ``offset`` are only
+documented in source comments.
+
+
+tarfile CLI
+-----------
+
+The CLI (``python -m tarfile``) will gain a ``--filter`` option
+that will take the nams of one of the provided default filters.
+It won't be possible to specify a custom filter function.
+
+If ``--filter`` is not given, the CLI will use the default filter
+(``'legacy_warning'`` for a deprecation period, then ``'data'``).
+
+There will be no short option. (``-f`` would be confusingly similar to
+the filename option of GNU ``tar``.)
+
+
 Other archive libraries
 -----------------------
 
-This PEP is meant to set a precedent.
-
 If and when other archive libraries, such as ``zipfile``, grow similar
 functionality, their extraction functions should use a ``filter`` argument
-that takes, at least, the strings ``'fully_trusted'`` and ``'data'``, with
-semantics similar to the ones in ``tarfile``.
+that takes, at least, the strings ``'fully_trusted'`` (which should disable
+any security precautions) and ``'data'`` (which should avoid features that
+might surprise users).
 
 Standardizing a function-based filter API is out of scope of this PEP.
 
@@ -361,19 +405,37 @@ Shutil
 ``shutil.unpack_archive`` will gain a ``filter`` argument.
 If it's given, it will be passed to the underlying extraction function.
 Passing it for a ``zip`` archive will fail for now (until ``zipfile`` gains a
-``filter`` argument).
+``filter`` argument, if it ever does).
 
 If ``filter`` is not specified (or left as ``None``), it won't be passed
 on, so extracting a tarball will use the default filter
 (``'legacy_warning'`` for a deprecation period, then ``'data'``).
 
+Complex filters
+---------------
+
+Note that some user-defined filters need, for example,
+to count extracted members of do post-processing.
+This requires a more complex API than a ``filter`` callable.
+However, that complex API need not be exposed to ``tarfile``.
+For example, with a hypothetical ``StatefulFilter`` users would write::
+
+    with StatefulFilter() as filter_func:
+        my_tar.extract(path, filter=filter_func)
+
+A simple ``StatefulFilter`` example will be added to the docs.
+
 
 Backwards Compatibility
 =======================
 
-The proposal follows Python's :pep:`backwards compatibility policy <387>`,
-using the shortest allowed deprecation period (two years) for the
-incompatible change.
+The default behavior of ``TarFile.extract`` and ``TarFile.extactall``
+will change, after raising ``DeprecationWarning`` for 2 releases
+(shortest deprecation period allowed in Python's
+:pep:`backwards compatibility policy <387>`).
+
+Additionally, code that relies on ``TarInfo`` object identity may break,
+see :ref:`706-offset`.
 
 
 Backporting & Forward Compatibility
@@ -404,13 +466,14 @@ will affect subsequent operations.
 
 * Fully trusted archive::
 
-    my_tarfile.extraction_filter = (lambda member: member)
+    my_tarfile.extraction_filter = (lambda member, path: member)
     my_tarfile.extractall()
 
 * Use the ``'data'`` filter if available, but revert to Python 3.11 behavior
   (``'fully_trusted'``) if this feature is not available::
 
-    my_tarfile.extraction_filter = getattr(tarfile, 'data_filter', lambda member: member)
+    my_tarfile.extraction_filter = getattr(tarfile, 'data_filter',
+                                           (lambda member, path: member))
     my_tarfile.extractall()
 
   (This is an unsafe operation, so it should be spelled out explicitly,
@@ -447,15 +510,14 @@ How to Teach This
 
 The API, usage notes and tips for further verification will be added to
 the documentation.
-These should be usable for users who know how to extract an archive, but are
-not familiar with the specifics of UNIX filesystems nor the related security
-issues.
+These should be usable for users who are familiar wth archives in general, but
+not with the specifics of UNIX filesystems nor the related security issues.
 
 
 Reference Implementation
 ========================
 
-XXX None yet.
+Draft implementation: https://github.com/python/cpython/compare/main...encukou:cpython:tarfile-dir-traversal-sq
 
 
 Rejected Ideas
@@ -477,8 +539,20 @@ However, many of the ideas behind SafeTarFile were reused in this PEP.
 Add absolute_path option to tarfile
 -----------------------------------
 
-A minimal change to check the “CVE resolved” box doesn't go far enough to
-protect the unaware, nor to empower the diligent and curious.
+Issue `gh-73974`_ asks for adding an ``absolute_path`` option to extraction
+methods. This would be a minimal change to formally resolve `CVE-2007-4559`_.
+It doesn't go far enough to protect the unaware, nor to empower the dilligent
+and curious.
+
+Other names for the ``'tar'`` filter
+------------------------------------
+
+The ``'tar'`` filter exposes features specific to UNIX-like filesystems,
+so it could be named ``'unix'``.
+Or ``'unix-like'``, ``'nix'``, ``'*nix'``, ``'posix'``?
+
+Fetaure-wise, *tar format* and *UNIX-like filesystem* are essentially
+equivalent, so ``tar`` is a good name.
 
 
 Open Issues
@@ -501,6 +575,8 @@ References
 .. _CVE-2007-4559: https://nvd.nist.gov/vuln/detail/CVE-2007-4559
 
 .. _gh-65308: https://github.com/python/cpython/issues/65308
+
+.. _gh-73974: https://github.com/python/cpython/issues/73974
 
 Copyright
 =========

--- a/pep-0706.rst
+++ b/pep-0706.rst
@@ -1,0 +1,509 @@
+PEP: 706
+Title: Filter for tarfile.extractall
+Author: Petr Viktorin <encukou@gmail.com>
+Discussions-To: 
+Status: Draft
+Type: Standards Track
+Content-Type: text/x-rst
+Created: 2023-01-30
+Python-Version: 3.12
+Post-History: `25-Jan-2023 <https://discuss.python.org/t/23149>`__,
+
+
+Abstract
+========
+
+The extraction methods in ``tarfile`` gain a ``filter`` argument,
+which allows rejecting files or modifying metadata as the archive is extracted.
+Three built-in named filters are provided, aimed at limiting features that
+might be surprising or dangerous.
+These can be used as-is, or serve as a base for custom filters.
+
+After a deprecation period, a strict (but safer) filter will become the default.
+
+The API is meant to set a precedent for other archive libraries, such as
+``zipfile``.
+
+
+Motivation
+==========
+
+The ``tar`` format is used for several use cases, many of which have different
+needs. For example:
+
+- A backup of a UNIX workstation should faithfully preserve all kinds of
+  details like file permissions, symlinks to system configuration, and various
+  kinds of special files.
+- When unpacking a data bundle, it’s much more important that the unpacking
+  will not have unintended consequences – like exposing password file by
+  symlinking it to a public place.
+
+To support all its use cases, the ``tar`` format has many features.
+In many cases, it's best to ignore or disallow some of them when extracting
+an archive.
+
+Python allows extracting ``tar`` archives using
+``tarfile.TarFile.extractall()``, whose docs warn to
+*never extract archives from untrusted sources without prior inspection*.
+However, it’s not clear what kind inspection should be done.
+Indeed, it’s quite tricky to do such an inspection correctly.
+And so many people don’t bother, or do the check incorrectly, resulting in
+security issues such as `CVE-2007-4559`_.
+
+Since tarfile was first written, it's become more accepted that warnings
+in documentation are not enough.
+Whenever possible, an unsafe operation should be *explicitly requested*;
+potentially dangerous operations should *look* dangerous.
+But, ``TarFile.extractall`` looks benign in a code review.
+
+Tarfile extraction is also exposed via `shutil.unpack_archive`, which allows
+the user to not care about the kind of archive they're dealing with.
+The API is very inviting to extracting archives without prior inspection,
+even though the docs again warn against it.
+
+It has been argued that Python is not wrong -- it behaves exactly as
+documented -- but that's beside the point.
+Let's improve the situation rather than assign/avoid blame.
+Python and its docs are the best place to improve things.
+
+
+Rationale
+=========
+
+How do we improve things?
+Unfortunately, we will need to change the defaults, which implies
+breaking backwards compatibility. `TarFile.extractall()` is what people reach
+for when they need to extract a tarball. Its default behaviour needs to change.
+
+What would be the best behaviour? That depends on the use case.
+So, we'll add several general “policies” to control extraction.
+They are based on *use cases*, and ideally they should have straightforward
+security implications:
+
+- Current behavior: trusting the archive. Suitable e.g. as a building block
+  for libraries that do the check themselves, or extracting an archive you just
+  made yourself.
+- Unpacking a UNIX archive: roughly following GNU ``tar``, e.g. stripping
+  leading ``/`` from filenames.
+- Unpacking a general data archive: the ``shutil.unpack_archive`` use case,
+  where it's not important to preserve details specific to ``tar`` or
+  Unix-like filesystems.
+
+After a deprecation period, the last option -- the most limited
+but most secure one -- will become the default.
+
+Even with better general defaults, users should still verify the archives
+they extract, and perhaps modify some of the metadata.
+Superficially, the following looks like a reasonable way to do this today:
+
+* Call ``TarFile.getmembers()``
+* Verify or modify each member's ``TarInfo``
+* Pass the result to ``extractall``'s ``members``
+
+However, there are some issues with this approach:
+
+- ``TarInfo`` does not officially allow modification. You can modify it, but you
+  can get surprising results since ``TarInfo`` objects are cached/shared.
+- Calling ``getmembers`` can be expensive and it 
+  `requires a seekable archive <https://github.com/python/cpython/issues/45385#issuecomment-1255615199>`__.
+- When verifying members in advance, it may be necessary to track how each
+  member would have changed the filesystem, e.g. how symlinks are being set up.
+  This is hard. We can't expect users to do it.
+
+To solve these issues we'll:
+
+- Provide a supported way to modify ``TarInfo`` when needed,
+  without unnecessary work when not.
+  A ``replace`` method, similar to `dataclass.replace <https://docs.python.org/3/library/dataclasses.html#dataclasses.replace>`_
+  or `namedtuple._replace <https://docs.python.org/3/library/collections.html#collections.somenamedtuple._replace>`_,
+  should do the trick.
+- Provide a “filter” hook in ``extractall``'s loop that can modify or discard
+  members before they are processed.
+- Require that this hook is called just before extracting each member,
+  so it can scan the *current* state of the disk. This will greatly simplify
+  the implementation of policies (both in stdlib and user code),
+  at the cost of not being able to do a precise “dry run”.
+
+The hook API will be very similar to the existing ``filter`` argument
+for ``TarFile.add``.
+We'll also name it ``filter``.
+(In some cases “policy” would be a more fitting name,
+but the API can be used for more than security policies.)
+
+The built-in policies/filters described above will be implemented using the
+public filter API, so they can be used as building blocks or examples.
+
+
+Setting a precedent
+-------------------
+
+If and when other libraries  archive extraction, such as ``zipfile``,
+gain similar functionality, they should mimic the API as much as it's
+reasonable.
+
+To enable this for simple cases, the built-in filters will have string names,
+e.g. users can pass ``filter='data'`` instead of a specific function that deals
+with ``TarInfo`` objects.
+
+The ``shutil.extract_archive()`` function will get a ``filter`` argument,
+which it will pass to ``extractall``.
+
+Adding *functional* API that would work across archive formats is
+out of scope of this PEP.
+
+
+Full disclosure & redistributor info
+------------------------------------
+
+The PEP author works for Red Hat, a redistributor of Python with different
+security needs and support periods than CPython in general.
+Such redistributors may want to carry vendor patches to:
+
+* Allow configuring the defaults system-wide, and
+* Change the default as soon as possible, even in older Python versions.
+
+The proposal makes this easy to do, and it allows users to query
+the settings.
+
+
+Specification
+=============
+
+Modifying and forgetting member metadata
+----------------------------------------
+
+The ``TarInfo`` class will gain a new method, ``replace()``,
+which will work similarly to ``dataclasses.replace``.
+It will return a *deep* copy of the ``TarInfo`` object with attributes
+replaced as specified by keyword-only arguments:
+
+* ``name``
+* ``mtime``
+* ``mode``
+* ``linkname``
+* ``uid``
+* ``gid``
+* ``uname``
+* ``gname``
+
+Any of these, except ``name`` and ``linkname``, will be allowed to be set
+to ``None``.
+When ``extract`` or ``extractall`` encounters such a ``None``, it will not
+set that piece of metadata, leaving it as if the file was created by ``open()``.
+When ``addfile`` encounters such a ``None``, it will raise an error.
+(It could also not store the attribute, if the format allows it,
+but that's a possible future enhancement.)
+
+The documentation will mention why the method is there:
+``TarInfo`` objects retreived from ``TarFile.getmembers()`` are “live”;
+modifiying them directly will affect subsequent unrelated operations.
+
+
+Filters
+-------
+
+``TarFile.extract`` and ``TarFile.extractall`` methods will grow a ``filter``
+parameter, which take a function with the signature::
+
+    filter(member: TarInfo) -> TarInfo|None
+
+When used it will be called on each member as it is extracted,
+and extraction will work with the result.
+On ``None`` the member will be skipped.
+
+The function can also raise an exception.
+This can, depending on ``Tarfile.errorlevel``, abort the extraction or cause
+the member to be skipped.
+
+We will also provide a set of defaults for common use cases.
+In addition to a function, the ``filter`` argument can be one
+of the following strings:
+
+* ``'fully_trusted'``: Current behavior: honor the metadata as is.
+  Should be used if the user trusts the archive completely, or implements their
+  own complex verification.
+* ``'tar'``: Roughly follow defaults of the GNU ``tar`` command
+  (when run as a normal user):
+
+  * Strip leading ``/`` from filenames
+  * Refuse to extract files with a ``..`` component in the filename
+  * Refuse to extract files whose absolute path (after following symlinks)
+    would end up outside the destination.
+    (Note that GNU ``tar`` instead delays creating some links.)
+  * Clear high mode bits (setuid, setgid, sticky) and group/other write bits
+    (``S_IWGRP|S_IWOTH``).
+    (This is an approximation of ``tar``'s default, which limits the mode by
+    the current ``umask`` setting.)
+
+* ``'data'``:  Extract a "data" archive, disallowing common attack vectors
+  but limiting functionality.
+  In particular, many features specific to UNIX-style filesystems (or
+  equivalently, to the ``tar`` archive format) are ignored, making this a good
+  filter for cross-platform archives.
+  In addition to ``tar``:
+
+  * Refuse to extract links (hard or soft) which end up linking to a path
+    outside of the destination.
+    (On systems that don't support links, ``tarfile`` will, in most cases,
+    fall back to creating regular files.
+    This proposal doesn't change that behaviour.)
+  * Refuse to extract device files (incl. pipes)
+  * For regular files and hard links:
+
+    * Set the owner read and write permissions (``S_IRUSR|S_IWUSR``).
+      (By now only the *executable* bits depend on information in the archive.)
+    * Remove the group & other *executable* permission (``S_IXGRP|S_IXOTH``)
+      if the user doesn't have it (``S_IXUSR``).
+
+  * For other files (directories), ignore mode entirely (set it to ``None``).
+  * Ignore user and group info (set ``uid``, ``gid``, ``uname``, ``gname``
+    to ``None``).
+
+* ``'legacy_warning'``: Like ``'fully_trusted'``, but emit a 
+  ``DeprecationWarning`` for each member that would be changed or removed under
+  ``'data'``.
+
+The corresponding filter functions will be available as
+``tarfile.fully_trusted_filter()``, ``tarfile.tar_filter()``, etc., so
+they can be easily used in custom policies.
+
+FilterError
+-----------
+
+A new exception, ``FilterError``, will be added.
+It'll have several new subclasses: one for each of the refusal reasons above.
+``FilterError``'s ``member`` attribute will contain the relevant ``TarInfo``.
+
+In the lists above, “refusing" to extract a file means that a ``FilterError``
+will be raised.
+As with other extraction errors, if the ``TarFile.errorlevel`` is 1 or more,
+this will abort the extraction; with ``errorlevel=0`` the error will be
+logged and the member will be ignored, but extraction will continue.
+Note that ``extractall()`` may leave the archive partially extracted;
+it is the user's responsibility to clean up.
+
+
+Defaults and their Configuration
+--------------------------------
+
+``TarFile`` will get a new class member ``extraction_filter``, with the
+default filter.
+This will be ``tarfile.legacy_warning_filter`` in Python 3.12 and 3.14,
+and ``tarfile.data_filter`` from Python 3.14 on.
+
+Applications and system integrators may wish to change ``extraction_filter``
+to suit their requirements.
+Users may also assign the ``extraction_filter`` attribute of an individual
+``TarFile`` instance to specify the default filter.
+Note that the attribute should be set to a filter function, not a string name.
+
+.. note::
+
+  Allowing string would encourage code like
+  ``my_tarfile.extraction_filter = 'data'``,
+  On Python versions without this feature, this would do nothing,
+  silently ignoring a security-related request.
+
+
+Hints for further verification
+------------------------------
+
+Even with the proposed changes, `tarfile` will not be suited for extracting
+untrusted file without prior inspection.
+Among other issues, the proposed policies don't prevent denial-of-service
+attacks.
+Users should do additional checks.
+
+New docs will tell users to consider:
+
+* extracting to a new empty directory,
+* checking filenames against an allow-list of characters (to filter out control
+  characters, confusables, etc.),
+* checking that filenames have expected extensions (discouraging files that
+  execute when you “click on them”, or extension-less files like Windows
+  special device names),
+* limiting the total size of extracted data, size of individual files,
+  and number of files,
+* checking for files that would be shadowed on case-insensitive filesystems.
+
+Also, the docs will note that:
+
+* tar files commonly contain multiple versions of the same file: later ones are
+  expected to overwrite earlier ones on extraction,
+* tarfile does not protect against issues with “live” data, e.g. an attacker
+  tinkering with the destination directory while extraction (or adding) is
+  going on (see the `GNU tar manual <https://www.gnu.org/software/tar/manual/html_node/Live-untrusted-data.html#Live-untrusted-data>`__
+  for more info).
+
+This list is not comprehensive, but the documentation is a good place to
+collect such general tips.
+It can be moved into a separate document if grows too long or if it needs to
+be consolidated with ``zipfile`` or ``shutil`` (which is out of scope for
+this proposal).
+
+
+Other archive libraries
+-----------------------
+
+This PEP is meant to set a precedent.
+
+If and when other archive libraries, such as ``zipfile``, grow similar
+functionality, their extraction functions should use a ``filter`` argument
+that takes, at least, the strings ``'fully_trusted'`` and ``'data'``, with
+semantics similar to the ones in ``tarfile``.
+
+Standardizing a *functional* filter API is out of scope of this PEP.
+
+
+Shutil
+------
+
+``shutil.unpack_archive`` will gain a ``filter`` argument.
+If it's given, it will be passed to the underlying extraction function.
+Passing it for a ``zip`` archive will fail for now (until ``zipfile`` gains a
+``filter`` argument).
+
+If ``filter`` is not specified (or left as ``None``), it won't be passed
+on, so extracting a tarball will use the default filter
+(``'legacy_warning'`` for a deprecation period, then ``'data'``).
+
+
+Backwards Compatibility
+=======================
+
+The proposal follows Python's :pep:`backwards compatibility policy <387>`,
+using the shortest allowed deprecation period (2 years) for the
+incompatible change.
+
+
+Backporting & Forward Compatibility
+===================================
+
+This feature may be backported to older versions of Python.
+
+In CPython, we don't add adding warnings to patch releases, so the default
+filter should be changed to ``'fully_trusted'`` in backports.
+
+Other than that, *all* of the changes to ``tarfile`` should be backported, so
+``hasattr(tarfile, 'data_filter')`` becomes a reliable check for all
+of the new functionality.
+
+Note that CPython's usual policy is to avoid adding new API in security
+backports.
+This feature does not make sense without new API
+(``TarFile.extraction_filter`` and the ``filter`` argument),
+so we'll make an exception.
+(See `Discourse comment 23149/16 <https://discuss.python.org/t/23149/16?u=encukou>`__
+for details.)
+
+Here are examples of code that takes into account that ``tarfile`` may or may
+not not have the proposed feature.
+
+When copying these snippets, note that setting ``extraction_filter``,
+will affect subsequent operations.
+
+* Fully trusted archive::
+
+    my_tarfile.extraction_filter = (lambda member: member)
+    my_tarfile.extractall()
+
+* Use the ``'data'`` filter if available, but revert to Python 3.11 behavior
+  (``'fully_trusted'``) if this feature is not available::
+
+    my_tarfile.extraction_filter = getattr(tarfile, 'data_filter', lambda x: x)
+    my_tarfile.extractall()
+
+  (This is an unsafe operation, so it should be spelled out explicitly,
+  ideally with a comment.)
+
+* Use the ``'data'`` filter, *fail* if it is not available::
+
+    my_tarfile.extractall(filter=tarfile.data_filter)
+
+  or::
+
+    my_tarfile.extraction_filter = tarfile.data_filter
+    my_tarfile.extractall()
+
+* Use the ``'data'`` filter, *warn* if it is not available::
+
+   if hasattr(tarfile, 'data_filter'):
+       my_tarfile.extractall(filter='data')
+   else:
+       # remove this when no longer needed
+       warn('Extracting may be unsafe, consider updating Python')
+       my_tarfile.extractall()
+
+
+Security Implications
+=====================
+
+This proposal improves security, at the expense of backwards compatibility.
+In particular, it will help users avoid `CVE-2007-4559`_.
+
+
+How to Teach This
+=================
+
+The API, usage notes and tips for further verification will be added to
+the documentation.
+These should be usable for users that know extracting an archive, but are
+not familiar with the specifics of UNIX filesystems nor the related security
+issues.
+
+
+Reference Implementation
+========================
+
+XXX None yet.
+
+
+Rejected Ideas
+==============
+
+SafeTarFile
+-----------
+
+An initial idea from Lars Gustäbel was to provide a separate class that
+implements security checks (see `gh-65308`_).
+There are two major issues with this approach:
+
+* The name is misleading. General achive operations can never be made “safe”
+  from all kinds of unwanted behavior, without impacting legitimate use cases.
+* It does not solve the problem of unsafe defaults.
+
+However, many of the ideas behind SafeTarFile were reused in this PEP.
+
+Add absolute_path option to tarfile
+-----------------------------------
+
+A minimal change to check the “CVE resolved” box doesn't go far enough to
+protect the unaware, nor to empower the dilligent and curious.
+
+
+Open Issues
+===========
+
+How far should this be backported?
+
+
+Thanks
+======
+
+This proposal is based on prior work and discussions by many people,
+in particular Lars Gustäbel, Gregory P. Smith, Larry Hastings, Joachim Wagner,
+Jan Matejek, Jakub Wilk, Daniel Garcia, Lumír Balhar, Miro Hrončok,
+and many others.
+
+References
+==========
+
+.. _CVE-2007-4559: https://nvd.nist.gov/vuln/detail/CVE-2007-4559
+
+.. _gh-65308: https://github.com/python/cpython/issues/65308
+
+Copyright
+=========
+
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.

--- a/pep-0706.rst
+++ b/pep-0706.rst
@@ -56,7 +56,7 @@ Whenever possible, an unsafe operation should be *explicitly requested*;
 potentially dangerous operations should *look* dangerous.
 But, ``TarFile.extractall`` looks benign in a code review.
 
-Tarfile extraction is also exposed via `shutil.unpack_archive`, which allows
+Tarfile extraction is also exposed via ``shutil.unpack_archive``, which allows
 the user to not care about the kind of archive they're dealing with.
 The API is very inviting to extracting archives without prior inspection,
 even though the docs again warn against it.
@@ -72,7 +72,7 @@ Rationale
 
 How do we improve things?
 Unfortunately, we will need to change the defaults, which implies
-breaking backwards compatibility. `TarFile.extractall()` is what people reach
+breaking backwards compatibility. ``TarFile.extractall()`` is what people reach
 for when they need to extract a tarball. Its default behaviour needs to change.
 
 What would be the best behaviour? That depends on the use case.
@@ -308,7 +308,7 @@ Note that the attribute should be set to a filter function, not a string name.
 Hints for further verification
 ------------------------------
 
-Even with the proposed changes, `tarfile` will not be suited for extracting
+Even with the proposed changes, ``tarfile`` will not be suited for extracting
 untrusted file without prior inspection.
 Among other issues, the proposed policies don't prevent denial-of-service
 attacks.

--- a/pep-0706.rst
+++ b/pep-0706.rst
@@ -1,7 +1,7 @@
 PEP: 706
 Title: Filter for tarfile.extractall
 Author: Petr Viktorin <encukou@gmail.com>
-Discussions-To: 
+Discussions-To:
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
@@ -35,7 +35,7 @@ needs. For example:
   details like file permissions, symlinks to system configuration, and various
   kinds of special files.
 - When unpacking a data bundle, it’s much more important that the unpacking
-  will not have unintended consequences – like exposing password file by
+  will not have unintended consequences – like exposing a password file by
   symlinking it to a public place.
 
 To support all its use cases, the ``tar`` format has many features.
@@ -45,20 +45,20 @@ an archive.
 Python allows extracting ``tar`` archives using
 ``tarfile.TarFile.extractall()``, whose docs warn to
 *never extract archives from untrusted sources without prior inspection*.
-However, it’s not clear what kind inspection should be done.
+However, it’s not clear what kind of inspection should be done.
 Indeed, it’s quite tricky to do such an inspection correctly.
-And so many people don’t bother, or do the check incorrectly, resulting in
+As a result, many people don’t bother, or do the check incorrectly, resulting in
 security issues such as `CVE-2007-4559`_.
 
-Since tarfile was first written, it's become more accepted that warnings
+Since :mod:`tarfile` was first written, it's become more accepted that warnings
 in documentation are not enough.
 Whenever possible, an unsafe operation should be *explicitly requested*;
 potentially dangerous operations should *look* dangerous.
-But, ``TarFile.extractall`` looks benign in a code review.
+However, ``TarFile.extractall`` looks benign in a code review.
 
 Tarfile extraction is also exposed via ``shutil.unpack_archive``, which allows
 the user to not care about the kind of archive they're dealing with.
-The API is very inviting to extracting archives without prior inspection,
+The API is very inviting for extracting archives without prior inspection,
 even though the docs again warn against it.
 
 It has been argued that Python is not wrong -- it behaves exactly as
@@ -114,8 +114,8 @@ To solve these issues we'll:
 
 - Provide a supported way to modify ``TarInfo`` when needed,
   without unnecessary work when not.
-  A ``replace`` method, similar to `dataclass.replace <https://docs.python.org/3/library/dataclasses.html#dataclasses.replace>`_
-  or `namedtuple._replace <https://docs.python.org/3/library/collections.html#collections.somenamedtuple._replace>`_,
+  A ``replace`` method, similar to :func:`dataclasses.replace`
+  or :func:`namedtuple._replace <collections.namedtuple._replace>`
   should do the trick.
 - Provide a “filter” hook in ``extractall``'s loop that can modify or discard
   members before they are processed.
@@ -125,7 +125,7 @@ To solve these issues we'll:
   at the cost of not being able to do a precise “dry run”.
 
 The hook API will be very similar to the existing ``filter`` argument
-for ``TarFile.add``.
+for :meth:`tarfile.TarFile.add`.
 We'll also name it ``filter``.
 (In some cases “policy” would be a more fitting name,
 but the API can be used for more than security policies.)
@@ -137,18 +137,18 @@ public filter API, so they can be used as building blocks or examples.
 Setting a precedent
 -------------------
 
-If and when other libraries  archive extraction, such as ``zipfile``,
-gain similar functionality, they should mimic the API as much as it's
+If and when other libraries for archive extraction, such as ``zipfile``,
+gain similar functionality, they should mimic this API as much as it's
 reasonable.
 
-To enable this for simple cases, the built-in filters will have string names,
+To enable this for simple cases, the built-in filters will have string names;
 e.g. users can pass ``filter='data'`` instead of a specific function that deals
 with ``TarInfo`` objects.
 
 The ``shutil.extract_archive()`` function will get a ``filter`` argument,
 which it will pass to ``extractall``.
 
-Adding *functional* API that would work across archive formats is
+Adding function-based API that would work across archive formats is
 out of scope of this PEP.
 
 
@@ -195,21 +195,21 @@ When ``addfile`` encounters such a ``None``, it will raise an error.
 but that's a possible future enhancement.)
 
 The documentation will mention why the method is there:
-``TarInfo`` objects retreived from ``TarFile.getmembers()`` are “live”;
-modifiying them directly will affect subsequent unrelated operations.
+``TarInfo`` objects retrieved from ``TarFile.getmembers()`` are “live”;
+modifying them directly will affect subsequent unrelated operations.
 
 
 Filters
 -------
 
 ``TarFile.extract`` and ``TarFile.extractall`` methods will grow a ``filter``
-parameter, which take a function with the signature::
+parameter, which takes a function with the signature::
 
     filter(member: TarInfo) -> TarInfo|None
 
 When used it will be called on each member as it is extracted,
 and extraction will work with the result.
-On ``None`` the member will be skipped.
+If it returns ``None``, the member will be skipped.
 
 The function can also raise an exception.
 This can, depending on ``Tarfile.errorlevel``, abort the extraction or cause
@@ -247,7 +247,7 @@ of the following strings:
     (On systems that don't support links, ``tarfile`` will, in most cases,
     fall back to creating regular files.
     This proposal doesn't change that behaviour.)
-  * Refuse to extract device files (incl. pipes)
+  * Refuse to extract device files (including pipes).
   * For regular files and hard links:
 
     * Set the owner read and write permissions (``S_IRUSR|S_IWUSR``).
@@ -271,7 +271,7 @@ FilterError
 -----------
 
 A new exception, ``FilterError``, will be added.
-It'll have several new subclasses: one for each of the refusal reasons above.
+It'll have several new subclasses, one for each of the refusal reasons above.
 ``FilterError``'s ``member`` attribute will contain the relevant ``TarInfo``.
 
 In the lists above, “refusing" to extract a file means that a ``FilterError``
@@ -283,12 +283,12 @@ Note that ``extractall()`` may leave the archive partially extracted;
 it is the user's responsibility to clean up.
 
 
-Defaults and their Configuration
+Defaults and their configuration
 --------------------------------
 
 ``TarFile`` will get a new class member ``extraction_filter``, with the
 default filter.
-This will be ``tarfile.legacy_warning_filter`` in Python 3.12 and 3.14,
+This will be ``tarfile.legacy_warning_filter`` in Python 3.12 and 3.13,
 and ``tarfile.data_filter`` from Python 3.14 on.
 
 Applications and system integrators may wish to change ``extraction_filter``
@@ -299,8 +299,8 @@ Note that the attribute should be set to a filter function, not a string name.
 
 .. note::
 
-  Allowing string would encourage code like
-  ``my_tarfile.extraction_filter = 'data'``,
+  Allowing strings would encourage code like
+  ``my_tarfile.extraction_filter = 'data'``.
   On Python versions without this feature, this would do nothing,
   silently ignoring a security-related request.
 
@@ -309,7 +309,7 @@ Hints for further verification
 ------------------------------
 
 Even with the proposed changes, ``tarfile`` will not be suited for extracting
-untrusted file without prior inspection.
+untrusted files without prior inspection.
 Among other issues, the proposed policies don't prevent denial-of-service
 attacks.
 Users should do additional checks.
@@ -330,8 +330,8 @@ Also, the docs will note that:
 
 * tar files commonly contain multiple versions of the same file: later ones are
   expected to overwrite earlier ones on extraction,
-* tarfile does not protect against issues with “live” data, e.g. an attacker
-  tinkering with the destination directory while extraction (or adding) is
+* ``tarfile`` does not protect against issues with “live” data, e.g. an attacker
+  tinkering with the destination directory while extracting (or adding) is
   going on (see the `GNU tar manual <https://www.gnu.org/software/tar/manual/html_node/Live-untrusted-data.html#Live-untrusted-data>`__
   for more info).
 
@@ -352,7 +352,7 @@ functionality, their extraction functions should use a ``filter`` argument
 that takes, at least, the strings ``'fully_trusted'`` and ``'data'``, with
 semantics similar to the ones in ``tarfile``.
 
-Standardizing a *functional* filter API is out of scope of this PEP.
+Standardizing a function-based filter API is out of scope of this PEP.
 
 
 Shutil
@@ -372,7 +372,7 @@ Backwards Compatibility
 =======================
 
 The proposal follows Python's :pep:`backwards compatibility policy <387>`,
-using the shortest allowed deprecation period (2 years) for the
+using the shortest allowed deprecation period (two years) for the
 incompatible change.
 
 
@@ -381,25 +381,25 @@ Backporting & Forward Compatibility
 
 This feature may be backported to older versions of Python.
 
-In CPython, we don't add adding warnings to patch releases, so the default
+In CPython, we don't add warnings to patch releases, so the default
 filter should be changed to ``'fully_trusted'`` in backports.
 
 Other than that, *all* of the changes to ``tarfile`` should be backported, so
 ``hasattr(tarfile, 'data_filter')`` becomes a reliable check for all
 of the new functionality.
 
-Note that CPython's usual policy is to avoid adding new API in security
+Note that CPython's usual policy is to avoid adding new APIs in security
 backports.
-This feature does not make sense without new API
+This feature does not make sense without a new API
 (``TarFile.extraction_filter`` and the ``filter`` argument),
 so we'll make an exception.
-(See `Discourse comment 23149/16 <https://discuss.python.org/t/23149/16?u=encukou>`__
+(See `Discourse comment 23149/16 <https://discuss.python.org/t/23149/16>`__
 for details.)
 
 Here are examples of code that takes into account that ``tarfile`` may or may
 not not have the proposed feature.
 
-When copying these snippets, note that setting ``extraction_filter``,
+When copying these snippets, note that setting ``extraction_filter``
 will affect subsequent operations.
 
 * Fully trusted archive::
@@ -410,13 +410,13 @@ will affect subsequent operations.
 * Use the ``'data'`` filter if available, but revert to Python 3.11 behavior
   (``'fully_trusted'``) if this feature is not available::
 
-    my_tarfile.extraction_filter = getattr(tarfile, 'data_filter', lambda x: x)
+    my_tarfile.extraction_filter = getattr(tarfile, 'data_filter', lambda member: member)
     my_tarfile.extractall()
 
   (This is an unsafe operation, so it should be spelled out explicitly,
   ideally with a comment.)
 
-* Use the ``'data'`` filter, *fail* if it is not available::
+* Use the ``'data'`` filter; *fail* if it is not available::
 
     my_tarfile.extractall(filter=tarfile.data_filter)
 
@@ -425,13 +425,13 @@ will affect subsequent operations.
     my_tarfile.extraction_filter = tarfile.data_filter
     my_tarfile.extractall()
 
-* Use the ``'data'`` filter, *warn* if it is not available::
+* Use the ``'data'`` filter; *warn* if it is not available::
 
    if hasattr(tarfile, 'data_filter'):
        my_tarfile.extractall(filter='data')
    else:
        # remove this when no longer needed
-       warn('Extracting may be unsafe, consider updating Python')
+       warn_the_user('Extracting may be unsafe; consider updating Python')
        my_tarfile.extractall()
 
 
@@ -447,7 +447,7 @@ How to Teach This
 
 The API, usage notes and tips for further verification will be added to
 the documentation.
-These should be usable for users that know extracting an archive, but are
+These should be usable for users who know how to extract an archive, but are
 not familiar with the specifics of UNIX filesystems nor the related security
 issues.
 
@@ -468,7 +468,7 @@ An initial idea from Lars Gustäbel was to provide a separate class that
 implements security checks (see `gh-65308`_).
 There are two major issues with this approach:
 
-* The name is misleading. General achive operations can never be made “safe”
+* The name is misleading. General archive operations can never be made “safe”
   from all kinds of unwanted behavior, without impacting legitimate use cases.
 * It does not solve the problem of unsafe defaults.
 
@@ -478,7 +478,7 @@ Add absolute_path option to tarfile
 -----------------------------------
 
 A minimal change to check the “CVE resolved” box doesn't go far enough to
-protect the unaware, nor to empower the dilligent and curious.
+protect the unaware, nor to empower the diligent and curious.
 
 
 Open Issues


### PR DESCRIPTION
This doesn't really need to be a PEP, but, not being the tarfile expert, I wrote it as part of my research. And it might be useful for others.

## Basic requirements (all PEP Types)

* [x] Read and followed [PEP 1](https://peps.python.org/1) & [PEP 12](https://peps.python.org/12)
* [x] File created from the [latest PEP template](https://github.com/python/peps/blob/main/pep-0012/pep-NNNN.rst?plain=1)
* [x] PEP has next available number, & set in filename (``pep-NNNN.rst``), PR title (``PEP 123: <Title of PEP>``) and ``PEP`` header
* [x] Title clearly, accurately and concisely describes the content in 79 characters or less
* [x] ``PEP``, ``Title``, ``Author``, ``Status`` (``Draft``), ``Type`` and ``Created`` headers filled out correctly
* [x] ``PEP-Delegate``, ``Topic``, ``Requires`` and ``Replaces`` headers completed if appropriate
* [x] Core dev/PEP editor listed as author or sponsor, and formally confirmed their approval
* [x] Required sections included
    * [x] Abstract (first section)
    * [x] Copyright (last section; exact wording from template required)
* [x] Code is well-formatted (PEP 7/PEP 8) and is in [code blocks, with the right lexer names](https://peps.python.org/pep-0012/#literal-blocks) if non-Python
* [x] PEP builds with no warnings, pre-commit checks pass and content displays as intended in the rendered HTML
* [x] Authors/sponsor added to ``.github/CODEOWNERS`` for the PEP


## Standards Track requirements

* [x] PEP topic [discussed in a suitable venue](https://peps.python.org/pep-0001/#start-with-an-idea-for-python) with general agreement that a PEP is appropriate
* [x] [Suggested sections](https://peps.python.org/pep-0012/#suggested-sections) included (unless not applicable)
    * [x] Motivation
    * [x] Rationale
    * [x] Specification
    * [x] Backwards Compatibility
    * [x] Security Implications
    * [x] How to Teach This
    * [x] Reference Implementation
    * [x] Rejected Ideas
    * [x] Open Issues
* [x] ``Python-Version`` set to valid (pre-beta) future Python version
* [n/a] Any project stated in the PEP as supporting/endorsing/benefiting from it confirms such
* [ ] Right before or after initial merging, [PEP discussion thread](https://peps.python.org/pep-0001/#discussing-a-pep) created and linked to in ``Discussions-To`` and ``Post-History``
