### PR TITLE
PEP 582: Tweek `sysconfig` and path details, and add some minor clarifications

### DIFF
--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -111,7 +111,11 @@ An absolute version of these two locations will be added to ``sys.path``, other
 directories or files in the ``__pypackages__`` directory will be silently
 ignored. The paths will be based on Python versions.
 
-.. note:: There is a possible option of having a separate new API, it is documented at `issue #3013 <https://github.com/python/peps/issues/3013>`_.
+.. note::
+
+    There is a possible option of having a separate new API, to avoid
+    `sysconfig` having to provide other scheme paths. It is documented at
+    `issue #3013 <https://github.com/python/peps/issues/3013>`_.
 
 
 Example

--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -97,18 +97,19 @@ works. For example, ``__pypackages__`` will be ignored if the ``-P`` option or
 the ``PYTHONSAFEPATH`` environment variable is set.
 
 In order to be recognised, the ``__pypackages__`` directory must be laid out
-according to a new ``localpackages`` scheme in the sysconfig module.
+according to a new ``local_packages`` scheme in the sysconfig module.
 Specifically, both of the ``purelib`` and ``platlib`` directories must be
 present, using the following code to determine the locations of those
 directories::
 
-    scheme = "localpackages"
-    purelib = sysconfig.get_path("purelib", scheme, vars={"base": "__pypackages__", "platbase": "__pypackages__"})
-    platlib = sysconfig.get_path("platlib", scheme, vars={"base": "__pypackages__", "platbase": "__pypackages__"})
+    >>> paths = sysconfig.get_paths("local_packages", vars={"base": ".", "platbase": "."})
+    >>> paths["purelib"], paths["platlib"]
+    ("./__pypackages__/3.10/site-packages", "./__pypackages__/3.10/site-packages")
 
-These two locations will be added to ``sys.path``, other directories or
-files in the ``__pypackages__`` directory will be silently ignored. The
-paths will be based on Python versions.
+
+An absolute version of these two locations will be added to ``sys.path``, other
+directories or files in the ``__pypackages__`` directory will be silently
+ignored. The paths will be based on Python versions.
 
 .. note:: There is a possible option of having a separate new API, it is documented at `issue #3013 <https://github.com/python/peps/issues/3013>`_.
 
@@ -118,21 +119,19 @@ Example
 
 The following shows an example project directory structure, and different ways
 the Python executable and any script will behave. The example is for Unix-like
-systems - on Windows the subdirectories will be different.
+systems - on Windows the subdirectories can be different.
 
 ::
 
-    foo
-        __pypackages__
-            lib
-                python3.10
-                           site-packages
-                                         bottle
-        myscript.py
+    foo/
+    ├── myscript.py
+    └── __pypackages__
+        └── 3.10
+            └── site-packages
 
     /> python foo/myscript.py
     sys.path[0] == 'foo'
-    sys.path[1] == 'foo/__pypackages__/lib/python3.10/site-packages/'
+    sys.path[1] == 'foo/__pypackages__/3.10/site-packages'
 
 
     cd foo
@@ -145,13 +144,13 @@ systems - on Windows the subdirectories will be different.
 
     foo> python
     sys.path[0] == '.'
-    sys.path[1] == './__pypackages__/lib/python3.10/site-packages'
+    sys.path[1] == './__pypackages__/3.10/site-packages'
 
     foo> python -m bottle
 
 We have a project directory called ``foo`` and it has a ``__pypackages__``
 inside of it. We have ``bottle`` installed in that
-``__pypackages__/lib/python3.10/site-packages/``, and have a ``myscript.py``
+``__pypackages__/3.10/site-packages/``, and have a ``myscript.py``
 file inside of the project directory. We have used whatever tool we generally
 use to install ``bottle`` in that location.
 

--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -230,7 +230,7 @@ significant issue, as it is unlikely that anyone would be able to write to
 
 For a ``__pypackages__`` directory in the current working directory, the
 interactive interpreter could be affected. However, this is not significantly
-different than the existing issue of someone having a ``math.py`` mdule in their
+different than the existing issue of someone having a ``math.py`` module in their
 current directory, and while (just like that case) it can cause user confusion,
 it does not introduce any new security implications.
 

--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -234,11 +234,11 @@ different than the existing issue of someone having a ``math.py`` module in thei
 current directory, and while (just like that case) it can cause user confusion,
 it does not introduce any new security implications.
 
