### PR TITLE
Infra: Fix topics links from pep-0000

### DIFF
--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -149,7 +149,7 @@ class PEPZeroWriter:
                 target = (
                     f"topic/{subindex}.html"
                     if builder == "html"
-                    else f"topic/{subindex}"
+                    else f"../topic/{subindex}"
                 )
                 self.emit_text(f"* `{subindex.title()} PEPs <{target}>`_")
                 self.emit_newline()


### PR DESCRIPTION
**Description**

This pull request addresses an issue where navigating from `/pep-0000/` to a topic would result in a 404 error page on the Python PEPs website. 

**Problem**

To reproduce the problem, follow these steps:

1. Go to [/pep-0000/](https://www.python.org/dev/peps/pep-0000/)
2. Click on any topic link.
3. Observe that a 404 error page is displayed. [Example](https://peps.python.org/pep-0000/topic/governance).

**Solution**

To fix the issue, I added a relative path to the topics folder. 

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3093.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->