### PR TITLE
PEP 696: Have Discussions-To point to thread rather than comment

### DIFF
--- a/pep-0696.rst
+++ b/pep-0696.rst
@@ -10,7 +10,7 @@ Content-Type: text/x-rst
 Created: 14-Jul-2022
 Python-Version: 3.12
 Post-History: `22-Mar-2022 <https://mail.python.org/archives/list/typing-sig@python.org/thread/7VWBZWXTCX6RAJO6GG67BAXUPFZ24NTC/>`__,
-              `08-Jan-2023 <https://discuss.python.org/t/pep-696-type-defaults-for-typevarlikes/22569/5/>`__,
+              `08-Jan-2023 <https://discuss.python.org/t/pep-696-type-defaults-for-typevarlikes/22569/>`__,
 
 Abstract
 --------


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

PR #3052 accidentally linked directly to an arbitrary comment in the Discussions-To thread rather than the thread itself, and managed to bypass the linter by adding a trailing slash, which was introduced in #3005 as an escape hatch in response to the author's desire in #3004 to link to a specific post, given a strong reason to do so. It was presumably unintentional here, and thus this PR fixes it.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3053.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->