### PR TITLE
PEP 695: Changes proposed as a result of implementation work

### DIFF
--- a/pep-0695.rst
+++ b/pep-0695.rst
@@ -302,6 +302,18 @@ the existing rules enforced by type checkers for a ``TypeVar`` constructor call.
     class ClassG[T: (list[S], str)]: ...  # Type checker error: generic type
 
 
+Runtime Representation of Bounds and Constraints
+------------------------------------------------
+
+The upper bounds and constraints of ``TypeVar`` objects are accessible at
+runtime through the ``__bound__`` and ``__constraints__`` attributes.
+For ``TypeVar`` objects defined through the new syntax, these attributes
+become lazily evaluated: when constructed, the object stores a closure that
+allows the evaluation of the value. When the ``__bound__`` or ``__constraints__``
+attribute is accessed, the value is evaluated and cached. This is consistent
+with the behavior of :pep:`649` and generally eliminates the need for quoted
+forward references.
+
 
 Generic Type Alias
 ------------------
@@ -365,13 +377,16 @@ At runtime, a ``type`` statement will generate an instance of
 include:
 
 * ``__name__`` is a str representing the name of the type alias
-* ``__parameters__`` is a tuple of ``TypeVar``, ``TypeVarTuple``, or
+* ``__type_params__`` is a tuple of ``TypeVar``, ``TypeVarTuple``, or
   ``ParamSpec`` objects that parameterize the type alias if it is generic
 * ``__value__`` is the evaluated value of the type alias
 
-The ``__value__`` attribute initially has a value of ``None`` while the type
-alias expression is evaluated. It is then updated after a successful evaluation.
-This allows for self-referential type aliases.
+All of these attributes are read-only.
+
+The value of the type alias is evaluated lazily. Access to the ``__value__`` attribute
+triggers evaluation of the value and caches the resulting value.
+This allows for self-referential and mutually recursive type aliases, and it
+should largely eliminate the need for quoted forward references in type aliases.
 
 
 Type Parameter Scopes
@@ -590,15 +605,10 @@ the defined type parameters.
 Accessing Type Parameters at Runtime
 ------------------------------------
 
-A new read-only attribute called ``__type_variables__`` is available on class,
-function, and type alias objects. This attribute is a tuple of the active
-type variables that are visible within the scope of that class, function,
-or type alias. This attribute is needed for runtime evaluation of stringified
-(forward referenced) type annotations that include references to type
-parameters. Functions like ``typing.get_type_hints`` can use this attribute
-to populate the ``locals`` dictionary with values for type parameters that
-are in scope when calling ``eval`` to evaluate the stringified expression.
-The tuple contains ``TypeVar`` instances.
+A new read-only attribute called ``__type_params__`` is available on generic class,
+function, and type alias objects. This attribute is a tuple of the
+type parameters that parameterize the class, function, or alias.
+The tuple contains ``TypeVar``, ``ParamSpec``, and ``TypeVarTuple`` instances.
 
 Type parameters declared using the new syntax will not appear within the
 dictionary returned by ``globals()`` or ``locals()``.
@@ -809,9 +819,13 @@ It also adds an AST node type that represents a type parameter.
         | ParamSpec(identifier name)
         | TypeVarTuple(identifier name)
 
+Bounds and constraints are represented identically in the AST. In the implementation,
+any expression that is syntactically a tuple is treated as a constraint, and any other
+expression is treated as a bound.
+
 It also modifies existing AST node types ``FunctionDef``, ``AsyncFunctionDef``
 and ``ClassDef`` to include an additional optional attribute called
-``typeparam*`` that includes a list of type parameters associated with the
+``typeparams`` that includes a list of type parameters associated with the
 function or class.
 
 
@@ -820,12 +834,9 @@ Library Changes
 
 Several classes in the ``typing`` module that are currently implemented in
 Python must be reimplemented in C. This includes: ``TypeVar``,
-``TypeVarTuple``, ``ParamSpec``, ``Generic``, and ``Union``. The new class
+``TypeVarTuple``, ``ParamSpec``, and ``Generic``. The new class
 ``TypeAliasType`` (described above) also must be implemented in C. The
 documented behaviors of these classes should not change.
-
-The ``typing.get_type_hints`` must be updated to use the new
-``__type_variables__`` attribute.
 
 
 Reference Implementation


### PR DESCRIPTION
This adds some clarifications and changes that I ran into while implementing the PEP.

The most important change is that TypeVar bounds and type alias values are lazily evaluated using PEP 649-like semantics. This will make the language more consistent once type annotations are evaluated using PEP 649.

Prior discussion:
- PEP 649-like semantics: erictraut/cpython#11
- `__type_params__` attribute replacing `__type_variables__`: erictraut/cpython#10, erictraut/cpython#8

I am marking this as draft for now in case I run into more things that need to be changed. We'll have to ask the SC for approval, but hopefully these changes are not controversial.

cc @erictraut 