### PR TITLE
PEP 101: PRs to the release management PEP shouldn't ping Guido and Barry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -49,7 +49,7 @@ pep-0020.txt  @tim-one
 pep-0042.txt  @jeremyhylton
 # ...
 pep-0100.txt  @malemburg
-pep-0101.txt  @warsaw @gvanrossum
+pep-0101.txt  @Yhg1s @pablogsal @ambv @ned-deily
 pep-0102.txt  @warsaw @gvanrossum
 # pep-0103.txt
 # ...


### PR DESCRIPTION
While they are the original authors, this is a living document that changes whenever the release process is tweaked.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3086.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->