### PR TITLE
PEP 709: Remove obsolete incompatibility subsection

### DIFF
--- a/pep-0709.rst
+++ b/pep-0709.rst
@@ -225,24 +225,6 @@ the library. In such a scenario it would usually be simpler and more reliable
 to raise the warning closer to the calling code and bypass fewer frames.
 
 
-UnboundLocalError instead of NameError
---------------------------------------
-
-Although the value of the comprehension iteration variable is saved and
-restored to provide isolation, it still becomes a local variable of the outer
-function under this PEP. This implies a small behavior change in a function
-where the comprehension iteration variable is accessed outside the
-comprehension without ever being set outside the comprehension::
-
-   def f(lst):
-       items = [x for x in lst]
-       return x
-
-Under this PEP, calling ``f()`` will raise ``UnboundLocalError``, where
-currently it raises ``NameError``. ``UnboundLocalError`` is a subclass of
-``NameError``, so this should not impact code catching ``NameError``.
-
-
 How to Teach This
 =================
 


### PR DESCRIPTION
This "incompatibility" does not actually exist in the current reference implementation, I just hadn't realized that it had been fixed.