### PR TITLE
Infra: Fix CODEOWNERS errors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -307,7 +307,7 @@ pep-0446/     @vstinner
 pep-0447.txt  @ronaldoussoren
 # pep-0448.txt
 pep-0449.txt  @dstufft
-pep-0450.txt
+# pep-0450.txt  @stevendaprano
 pep-0451.txt  @ericsnowcurrently
 pep-0452.txt  @tiran
 pep-0453.txt  @dstufft @ncoghlan
@@ -370,7 +370,7 @@ pep-0503.txt  @dstufft
 pep-0504.txt  @ncoghlan
 pep-0505.rst  @zooba
 pep-0505/     @zooba
-pep-0506.txt
+# pep-0506.txt  @stevendaprano
 pep-0507.txt  @warsaw
 pep-0508.txt  @rbtcollins
 pep-0509.txt  @vstinner
@@ -453,7 +453,7 @@ pep-0578.rst  @zooba
 pep-0581.rst  @Mariatta
 pep-0582.rst  @kushaldas @zooba @dstufft @ncoghlan
 # pep-0583.rst
-pep-0584.rst  @brandtbucher
+pep-0584.rst  @brandtbucher  # @stevendaprano
 pep-0585.rst  @ambv
 pep-0586.rst  @ilevkivskyi
 pep-0587.rst  @vstinner @ncoghlan
@@ -515,7 +515,7 @@ pep-0633.rst  @brettcannon
 pep-0634.rst  @brandtbucher @gvanrossum
 pep-0635.rst  @brandtbucher @gvanrossum
 pep-0636.rst  @brandtbucher @gvanrossum
-pep-0637.rst
+# pep-0637.rst  @stevendaprano
 pep-0638.rst  @markshannon
 pep-0639.rst  @CAM-Gerlach
 pep-0640.rst  @Yhg1s

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -307,7 +307,7 @@ pep-0446/     @vstinner
 pep-0447.txt  @ronaldoussoren
 # pep-0448.txt
 pep-0449.txt  @dstufft
-pep-0450.txt  @stevendaprano
+pep-0450.txt
 pep-0451.txt  @ericsnowcurrently
 pep-0452.txt  @tiran
 pep-0453.txt  @dstufft @ncoghlan
@@ -370,7 +370,7 @@ pep-0503.txt  @dstufft
 pep-0504.txt  @ncoghlan
 pep-0505.rst  @zooba
 pep-0505/     @zooba
-pep-0506.txt  @stevendaprano
+pep-0506.txt
 pep-0507.txt  @warsaw
 pep-0508.txt  @rbtcollins
 pep-0509.txt  @vstinner
@@ -453,7 +453,7 @@ pep-0578.rst  @zooba
 pep-0581.rst  @Mariatta
 pep-0582.rst  @kushaldas @zooba @dstufft @ncoghlan
 # pep-0583.rst
-pep-0584.rst  @stevendaprano @brandtbucher
+pep-0584.rst  @brandtbucher
 pep-0585.rst  @ambv
 pep-0586.rst  @ilevkivskyi
 pep-0587.rst  @vstinner @ncoghlan
@@ -515,7 +515,7 @@ pep-0633.rst  @brettcannon
 pep-0634.rst  @brandtbucher @gvanrossum
 pep-0635.rst  @brandtbucher @gvanrossum
 pep-0636.rst  @brandtbucher @gvanrossum
-pep-0637.rst  @stevendaprano
+pep-0637.rst
 pep-0638.rst  @markshannon
 pep-0639.rst  @CAM-Gerlach
 pep-0640.rst  @Yhg1s


### PR DESCRIPTION
Temporarily remove `@stevendaprano` from [`CODEOWNERS`](https://github.com/python/peps/blob/main/.github/CODEOWNERS) pending https://discuss.python.org/t/suspending-a-core-developer-for-conduct-issues/25278 to fix:

![image](https://user-images.githubusercontent.com/1324225/228529214-5bc7491d-fd8e-452c-86c2-f2edd39a1a28.png)



<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3079.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->