### PR TITLE
PEP 558: fix typo & tweak wording in deferral note

### DIFF
--- a/pep-0558.rst
+++ b/pep-0558.rst
@@ -21,9 +21,9 @@ viable as an implementation of the PEP as written.
 
 This situation came about for two main reasons:
 
-* first, several keys parts of the original implementation were invalidated when
+* first, several key parts of the original implementation were invalidated when
   the semantic improvements arising from the development of :pep:`667` resulted in
-  the PEP as written diverging from what had previously been implemented
+  the proposal in the PEP diverging from what had previously been implemented
 * second, several remaining practical aspects of the original implementation were
   invalidated by the frame management changes that formed part of the significant
   performance improvements published in the CPython 3.11 release, so the development


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3051.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->