### PR TITLE
PEP 689: Tweak a policy, add canonical-doc and Mark as Final

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -49,6 +49,7 @@ exclude_patterns = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'packaging': ('https://packaging.python.org/en/latest/', None),
+    'devguide': ('https://devguide.python.org/', None),
     'py3.11': ('https://docs.python.org/3.11/', None),
     'py3.12': ('https://docs.python.org/3.12/', None),
 }

--- a/pep-0689.rst
+++ b/pep-0689.rst
@@ -2,7 +2,7 @@ PEP: 689
 Title: Unstable C API tier
 Author: Petr Viktorin <encukou@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-689-unstable-c-api-tier/20452
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Requires: 523
@@ -12,6 +12,10 @@ Post-History: `27-Apr-2022 <https://mail.python.org/archives/list/python-dev@pyt
               `25-Aug-2022 <https://discuss.python.org/t/c-api-what-should-the-leading-underscore-py-mean/18486>`__,
               `27-Oct-2022 <https://discuss.python.org/t/pep-689-unstable-c-api-tier/20452>`__,
 Resolution: https://discuss.python.org/t/pep-689-unstable-c-api-tier/20452/13
+
+.. canonical-doc:: :ref:`devguide:c-api`
+
+   User-facing documentation is at :ref:`py3.12:unstable-c-api`.
 
 
 Abstract
@@ -152,8 +156,7 @@ Several rules for dealing with the unstable tier will be introduced:
 -  To move an API from the unstable tier to the public tier, it should be
    exposed without the ``PyUnstable_*`` prefix.
 
-   The old name should remain available until the first incompatible change
-   is made or the API is removed.
+   The old name should remain available until the API is deprecated or removed.
 
 -  Adding new unstable API *for existing features* is allowed even after
    Beta feature freeze, up until the first Release Candidate.


### PR DESCRIPTION
## Mark Final

* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [x] Any substantial changes since the accepted version approved by the SC/PEP delegate
  -  I've linked this PR in the [Steering Council request](https://github.com/python/steering-council/issues/185)
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
  - I hope it is!
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive (or ``pypa-spec``, for packaging PEPs)

## Change an existing PEP

* Change is either:
    * To a Draft PEP
    * [x] To an Accepted or Final PEP, with Steering Council approval
      - I've linked this PR in the [Steering Council request](https://github.com/python/steering-council/issues/185)
    * To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3123.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->