### PR TITLE
PEP 708: Extending the Repository API to Mitigate Dependency Confusion Attacks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -587,6 +587,7 @@ pep-0703.rst  @ambv
 pep-0704.rst  @brettcannon @pradyunsg
 # pep-0705.rst
 pep-0706.rst  @encukou
+pep-0708.rst  @dstufft
 # ...
 # pep-0754.txt
 # ...

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -114,7 +114,7 @@ This would give us something like:
 
     {
       "meta": {
-        "api-version": "1.0",
+        "api-version": "1.2",
         "tracks": "https://pypi.org/simple/holygrail/"
       },
       "name": "holygrail",
@@ -143,7 +143,7 @@ or
     <!DOCTYPE html>
     <html>
       <head>
-        <meta name="pypi:repository-version" content="1.0">
+        <meta name="pypi:repository-version" content="1.2">
         <meta name="pypi:tracks" content="https://pypi.org/simple/holygrail/">
       </head>
       <body>
@@ -233,7 +233,7 @@ This would give us something like:
 
     {
       "meta": {
-        "api-version": "1.0"
+        "api-version": "1.2"
       },
       "name": "holygrail",
       "alternate-locations": ["https://pypi.org/simple/holygrail/", "https://test.pypi.org/simple/holygrail/"],
@@ -262,7 +262,7 @@ or
     <!DOCTYPE html>
     <html>
       <head>
-        <meta name="pypi:repository-version" content="1.0">
+        <meta name="pypi:repository-version" content="1.2">
         <meta name="pypi:alternate-locations" content="https://pypi.org/simple/holygrail/">
         <meta name="pypi:alternate-locations" content="https://test.pypi.org/simple/holygrail/">
       </head>

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -627,7 +627,7 @@ This idea has been rejected because:
 
 
 Only recommend that installers offer explicit configuration
-------------------------------------------------------
+-----------------------------------------------------------
 
 One idea that has come up is to essentially just implement the explicit
 configuration and don't make any other changes to anything else. The specific

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -196,7 +196,7 @@ the projects from disparate repositories.
 
 
 JSON
-++++
+~~~~
 
 .. code-block:: JSON
 
@@ -226,7 +226,7 @@ JSON
 
 
 HTML
-++++
+~~~~
 
 .. code-block:: HTML
 
@@ -273,7 +273,7 @@ same namespace across multiple repositories.
 
 
 JSON
-++++
+~~~~
 
 .. code-block:: JSON
 
@@ -303,7 +303,7 @@ JSON
 
 
 HTML
-++++
+~~~~
 
 .. code-block:: HTML
 

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -14,7 +14,7 @@ Abstract
 ========
 
 Dependency confusion attacks, in which a malicious package is installed instead
-of the one the user expected, are an `increasingly common supply chain threat 
+of the one the user expected, are an `increasingly common supply chain threat
 <https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610>`__.
 Most such attacks against Python dependencies, including the
 `recent PyTorch incident <https://pytorch.org/blog/compromised-nightly-dependency/>`_,
@@ -27,9 +27,10 @@ to allow repository operators to indicate that a project found on their
 repository "tracks" a project on a different repository, and allows projects to
 extend their namespaces across multiple repositories.
 
-These features will allow installers to determine when a project being made available
-from a particular mix of repositories is expected and should be allowed,
-and when it is not and should halt the install with an error to protect the user.
+These features will allow installers to determine when a project being made
+available from a particular mix of repositories is expected and should be
+allowed, and when it is not and should halt the install with an error to protect
+the user.
 
 
 Motivation
@@ -90,8 +91,9 @@ project naturally spans multiple distinct namespaces, while maintaining the
 ability for an installer to be secure by default.
 
 On its own, this PEP does not solve dependency confusion attacks, but what it
-does do is provide enough information so that installers can prevent them without
-causing too much collateral damage to otherwise valid and safe use cases.
+does do is provide enough information so that installers can prevent them
+without causing too much collateral damage to otherwise valid and safe use
+cases.
 
 
 Rationale
@@ -781,8 +783,8 @@ Only recommend that installers offer explicit configuration
 
 One idea that has come up is to essentially just implement the explicit
 configuration and don't make any other changes to anything else. The specific
-proposal for a mapping policy is what actually inspired the explicit configuration
-option, and created a file that looked something like:
+proposal for a mapping policy is what actually inspired the explicit
+configuration option, and created a file that looked something like:
 
 .. code-block:: JSON
 

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -46,7 +46,7 @@ likely to remain vulnerable, even if they are ultimately aware of these types of
 attacks.
 
 Ultimately the underlying cause of these attacks come from the fact that there
-is no globally unique namespace that all Python package names come from. instead,
+is no globally unique namespace that all Python package names come from. Instead,
 each repository is its own distinct namespace, and when given an "abstract" name
 such as ``spam`` to install, an installer has to implicitly turn that into a
 "concrete" name such as ``pypi.org:spam`` or ``example.com:spam``. Currently

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -7,6 +7,7 @@ Type: Standards Track
 Topic: Packaging
 Content-Type: text/x-rst
 Created: 20-Feb-2023
+Post-History: `01-Feb-2023 <https://discuss.python.org/t/proposal-preventing-dependency-confusion-attacks-with-the-map-file/23414/>`__,
 
 
 Abstract
@@ -17,7 +18,7 @@ attacks, which roughly boil down to an individual user expected to get package
 ``A``, but instead they got ``B``. In Python, this almost always happens due to
 the configuration of multiple repositories (possibly including the default of
 PyPI), where they expected package ``A`` to come from repository ``X``, but
-someone is able to publish to repository ``Y`` under the same name.
+someone is able to publish package ``B`` to repository ``Y`` under the same name.
 
 A specific example of this is the recent case where the PyTorch project had an
 internal project named ``torchtriton`` which was only ever intended to be
@@ -26,14 +27,15 @@ but that repository was designed to be used in conjunction with PyPI, and
 the name of ``torchtriton`` was not claimed on PyPI, which allowed the attacker
 to use that name and publish a malicious version.
 
-This PEP proposes an extension to the Repository API that would enable
+This PEP proposes an extension to the :ref:`Simple Repository API
+<packaging:simple-repository-api>` that would enable
 installers to determine when it is safe to install a given package that appears
 in multiple repositories, allowing them to be stricter in the cases where they
 do not know if it is safe.
 
 
-Rationale
-=========
+Motivation
+===========
 
 Dependency Confusion attacks have long been possible, but they've recently
 gained press with public examples of cases where these attacks were successfully
@@ -60,8 +62,9 @@ confusion attacks become possible.
 
 What makes this particularly tricky is two competing things:
 
-1. Collapsing the namespaces is exactly the behavior that you want at times, for
-   instance the Piwheels project which does not manage a namespace of its own,
+1. Collapsing the namespaces is exactly the behavior that you want at times;
+   for instance, the `Piwheels project <https://www.piwheels.org/>`_
+   does not manage a namespace of its own,
    but rather exists to supplment the namespace from PyPI with additional files.
 2. Not collapsing the namespaces is the behavior that you want for instances
    like ``torchtriton`` where the name on PyPI and the name on PyTorch's

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -1,4 +1,4 @@
-PEP: 9999
+PEP: 708
 Title: Preventing Dependency Confusion Attacks
 Author: Donald Stufft <donald@stufft.io>
 PEP-Delegate: Paul Moore <p.f.moore@gmail.com>

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -697,7 +697,8 @@ completely control their own destiny.
 Scopes à la npm
 ---------------
 
-There's been some suggestion that scopes similar to how npm has implemented them
+There's been some suggestion that
+`scopes similar to how npm has implemented them <https://docs.npmjs.com/cli/v9/using-npm/scope>`__
 may ultimately solve this. Ultimately scopes do not change anything about this
 problem. As far as I know scopes in npm are not globally unique, they're tied to
 a specific registry just like unscoped names are. However what scopes do enable

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -56,11 +56,12 @@ Currently the standard behavior in Python installation tools is to implicitly
 flatten these multiple namespaces into one that contains the files from all
 namespaces.
 
-This assumption that collapsing the namespaces is what was expected, means that
-when the different names in different repositories are not the same (such as in
-the ``torchtriton`` case) dependency confusion attacks become possible.
+This assumption that collapsing the namespaces is what was expected means that
+when packages with the same name in different repositories
+are authored by different parties (such as in the ``torchtriton`` case)
+dependency confusion attacks become possible.
 
-This is made particularly tricky in that there is no "right" answer, there are
+This is made particularly tricky in that there is no "right" answer; there are
 valid use cases both for wanting two repositories merged into one namespace
 *and* for wanting two repositories to be treated as distinct namespaces. This
 means that an installer needs some mechanism by which to determine when it
@@ -75,8 +76,8 @@ projects and repositories to "work by default", even when their
 project naturally spans multiple distinct namespaces, while maintaining the
 ability for an installer to be secure by default.
 
-On its' own, this PEP does not solve dependency confusion attacks, but what it
-does do, is provide enough information that installers can prevent them without
+On its own, this PEP does not solve dependency confusion attacks, but what it
+does do is provide enough information so that installers can prevent them without
 causing too much collateral damage to otherwise valid and safe use cases.
 
 
@@ -86,7 +87,7 @@ Rationale
 There are two broad use cases for merging names across repositories that this
 PEP seeks to enable.
 
-The first use case is when one repository is not defining it's own names, but
+The first use case is when one repository is not defining its own names, but
 rather is extending names defined in another repository. This commonly happens
 in cases where a project is being mirrored from one repository to another (see
 `Bandersnatch <https://pypi.org/project/bandersnatch/>`__) or when a repository
@@ -125,8 +126,8 @@ one isn't a dependency confusion attack.
 Without some way for the installer to validate the metadata between multiple
 repositories, projects would be forced into becoming repository operators to
 safely support this use case. That wouldn't be a particularly wrong choice to
-make, however there is a danger that if we don't provide a way for repositories
-to let project owners express this relationship safely that they will be
+make; however, there is a danger that if we don't provide a way for repositories
+to let project owners express this relationship safely, they will be
 incentivized to let them use the repository operator's metadata instead which
 would reintroduce the original insecurity.
 
@@ -618,10 +619,11 @@ That is true in that it does improve things, but it has many of the same
 problems as the general ordering idea (though not all of them).
 
 It also assumes that PyPI, or whatever repository is configured as the
-"default", is the only repository with open registration of names but projects
-like `Piwheels <https://www.piwheels.org/>`__ exist where users are expected to
-use it in addition to PyPI while it also effectively has open registration of
-names since it tracks whatever names are registered on PyPI.
+"default", is the only repository with open registration of names.
+However, projects like `Piwheels <https://www.piwheels.org/>`_ exist
+which users are expected to use in addition to PyPI,
+which also effectively have open registration of names
+since it tracks whatever names are registered on PyPI.
 
 
 Rely on repository proxies
@@ -832,7 +834,7 @@ do just that.
 Open Questions
 ==============
 
-1. The `original proposal document <https://docs.google.com/document/d/184fQkb6NggVQfYmjTDA7p_U3iWDKk6grc2DigT1X3Es/>`__
+*  The `original proposal document <https://docs.google.com/document/d/184fQkb6NggVQfYmjTDA7p_U3iWDKk6grc2DigT1X3Es/>`__
    was targeted more specifically to a change to pip, and went into more
    specific details as to what we expected from pip. Since dictating UX to
    installers isn't something that we do in PEPs, I've rewritten those parts to

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -13,10 +13,23 @@ Post-History: `01-Feb-2023 <https://discuss.python.org/t/proposal-preventing-dep
 Abstract
 ========
 
-This PEP proposes extending the :ref:`Simple Repository API <packaging:simple-repository-api>`
+Dependency confusion attacks, in which a malicious package is installed instead
+of the one the user expected, are an `increasingly common supply chain threat 
+<https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610>`__.
+Most such attacks against Python dependencies, including the
+`recent PyTorch incident <https://pytorch.org/blog/compromised-nightly-dependency/>`_,
+occur with multiple package repositories, where a dependency expected to come
+from one repository (e.g. a custom index) is installed from another (e.g. PyPI).
+
+To help address this problem, this PEP proposes extending the
+:ref:`Simple Repository API <packaging:simple-repository-api>`
 to allow repository operators to indicate that a project found on their
-repository "tracks" a project on a different repository and allows projects to
-extend their namespace in one repository across multiple repositories.
+repository "tracks" a project on a different repository, and allows projects to
+extend their namespaces across multiple repositories.
+
+These features will allow installers to determine when a project being made available
+from a particular mix of repositories is expected and should be allowed,
+and when it is not and should halt the install with an error to protect the user.
 
 
 Motivation

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -66,7 +66,7 @@ What makes this particularly tricky is two competing things:
    for instance, the `Piwheels project <https://www.piwheels.org/>`_
    does not manage a namespace of its own,
    but rather exists to supplement the namespace from PyPI with additional files.
-2. Not collapsing the namespaces is the behavior that you want, for instances
+2. Not collapsing the namespaces is the behavior that you want for instances
    like ``torchtriton`` where the name on PyPI and the name on PyTorch's
    repositories were fundamentally different things.
 

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -425,6 +425,138 @@ during what is likely to be a long transition until the default behavior is
 safe.
 
 
+How to Communicate This
+=======================
+
+.. note::
+
+  This example is pip specific and assumes specifics about how pip will
+  choose to implement this PEP; it's included as an example of how we can
+  communicate this change, and not intended to constrain pip or any other
+  installer in how they implement this. This may ultimately be the actual basis
+  for communication, and if so will need be edited for accuracy and clarity.
+
+  This section should be read as if it were an entire "post" to communicate this
+  change that could be used for a blog post, email, or discourse post.
+
+There's a long-standing class of attacks that are called "dependency confusion"
+attacks, which roughly boil down to an individual expected to get package ``A``,
+but instead they got ``B``. In Python, this almost always happens due to the end
+user having configured multiple repositories, where they expect package ``A`` to
+come from repository ``X``, but someone is able to publish package ``B`` with
+the same name as package ``A`` in repository ``Y``.
+
+There are a number of ways to mitigate against these attacks today, but they all
+require that the end user explicitly go out of their way to protect themselves,
+rather than it being inherently safe.
+
+In an effort to secure pip's users and protect them from these types of attacks,
+we will be changing how pip discovers packages to install.
+
+
+What is Changing?
+-----------------
+
+When pip discovers that the same project is available from multiple remote
+repositories, by default it will generate an error and refuse to proceed rather
+than make a guess about which repository was the correct one to install from.
+
+Projects that natively publish to multiple repositories will be given the
+ability to safely "link" their repositories together so that pip does not error
+when those repositories are used together.
+
+End users of pip will be given the ability to explicitly define one or more
+repositories that are valid for a specific project, causing pip to only consider
+those repositories for that project, and avoiding generating an error
+altogether.
+
+See TBD for more information.
+
+
+Who is Affected?
+----------------
+
+Users who are installing from multiple remote (e.g. not present on the local
+filesystem) repositories may be affected by having pip error instead of
+successfully install if:
+
+- They install a project where the same "name" is being served by multiple
+  remote repositories.
+- The project name that is available from multiple remote repositories has not
+  used one of the defined mechanisms to link those repositories together.
+- The user invoking pip has not used the defined mechanism to explicitly control
+  what repositories are valid for a particular project.
+
+Users who are not using multiple remote repositories will not be affected at
+all, which includes users who are only using a single remote repository, plus a
+local filesystem "wheel house".
+
+
+What do I need to do?
+---------------------
+
+As a pip User?
+~~~~~~~~~~~~~~
+
+If you're using only a single remote repository you do not have to do anything.
+
+If you're using multiple remote repositories, you can opt into the new behavior
+by adding ``--use-feature=TBD`` to your pip invocation to see if any of your
+dependencies are being served from multiple remote repositories. If they are,
+you should audit them to determine why they are, and what the best remediation
+step will be for you.
+
+Once this behavior becomes the default, you can opt out of it temporarily by
+adding ``--use-deprecated=TBD`` to your pip invocation.
+
+If you're using projects that are not hosted on a public repository, but you
+still have the public repository as a fallback, consider configuring pip with a
+repository file to be explicit where that dependency is meant to come from to
+prevent registration of that name in a public repository to cause pip to error
+for you.
+
+
+As a Project Owner?
+~~~~~~~~~~~~~~~~~~~
+
+If you only publish your project to a single repository, then you do not have to
+do anything.
+
+If you publish your project to multiple repositories that are intended to be
+used together at the same time, configure all repositories to serve the
+alternate repository metadata to prevent breakages for your end users.
+
+If you publish your project to a single repository, but it is commonly used in
+conjunction with other repositories, consider preemptively registering your
+names with those repositories to prevent a third party from being able to cause
+your users ``pip install`` invocations to start failing. This may not be
+available if your project name is too generic or if the repositories have
+policies that prevent defensive name squatting.
+
+
+As a Repository Operator?
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You'll need to decide how you intend for your repository to be used by your end
+users and how you want them to use it.
+
+For private repositories that host private projects, it is recommended that you
+mirror the public projects that your users depend on into your own repository,
+taking care not to let a public project merge with a private project, and tell
+your users to use the ``--index-url`` option to use only your repository.
+
+For public repositories that host public projects, you should implement the
+alternate repository mechanism and enable the owners of those projects to
+configure the list of repositories that their project is available from if they
+make it available from more than one repository.
+
+For public repositories that "track" another repository, but provide
+supplemental artifacts such as wheels built for a specific platform, you should
+implement the "tracks" metadata for your repository. However, this information
+**MUST NOT** be settable by end users who are publishing projects to your
+repository. See TBD for more information.
+
+
 Rejected Ideas
 ==============
 
@@ -727,136 +859,6 @@ Open Questions
    file looks like so the same file can be given to multiple installers instead
    of hand waving around the specific mechanism installers would use for
    explicit configuration?
-2. Is the Appendix section on communicating the change useful or confusing?
-
-
-Appendix: Communicating the Change
-==================================
-
-*Note: This is pip specific and assumes specifics about how pip will choose to
-implement this PEP; it's included as an example of how we can communicate this
-change out to end users as the ecosystem rolls this change out. The entire
-Appendix should be considered to be a single communication (blog post, discuss
-post, email, whatever).*
-
-
-There's a long-standing class of attacks that are called "dependency confusion"
-attacks, which roughly boil down to an individual expected to get package ``A``,
-but instead they got ``B``. In Python, this almost always happens due to the end
-user having configured multiple repositories, where they expect package ``A`` to
-come from repository ``X``, but someone is able to publish package ``B`` with
-the same name as package ``A`` in repository ``Y``.
-
-There are a number of ways to mitigate against these attacks today, but they all
-require that the end user explicitly go out of their way to protect themselves,
-rather than it being inherently safe.
-
-In an effort to secure pip's users and protect them from these types of attacks,
-we will be changing how pip discovers packages to install.
-
-
-What is Changing?
------------------
-
-When pip discovers that the same project is available from multiple remote
-repositories, by default it will generate an error and refuse to proceed rather
-than make a guess about which repository was the correct one to install from.
-
-Projects that natively publish to multiple repositories will be given the
-ability to safely "link" their repositories together so that pip does not error
-when those repositories are used together.
-
-End users of pip will be given the ability to explicitly define one or more
-repositories that are valid for a specific project, causing pip to only consider
-those repositories for that project, and avoiding generating an error
-altogether.
-
-See TBD for more information.
-
-
-Who is Affected?
-----------------
-
-Users who are installing from multiple remote (e.g. not present on the local
-filesystem) repositories may be affected by having pip error instead of
-successfully install if:
-
-- They install a project where the same "name" is being served by multiple
-  remote repositories.
-- The project name that is available from multiple remote repositories has not
-  used one of the defined mechanisms to link those repositories together.
-- The user invoking pip has not used the defined mechanism to explicitly control
-  what repositories are valid for a particular project.
-
-Users who are not using multiple remote repositories will not be affected at
-all, which includes users who are only using a single remote repository, plus a
-local filesystem "wheel house".
-
-
-What do I need to do?
----------------------
-
-As a pip User?
-~~~~~~~~~~~~~~
-
-If you're using only a single remote repository you do not have to do anything.
-
-If you're using multiple remote repositories, you can opt into the new behavior
-by adding ``--use-feature=TBD`` to your pip invocation to see if any of your
-dependencies are being served from multiple remote repositories. If they are,
-you should audit them to determine why they are, and what the best remediation
-step will be for you.
-
-Once this behavior becomes the default, you can opt out of it temporarily by
-adding ``--use-deprecated=TBD`` to your pip invocation.
-
-If you're using projects that are not hosted on a public repository, but you
-still have the public repository as a fallback, consider configuring pip with a
-repository file to be explicit where that dependency is meant to come from to
-prevent registration of that name in a public repository to cause pip to error
-for you.
-
-
-As a Project Owner?
-~~~~~~~~~~~~~~~~~~~
-
-If you only publish your project to a single repository, then you do not have to
-do anything.
-
-If you publish your project to multiple repositories that are intended to be
-used together at the same time, configure all repositories to serve the
-alternate repository metadata to prevent breakages for your end users.
-
-If you publish your project to a single repository, but it is commonly used in
-conjunction with other repositories, consider preemptively registering your
-names with those repositories to prevent a third party from being able to cause
-your users ``pip install`` invocations to start failing. This may not be
-available if your project name is too generic or if the repositories have
-policies that prevent defensive name squatting.
-
-
-As a Repository Operator?
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You'll need to decide how you intend for your repository to be used by your end
-users and how you want them to use it.
-
-For private repositories that host private projects, it is recommended that you
-mirror the public projects that your users depend on into your own repository,
-taking care not to let a public project merge with a private project, and tell
-your users to use the ``--index-url`` option to use only your repository.
-
-For public repositories that host public projects, you should implement the
-alternate repository mechanism and enable the owners of those projects to
-configure the list of repositories that their project is available from if they
-make it available from more than one repository.
-
-For public repositories that "track" another repository, but provide
-supplemental artifacts such as wheels built for a specific platform, you should
-implement the "tracks" metadata for your repository. However, this information
-**MUST NOT** be settable by end users who are publishing projects to your
-repository. See TBD for more information.
-
 
 Copyright
 =========

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -46,11 +46,11 @@ likely to remain vulnerable, even if they are ultimately aware of these types of
 attacks.
 
 Ultimately the underlying cause of these attacks come from the fact that there
-is no globally unique namespace that all Python package names come from, instead
+is no globally unique namespace that all Python package names come from. instead,
 each repository is its own distinct namespace, and when given an "abstract" name
-such as ``spam`` to install, an installer has implicitly turn that into a
+such as ``spam`` to install, an installer has to implicitly turn that into a
 "concrete" name such as ``pypi.org:spam`` or ``example.com:spam``. Currently
-the standard behavior in Python installation tools, is to implicitly flatten
+the standard behavior in Python installation tools is to implicitly flatten
 these multiple namespaces into one that contains the files from all namespaces.
 
 This implicit assumption that collapsing the namespaces is what was expected,
@@ -60,21 +60,21 @@ confusion attacks become possible.
 What makes this particularly tricky is two competing things:
 
 1. Collapsing the namespaces is exactly the behavior that you want at times, for
-   instance the Piwheels project which does not manage a namespace of it's own,
+   instance the Piwheels project which does not manage a namespace of its own,
    but rather exists to supplment the namespace from PyPI with additional files.
-2. Not collapsing the namespaces is the behavior that you want, for instances
+2. Not collapsing the namespaces is the behavior that you want for instances
    like ``torchtriton`` where the name on PyPI and the name on PyTorch's
    repositories were fundamentally different things.
 
 So an installer needs some mechanism by which to determine when it should
 flatten the namespaces of multiple repositories and when it should not, rather
-than having to either choose between always flattening and never flattening.
+than having to choose between always flattening and never flattening.
 
 This functionaly could be pushed directly into the end user, since ultimately
 the end user is the person whose expectations of what gets installed from what
 repository actually matters. However, by extending the repository specification
 to allow a repository to indicate when it is safe, we can enable individual
-projects and repositories the ability to "work by default", even when their
+projects and repositories to "work by default", even when their
 project naturally spans multiple distinct namespaces, while maintaining the
 ability for an installer to be secure by default.
 
@@ -164,7 +164,7 @@ metadata:
   - This does not mean that it needs to serve the same files. It is valid for it
     to include binaries built on different platforms, copies with local patches
     being applied, etc. This is purposefully left vague as it's ultimately up to
-    the expectations that the users have of the repository and it's operators
+    the expectations that the users have of the repository and its operators
     what exactly constitutes the "same" project.
 
 - It **MUST** point to the repository that "owns" the namespace, not another
@@ -189,11 +189,11 @@ This means that given the users trust the repository operators, then it is safe
 for them to trust the repository operators when they provide information about
 which repositories they are tracking.
 
-It is also not ambiguous what repository a user is referring to, given a
+It is also not ambiguous what repository a user is referring to: given a
 repository like ``https://example.com/``, there is only one owner of example.com
 globally, so there is no ambiguity who the user is intending to trust.
 
-The same is not true for projects that have been published to a repository, the
+The same is not true for projects that have been published to a repository. The
 whole fundamental problem is that we're trying to turn an ambiguous name into a
 concrete name, so we don't have any inherent trust in the publishers for any of
 the projects from disparate repositories.
@@ -207,14 +207,14 @@ in cases where the project wants to publish to one "main" repository, but then
 have additional repositories that provide binaries for additional platforms,
 GPUs, CPUs, etc. Currently wheel tags are not sufficiently able to express these
 types of binary compatibility, so projects that wish to rely on them are forced
-to setup multiple repositories and have their users manually select them to get
+to set up multiple repositories and have their users manually select them to get
 "better" binaries, but still wish to provide some default binaries on the main
 repository.
 
 This could be implemented using the "tracks" metadata, as it conceptually is
-expressing the same thing, however the "tracks" metadata relies on the
-repository operator retaining control for the security of it, and that would
-mean that projects would be forced to stand up their own repositories for this
+expressing the same thing, but the "tracks" metadata relies on the
+repository operator retaining control for security purposes, and that would
+mean that projects would be forced to set up their own repositories for this
 use case even if there is a public, open repository that they would prefer to
 use instead.
 
@@ -294,7 +294,7 @@ same set of data AND the locations that installer located files at are a subset
 of the alternate locations, then the installer will implicitly merge those
 locations as they does now.
 
-If any location that installer found files at does not exist in the list of
+If any location that the installer found files at does not exist in the list of
 alternate locations, then the installer SHOULD NOT assume it is safe to flatten
 the namespace, unless some other trusted information informs the installer of
 that.
@@ -304,7 +304,7 @@ Recommendations
 ===============
 
 This section is non-normative, it provides recommendations to installers in how
-to interpret this metadata, that this PEP feels provides the best trade off
+to interpret this metadata, that this PEP feels provides the best tradeoff
 between protecting users by default and minimizing breakages to existing
 workflows. These recommendations are not binding, and installers are free to
 ignore them, or apply them selectively as they make sense in their specific
@@ -314,13 +314,13 @@ situations.
 File Discovery Algorithm
 ------------------------
 
-*Note: This algoritm is written based on how pip currently discovers files,
+*Note: This algorithm is written based on how pip currently discovers files,
 other installers may adapt this based on their own discovery procedures.*
 
 Currently the "standard" file discovery algorithm looks something like this:
 
 1. Generate a list of all files across all configured repositories.
-2. Filter out any files that do match known hashes from a lockfile or
+2. Filter out any files that do not match known hashes from a lockfile or
    requirements file.
 3. Filter out any files that do not match the current platform, Python version,
    etc.
@@ -333,7 +333,7 @@ into account the new metadata, and instead do:
 
 1. Generate a list of all files across all configured repositories.
 
-2. Filter out any files that do match known hashes from a lockfile or
+2. Filter out any files that do not match known hashes from a lockfile or
    requirements file.
 
 3. If the end user has explicitly told the installer to fetch the project from
@@ -369,7 +369,7 @@ This is somewhat subtle, but the key things in the recommendation are:
   no chance of dependency confusion, so there's no reason to do anything but
   allow.
 - We check for the metadata in this PEP before filtering out based on platform,
-  python, etc because we don't want errors that only show up on certain
+  Python version, etc., because we don't want errors that only show up on certain
   platforms, Python versions, etc.
 - If nothing tells us merging the namespaces is safe, we refuse to implicitly
   assume it is, and generate an error instead.
@@ -380,9 +380,9 @@ namespaces can be flattened into one, which for all practical purposes
 eliminates the possibility of any kind of dependency confusion attack, while
 still giving power throughout the stack in a safe way to allow people to
 explicitly declare when those disparate namespaces are actually one logical
-namespace than can be safely merged.
+namespace that can be safely merged.
 
-The above algorithm is mostly a conceptual model, In reality the algorithm may
+The above algorithm is mostly a conceptual model. In reality the algorithm may
 end up being slightly different in order to be more privacy preserving and
 faster, or even just adapted to fit a specific installer better.
 
@@ -394,7 +394,7 @@ This PEP avoids dictating or recommending a specific mechanism by which an
 installer allows an end user to configure exactly what repositories it wants a
 specific package to be installed from. However, it does recommend that
 installers do provide *some* mechanism for end users to provide that
-configuration, as without it users can end up in a DoS situation where in cases
+configuration, as without it users can end up in a DoS situation in cases
 like ``torchtriton`` where they're just completely broken unless they resolve
 the namespace collision externally (get the name taken down on one repository,
 stand up a personal repository that handles the merging, etc).
@@ -425,7 +425,7 @@ Unfortunately, this has two failings that make it undesirable:
   not repositories that "track" another one, which ends up being a more generic
   solution.
 - Even in the case of exact mirrors, multiple repositories mirroring each other
-  is a distributed system that will not always be fully consistent with each
+  is a distributed system will not always be fully consistent with each
   other, effectively an eventually consistent system. This means that
   repositories that relied on this implicit heuristic to work would have
   sporadic failures due to drift between the source repository and the mirror
@@ -447,7 +447,7 @@ However, this has been rejected for a number of reasons:
   would be difficult to backpedal on that and start saying that now order
   matters.
 - Users can easily rearrange the order that they specify their repositories in
-  within a single location, however when loading repositories from multiple
+  within a single location, but when loading repositories from multiple
   locations (env var, conf file, requirements file, cli arguments) the order is
   hard coded into pip. While it would be a deterministic and documented order,
   there's no reason to assume it's the order that the user wants their
@@ -554,7 +554,7 @@ Require all projects to exist in the "default" repository
 ---------------------------------------------------------
 
 Another idea is that we can narrow the scope of ``--extra-index-url`` such that
-it's only supported use is to refer to supplemental repositories to the default
+its only supported use is to refer to supplemental repositories to the default
 repository, effectively saying that the default repository defines the
 namespace, and every additional repository just extends it with extra packages.
 

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -46,12 +46,13 @@ likely to remain vulnerable, even if they are ultimately aware of these types of
 attacks.
 
 Ultimately the underlying cause of these attacks come from the fact that there
-is no globally unique namespace that all Python package names come from. Instead,
-each repository is its own distinct namespace, and when given an "abstract" name
-such as ``spam`` to install, an installer has to implicitly turn that into a
-"concrete" name such as ``pypi.org:spam`` or ``example.com:spam``. Currently
-the standard behavior in Python installation tools is to implicitly flatten
-these multiple namespaces into one that contains the files from all namespaces.
+is no globally unique namespace that all Python package names come from.
+Instead, each repository is its own distinct namespace, and when given an
+"abstract" name such as ``spam`` to install, an installer has to implicitly turn
+that into a "concrete" name such as ``pypi.org:spam`` or ``example.com:spam``.
+Currently the standard behavior in Python installation tools is to implicitly
+flatten these multiple namespaces into one that contains the files from all
+namespaces.
 
 This implicit assumption that collapsing the namespaces is what was expected,
 means that that when it was not (such as in the ``torchtriton`` case) dependency
@@ -369,8 +370,8 @@ This is somewhat subtle, but the key things in the recommendation are:
   no chance of dependency confusion, so there's no reason to do anything but
   allow.
 - We check for the metadata in this PEP before filtering out based on platform,
-  Python version, etc., because we don't want errors that only show up on certain
-  platforms, Python versions, etc.
+  Python version, etc., because we don't want errors that only show up on
+  certain platforms, Python versions, etc.
 - If nothing tells us merging the namespaces is safe, we refuse to implicitly
   assume it is, and generate an error instead.
 - Otherwise we merge the namespaces, and continue on.
@@ -724,8 +725,8 @@ There's a long-standing class of attacks that are called "dependency confusion"
 attacks, which roughly boil down to an individual expected to get package ``A``,
 but instead they got ``B``. In Python, this almost always happens due to the end
 user having configured multiple repositories, where they expect package ``A`` to
-come from repository ``X``, but someone is able to publish package ``B`` with the
-same name as package ``A`` in repository ``Y``.
+come from repository ``X``, but someone is able to publish package ``B`` with
+the same name as package ``A`` in repository ``Y``.
 
 There are a number of ways to mitigate against these attacks today, but they all
 require that the end user explicitly go out of their way to protect themselves,
@@ -748,7 +749,8 @@ when those repositories are used together.
 
 End users of pip will be given the ability to explicitly define one or more
 repositories that are valid for a specific project, causing pip to only consider
-those repositories for that project, and avoiding generating an error altogether.
+those repositories for that project, and avoiding generating an error
+altogether.
 
 See TBD for more information.
 

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -480,14 +480,13 @@ all repositories but the "default" one as equal priority, and then treat the
 default one as a lower priority then we'll fix things.
 
 That is true in that it does improve things, but it has many of the same
-problems as the general ordering idea (though not all of them), and it comes
-along with one of its own:
+problems as the general ordering idea (though not all of them).
 
-- There's no reason to assume that PyPI is the only repository with open
-  registration of names or that it would only be the "default" repository that
-  does this. Projects like Piwheels is an example where users are expected to
-  have a non default repository that also effectively has open registration of
-  names (since it just tracks whatever is registered on PyPI).
+It also assumes that PyPI, or whatever repository is configured as the
+"default", is the only repository with open registration of names but projects
+like `Piwheels <https://www.piwheels.org/>`__ exist where users are expected to
+use it in addition to PyPI while it also effectively has open registration of
+names since it tracks whatever names are registered on PyPI.
 
 
 Rely on repository proxies

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -478,9 +478,8 @@ However, this has been rejected for a number of reasons:
   rather than by implicitly using the order they were defined in; however, that
   then means that the protections are not provided unless the user does some
   explicit configuration.
-- Ordering assumes that there is a linear ordering of repositories where two
-  repositories have the same name, we always prefer repositories in the same
-  order for every project, however that is not necessarily true.
+- Ordering assumes that one repository is *always* preferred over another
+  repository without any way to decide on a project by project basis.
 - Relying on ordering is subtle; if I look at an ordering of repositories, I
   have no way of knowing or ensuring in advance what names are going
   to come from what repositories. I can only know in that moment what names are

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -13,20 +13,6 @@ Post-History: `01-Feb-2023 <https://discuss.python.org/t/proposal-preventing-dep
 Abstract
 ========
 
-There is a long-standing class of attacks that are called "dependency confusion"
-attacks, which roughly boil down to an individual user expected to get package
-``A``, but instead they got ``B``. In Python, this almost always happens due to
-the configuration of multiple repositories (possibly including the default of
-PyPI), where they expected package ``A`` to come from repository ``X``, but
-someone is able to publish package ``B`` to repository ``Y`` under the same name.
-
-A specific example of this is the recent case where the PyTorch project had an
-internal package named ``torchtriton`` which was only ever intended to be
-installed from their repositories located at ``https://download.pytorch.org/``,
-but that repository was designed to be used in conjunction with PyPI, and
-the name of ``torchtriton`` was not claimed on PyPI, which allowed the attacker
-to use that name and publish a malicious version.
-
 This PEP proposes an extension to the :ref:`Simple Repository API
 <packaging:simple-repository-api>` that would enable
 installers to determine when it is safe to install a given package that appears
@@ -37,9 +23,24 @@ do not know if it is safe.
 Motivation
 ===========
 
+There is a long-standing class of attacks that are called "dependency confusion"
+attacks, which roughly boil down to an individual user expected to get package
+``A``, but instead they got ``B``. In Python, this almost always happens due to
+the configuration of multiple repositories (possibly including the default of
+PyPI), where they expected package ``A`` to come from repository ``X``, but
+someone is able to publish package ``B`` to repository ``Y`` under the same
+name.
+
 Dependency Confusion attacks have long been possible, but they've recently
-gained press with public examples of cases where these attacks were successfully
-executed.
+gained press with
+`public examples of cases where these attacks were successfully executed <https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610>`__.
+
+A specific example of this is the recent case where the PyTorch project had an
+internal package named ``torchtriton`` which was only ever intended to be
+installed from their repositories located at ``https://download.pytorch.org/``,
+but that repository was designed to be used in conjunction with PyPI, and
+the name of ``torchtriton`` was not claimed on PyPI, which allowed the attacker
+to use that name and publish a malicious version.
 
 There are a number of ways to mitigate against these attacks today, but they all
 require that the end user go out of their way to protect themselves, rather than
@@ -56,23 +57,16 @@ Currently the standard behavior in Python installation tools is to implicitly
 flatten these multiple namespaces into one that contains the files from all
 namespaces.
 
-This implicit assumption that collapsing the namespaces is what was expected,
-means that that when it was not (such as in the ``torchtriton`` case) dependency
-confusion attacks become possible.
+This assumption that collapsing the namespaces is what was expected, means that
+when the different names in different repositories are not the same (such as in
+the ``torchtriton`` case) dependency confusion attacks become possible.
 
-What makes this particularly tricky is two competing things:
-
-1. Collapsing the namespaces is exactly the behavior that you want at times;
-   for instance, the `Piwheels project <https://www.piwheels.org/>`_
-   does not manage a namespace of its own,
-   but rather exists to supplement the namespace from PyPI with additional files.
-2. Not collapsing the namespaces is the behavior that you want for instances
-   like ``torchtriton`` where the name on PyPI and the name on PyTorch's
-   repositories were fundamentally different things.
-
-So an installer needs some mechanism by which to determine when it should
-flatten the namespaces of multiple repositories and when it should not, rather
-than having to choose between always flattening and never flattening.
+This is made particularly tricky in that there is no "right" answer, there are
+valid use cases both for wanting two repositories merged into one namespace
+*and* for wanting two repositories to be treated as distinct namespaces. This
+means that an installer needs some mechanism by which to determine when it
+should merge the namespaces of multiple repositories and when it should not,
+rather than a blanket always merge or never merge rule.
 
 This functionality could be pushed directly to the end user, since ultimately
 the end user is the person whose expectations of what gets installed from what
@@ -81,6 +75,10 @@ to allow a repository to indicate when it is safe, we can enable individual
 projects and repositories to "work by default", even when their
 project naturally spans multiple distinct namespaces, while maintaining the
 ability for an installer to be secure by default.
+
+On its' own, this PEP does not solve dependency confusion attacks, but what it
+does do, is provide enough information that installers can prevent them without
+causing too much collateral damage to otherwise valid and safe use cases.
 
 
 Specification

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -860,6 +860,20 @@ Open Questions
    of hand waving around the specific mechanism installers would use for
    explicit configuration?
 
+
+Acknowledgements
+================
+
+Thanks to Trishank Kuppusamy for kick starting the discussion that lead to this
+PEP with his `proposal <https://discuss.python.org/t/proposal-preventing-dependency-confusion-attacks-with-the-map-file/23414>`__.
+
+Thanks to Paul Moore, Pradyun Gedam, Steve Dower, and Trishank Kuppusamy for
+providing early feedback and discussion on the ideas in this PEP.
+
+Thanks to Jelle Zijlstra, C.A.M. Gerlach, Hugo van Kemenade, and Stefano Rivera
+for copy editing and improving the structure and quality of this PEP.
+
+
 Copyright
 =========
 

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -315,8 +315,10 @@ situations.
 File Discovery Algorithm
 ------------------------
 
-*Note: This algorithm is written based on how pip currently discovers files;
-other installers may adapt this based on their own discovery procedures.*
+.. note::
+
+  This algorithm is written based on how pip currently discovers files;
+  other installers may adapt this based on their own discovery procedures.
 
 Currently the "standard" file discovery algorithm looks something like this:
 

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -332,17 +332,26 @@ It is recommended that installers change their file discovery algorithm to take
 into account the new metadata, and instead do:
 
 1. Generate a list of all files across all configured repositories.
+
 2. Filter out any files that do match known hashes from a lockfile or
    requirements file.
+
 3. If the end user has explicitly told the installer to fetch the project from
    specific repositories, filter out all other repositories and skip to 5.
+
 4. Look to see if the discovered files span multiple repositories, if they do
    then determine if either "Tracks" or "Alternate Locations" metadata allows
    safely merging *ALL* of the repositories where files were discovered
    together. If that metadata does **NOT** allow that, then generate an error,
    otherwise continue.
+
+   - **Note:** This only applies to *remote* repositories, repositories that
+     exist on the local filesystem **SHOULD** always be implicitly allowed to be
+     merged to any remote repository.
+
 5. Filter out any files that do not match the current platform, Python version,
    etc.
+
 6. Pass that list of files into the resolver where it will attempt to resolve
    the "best" match out of those files, irrespective of what repository it came
    from.

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -174,26 +174,6 @@ repository, or that they all track a repository at all. Mixed use repositories
 where some names track a repository and some names do not are explicitly
 allowed.
 
-At first glance, this may appear to be unsafe because it's allowing a repository
-to lay claim to a namespace that is originating in another repository. However,
-in the Python ecosystem, whenever a user decides to install from a particular
-repository, they are implicitly trusting the operators of that repository.
-Nothing we provide here can allow repository operators to operate without the
-user granting them that trust.
-
-This means that given the users trust the repository operators, then it is safe
-for them to trust the repository operators when they provide information about
-which repositories they are tracking.
-
-It is also not ambiguous what repository a user is referring to: given a
-repository like ``https://example.com/``, there is only one owner of example.com
-globally, so there is no ambiguity over who the user is intending to trust.
-
-The same is not true for projects that have been published to a repository. The
-whole fundamental problem is that we're trying to turn an ambiguous name into a
-concrete name, so we don't have any inherent trust in the publishers for any of
-the projects from disparate repositories.
-
 
 JSON
 ~~~~

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -21,7 +21,7 @@ PyPI), where they expected package ``A`` to come from repository ``X``, but
 someone is able to publish package ``B`` to repository ``Y`` under the same name.
 
 A specific example of this is the recent case where the PyTorch project had an
-internal project named ``torchtriton`` which was only ever intended to be
+internal package named ``torchtriton`` which was only ever intended to be
 installed from their repositories located at ``https://download.pytorch.org/``,
 but that repository was designed to be used in conjunction with PyPI, and
 the name of ``torchtriton`` was not claimed on PyPI, which allowed the attacker
@@ -65,8 +65,8 @@ What makes this particularly tricky is two competing things:
 1. Collapsing the namespaces is exactly the behavior that you want at times;
    for instance, the `Piwheels project <https://www.piwheels.org/>`_
    does not manage a namespace of its own,
-   but rather exists to supplment the namespace from PyPI with additional files.
-2. Not collapsing the namespaces is the behavior that you want for instances
+   but rather exists to supplement the namespace from PyPI with additional files.
+2. Not collapsing the namespaces is the behavior that you want, for instances
    like ``torchtriton`` where the name on PyPI and the name on PyTorch's
    repositories were fundamentally different things.
 
@@ -74,7 +74,7 @@ So an installer needs some mechanism by which to determine when it should
 flatten the namespaces of multiple repositories and when it should not, rather
 than having to choose between always flattening and never flattening.
 
-This functionaly could be pushed directly into the end user, since ultimately
+This functionality could be pushed directly to the end user, since ultimately
 the end user is the person whose expectations of what gets installed from what
 repository actually matters. However, by extending the repository specification
 to allow a repository to indicate when it is safe, we can enable individual
@@ -86,12 +86,8 @@ ability for an installer to be secure by default.
 Specification
 =============
 
-This specification defines version 1.2 of the simple repository API to make the
-following changes:
-
-- Bumping the api version to 1.2.
-- Repository "Tracks" Metadata
-- "Alternate Locations" Metadata
+This specification defines the changes in version 1.2 of the simple repository API,
+adding new two new metadata items: Repository "Tracks" and "Alternate Locations".
 
 
 Repository "Tracks" Metadata
@@ -99,22 +95,22 @@ Repository "Tracks" Metadata
 
 A valid use case for when an installer should merge the same name from two
 repositories is in the case when one repository isn't actually defining its
-own namespace, but rather is extending the namespace provided for by another
+own namespace, but rather is extending the namespace provided by another
 repository. This commonly happens in cases where a project is being mirrored
 from one repository to another or when a repository is providing supplementary
 artifacts such as providing binary wheels for a specific platform.
 
 In this case neither the repository nor the projects that are being "tracked"
-may have any knowledge they are being tracked or by who, so this cannot rely on
+may have any knowledge that they are being tracked or by whom, so this cannot rely on
 any information that isn't present in the "tracking" repository itself.
 
 To enable this we will extend both the JSON and the HTML content types for a
-project to include an optional "tracks" url, named ``meta.tracks`` for JSON and
+project to include an optional "tracks" URL, named ``meta.tracks`` for JSON and
 ``<meta name="pypi:tracks">`` for HTML.
 
 This would give us something like:
 
-  .. code-block:: JSON
+.. code-block:: JSON
 
     {
       "meta": {
@@ -142,7 +138,7 @@ This would give us something like:
 
 or
 
-  .. code-block:: HTML
+.. code-block:: HTML
 
     <!DOCTYPE html>
     <html>
@@ -157,7 +153,7 @@ or
     </html>
 
 
-There are a few key properties that **MUST** be observed when using this
+There are a few key properties that **MUST** be preserved when using this
 metadata:
 
 - It **MUST** be under the control of the repository operators themselves, not
@@ -174,8 +170,7 @@ metadata:
 - It **MUST** point to the repository that "owns" the namespace, not another
   repository that is also tracking that namespace.
 
-- It **MUST** point to a project with the exact same name (taking into account
-  normalization).
+- It **MUST** point to a project with the exact same name (after normalization).
 
 It is **NOT** required that every name in a repository tracks the same
 repository, or that they all track a repository at all. Mixed use repositories
@@ -195,7 +190,7 @@ which repositories they are tracking.
 
 It is also not ambiguous what repository a user is referring to: given a
 repository like ``https://example.com/``, there is only one owner of example.com
-globally, so there is no ambiguity who the user is intending to trust.
+globally, so there is no ambiguity over who the user is intending to trust.
 
 The same is not true for projects that have been published to a repository. The
 whole fundamental problem is that we're trying to turn an ambiguous name into a
@@ -228,20 +223,20 @@ break the contract of the "tracks" metadata to give that ability to their users
 and then reintroduce the original insecurity.
 
 To enable this we will extend both the JSON and the HTML content types for a
-project to include optional "alternate locations" urls, named
+project to include optional "alternate locations" URLs, named
 ``alternate-locations`` for JSON and ``<meta name="pypi:alternate-locations">``
 for HTML.
 
 This would give us something like:
 
-  .. code-block:: JSON
+.. code-block:: JSON
 
     {
       "meta": {
         "api-version": "1.0"
       },
       "name": "holygrail",
-      "alternate-locations": ["https://pypi.org/simple/holygrail/"],
+      "alternate-locations": ["https://pypi.org/simple/holygrail/", "https://test.pypi.org/simple/holygrail/"],
       "files": [
         {
           "filename": "holygrail-1.0.tar.gz",
@@ -262,7 +257,7 @@ This would give us something like:
 
 or
 
-  .. code-block:: HTML
+.. code-block:: HTML
 
     <!DOCTYPE html>
     <html>
@@ -284,7 +279,7 @@ metadata:
   all locations where that project is found as to what the alternate locations
   are.
 - When using alternate locations, clients **MUST** implicitly assume that the
-  url the response was fetched from was included in the list. This means, that
+  url the response was fetched from was included in the list. This means that
   if you fetch from ``https://pypi.org/simple/foo/`` and it has an
   ``alternate-locations`` metadata that has the value
   ``["https://example.com/simple/foo/"]``, then you **MUST** treat it as if it
@@ -296,7 +291,7 @@ When an installer encounters a project that spans multiple remote repositories,
 it will look at this alternate location metadata, and if they all agree on the
 same set of data AND the locations that installer located files at are a subset
 of the alternate locations, then the installer will implicitly merge those
-locations as they does now.
+locations as it does now.
 
 If any location that the installer found files at does not exist in the list of
 alternate locations, then the installer SHOULD NOT assume it is safe to flatten
@@ -307,8 +302,8 @@ that.
 Recommendations
 ===============
 
-This section is non-normative, it provides recommendations to installers in how
-to interpret this metadata, that this PEP feels provides the best tradeoff
+This section is non-normative; it provides recommendations to installers in how
+to interpret this metadata that this PEP feels provides the best tradeoff
 between protecting users by default and minimizing breakages to existing
 workflows. These recommendations are not binding, and installers are free to
 ignore them, or apply them selectively as they make sense in their specific
@@ -318,7 +313,7 @@ situations.
 File Discovery Algorithm
 ------------------------
 
-*Note: This algorithm is written based on how pip currently discovers files,
+*Note: This algorithm is written based on how pip currently discovers files;
 other installers may adapt this based on their own discovery procedures.*
 
 Currently the "standard" file discovery algorithm looks something like this:
@@ -329,7 +324,7 @@ Currently the "standard" file discovery algorithm looks something like this:
 3. Filter out any files that do not match the current platform, Python version,
    etc.
 4. Pass that list of files into the resolver where it will attempt to resolve
-   the "best" match out of those files, irrespective of what repository it came
+   the "best" match out of those files, irrespective of which repository it came
    from.
 
 It is recommended that installers change their file discovery algorithm to take
@@ -343,13 +338,13 @@ into account the new metadata, and instead do:
 3. If the end user has explicitly told the installer to fetch the project from
    specific repositories, filter out all other repositories and skip to 5.
 
-4. Look to see if the discovered files span multiple repositories, if they do
+4. Look to see if the discovered files span multiple repositories; if they do
    then determine if either "Tracks" or "Alternate Locations" metadata allows
    safely merging *ALL* of the repositories where files were discovered
    together. If that metadata does **NOT** allow that, then generate an error,
    otherwise continue.
 
-   - **Note:** This only applies to *remote* repositories, repositories that
+   - **Note:** This only applies to *remote* repositories; repositories that
      exist on the local filesystem **SHOULD** always be implicitly allowed to be
      merged to any remote repository.
 
@@ -365,7 +360,7 @@ This is somewhat subtle, but the key things in the recommendation are:
 - Users who are using lock files or requirements files that include specific
   hashes of artifacts that are "valid" are assumed to be protected by nature of
   those hashes, since the rest of these recommendations would apply during
-  hash generation, thus we filter out unknown hashes up front.
+  hash generation. Thus, we filter out unknown hashes up front.
 - If the user has explicitly told the installer that it wants to fetch a project
   from a certain set of repositories, then there is no reason to question that
   and we assume that they've made sure it is safe to merge those namespaces.
@@ -395,7 +390,7 @@ Explicit Configuration for End Users
 ------------------------------------
 
 This PEP avoids dictating or recommending a specific mechanism by which an
-installer allows an end user to configure exactly what repositories it wants a
+installer allows an end user to configure exactly what repositories they want a
 specific package to be installed from. However, it does recommend that
 installers do provide *some* mechanism for end users to provide that
 configuration, as without it users can end up in a DoS situation in cases
@@ -455,23 +450,23 @@ However, this has been rejected for a number of reasons:
   locations (env var, conf file, requirements file, cli arguments) the order is
   hard coded into pip. While it would be a deterministic and documented order,
   there's no reason to assume it's the order that the user wants their
-  repositories to be defined in, forcing them to contort thow they configure pip
+  repositories to be defined in, forcing them to contort how they configure pip
   so that the implicit ordering ends up being the correct one.
 - The above can be mitigated by providing a way to explicitly declare the order
-  rather than by implicitly using the order they were defined in, however that
+  rather than by implicitly using the order they were defined in; however, that
   then means that the protections are not provided unless the user does some
   explicit configuration.
 - Ordering assumes that there is a linear ordering of repositories where two
   repositories have the same name, we always prefer repositories in the same
   order for every project, however that is not necessarily true.
-- Relying on ordering is subtle, if I look at an ordering of repositories, I
-  have no way of knowing in advance or ensuring in advance what names are going
+- Relying on ordering is subtle; if I look at an ordering of repositories, I
+  have no way of knowing or ensuring in advance what names are going
   to come from what repositories. I can only know in that moment what names are
   provided by which repositories.
 - Relying on ordering is fragile. There's no reason to assume that two disparate
-  repositories are not going to have random naming collisions, what happens if
+  repositories are not going to have random naming collisions—what happens if
   I'm using a library from a lower priority repository and then a higher
-  priority repository happens to start having a colliding name.
+  priority repository happens to start having a colliding name?
 - In cases where ordering does the wrong thing, it does so silently, with no
   feedback given to the user. This is by design because it doesn't actually know
   what the wrong or right thing is, it's just hoping that order will give the
@@ -485,8 +480,8 @@ all repositories but the "default" one as equal priority, and then treat the
 default one as a lower priority then we'll fix things.
 
 That is true in that it does improve things, but it has many of the same
-problems as the general ordering idea (though not all of them), but it comes
-along with some of it's own:
+problems as the general ordering idea (though not all of them), and it comes
+along with one of its own:
 
 - There's no reason to assume that PyPI is the only repository with open
   registration of names or that it would only be the "default" repository that
@@ -515,7 +510,7 @@ However, that has been rejected because:
 
 - A user may need different outcomes of merging multiple repositories in
   different contexts, or may need to merge different, mutually exclusive
-  repositories. This means they'll need to actually setup multiple repository
+  repositories. This means they'll need to actually set up multiple repository
   proxies for each unique set of options.
 
 - It requires users to maintain infrastructure or it requires adding features in
@@ -534,17 +529,17 @@ Rely only on hash checking
 --------------------------
 
 Another possible solution is to rely on hash checking, since with hash checking
-enabled users cannot get an artifact that they didn't expect, it doesn't matter
+enabled users cannot get an artifact that they didn't expect; it doesn't matter
 if the namespaces are incorrectly merged or not.
 
-This is certainly a solution, unfortunately it also suffers from problems that
+This is certainly a solution; unfortunately it also suffers from problems that
 make it unworkable:
 
 - It requires users to opt in to it, so users are still unprotected by default.
 - It requires users to do a bunch of labor to manage their hashes, which is
   something that most users are unlikely to be willing to do.
-- It is difficult and verbose to get the protection when not using a
-  ``requirements.txt`` file as the source of your dependencies (this affects
+- It is difficult and verbose to get the protection when users are not using a
+  ``requirements.txt`` file as the source of their dependencies (this affects
   build time dependencies, and dependencies provided at the command line).
 - It only sort of solves the problem, in a way it just shifts the responsibility
   of the problem to be whatever system is generating the hashes that the
@@ -583,7 +578,7 @@ ultimately it has been rejected because:
   from the start and make it stick, but it's going to be incredibly difficult to
   get the ecosystem to adjust to that change.
 
-  - This is a fundamental issue with this approach, the underlying problem that
+  - This is a fundamental issue with this approach; the underlying problem that
     drives dependency confusion is that we're taking disparate namespaces and
     flattening them into one. This approach essentially just declares that OK,
     and attempts to mitigate it by requiring everyone to register their names.
@@ -603,7 +598,7 @@ ultimately it has been rejected because:
   their names in their default repository as a defensive name squat. Their
   ability to do this will depend on the specific policies of their default
   repository, whether someone already has that name, whether it's too generic,
-  etc. At a best case scenario it will cause needless placeholder projects that
+  etc. As a best case scenario it will cause needless placeholder projects that
   serve no purpose other than to secure some internal use of a name.
 
 
@@ -632,15 +627,15 @@ This idea has been rejected because:
   system it's hard to even know where to start to list them.
 
 
-Only recommend installers offer explicit configuration
+Only recommend that installers offer explicit configuration
 ------------------------------------------------------
 
 One idea that has come up is to essentially just implement the explicit
 configuration and don't make any other changes to anything else. The specific
-proposal for a mapping policy is what actually inspired explicit configuration
+proposal for a mapping policy is what actually inspired the explicit configuration
 option, and created a file that looked something like:
 
-  .. code-block:: JSON
+.. code-block:: JSON
 
     {
       "repositories": {
@@ -666,7 +661,7 @@ their users.
 
 Ultimately only implementing some kind of explicit configuration was rejected
 because by its nature it's opt in, so it doesn't protect average users who are
-least capable to solve the problem with the existing tools, by adding additional
+least capable to solve the problem with the existing tools; by adding additional
 protections alongside the explicit configuration, we are able to protect all
 users by default.
 
@@ -699,14 +694,14 @@ common for people to use their own registries, but in Python we encourage you to
 do just that.
 
 
-Open questions
+Open Questions
 ==============
 
 1. The `original proposal document <https://docs.google.com/document/d/184fQkb6NggVQfYmjTDA7p_U3iWDKk6grc2DigT1X3Es/>`__
    was targeted more specifically to a change to pip, and went into more
    specific details as to what we expected from pip. Since dictating UX to
    installers isn't something that we do in PEPs, I've rewritten those parts to
-   be more generic, however that means that we lose the information on
+   be more generic; however, that means that we lose the information on
    repository files. Is that fine? Or should we standardize what a repository
    file looks like so the same file can be given to multiple installers instead
    of hand waving around the specific mechanism installers would use for
@@ -718,7 +713,7 @@ Appendix: Communicating the Change
 ==================================
 
 *Note: This is pip specific and assumes specifics about how pip will choose to
-implement this PEP, it's included as an example of how we can communicate this
+implement this PEP; it's included as an example of how we can communicate this
 change out to end users as the ecosystem rolls this change out. The entire
 Appendix should be considered to be a single communication (blog post, discuss
 post, email, whatever).*
@@ -769,7 +764,7 @@ successfully install if:
   remote repositories.
 - The project name that is available from multiple remote repositories has not
   used one of the defined mechanisms to link those repositories together.
-- The user invoking pip has not used the define mechanism to explicitly control
+- The user invoking pip has not used the defined mechanism to explicitly control
   what repositories are valid for a particular project.
 
 Users who are not using multiple remote repositories will not be affected at

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -13,11 +13,10 @@ Post-History: `01-Feb-2023 <https://discuss.python.org/t/proposal-preventing-dep
 Abstract
 ========
 
-This PEP proposes an extension to the :ref:`Simple Repository API
-<packaging:simple-repository-api>` that would enable
-installers to determine when it is safe to install a given package that appears
-in multiple repositories, allowing them to be stricter in the cases where they
-do not know if it is safe.
+This PEP proposes extending the :ref:`Simple Repository API <packaging:simple-repository-api>`
+to allow repository operators to indicate that a project found on their
+repository "tracks" a project on a different repository and allows projects to
+extend their namespace in one repository across multiple repositories.
 
 
 Motivation
@@ -81,75 +80,72 @@ does do, is provide enough information that installers can prevent them without
 causing too much collateral damage to otherwise valid and safe use cases.
 
 
+Rationale
+=========
+
+There are two broad use cases for merging names across repositories that this
+PEP seeks to enable.
+
+The first use case is when one repository is not defining it's own names, but
+rather is extending names defined in another repository. This commonly happens
+in cases where a project is being mirrored from one repository to another (see
+`Bandersnatch <https://pypi.org/project/bandersnatch/>`__) or when a repository
+is providing supplementary artifacts for a specific platform (see
+`Piwheels <https://www.piwheels.org/>`__).
+
+In this case neither the repository nor the projects that are being extended
+may have any knowledge that they are being extended or by whom, so this cannot
+rely on any information that isn't present in the "extending" repository itself.
+
+The second use case is when the project wants to publish to one "main"
+repository, but then have additional repositories that provide binaries for
+additional platforms, GPUs, CPUs, etc. Currently wheel tags are not sufficiently
+able to express these types of binary compatibility, so projects that wish to
+rely on them are forced to set up multiple repositories and have their users
+manually configure them to get the correct binaries for their platform, GPU,
+CPU, etc.
+
+This use case is similiar to the first, but the important difference that makes
+it a distinct use case on it's own is who is providing the information and what
+their level of trust is.
+
+When a user configures a specific repository (or relies on the default) there
+is no ambiguity as to what repository they mean. A repository is identified by
+an URL, and through the domain system, URLs are globally unique identifiers.
+This lack of ambiguity means that an installer can assume that the repository
+operator is trustworthy and can trust metadata that they provide without needing
+to validate it.
+
+On the flip side, given an installer finds a name in multiple repositories it is
+ambiguous which of them the installer should trust. This ambiguity means that an
+installer cannot assume that the project owner on either repository is
+trustworthy and needs to validate that they are indeed the same project and that
+one isn't a dependency confusion attack.
+
+Without some way for the installer to validate the metadata between multiple
+repositories, projects would be forced into becoming repository operators to
+safely support this use case. That wouldn't be a particularly wrong choice to
+make, however there is a danger that if we don't provide a way for repositories
+to let project owners express this relationship safely that they will be
+incentivized to let them use the repository operator's metadata instead which
+would reintroduce the original insecurity.
+
+
 Specification
 =============
 
-This specification defines the changes in version 1.2 of the simple repository API,
-adding new two new metadata items: Repository "Tracks" and "Alternate Locations".
+This specification defines the changes in version 1.2 of the simple repository
+API, adding new two new metadata items: Repository "Tracks" and "Alternate
+Locations".
 
 
 Repository "Tracks" Metadata
 ----------------------------
 
-A valid use case for when an installer should merge the same name from two
-repositories is in the case when one repository isn't actually defining its
-own namespace, but rather is extending the namespace provided by another
-repository. This commonly happens in cases where a project is being mirrored
-from one repository to another or when a repository is providing supplementary
-artifacts such as providing binary wheels for a specific platform.
-
-In this case neither the repository nor the projects that are being "tracked"
-may have any knowledge that they are being tracked or by whom, so this cannot rely on
-any information that isn't present in the "tracking" repository itself.
-
-To enable this we will extend both the JSON and the HTML content types for a
-project to include an optional "tracks" URL, named ``meta.tracks`` for JSON and
-``<meta name="pypi:tracks">`` for HTML.
-
-This would give us something like:
-
-.. code-block:: JSON
-
-    {
-      "meta": {
-        "api-version": "1.2",
-        "tracks": "https://pypi.org/simple/holygrail/"
-      },
-      "name": "holygrail",
-      "files": [
-        {
-          "filename": "holygrail-1.0.tar.gz",
-          "url": "https://example.com/files/holygrail-1.0.tar.gz",
-          "hashes": {"sha256": "...", "blake2b": "..."},
-          "requires-python": ">=3.7",
-          "yanked": "Had a vulnerability"
-        },
-        {
-          "filename": "holygrail-1.0-py3-none-any.whl",
-          "url": "https://example.com/files/holygrail-1.0-py3-none-any.whl",
-          "hashes": {"sha256": "...", "blake2b": "..."},
-          "requires-python": ">=3.7",
-          "dist-info-metadata": true
-        }
-      ]
-    }
-
-or
-
-.. code-block:: HTML
-
-    <!DOCTYPE html>
-    <html>
-      <head>
-        <meta name="pypi:repository-version" content="1.2">
-        <meta name="pypi:tracks" content="https://pypi.org/simple/holygrail/">
-      </head>
-      <body>
-        <a href="https://example.com/files/holygrail-1.0.tar.gz#sha256=...">
-        <a href="https://example.com/files/holygrail-1.0-py3-none-any.whl#sha256=...">
-      </body>
-    </html>
-
+To enable one repository to extend another, this PEP allows the extending
+repository to declare that it "tracks" another repository by adding the URL
+of the repository that it is extending. This is exposed in JSON as the key
+``meta.tracks`` and in HTML as a meta element named ``pypi:tracks``.
 
 There are a few key properties that **MUST** be preserved when using this
 metadata:
@@ -169,6 +165,9 @@ metadata:
   repository that is also tracking that namespace.
 
 - It **MUST** point to a project with the exact same name (after normalization).
+
+- It **MUST** point to the actual URL for that project, not the base URL for the
+  extended repository.
 
 It is **NOT** required that every name in a repository tracks the same
 repository, or that they all track a repository at all. Mixed use repositories
@@ -196,36 +195,85 @@ concrete name, so we don't have any inherent trust in the publishers for any of
 the projects from disparate repositories.
 
 
+JSON
+++++
+
+.. code-block:: JSON
+
+    {
+      "meta": {
+        "api-version": "1.2",
+        "tracks": "https://pypi.org/simple/holygrail/"
+      },
+      "name": "holygrail",
+      "files": [
+        {
+          "filename": "holygrail-1.0.tar.gz",
+          "url": "https://example.com/files/holygrail-1.0.tar.gz",
+          "hashes": {"sha256": "...", "blake2b": "..."},
+          "requires-python": ">=3.7",
+          "yanked": "Had a vulnerability"
+        },
+        {
+          "filename": "holygrail-1.0-py3-none-any.whl",
+          "url": "https://example.com/files/holygrail-1.0-py3-none-any.whl",
+          "hashes": {"sha256": "...", "blake2b": "..."},
+          "requires-python": ">=3.7",
+          "dist-info-metadata": true
+        }
+      ]
+    }
+
+
+HTML
+++++
+
+.. code-block:: HTML
+
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta name="pypi:repository-version" content="1.2">
+        <meta name="pypi:tracks" content="https://pypi.org/simple/holygrail/">
+      </head>
+      <body>
+        <a href="https://example.com/files/holygrail-1.0.tar.gz#sha256=...">
+        <a href="https://example.com/files/holygrail-1.0-py3-none-any.whl#sha256=...">
+      </body>
+    </html>
+
+
 "Alternate Locations" Metadata
 ------------------------------
 
-Another valid use case for having a project extend over multiple repositories is
-in cases where the project wants to publish to one "main" repository, but then
-have additional repositories that provide binaries for additional platforms,
-GPUs, CPUs, etc. Currently wheel tags are not sufficiently able to express these
-types of binary compatibility, so projects that wish to rely on them are forced
-to set up multiple repositories and have their users manually select them to get
-"better" binaries, but still wish to provide some default binaries on the main
-repository.
+To enable a project to extend its namespace across multiple repositories, this
+PEP allows a project owner to declare a list of "alternate locations" for their
+project. This is exposed in JSON as the key ``alternate-locations`` and in HTML
+as a meta element named ``pypi-alternate-locations``, which may be used multiple
+times.
 
-This could be implemented using the "tracks" metadata, as it conceptually is
-expressing the same thing, but the "tracks" metadata relies on the
-repository operator retaining control for security purposes, and that would
-mean that projects would be forced to set up their own repositories for this
-use case even if there is a public, open repository that they would prefer to
-use instead.
+There are a few key properties that **MUST** be observed when using this
+metadata:
 
-There's also the danger that if we don't provide a way for repositories to let
-publishers express this same relationship, that they will be incentivized to
-break the contract of the "tracks" metadata to give that ability to their users
-and then reintroduce the original insecurity.
+- In order for this metadata to be trusted, there **MUST** be agreement between
+  all locations where that project is found as to what the alternate locations
+  are.
+- When using alternate locations, clients **MUST** implicitly assume that the
+  url the response was fetched from was included in the list. This means that
+  if you fetch from ``https://pypi.org/simple/foo/`` and it has an
+  ``alternate-locations`` metadata that has the value
+  ``["https://example.com/simple/foo/"]``, then you **MUST** treat it as if it
+  had the value
+  ``["https://example.com/simple/foo/", "https://pypi.org/simple/foo/"]``.
+- Order of the elements within the array does not have any particular meaning.
 
-To enable this we will extend both the JSON and the HTML content types for a
-project to include optional "alternate locations" URLs, named
-``alternate-locations`` for JSON and ``<meta name="pypi:alternate-locations">``
-for HTML.
+When an installer encounters a project that is using the alternate locations
+metadata it **SHOULD** consider that all repositories named are extending the
+same namespace across multiple repositories.
 
-This would give us something like:
+
+JSON
+++++
 
 .. code-block:: JSON
 
@@ -253,7 +301,9 @@ This would give us something like:
       ]
     }
 
-or
+
+HTML
+++++
 
 .. code-block:: HTML
 
@@ -269,32 +319,6 @@ or
         <a href="https://example.com/files/holygrail-1.0-py3-none-any.whl#sha256=...">
       </body>
     </html>
-
-There are a few key properties that **MUST** be observed when using this
-metadata:
-
-- In order for this metadata to be trusted, there **MUST** be agreement between
-  all locations where that project is found as to what the alternate locations
-  are.
-- When using alternate locations, clients **MUST** implicitly assume that the
-  url the response was fetched from was included in the list. This means that
-  if you fetch from ``https://pypi.org/simple/foo/`` and it has an
-  ``alternate-locations`` metadata that has the value
-  ``["https://example.com/simple/foo/"]``, then you **MUST** treat it as if it
-  had the value
-  ``["https://example.com/simple/foo/", "https://pypi.org/simple/foo/"]``.
-- Order of the elements within the array does not have any particular meaning.
-
-When an installer encounters a project that spans multiple remote repositories,
-it will look at this alternate location metadata, and if they all agree on the
-same set of data AND the locations that installer located files at are a subset
-of the alternate locations, then the installer will implicitly merge those
-locations as it does now.
-
-If any location that the installer found files at does not exist in the list of
-alternate locations, then the installer SHOULD NOT assume it is safe to flatten
-the namespace, unless some other trusted information informs the installer of
-that.
 
 
 Recommendations

--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -1,5 +1,5 @@
 PEP: 708
-Title: Preventing Dependency Confusion Attacks
+Title: Extending the Repository API to Mitigate Dependency Confusion Attacks
 Author: Donald Stufft <donald@stufft.io>
 PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
 Status: Draft

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -1,0 +1,835 @@
+PEP: 9999
+Title: Preventing Dependency Confusion Attacks
+Author: Donald Stufft <donald@stufft.io>
+PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
+Status: Draft
+Type: Standards Track
+Topic: Packaging
+Content-Type: text/x-rst
+Created: 20-Feb-2023
+
+
+Abstract
+========
+
+There is a long-standing class of attacks that are called "dependency confusion"
+attacks, which roughly boil down to an individual user expected to get package
+``A``, but instead they got ``B``. In Python, this almost always happens due to
+the configuration of multiple repositories (possibly including the default of
+PyPI), where they expected package ``A`` to come from repository ``X``, but
+someone is able to publish to repository ``Y`` under the same name.
+
+A specific example of this is the recent case where the PyTorch project had an
+internal project named ``torchtriton`` which was only ever intended to be
+installed from their repositories located at ``https://download.pytorch.org/``,
+but that repository was designed to be used in conjunction with PyPI, and
+the name of ``torchtriton`` was not claimed on PyPI, which allowed the attacker
+to use that name and publish a malicious version.
+
+This PEP proposes an extension to the Repository API that would enable
+installers to determine when it is safe to install a given package that appears
+in multiple repositories, allowing them to be stricter in the cases where they
+do not know if it is safe.
+
+
+Rationale
+=========
+
+Dependency Confusion attacks have long been possible, but they've recently
+gained press with public examples of cases where these attacks were successfully
+executed.
+
+There are a number of ways to mitigate against these attacks today, but they all
+require that the end user go out of their way to protect themselves, rather than
+being protected by default. This means that for the vast bulk of users, they are
+likely to remain vulnerable, even if they are ultimately aware of these types of
+attacks.
+
+Ultimately the underlying cause of these attacks come from the fact that there
+is no globally unique namespace that all Python package names come from, instead
+each repository is its own distinct namespace, and when given an "abstract" name
+such as ``spam`` to install, an installer has implicitly turn that into a
+"concrete" name such as ``pypi.org:spam`` or ``example.com:spam``. Currently
+the standard behavior in Python installation tools, is to implicitly flatten
+these multiple namespaces into one that contains the files from all namespaces.
+
+This implicit assumption that collapsing the namespaces is what was expected,
+means that that when it was not (such as in the ``torchtriton`` case) dependency
+confusion attacks become possible.
+
+What makes this particularly tricky is two competing things:
+
+1. Collapsing the namespaces is exactly the behavior that you want at times, for
+   instance the Piwheels project which does not manage a namespace of it's own,
+   but rather exists to supplment the namespace from PyPI with additional files.
+2. Not collapsing the namespaces is the behavior that you want, for instances
+   like ``torchtriton`` where the name on PyPI and the name on PyTorch's
+   repositories were fundamentally different things.
+
+So an installer needs some mechanism by which to determine when it should
+flatten the namespaces of multiple repositories and when it should not, rather
+than having to either choose between always flattening and never flattening.
+
+This functionaly could be pushed directly into the end user, since ultimately
+the end user is the person whose expectations of what gets installed from what
+repository actually matters. However, by extending the repository specification
+to allow a repository to indicate when it is safe, we can enable individual
+projects and repositories the ability to "work by default", even when their
+project naturally spans multiple distinct namespaces, while maintaining the
+ability for an installer to be secure by default.
+
+
+Specification
+=============
+
+This specification defines version 1.2 of the simple repository API to make the
+following changes:
+
+- Bumping the api version to 1.2.
+- Repository "Tracks" Metadata
+- "Alternate Locations" Metadata
+
+
+Repository "Tracks" Metadata
+----------------------------
+
+A valid use case for when an installer should merge the same name from two
+repositories is in the case when one repository isn't actually defining its
+own namespace, but rather is extending the namespace provided for by another
+repository. This commonly happens in cases where a project is being mirrored
+from one repository to another or when a repository is providing supplementary
+artifacts such as providing binary wheels for a specific platform.
+
+In this case neither the repository nor the projects that are being "tracked"
+may have any knowledge they are being tracked or by who, so this cannot rely on
+any information that isn't present in the "tracking" repository itself.
+
+To enable this we will extend both the JSON and the HTML content types for a
+project to include an optional "tracks" url, named ``meta.tracks`` for JSON and
+``<meta name="pypi:tracks">`` for HTML.
+
+This would give us something like:
+
+  .. code-block:: JSON
+
+    {
+      "meta": {
+        "api-version": "1.0",
+        "tracks": "https://pypi.org/simple/holygrail/"
+      },
+      "name": "holygrail",
+      "files": [
+        {
+          "filename": "holygrail-1.0.tar.gz",
+          "url": "https://example.com/files/holygrail-1.0.tar.gz",
+          "hashes": {"sha256": "...", "blake2b": "..."},
+          "requires-python": ">=3.7",
+          "yanked": "Had a vulnerability"
+        },
+        {
+          "filename": "holygrail-1.0-py3-none-any.whl",
+          "url": "https://example.com/files/holygrail-1.0-py3-none-any.whl",
+          "hashes": {"sha256": "...", "blake2b": "..."},
+          "requires-python": ">=3.7",
+          "dist-info-metadata": true
+        }
+      ]
+    }
+
+or
+
+  .. code-block:: HTML
+
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta name="pypi:repository-version" content="1.0">
+        <meta name="pypi:tracks" content="https://pypi.org/simple/holygrail/">
+      </head>
+      <body>
+        <a href="https://example.com/files/holygrail-1.0.tar.gz#sha256=...">
+        <a href="https://example.com/files/holygrail-1.0-py3-none-any.whl#sha256=...">
+      </body>
+    </html>
+
+
+There are a few key properties that **MUST** be observed when using this
+metadata:
+
+- It **MUST** be under the control of the repository operators themselves, not
+  any individual publisher using that repository.
+
+- It **MUST** represent the same "project" as the project at the referenced URL.
+
+  - This does not mean that it needs to serve the same files. It is valid for it
+    to include binaries built on different platforms, copies with local patches
+    being applied, etc. This is purposefully left vague as it's ultimately up to
+    the expectations that the users have of the repository and it's operators
+    what exactly constitutes the "same" project.
+
+- It **MUST** point to the repository that "owns" the namespace, not another
+  repository that is also tracking that namespace.
+
+- It **MUST** point to a project with the exact same name (taking into account
+  normalization).
+
+It is **NOT** required that every name in a repository tracks the same
+repository, or that they all track a repository at all. Mixed use repositories
+where some names track a repository and some names do not are explicitly
+allowed.
+
+At first glance, this may appear to be unsafe because it's allowing a repository
+to lay claim to a namespace that is originating in another repository. However,
+in the Python ecosystem, whenever a user decides to install from a particular
+repository, they are implicitly trusting the operators of that repository.
+Nothing we provide here can allow repository operators to operate without the
+user granting them that trust.
+
+This means that given the users trust the repository operators, then it is safe
+for them to trust the repository operators when they provide information about
+which repositories they are tracking.
+
+It is also not ambiguous what repository a user is referring to, given a
+repository like ``https://example.com/``, there is only one owner of example.com
+globally, so there is no ambiguity who the user is intending to trust.
+
+The same is not true for projects that have been published to a repository, the
+whole fundamental problem is that we're trying to turn an ambiguous name into a
+concrete name, so we don't have any inherent trust in the publishers for any of
+the projects from disparate repositories.
+
+
+"Alternate Locations" Metadata
+------------------------------
+
+Another valid use case for having a project extend over multiple repositories is
+in cases where the project wants to publish to one "main" repository, but then
+have additional repositories that provide binaries for additional platforms,
+GPUs, CPUs, etc. Currently wheel tags are not sufficiently able to express these
+types of binary compatibility, so projects that wish to rely on them are forced
+to setup multiple repositories and have their users manually select them to get
+"better" binaries, but still wish to provide some default binaries on the main
+repository.
+
+This could be implemented using the "tracks" metadata, as it conceptually is
+expressing the same thing, however the "tracks" metadata relies on the
+repository operator retaining control for the security of it, and that would
+mean that projects would be forced to stand up their own repositories for this
+use case even if there is a public, open repository that they would prefer to
+use instead.
+
+There's also the danger that if we don't provide a way for repositories to let
+publishers express this same relationship, that they will be incentivized to
+break the contract of the "tracks" metadata to give that ability to their users
+and then reintroduce the original insecurity.
+
+To enable this we will extend both the JSON and the HTML content types for a
+project to include optional "alternate locations" urls, named
+``alternate-locations`` for JSON and ``<meta name="pypi:alternate-locations">``
+for HTML.
+
+This would give us something like:
+
+  .. code-block:: JSON
+
+    {
+      "meta": {
+        "api-version": "1.0"
+      },
+      "name": "holygrail",
+      "alternate-locations": ["https://pypi.org/simple/holygrail/"],
+      "files": [
+        {
+          "filename": "holygrail-1.0.tar.gz",
+          "url": "https://example.com/files/holygrail-1.0.tar.gz",
+          "hashes": {"sha256": "...", "blake2b": "..."},
+          "requires-python": ">=3.7",
+          "yanked": "Had a vulnerability"
+        },
+        {
+          "filename": "holygrail-1.0-py3-none-any.whl",
+          "url": "https://example.com/files/holygrail-1.0-py3-none-any.whl",
+          "hashes": {"sha256": "...", "blake2b": "..."},
+          "requires-python": ">=3.7",
+          "dist-info-metadata": true
+        }
+      ]
+    }
+
+or
+
+  .. code-block:: HTML
+
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta name="pypi:repository-version" content="1.0">
+        <meta name="pypi:alternate-locations" content="https://pypi.org/simple/holygrail/">
+        <meta name="pypi:alternate-locations" content="https://test.pypi.org/simple/holygrail/">
+      </head>
+      <body>
+        <a href="https://example.com/files/holygrail-1.0.tar.gz#sha256=...">
+        <a href="https://example.com/files/holygrail-1.0-py3-none-any.whl#sha256=...">
+      </body>
+    </html>
+
+There are a few key properties that **MUST** be observed when using this
+metadata:
+
+- In order for this metadata to be trusted, there **MUST** be agreement between
+  all locations where that project is found as to what the alternate locations
+  are.
+- When using alternate locations, clients **MUST** implicitly assume that the
+  url the response was fetched from was included in the list. This means, that
+  if you fetch from ``https://pypi.org/simple/foo/`` and it has an
+  ``alternate-locations`` metadata that has the value
+  ``["https://example.com/simple/foo/"]``, then you **MUST** treat it as if it
+  had the value
+  ``["https://example.com/simple/foo/", "https://pypi.org/simple/foo/"]``.
+- Order of the elements within the array does not have any particular meaning.
+
+When an installer encounters a project that spans multiple remote repositories,
+it will look at this alternate location metadata, and if they all agree on the
+same set of data AND the locations that installer located files at are a subset
+of the alternate locations, then the installer will implicitly merge those
+locations as they does now.
+
+If any location that installer found files at does not exist in the list of
+alternate locations, then the installer SHOULD NOT assume it is safe to flatten
+the namespace, unless some other trusted information informs the installer of
+that.
+
+
+Recommendations
+===============
+
+This section is non-normative, it provides recommendations to installers in how
+to interpret this metadata, that this PEP feels provides the best trade off
+between protecting users by default and minimizing breakages to existing
+workflows. These recommendations are not binding, and installers are free to
+ignore them, or apply them selectively as they make sense in their specific
+situations.
+
+
+File Discovery Algorithm
+------------------------
+
+*Note: This algoritm is written based on how pip currently discovers files,
+other installers may adapt this based on their own discovery procedures.*
+
+Currently the "standard" file discovery algorithm looks something like this:
+
+1. Generate a list of all files across all configured repositories.
+2. Filter out any files that do match known hashes from a lockfile or
+   requirements file.
+3. Filter out any files that do not match the current platform, Python version,
+   etc.
+4. Pass that list of files into the resolver where it will attempt to resolve
+   the "best" match out of those files, irrespective of what repository it came
+   from.
+
+It is recommended that installers change their file discovery algorithm to take
+into account the new metadata, and instead do:
+
+1. Generate a list of all files across all configured repositories.
+2. Filter out any files that do match known hashes from a lockfile or
+   requirements file.
+3. If the end user has explicitly told the installer to fetch the project from
+   specific repositories, filter out all other repositories and skip to 5.
+4. Look to see if the discovered files span multiple repositories, if they do
+   then determine if either "Tracks" or "Alternate Locations" metadata allows
+   safely merging *ALL* of the repositories where files were discovered
+   together. If that metadata does **NOT** allow that, then generate an error,
+   otherwise continue.
+5. Filter out any files that do not match the current platform, Python version,
+   etc.
+6. Pass that list of files into the resolver where it will attempt to resolve
+   the "best" match out of those files, irrespective of what repository it came
+   from.
+
+This is somewhat subtle, but the key things in the recommendation are:
+
+- Users who are using lock files or requirements files that include specific
+  hashes of artifacts that are "valid" are assumed to be protected by nature of
+  those hashes, since the rest of these recommendations would apply during
+  hash generation, thus we filter out unknown hashes up front.
+- If the user has explicitly told the installer that it wants to fetch a project
+  from a certain set of repositories, then there is no reason to question that
+  and we assume that they've made sure it is safe to merge those namespaces.
+- If the project in question only comes from a single repository, then there is
+  no chance of dependency confusion, so there's no reason to do anything but
+  allow.
+- We check for the metadata in this PEP before filtering out based on platform,
+  python, etc because we don't want errors that only show up on certain
+  platforms, Python versions, etc.
+- If nothing tells us merging the namespaces is safe, we refuse to implicitly
+  assume it is, and generate an error instead.
+- Otherwise we merge the namespaces, and continue on.
+
+This algorithm ensures that an installer never assumes that two disparate
+namespaces can be flattened into one, which for all practical purposes
+eliminates the possibility of any kind of dependency confusion attack, while
+still giving power throughout the stack in a safe way to allow people to
+explicitly declare when those disparate namespaces are actually one logical
+namespace than can be safely merged.
+
+The above algorithm is mostly a conceptual model, In reality the algorithm may
+end up being slightly different in order to be more privacy preserving and
+faster, or even just adapted to fit a specific installer better.
+
+
+Explicit Configuration for End Users
+------------------------------------
+
+This PEP avoids dictating or recommending a specific mechanism by which an
+installer allows an end user to configure exactly what repositories it wants a
+specific package to be installed from. However, it does recommend that
+installers do provide *some* mechanism for end users to provide that
+configuration, as without it users can end up in a DoS situation where in cases
+like ``torchtriton`` where they're just completely broken unless they resolve
+the namespace collision externally (get the name taken down on one repository,
+stand up a personal repository that handles the merging, etc).
+
+This configuration also allows end users to pre-emptively secure themselves
+during what is likely to be a long transition until the default behavior is
+safe.
+
+
+Rejected Ideas
+==============
+
+*Note: Some of these are somewhat specific to pip, but any solution that doesn't
+work for pip isn't a particularly useful solution.*
+
+
+Implicitly allow mirrors when the list of files are the same
+------------------------------------------------------------
+
+If every repository returns the exact same list of files, then it is safe to
+consider those repositories to be the same namespace and implicitly merge them.
+This would possibly mean that mirrors would be automatically allowed without any
+work on any user or repository operator's part.
+
+Unfortunately, this has two failings that make it undesirable:
+
+- It only solves the case of mirrors that are exact copies of each other, but
+  not repositories that "track" another one, which ends up being a more generic
+  solution.
+- Even in the case of exact mirrors, multiple repositories mirroring each other
+  is a distributed system that will not always be fully consistent with each
+  other, effectively an eventually consistent system. This means that
+  repositories that relied on this implicit heuristic to work would have
+  sporadic failures due to drift between the source repository and the mirror
+  repositories.
+
+
+Provide a mechanism to order the repositories
+---------------------------------------------
+
+Providing some mechanism to give the repositories an order, and then short
+circuiting the discovery algorithm when it finds the first repository that
+provides files for that project is another workable solution that is safe if the
+order is specified correctly.
+
+However, this has been rejected for a number of reasons:
+
+- We've spent 15+ years educating users that the ordering of repositories being
+  specified is not meaningful, and they effectively have an undefined order. It
+  would be difficult to backpedal on that and start saying that now order
+  matters.
+- Users can easily rearrange the order that they specify their repositories in
+  within a single location, however when loading repositories from multiple
+  locations (env var, conf file, requirements file, cli arguments) the order is
+  hard coded into pip. While it would be a deterministic and documented order,
+  there's no reason to assume it's the order that the user wants their
+  repositories to be defined in, forcing them to contort thow they configure pip
+  so that the implicit ordering ends up being the correct one.
+- The above can be mitigated by providing a way to explicitly declare the order
+  rather than by implicitly using the order they were defined in, however that
+  then means that the protections are not provided unless the user does some
+  explicit configuration.
+- Ordering assumes that there is a linear ordering of repositories where two
+  repositories have the same name, we always prefer repositories in the same
+  order for every project, however that is not necessarily true.
+- Relying on ordering is subtle, if I look at an ordering of repositories, I
+  have no way of knowing in advance or ensuring in advance what names are going
+  to come from what repositories. I can only know in that moment what names are
+  provided by which repositories.
+- Relying on ordering is fragile. There's no reason to assume that two disparate
+  repositories are not going to have random naming collisions, what happens if
+  I'm using a library from a lower priority repository and then a higher
+  priority repository happens to start having a colliding name.
+- In cases where ordering does the wrong thing, it does so silently, with no
+  feedback given to the user. This is by design because it doesn't actually know
+  what the wrong or right thing is, it's just hoping that order will give the
+  right thing, and if it does then users are protected without any breakage.
+  However, when it does the wrong thing, users are left with a very confusing
+  behavior coming from pip, where it's just silently installing the wrong thing.
+
+There is a variant of this idea which effectively says that it's really just
+PyPI's nature of open registration that causes the real problems, so if we treat
+all repositories but the "default" one as equal priority, and then treat the
+default one as a lower priority then we'll fix things.
+
+That is true in that it does improve things, but it has many of the same
+problems as the general ordering idea (though not all of them), but it comes
+along with some of it's own:
+
+- There's no reason to assume that PyPI is the only repository with open
+  registration of names or that it would only be the "default" repository that
+  does this. Projects like Piwheels is an example where users are expected to
+  have a non default repository that also effectively has open registration of
+  names (since it just tracks whatever is registered on PyPI).
+
+
+Rely on repository proxies
+--------------------------
+
+One possible solution is to instead of having the installer have to solve this,
+to instead depend on repository proxies that can intelligently merge multiple
+repositories safely. This could provide a better experience for people with
+complex needs because they can have configuration and features that are
+dedicated to the problem space.
+
+However, that has been rejected because:
+
+- It requires users to opt into using them, unless we also remove the facilities
+  to have more than one repository in installers to force users into using a
+  repository proxy when they need multiple repositories.
+
+  - Removing facilities to have more than one repository configured has been
+    rejected because it would be too disruptive to end users.
+
+- A user may need different outcomes of merging multiple repositories in
+  different contexts, or may need to merge different, mutually exclusive
+  repositories. This means they'll need to actually setup multiple repository
+  proxies for each unique set of options.
+
+- It requires users to maintain infrastructure or it requires adding features in
+  installers to automatically spin up a repository for each invocation.
+
+- It doesn't actually change the requirement to need to have a solution to these
+  problems, it just shifts the responsibility of implementation from installers
+  to some repository proxy, but in either case we still need something that
+  figures out how to merge these disparate namespaces.
+
+- Ultimately, most users do not want to have to stand up a repository proxy just
+  to safely interact with multiple repositories.
+
+
+Rely only on hash checking
+--------------------------
+
+Another possible solution is to rely on hash checking, since with hash checking
+enabled users cannot get an artifact that they didn't expect, it doesn't matter
+if the namespaces are incorrectly merged or not.
+
+This is certainly a solution, unfortunately it also suffers from problems that
+make it unworkable:
+
+- It requires users to opt in to it, so users are still unprotected by default.
+- It requires users to do a bunch of labor to manage their hashes, which is
+  something that most users are unlikely to be willing to do.
+- It is difficult and verbose to get the protection when not using a
+  ``requirements.txt`` file as the source of your dependencies (this affects
+  build time dependencies, and dependencies provided at the command line).
+- It only sort of solves the problem, in a way it just shifts the responsibility
+  of the problem to be whatever system is generating the hashes that the
+  installer would use. If that system isn't a human manually validating hashes,
+  which it's unlikely it would be, then we've just shifted the question of how
+  to merge these namespaces to whatever tool implements the maintenance of the
+  hashes.
+
+
+Require all projects to exist in the "default" repository
+---------------------------------------------------------
+
+Another idea is that we can narrow the scope of ``--extra-index-url`` such that
+it's only supported use is to refer to supplemental repositories to the default
+repository, effectively saying that the default repository defines the
+namespace, and every additional repository just extends it with extra packages.
+
+The implementation of this would roughly be to require that the project **MUST**
+be registered with the default repository in order for any additional
+repositories to work.
+
+This sort of works if you successfully narrow the scope in that way, but
+ultimately it has been rejected because:
+
+- Users are unlikely to understand or accept this reduced scope, and thus are
+  likely to attempt to continue to use it in the now unsupported fashion.
+
+  - This is complicated by the fact that with the scope now narrowed, users who
+    have the excluded workflow no longer have any alternative besides setting up
+    a repository proxy, which takes infrastructure and effort that they
+    previously didn't have to do.
+
+- It assumes that just because a name in an "extra" repository is the same as in
+  the default repository, that they are the same project. If we were starting
+  from scratch in a brand new ecosystem then maybe we could make this assumption
+  from the start and make it stick, but it's going to be incredibly difficult to
+  get the ecosystem to adjust to that change.
+
+  - This is a fundamental issue with this approach, the underlying problem that
+    drives dependency confusion is that we're taking disparate namespaces and
+    flattening them into one. This approach essentially just declares that OK,
+    and attempts to mitigate it by requiring everyone to register their names.
+
+- Because of the above assumption, in cases where a name in an extra repository
+  collides by accident with the default repository, it's going to appear to work
+  for those users, but they are going to be silently in a state of dependency
+  confusion.
+
+  - This is made worse by the fact that the person who owns the name that is
+    allowing this to work is going to be completely unaware of the role that
+    they're playing for that user, and might possibly delete their project or
+    hand it off to someone else, potentially allowing them to inadvertently
+    allow a malicious user to take it over.
+
+- Users are likely to attempt to get back to a working state by registering
+  their names in their default repository as a defensive name squat. Their
+  ability to do this will depend on the specific policies of their default
+  repository, whether someone already has that name, whether it's too generic,
+  etc. At a best case scenario it will cause needless placeholder projects that
+  serve no purpose other than to secure some internal use of a name.
+
+
+Move to Globally Unique Names
+-----------------------------
+
+The main reason this problem exists is that we don't have globally unique names,
+we have locally unique names that exist under multiple namespaces that we are
+attempting to merge into a single flat namespace. If we could instead come up
+with a way to have globally unique names, we could sidestep the entire issue.
+
+This idea has been rejected because:
+
+- Generating globally unique but secure names that are also meaningful to humans
+  is a nearly impossible feat without piggybacking off of some kind of
+  centralized database. To my knowledge the only systems that have managed to do
+  this end up piggybacking off of the domain system and refer to packages by
+  URLs with domains etc.
+- Even if we come up with a mechanism to get globally unique names, our ability
+  to retrofit that into our decades old system is practically zero without
+  burning it all to the ground and starting over. The best we could probably do
+  is declare that all non globally unique names are implicitly names on the PyPI
+  domain name, and force everyone with a non PyPI package to rename their
+  package.
+- This would upend so many core assumptions and fundamental parts of our current
+  system it's hard to even know where to start to list them.
+
+
+Only recommend installers offer explicit configuration
+------------------------------------------------------
+
+One idea that has come up is to essentially just implement the explicit
+configuration and don't make any other changes to anything else. The specific
+proposal for a mapping policy is what actually inspired explicit configuration
+option, and created a file that looked something like:
+
+  .. code-block:: JSON
+
+    {
+      "repositories": {
+        "PyTorch": ["https://download.pytorch.org/whl/nightly"],
+        "PyPI": ["https://pypi.org/simple"]
+      },
+      "mapping": [
+        {
+          "paths": ["torch*"],
+          "repositories": ["PyTorch"],
+          "terminating": true
+        },
+        {
+          "paths": ["*"],
+          "repositories": ["PyPI"]
+        }
+      ]
+    }
+
+The recommendation to have explicit configuration pushes the decision on how to
+implement that onto each installer, allowing them to choose what works best for
+their users.
+
+Ultimately only implementing some kind of explicit configuration was rejected
+because by its nature it's opt in, so it doesn't protect average users who are
+least capable to solve the problem with the existing tools, by adding additional
+protections alongside the explicit configuration, we are able to protect all
+users by default.
+
+Additionally, relying on only explicit configuration also means that every end
+user has to resolve the same problem over and over again, even in cases like
+mirrors of PyPI, Piwheels, PyTorch, etc. In each and every case they have to sit
+there and make decisions (or find some example to cargo cult) in order to be
+secure. Adding extra features into the mix allows us to centralize those
+protections where we can, while still giving advanced end users the ability to
+completely control their own destiny.
+
+
+Scopes à la npm
+---------------
+
+There's been some suggestion that scopes similar to how npm has implemented them
+may ultimately solve this. Ultimately scopes do not change anything about this
+problem. As far as I know scopes in npm are not globally unique, they're tied to
+a specific registry just like unscoped names are. However what scopes do enable
+is an obvious mechanism for grouping related projects and the ability for a user
+or organization on npm.org to claim an entire scope, which makes explicit
+configuration significantly easier to handle because you can be assured that
+there's a whole little slice of the namespace that wholly belongs to you, and
+you can easily write a rule that assigns an entire scope to a specific non
+public registry.
+
+Unfortunately, it basically ends up being an easier version of the idea to only
+use explicit configuration, which works ok in npm because its not particularly
+common for people to use their own registries, but in Python we encourage you to
+do just that.
+
+
+Open questions
+==============
+
+1. The `original proposal document <https://docs.google.com/document/d/184fQkb6NggVQfYmjTDA7p_U3iWDKk6grc2DigT1X3Es/>`__
+   was targeted more specifically to a change to pip, and went into more
+   specific details as to what we expected from pip. Since dictating UX to
+   installers isn't something that we do in PEPs, I've rewritten those parts to
+   be more generic, however that means that we lose the information on
+   repository files. Is that fine? Or should we standardize what a repository
+   file looks like so the same file can be given to multiple installers instead
+   of hand waving around the specific mechanism installers would use for
+   explicit configuration?
+2. Is the Appendix section on communicating the change useful or confusing?
+
+
+Appendix: Communicating the Change
+==================================
+
+*Note: This is pip specific and assumes specifics about how pip will choose to
+implement this PEP, it's included as an example of how we can communicate this
+change out to end users as the ecosystem rolls this change out. The entire
+Appendix should be considered to be a single communication (blog post, discuss
+post, email, whatever).*
+
+
+There's a long-standing class of attacks that are called "dependency confusion"
+attacks, which roughly boil down to an individual expected to get package ``A``,
+but instead they got ``B``. In Python, this almost always happens due to the end
+user having configured multiple repositories, where they expect package ``A`` to
+come from repository ``X``, but someone is able to publish package ``B`` with the
+same name as package ``A`` in repository ``Y``.
+
+There are a number of ways to mitigate against these attacks today, but they all
+require that the end user explicitly go out of their way to protect themselves,
+rather than it being inherently safe.
+
+In an effort to secure pip's users and protect them from these types of attacks,
+we will be changing how pip discovers packages to install.
+
+
+What is Changing?
+-----------------
+
+When pip discovers that the same project is available from multiple remote
+repositories, by default it will generate an error and refuse to proceed rather
+than make a guess about which repository was the correct one to install from.
+
+Projects that natively publish to multiple repositories will be given the
+ability to safely "link" their repositories together so that pip does not error
+when those repositories are used together.
+
+End users of pip will be given the ability to explicitly define one or more
+repositories that are valid for a specific project, causing pip to only consider
+those repositories for that project, and avoiding generating an error altogether.
+
+See TBD for more information.
+
+
+Who is Affected?
+----------------
+
+Users who are installing from multiple remote (e.g. not present on the local
+filesystem) repositories may be affected by having pip error instead of
+successfully install if:
+
+- They install a project where the same "name" is being served by multiple
+  remote repositories.
+- The project name that is available from multiple remote repositories has not
+  used one of the defined mechanisms to link those repositories together.
+- The user invoking pip has not used the define mechanism to explicitly control
+  what repositories are valid for a particular project.
+
+Users who are not using multiple remote repositories will not be affected at
+all, which includes users who are only using a single remote repository, plus a
+local filesystem "wheel house".
+
+
+What do I need to do?
+---------------------
+
+As a pip User?
+~~~~~~~~~~~~~~
+
+If you're using only a single remote repository you do not have to do anything.
+
+If you're using multiple remote repositories, you can opt into the new behavior
+by adding ``--use-feature=TBD`` to your pip invocation to see if any of your
+dependencies are being served from multiple remote repositories. If they are,
+you should audit them to determine why they are, and what the best remediation
+step will be for you.
+
+Once this behavior becomes the default, you can opt out of it temporarily by
+adding ``--use-deprecated=TBD`` to your pip invocation.
+
+If you're using projects that are not hosted on a public repository, but you
+still have the public repository as a fallback, consider configuring pip with a
+repository file to be explicit where that dependency is meant to come from to
+prevent registration of that name in a public repository to cause pip to error
+for you.
+
+
+As a Project Owner?
+~~~~~~~~~~~~~~~~~~~
+
+If you only publish your project to a single repository, then you do not have to
+do anything.
+
+If you publish your project to multiple repositories that are intended to be
+used together at the same time, configure all repositories to serve the
+alternate repository metadata to prevent breakages for your end users.
+
+If you publish your project to a single repository, but it is commonly used in
+conjunction with other repositories, consider preemptively registering your
+names with those repositories to prevent a third party from being able to cause
+your users ``pip install`` invocations to start failing. This may not be
+available if your project name is too generic or if the repositories have
+policies that prevent defensive name squatting.
+
+
+As a Repository Operator?
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You'll need to decide how you intend for your repository to be used by your end
+users and how you want them to use it.
+
+For private repositories that host private projects, it is recommended that you
+mirror the public projects that your users depend on into your own repository,
+taking care not to let a public project merge with a private project, and tell
+your users to use the ``--index-url`` option to use only your repository.
+
+For public repositories that host public projects, you should implement the
+alternate repository mechanism and enable the owners of those projects to
+configure the list of repositories that their project is available from if they
+make it available from more than one repository.
+
+For public repositories that "track" another repository, but provide
+supplemental artifacts such as wheels built for a specific platform, you should
+implement the "tracks" metadata for your repository. However, this information
+**MUST NOT** be settable by end users who are publishing projects to your
+repository. See TBD for more information.
+
+
+Copyright
+=========
+
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.


### PR DESCRIPTION
## Basic requirements (all PEP Types)

* [x] Read and followed [PEP 1](https://peps.python.org/1) & [PEP 12](https://peps.python.org/12)
* [x] File created from the [latest PEP template](https://github.com/python/peps/blob/main/pep-0012/pep-NNNN.rst?plain=1)
* [x] PEP has next available number, & set in filename (``pep-NNNN.rst``), PR title (``PEP 123: <Title of PEP>``) and ``PEP`` header
* [x] Title clearly, accurately and concisely describes the content in 79 characters or less
* [x] ``PEP``, ``Title``, ``Author``, ``Status`` (``Draft``), ``Type`` and ``Created`` headers filled out correctly
* [x] ``PEP-Delegate``, ``Topic``, ``Requires`` and ``Replaces`` headers completed if appropriate
* [x] Core dev/PEP editor listed as author or sponsor, and formally confirmed their approval
* [x] Required sections included
    * [x] Abstract (first section)
    * [x] Copyright (last section; exact wording from template required)
* [x] Code is well-formatted (PEP 7/PEP 8) and is in [code blocks, with the right lexer names](https://peps.python.org/pep-0012/#literal-blocks) if non-Python
* [x] PEP builds with no warnings, pre-commit checks pass and content displays as intended in the rendered HTML
* [x] Authors/sponsor added to ``.github/CODEOWNERS`` for the PEP


## Standards Track requirements

* [x] PEP topic [discussed in a suitable venue](https://peps.python.org/pep-0001/#start-with-an-idea-for-python) with general agreement that a PEP is appropriate
* [x] [Suggested sections](https://peps.python.org/pep-0012/#suggested-sections) included (unless not applicable)
    * [x] Motivation
    * [x] Rationale
    * [x] Specification
    * [x] ~~Backwards Compatibility~~
    * [x] ~~Security Implications~~
    * [x] ~~How to Teach This~~
    * [x] ~~Reference Implementation~~
    * [x] Rejected Ideas
    * [x] Open Issues
* [x] ~~``Python-Version`` set to valid (pre-beta) future Python version~~
* [x] Any project stated in the PEP as supporting/endorsing/benefiting from it confirms such
* [ ] Right before or after initial merging, [PEP discussion thread](https://peps.python.org/pep-0001/#discussing-a-pep) created and linked to in ``Discussions-To`` and ``Post-History``
