### PR TITLE
PEP 709: clarify that async comprehensions are also inlined

### DIFF
--- a/pep-0709.rst
+++ b/pep-0709.rst
@@ -156,6 +156,9 @@ Generator expressions are currently not inlined in the reference implementation
 of this PEP. In the future, some generator expressions may be inlined, where the
 returned generator object does not leak.
 
+Asynchronous comprehensions are inlined the same as synchronous ones; no special
+handling is needed.
+
 
 Backwards Compatibility
 =======================


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3071.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->