### PR TITLE
Infra: Only add Topics index to PEP 0, not topic indices

### DIFF
--- a/pep_sphinx_extensions/pep_zero_generator/constants.py
+++ b/pep_sphinx_extensions/pep_zero_generator/constants.py
@@ -35,6 +35,10 @@ ACTIVE_ALLOWED = {TYPE_PROCESS, TYPE_INFO}
 
 # map of topic -> additional description
 SUBINDICES_BY_TOPIC = {
+    "governance": """\
+These PEPs detail Python's governance, including governance model proposals
+and selection, and the results of the annual steering council elections.
+    """,
     "packaging": """\
 Packaging PEPs follow the `PyPA specification update process`_.
 They are used to propose major additions or changes to the PyPA specifications.
@@ -55,9 +59,5 @@ See the `developer's guide`_ for more information.
 Many recent PEPs propose changes to Python's static type system
 or otherwise relate to type annotations.
 They are listed here for reference.
-""",
-    "governance": """\
-These PEPs detail Python's governance, including governance model proposals
-and selection, and the results of the annual steering council elections.
 """,
 }

--- a/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
+++ b/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
@@ -55,7 +55,7 @@ def create_pep_json(peps: list[parser.PEP]) -> str:
 def create_pep_zero(app: Sphinx, env: BuildEnvironment, docnames: list[str]) -> None:
     peps = _parse_peps()
 
-    pep0_text = writer.PEPZeroWriter().write_pep0(peps)
+    pep0_text = writer.PEPZeroWriter().write_pep0(peps, builder=env.settings["builder"])
     pep0_path = subindices.update_sphinx("pep-0000", pep0_text, docnames, env)
     peps.append(parser.PEP(pep0_path))
 

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -132,13 +132,16 @@ class PEPZeroWriter:
         self.emit_newline()
 
         # PEPs by topic
-        self.emit_title("Topics")
-        self.emit_text("PEPs for specialist subjects are :doc:`indexed by topic <topic/index>`.")
-        self.emit_newline()
-        for subindex in SUBINDICES_BY_TOPIC:
-            self.emit_text(f"* `{subindex.title()} PEPs <topic/{subindex}>`_")
+        if is_pep0:
+            self.emit_title("Topics")
+            self.emit_text(
+                "PEPs for specialist subjects are :doc:`indexed by topic <topic/index>`."
+            )
             self.emit_newline()
-        self.emit_newline()
+            for subindex in SUBINDICES_BY_TOPIC:
+                self.emit_text(f"* `{subindex.title()} PEPs <topic/{subindex}>`_")
+                self.emit_newline()
+            self.emit_newline()
 
         # PEPs by category
         self.emit_title("Index by Category")

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -118,7 +118,14 @@ class PEPZeroWriter:
             self.emit_text("     -")
         self.emit_newline()
 
-    def write_pep0(self, peps: list[PEP], header: str = HEADER, intro: str = INTRO, is_pep0: bool = True):
+    def write_pep0(
+        self,
+        peps: list[PEP],
+        header: str = HEADER,
+        intro: str = INTRO,
+        is_pep0: bool = True,
+        builder: str = None,
+    ):
         if len(peps) == 0:
             return ""
 
@@ -139,7 +146,12 @@ class PEPZeroWriter:
             )
             self.emit_newline()
             for subindex in SUBINDICES_BY_TOPIC:
-                self.emit_text(f"* `{subindex.title()} PEPs <topic/{subindex}>`_")
+                target = (
+                    f"topic/{subindex}.html"
+                    if builder == "html"
+                    else f"topic/{subindex}"
+                )
+                self.emit_text(f"* `{subindex.title()} PEPs <{target}>`_")
                 self.emit_newline()
             self.emit_newline()
 


### PR DESCRIPTION
<!--
This template is for an infra or meta change not belonging to another category.
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

Follow on from https://github.com/python/peps/pull/2892.

That PR also inserts the links on subindex pages too:

<img width="810" alt="image" src="https://user-images.githubusercontent.com/1324225/222894434-006a9d62-853c-44d2-ae3b-752677bf81af.png">

But the links are 404, e.g. https://peps.python.org/topic/packaging/topic/packaging

We don't really need them there, so let's only add it for the "real" PEP 0 page.

---

Also, fix the links to have `.html` for the "html" builder, and put Governance first in the list, to match the https://peps.python.org/topic/ page.


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3037.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->