### PR TITLE
Infra: Automatically edit PRs with link to RTD preview

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -1,0 +1,16 @@
+name: Read the Docs PR preview
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "pep-previews"


### PR DESCRIPTION
Once merged, this will automatically add a docs preview link to PRs.

> GitHub Action that automatically edits Pull Requests' descriptions with a link to documentation's preview on Read the Docs.

https://github.com/readthedocs/actions/tree/v1/preview

For example: https://github.com/python/docs-community/pull/75