### PR TITLE
PEP 649: Fix the lint checks

### DIFF
--- a/pep-0649.rst
+++ b/pep-0649.rst
@@ -249,7 +249,7 @@ make use of this functionality were slow to emerge.
 After years of little progress, the BDFL chose a particular
 approach for expressing static type information, called
 *type hints,* as defined in :pep:`484`.  Python 3.5 shipped
-with a new `typing` module which quickly became very popular.
+with a new ``typing`` module which quickly became very popular.
 
 Python 3.6 added syntax to annotate local variables,
 class attributes, and module attributes, using the approach
@@ -676,7 +676,7 @@ an object of any of these three types:
     doesn't have a cached annotations value, and ``fn.__annotate__``
     is ``None``, the ``fn.__annotations__`` data descriptor
     creates, caches, and returns a new empty dict.  (This is for
-    backwards compatibility with :pep:``3107`` semantics.)
+    backwards compatibility with :pep:`3107` semantics.)
 
 
 
@@ -1145,7 +1145,7 @@ annotations from stock semantics:
 * The format of the annotations dict stored in
   the ``__annotations__`` attribute is unchanged.
   Annotations dicts contain real values, not strings
-  as per :pep:``563``.
+  as per :pep:`563`.
 * Annotations dicts are mutable, and any changes to them are
   preserved.
 * The ``__annotations__`` attribute can be explicitly set,


### PR DESCRIPTION
This fixes the output and incorrect markup in certain instances.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3108.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->