### PR TITLE
PEP 649: Fix literal block syntax

### DIFF
--- a/pep-0649.rst
+++ b/pep-0649.rst
@@ -693,12 +693,10 @@ that were permitted in stock semantics, but are disallowed when
 ``from __future__ import annotations`` is active, and will have
 to be disallowed when this PEP is active:
 
-```
-:=
-yield
-yield from
-await
-```
+* ``:=``
+* ``yield``
+* ``yield from``
+* ``await``
 
 Changes to ``inspect.get_annotations`` and ``typing.get_type_hints``
 ====================================================================


### PR DESCRIPTION
Follow-up from #3124. The syntax is currently 'broken' on https://peps.python.org/pep-0649/ -- image below:

![image](https://user-images.githubusercontent.com/9087854/234423015-8741c89b-3c87-4cca-97ff-3095c6ff4f0d.png)

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3125.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->