### PR TITLE
Meta: Document the shortcut links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,10 @@ Canonical links
 ===============
 
 The canonical form of PEP links are zero-padded, such as
-https://peps.python.org/pep-0008/
+``https://peps.python.org/pep-0008/``
 
 Shortcut redirects are also available.
-For example, https://peps.python.org/8 redirects to the canonical form.
+For example, ``https://peps.python.org/8`` redirects to the canonical link.
 
 
 Contributing to PEPs

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,16 @@ about writing one, please start reading at :pep:`1`. Note that the PEP Index
 (:pep:`0`) is automatically generated based on the metadata headers in other PEPs.
 
 
+Canonical links
+===============
+
+The canonical form of PEP links are zero-padded, such as
+https://peps.python.org/pep-0008/
+
+Shortcut redirects are also available.
+For example, https://peps.python.org/8 redirects to the canonical form.
+
+
 Contributing to PEPs
 ====================
 


### PR DESCRIPTION
Fixes https://github.com/python/peps/issues/2985.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3043.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->