### PR TITLE
PEP 713: Add link to reference implementation

### DIFF
--- a/pep-0713.rst
+++ b/pep-0713.rst
@@ -169,6 +169,13 @@ covering callable modules, with example code, similar to the section for
 __ https://docs.python.org/3/reference/datamodel.html#customizing-module-attribute-access
 
 
+Reference Implementation
+========================
+
+The proposed implementation of callable modules is available in
+`cpython PR #103742 <https://github.com/python/cpython/pull/103742>`_.
+
+
 Rejected Ideas
 ==============
 

--- a/pep-0713.rst
+++ b/pep-0713.rst
@@ -173,7 +173,7 @@ Reference Implementation
 ========================
 
 The proposed implementation of callable modules is available in
-`cpython PR #103742 <https://github.com/python/cpython/pull/103742>`_.
+`CPython PR #103742 <https://github.com/python/cpython/pull/103742>`_.
 
 
 Rejected Ideas


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3130.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->