### PR TITLE
Infra: Make the sticky banner opaque for better readability

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -410,4 +410,5 @@ dl.footnote > dd {
 .sticky-banner {
   top: 0;
   position: sticky;
+  z-index: 1;
 }


### PR DESCRIPTION
Before:
<img width="854" alt="image" src="https://user-images.githubusercontent.com/12986082/227958052-1039eb4c-d1de-474d-917e-ccd6a58322ec.png">
After:
<img width="823" alt="image" src="https://user-images.githubusercontent.com/12986082/227958259-16d9a0ec-f752-4aed-80b0-85bda708cc2c.png">


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3075.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->