### PR TITLE
PEP 619: Update with final release date for 3.10.11

### DIFF
--- a/pep-0619.rst
+++ b/pep-0619.rst
@@ -72,10 +72,9 @@ Actual:
 - 3.10.8: Tuesday, 2022-10-11
 - 3.10.9: Tuesday, 2022-12-06
 - 3.10.10: Wednesday, 2023-02-08
+- 3.10.11: Tuesday, 2023-04-05 (final regular bugfix release with binary
+  installers)
 
-Final regular bugfix release with binary installers:
-
-- 3.10.11: Monday, 2023-04-03
 
 3.10 Lifespan
 -------------


### PR DESCRIPTION
See https://www.python.org/downloads/release/python-31011/

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3116.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->