### PR TITLE
PEP 566: Fix keywords delimiter in JSON conversion

### DIFF
--- a/pep-0566.rst
+++ b/pep-0566.rst
@@ -137,7 +137,7 @@ as follows:
 #. The transformed value for any field marked with "(Multiple-use") should be a
    single list containing all the original values for the given key;
 #. The ``Keywords`` field should be converted to a list by splitting the
-   original value on whitespace characters;
+   original value on commas;
 #. The message body, if present, should be set to the value of the
    ``description`` key.
 #. The result should be stored as a string-keyed dictionary.


### PR DESCRIPTION
This PR updates the spec to better match reality rather than attempting to do the opposite.

Ref: https://packaging.python.org/en/latest/specifications/core-metadata/#keywords
Ref: https://github.com/pypa/packaging/issues/570#issuecomment-1186093995