### PR TITLE
PEP 649: Fix typo.

### DIFF
--- a/pep-0649.rst
+++ b/pep-0649.rst
@@ -55,7 +55,7 @@ annotations, the Python compiler will write the expressions
 computing the annotations into its own function.  When run,
 the function will return the annotations dict.  The Python
 compiler then stores a reference to this function in
-``__annotate`` on the object.
+``__annotate__`` on the object.
 
 Furthermore, ``__annotations__`` is redefined to be a
 "data descriptor" which calls this annotation function once


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3112.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->