### PR TITLE
PEP 704: Add a missing word in PEP withdrawal notice

### DIFF
--- a/pep-0704.rst
+++ b/pep-0704.rst
@@ -20,7 +20,7 @@ This PEP recommends that package installers like ``pip``  require a virtual envi
 PEP Withdrawal
 ==============
 
-During discussion of this PEP, it became clear that changes to pip's UX are not controlled by PEPs as proposed. It also became clear that a significant number of users rely on being able to mix managed-pip dependencies with managed-by-some-other-tool dependencies (most prominently, when using Conda).
+During discussion of this PEP, it became clear that changes to pip's UX are not controlled by PEPs as proposed. It also became clear that a significant number of users rely on being able to mix managed-by-pip dependencies with managed-by-some-other-tool dependencies (most prominently, when using Conda).
 
 Further, a significant subset of the benefits of the proposed change are achievable via :pep:`668` (accepted and implemented at the time of writing). It provides redistributors of the Python interpreter control over whether users should be required to use a virtual environment, what the messaging presented to the user is and how the rollout of that change should happen for their users.
 


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3111.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->