### PR TITLE
PEP 667: Update to reflect latest discussion and ideas

### DIFF
--- a/pep-0667.rst
+++ b/pep-0667.rst
@@ -129,22 +129,41 @@ C-API
 Extensions to the API
 '''''''''''''''''''''
 
-Two new C-API functions will be added::
+Four new C-API functions will be added::
 
-    PyObject *PyEval_Locals(void)
+    PyObject *PyEval_GetFrameLocals(void)
+    PyObject *PyEval_GetFrameGlobals(void)
+    PyObject *PyEval_GetFrameBuiltins(void)
     PyObject *PyFrame_GetLocals(PyFrameObject *f)
 
-``PyEval_Locals()`` is equivalent to: ``locals()``.
+``PyEval_GetFrameLocals()`` is equivalent to: ``locals()``.
+``PyEval_GetFrameGlobals()`` is equivalent to: ``globals()``.
 
 ``PyFrame_GetLocals(f)`` is equivalent to: ``f.f_locals``.
 
-Both functions will return a new reference.
+All these functions will return a new reference.
 
 Changes to existing APIs
 ''''''''''''''''''''''''
 
-The C-API function ``PyEval_GetLocals()`` will be deprecated.
-``PyEval_Locals()`` should be used instead.
+The following C-API functions will be deprecated, as they return borrowed references::
+
+   PyEval_GetLocals()
+   PyEval_GetGlobals()
+   PyEval_GetBuiltins()
+
+They will be will be removed in 3.14.
+
+The following functions should be used instead::
+
+   PyEval_GetFrameLocals()
+   PyEval_GetFrameGlobals()
+   PyEval_GetFrameBuiltins()
+
+which return new references.
+
+The semantics of ``PyEval_GetLocals()`` is changed as it now returns a
+view of the frame locals, not a dictionary.
 
 The following three functions will become no-ops, and will be deprecated::
 
@@ -152,7 +171,7 @@ The following three functions will become no-ops, and will be deprecated::
     PyFrame_FastToLocals()
     PyFrame_LocalsToFast()
 
-The above four deprecated functions will be removed in 3.13.
+They will be will be removed in 3.14.
 
 Behavior of f_locals for optimized functions
 --------------------------------------------
@@ -186,10 +205,7 @@ PyEval_GetLocals
 
 Because ``PyEval_GetLocals()`` returns a borrowed reference, it requires
 the dictionary to be cached on the frame, extending its lifetime and
-forces memory to be allocated for the frame object on the heap as well.
-
-Using ``PyEval_Locals()`` will be much more efficient
-than ``PyEval_GetLocals()``.
+creating a cycle. ``PyEval_GetFrameLocals()`` should be used instead.
 
 This code::
 
@@ -201,7 +217,7 @@ This code::
 
 should be replaced with::
 
-    locals = PyEval_Locals();
+    locals = PyEval_GetFrameLocals();
     if (locals == NULL) {
         goto error_handler;
     }
@@ -268,9 +284,11 @@ They serve only to illustrate the proposed design.
 
         _locals : array[Object] # The values of the local variables, items may be NULL.
         _extra_locals: dict | NULL # Dictionary for storing extra locals not in _locals.
+        _locals_cache: FrameLocalsProxy | NULL # required to support PyEval_GetLocals()
 
         def __init__(self, ...):
             self._extra_locals = NULL
+            self._locals_cache = NULL
             ...
 
         @property
@@ -360,8 +378,9 @@ C API
 
     PyObject *PyEval_GetLocals(void) {
         PyFrameObject * = ...; // Get the current frame.
-        Py_CLEAR(frame->_locals_cache);
-        frame->_locals_cache = PyEval_Locals();
+        if (frame->_locals_cache == NULL) {
+            frame->_locals_cache = PyEval_GetFrameLocals();
+        }
         return frame->_locals_cache;
     }
 
@@ -383,9 +402,11 @@ whereas this PEP does not.
 :pep:`558` does not specify exactly when the internal copy is
 updated, making the behavior of :pep:`558` impossible to reason about.
 
-
 Open Issues
 ===========
+
+Have locals() return a mapping proxy
+''''''''''''''''''''''''''''''''''''
 
 An alternative way to define ``locals()`` would be simply as::
 
@@ -395,6 +416,20 @@ An alternative way to define ``locals()`` would be simply as::
 This would be simpler and easier to understand. However,
 there would be backwards compatibility issues when ``locals`` is assigned
 to a local variable or when passed to ``eval`` or ``exec``.
+
+Lifetime of the mapping proxy
+'''''''''''''''''''''''''''''
+
+Each read of the ``f_locals`` attributes creates a new mapping proxy.
+This is done to avoid creating a reference cycle.
+
+An alternative would be to cache the proxy on the frame, so that
+``frame.f_locals is frame.f_locals`` would be true.
+The downside of this is that the reference cycle would delay collection
+of both the frame and mapping proxy until the next cycle collection.
+
+``PyEval_GetLocals()`` already creates a cycle, as it returns a borrowed reference.
+
 
 References
 ==========

--- a/pep-0667.rst
+++ b/pep-0667.rst
@@ -406,7 +406,7 @@ Open Issues
 ===========
 
 Have locals() return a mapping proxy
-''''''''''''''''''''''''''''''''''''
+------------------------------------
 
 An alternative way to define ``locals()`` would be simply as::
 
@@ -418,7 +418,7 @@ there would be backwards compatibility issues when ``locals`` is assigned
 to a local variable or when passed to ``eval`` or ``exec``.
 
 Lifetime of the mapping proxy
-'''''''''''''''''''''''''''''
+-----------------------------
 
 Each read of the ``f_locals`` attributes creates a new mapping proxy.
 This is done to avoid creating a reference cycle.


### PR DESCRIPTION
Renames `PyEval_Locals()` to `PyEval_GetFrameLocals()`. As @ncoghlan pointed out, `PyEval_Locals` is not a good name.
Adds `PyEval_GetFrameGlobals()` and `PyEval_GetFrameBuiltins()` for safety and consistency.

Adds a bit more explanation of lifetimes and alternatives.
