### PR TITLE
Infra: RTD preview links should be single version

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -14,3 +14,4 @@ jobs:
       - uses: readthedocs/actions/preview@v1
         with:
           project-slug: "pep-previews"
+          single-version: "true"


### PR DESCRIPTION
Follow on from https://github.com/python/peps/pull/3031.

See for example https://github.com/python/peps/pull/3034: it links to https://pep-previews--3034.org.readthedocs.build/en/3034/ (404) but should like to https://pep-previews--3034.org.readthedocs.build/ because we build Read the Docs as a "single version" with no language or other versions.

Docs: https://github.com/readthedocs/actions/tree/v1/preview#configuration

Likely needs merging to take effect.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3035.org.readthedocs.build/en/3035/

<!-- readthedocs-preview pep-previews end -->