### PR TITLE
PEP 697: Fix typo

### DIFF
--- a/pep-0697.rst
+++ b/pep-0697.rst
@@ -332,7 +332,7 @@ In CPython, this function will be defined as:
        return (char *)obj + _align(cls->tp_base->tp_basicsize);
    }
 
-Another function will be added to retreive the size of this memory area:
+Another function will be added to retrieve the size of this memory area:
 
 .. code-block:: c
 


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3099.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->