### PR TITLE
PEP 693: Update with the release date for 3.12.0a6

### DIFF
--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -48,7 +48,7 @@ Actual:
 - 3.12.0 alpha 3: Tuesday, 2022-12-06
 - 3.12.0 alpha 4: Tuesday, 2023-01-10
 - 3.12.0 alpha 5: Tuesday, 2023-02-07
-- 3.12.0 alpha 6: Wednesday, 2023-03-08
+- 3.12.0 alpha 6: Tuesday, 2023-03-07
 
 Expected:
 

--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -48,10 +48,10 @@ Actual:
 - 3.12.0 alpha 3: Tuesday, 2022-12-06
 - 3.12.0 alpha 4: Tuesday, 2023-01-10
 - 3.12.0 alpha 5: Tuesday, 2023-02-07
+- 3.12.0 alpha 6: Wednesday, 2023-03-08
 
 Expected:
 
-- 3.12.0 alpha 6: Monday, 2023-03-06
 - 3.12.0 alpha 7: Monday, 2023-04-03
 - 3.12.0 beta 1: Monday, 2023-05-08
   (No new features beyond this point.)


### PR DESCRIPTION
> Release Date: March 8, 2023

* https://www.python.org/downloads/release/python-3120a6/


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3045.org.readthedocs.build/pep-0693/

<!-- readthedocs-preview pep-previews end -->