### PR TITLE
Infra: Fix hiding of References if it contains invisible SystemMessage

### DIFF
--- a/pep_sphinx_extensions/pep_processor/transforms/pep_footer.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_footer.py
@@ -40,7 +40,7 @@ class PEPFooter(transforms.Transform):
                     types.add(type(node))
                     if isinstance(node, nodes.target):
                         to_hoist.append(node)
-                if types <= {nodes.title, nodes.target}:
+                if types <= {nodes.title, nodes.target, nodes.system_message}:
                     section.parent.extend(to_hoist)
                     section.parent.remove(section)
 


### PR DESCRIPTION
As originally discovered reviewing PEP 710 (PEP-710) in PR #3076 , the References section does not get hidden as intended if its doctree contains `node`s of type `system_message`, which are invisible docutils messages hidden in the rendered output (and thus not adding any visible content to the section). This can happen if the References section contains any hyperlink target labels that have the same name as the implicit targets generated for each section heading (i.e. the name of the section). This isn't a real issue, particularly since both we and Sphinx discourage using these implict section heading links for multiple reasons anyway, but we should still properly hide the References section in cases like these.

Therefore, we just add `nodes.system_message` to the list of "invisible" node types that prompt hiding this section.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3083.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->