### PR TITLE
PEP 649: Change default args from Overview example

### DIFF
--- a/pep-0649.rst
+++ b/pep-0649.rst
@@ -108,7 +108,7 @@ code actually works something like this:
 .. code-block::
 
     annotations = {'x': int, 'y': MyType, 'return': float}
-    def foo(x = 3, y = "abc"):
+    def foo(x = 3, y = None):
         ...
     foo.__annotations__ = annotations
     class MyType:
@@ -128,7 +128,7 @@ The equivalent runtime code would look something like this:
 .. code-block::
 
     annotations = {'x': 'int', 'y': 'MyType', 'return': 'float'}
-    def foo(x = 3, y = "abc"):
+    def foo(x = 3, y = None):
         ...
     foo.__annotations__ = annotations
     class MyType:
@@ -160,7 +160,7 @@ like this:
 
     def foo_annotations_fn():
         return {'x': int, 'y': MyType, 'return': float}
-    def foo(x = 3, y = "abc"):
+    def foo(x = 3, y = None):
         ...
     foo.__co_annotations__ = foo_annotations_fn
     class MyType:


### PR DESCRIPTION
This is not a huge/important change. While reading the PEP I noticed that the example starts with y having a None value as the default argument:

https://github.com/python/peps/blob/65a56a21427591e8ceaf61caa87fbb5af420a489/pep-0649.rst?plain=1#L91

But then it changes to an `"abc"` str as we go deep into the example:

https://github.com/python/peps/blob/65a56a21427591e8ceaf61caa87fbb5af420a489/pep-0649.rst?plain=1#L111

**I** think we should keep the same `None` value as the default argument in the following examples to reduce confusion to the reader unless that change in the default argument value is expected.