-When running a script, any ``__pypackages__`` directory in the current working
-directory is ignored. This is the same approach Python uses for adding the
-current working directory to ``sys.path`` and ensures that it is not possible
-to change the behaviour of a script by modifying files in the current
-directory.
+When running a script from a different path, any ``__pypackages__`` directory in
+the current working directory is ignored. This is the same approach Python uses
+for adding the current working directory to ``sys.path`` and ensures that it is
+not possible to change the behaviour of a script by modifying files in the
+current directory.
 
 Also, a ``__pypackages__`` directory is only recognised in the current (or
 script) directory. The interpreter will *not* scan for ``__pypackages__`` in

--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -97,10 +97,11 @@ works. For example, ``__pypackages__`` will be ignored if the ``-P`` option or
 the ``PYTHONSAFEPATH`` environment variable is set.
 
 In order to be recognised, the ``__pypackages__`` directory must be laid out
-according to a new ``local_packages`` scheme in the sysconfig module.
-Specifically, both of the ``purelib`` and ``platlib`` directories must be
-present, using the following code to determine the locations of those
-directories::
+according to a new ``local_packages`` scheme in the sysconfig module. The scheme
+will provide the ``purelib`` and ``platlib`` paths, but is not required to
+provide any additional paths.
+
+The following code can be used to determine the locations of the directories::
 
     >>> paths = sysconfig.get_paths("local_packages", vars={"base": ".", "platbase": "."})
     >>> paths["purelib"], paths["platlib"]

--- a/pep-0582.rst
+++ b/pep-0582.rst
@@ -114,8 +114,8 @@ ignored. The paths will be based on Python versions.
 .. note::
 
     There is a possible option of having a separate new API, to avoid
-    `sysconfig` having to provide other scheme paths. It is documented at
-    `issue #3013 <https://github.com/python/peps/issues/3013>`_.
+    `sysconfig` having to provide other scheme paths. It is documented in
+    `Kushal's fork <https://github.com/kushaldas/peps/issues/3>`_.
 
 
 Example


### PR DESCRIPTION
@kushaldas I have a couple changes here, mostly related to `sysconfig`. Could you have a look?

Changes:

- Rename the `sysconfig` scheme from `localpackages` to `local_packages`
  - It now follows the naming scheme, where words are separated by an underscore
- Clarify that the scheme `local_packages` is only required to provide the `purelib` and `platlib` paths
  - I still plan to provide the other paths, to keep backwards compatibility, if we don't have a new `sysconfig` by the time PEP 582 is released
- Remove `__pypackages__` directory from the `base`/`platbase` definitions
  - IMO it should be part of the scheme, eg.
    ```
    ...
    'local_packages_posix': {
        'stdlib': '{installed_base}/{platlibdir}/python{py_version_short}',
        'platstdlib': '{installed_platbase}/{platlibdir}/python{py_version_short}',
        'include': '{installed_base}/include/python{py_version_short}{abiflags}',
        'platinclude': '{installed_platbase}/include/python{py_version_short}{abiflags}',
        'purelib': '{base}/__pypackages__/{py_version_short}/site-packages',
        'platlib': '{platbase}/__pypackages__/{py_version_short}/site-packages',
        'scripts': '{base}/__pypackages__/bin',
        'data': '{base}/__pypackages__/data',
    },
    ...
    ```
- Change the layout to `__pypackages__/3.10/site-packages`
  - There's no need for all that clutter in the path here, we are not installing on the system, we are installing language-specific directory
- Clarify that the subdirectory paths on Windows do not need to be different ("will be different" > "can be different")
- Specify that we will expand the local packages paths to an absolute path before adding them to `sys.path`
  - If we let them be relative, `os.chdir`  will change the location of the `__pypackages__`, bypassing the mechanisms described in the security considerations section
- Clarify why we are offering an alternative option for the `sysconfig` API
  - This gives a bit more context to the reader, which IMO makes it a bit easier to follow
- Update link of the `sysconfig` API proposal to Kushal's fork, where it was moved to
- Clarify that when we say that the `__pypackages__` in the current directory will be ignored when running a script, that we mean when running a script *from a different path*
  - Running a script in the current path will still pick up `__pypackages__` from the current directory

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3036.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->