### PR TITLE
Fix invalid escape sequence and dangling hyphens.

### DIFF
--- a/pep-0426/pepsort.py
+++ b/pep-0426/pepsort.py
@@ -17,10 +17,10 @@ from distlib.version import suggest_normalized_version, legacy_key, normalized_k
 
 logger = logging.getLogger(__name__)
 
-PEP426_VERSION_RE = re.compile('^(\d+(\.\d+)*)((a|b|c|rc)(\d+))?'
-                               '(\.(post)(\d+))?(\.(dev)(\d+))?$')
+PEP426_VERSION_RE = re.compile(r'^(\d+(\.\d+)*)((a|b|c|rc)(\d+))?'
+                               r'(\.(post)(\d+))?(\.(dev)(\d+))?$')
 
-PEP426_PRERELEASE_RE = re.compile('(a|b|c|rc|dev)\d+')
+PEP426_PRERELEASE_RE = re.compile(r'(a|b|c|rc|dev)\d+')
 
 def pep426_key(s):
     s = s.strip()

--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -1524,8 +1524,8 @@ not at the same time).
 
 The proposed module maintains this behavior.  Subinterpreters are not
 tied to threads.  Only calls to ``Interpreter.run()`` are.  However,
-one of the key objectives of this PEP is to provide a more human-
-centric concurrency model.  With that in mind, from a conceptual
+one of the key objectives of this PEP is to provide a more
+human-centric concurrency model.  With that in mind, from a conceptual
 standpoint the module *might* be easier to understand if each
 subinterpreter were associated with its own thread.
 

--- a/pep-0560.rst
+++ b/pep-0560.rst
@@ -280,8 +280,8 @@ With the reference implementation I measured negligible performance effects
 time performance of generics is significantly improved:
 
 * ``importlib.reload(typing)`` is up to 7x faster
-* Creation of user defined generic classes is up to 4x faster (on a micro-
-  benchmark with an empty body)
+* Creation of user defined generic classes is up to 4x faster (on a
+  micro-benchmark with an empty body)
 * Instantiation of generic classes is up to 5x faster (on a micro-benchmark
   with an empty ``__init__``)
 * Other operations with generic types and instances (like method lookup and

--- a/pep-0633.rst
+++ b/pep-0633.rst
@@ -116,8 +116,9 @@ Requirement table
 
 The keys of the requirement table are as follows (all are optional):
 
-- ``version`` (string): a :pep:`440` version specifier, which is a comma-
-  delimited list of version specifier clauses. The string MUST be non-empty.
+- ``version`` (string): a :pep:`440` version specifier, which is a
+  comma-delimited list of version specifier clauses. The string MUST be
+  non-empty.
 
 - ``extras`` (array of strings): a list of :pep:`508` extras declarations for
   the distribution. The list MUST be non-empty.


### PR DESCRIPTION
see https://github.com/sphinx-contrib/sphinx-lint/pull/56 and https://github.com/sphinx-contrib/sphinx-lint/issues/54.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3049.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->