### PR TITLE
Meta: Change make render to make html in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,8 +58,8 @@ In summary, run the following in a fresh, activated virtual environment:
     # Install requirements
     python -m pip install -U -r requirements.txt
 
-    # Render the PEPs
-    make render
+    # Build the PEPs
+    make html
 
     # Or, if you don't have 'make':
     python build.py

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -43,7 +43,7 @@ Render PEPs locally
 
    .. code-block:: shell
 
-      make render
+      make html
 
    If you don't have access to ``make``, run:
 


### PR DESCRIPTION
The current command `make render` is deprecated and should be replaced with `make html` to build.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3094.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->