### PR TITLE
Infra: improve text readability and webpage performance

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -2,25 +2,10 @@
 
 /* Media Queries */
 
-/* Further reduce width of fixed elements for smallest screens */
-@media (max-width: 32em) {
-    section#pep-page-section {
-        padding: 0.25rem;
-    }
-    dl.footnote > dt,
-    dl.footnote > dd {
-        padding-left: 0;
-        padding-right: 0;
-    }
-    pre {
-        font-size: 0.75rem;
-    }
-}
-
 /* Reduce padding & margins for smaller screens */
 @media (max-width: 40em) {
     section#pep-page-section {
-        padding: 0.5rem;
+        padding: 1rem;
     }
     section#pep-page-section > header > h1 {
         padding-right: 0;

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -183,6 +183,12 @@ a img {
     margin: 0 auto;
 }
 
+/* List rules */
+ol.loweralpha {list-style: lower-alpha}
+ol.upperalpha {list-style: upper-alpha}
+ol.lowerroman {list-style: lower-roman}
+ol.upperroman {list-style: upper-roman}
+
 /* Maths rules */
 sub,
 sup {

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -61,11 +61,9 @@ img.invert-in-dark-mode {
 :root {color-scheme: light dark}
 html {
     overflow-y: scroll;
-    margin: 0;
-    line-height: 1.4;
-    font-weight: normal;
+    line-height: 1.5;
     font-size: 1rem;
-    font-family: "Source Sans Pro", Arial, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
 }
 body {
     margin: 0;
@@ -76,40 +74,27 @@ section#pep-page-section {
     padding: 0.25rem;
 }
 
-/* Reduce margin sizes for body text */
-p {margin: .5rem 0}
-
 /* Header rules */
 h1 {
     font-size: 2rem;
     font-weight: bold;
-    margin-top: 1.25rem;
-    margin-bottom: 1rem;
 }
 h2 {
     font-size: 1.6rem;
     font-weight: bold;
-    margin-top: 1rem;
-    margin-bottom: .5rem;
 }
 h3 {
     font-size: 1.4rem;
     font-weight: normal;
-    margin-top: 1rem;
-    margin-bottom: 0.5rem;
 }
 h4 {
     font-size: 1.2rem;
     font-weight: normal;
-    margin-top: .5rem;
-    margin-bottom: 0;
 }
 h5,
 h6 {
     font-size: 1rem;
     font-weight: bold;
-    margin-top: 0;
-    margin-bottom: 0;
 }
 
 /* Anchor link rules */
@@ -131,7 +116,6 @@ a:focus {
 blockquote {
     font-style: italic;
     border-left: 1px solid var(--colour-rule-strong);
-    margin: .5rem;
     padding: .5rem 1rem;
 }
 blockquote em {
@@ -145,7 +129,7 @@ cite {
 /* Code rules (code literals and Pygments highlighting blocks) */
 code,
 pre {
-    font-family: ui-monospace, "Cascadia Mono", "Segoe UI Mono", "DejaVu Sans Mono", Consolas, monospace;
+    font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace;
     font-size: 0.875rem;
     -webkit-hyphens: none;
     hyphens: none;
@@ -189,9 +173,8 @@ dl dd {
 hr {
     border: 0;
     border-top: 1px solid var(--colour-rule-light);
-    margin: 0;
 }
-/*Image rules */
+/* Image rules */
 img {
     max-width: 100%;
 }
@@ -201,11 +184,6 @@ a img {
 }
 
 /* List rules */
-ul,
-ol {
-    padding: 0;
-    margin: 0 0 0 1.5rem;
-}
 ul {list-style: square}
 ol.arabic {list-style: decimal}
 ol.loweralpha {list-style: lower-alpha}
@@ -263,7 +241,6 @@ section#pep-page-section > header {
 }
 section#pep-page-section > header > h1 {
     font-size: 1.1rem;
-    line-height: 1.4;
     margin: 0;
     display: inline-block;
     padding-right: .6rem;
@@ -379,7 +356,15 @@ dl.footnote > dd {
 #pep-sidebar > h2 {
     font-size: 1.4rem;
 }
+#contents ol,
+#contents ul,
+#pep-sidebar ol,
 #pep-sidebar ul {
+    padding: 0;
+    margin: 0 0 0 1.5rem;
+}
+#pep-sidebar ul {
+    font-size: .9rem;
     margin-left: 1rem;
 }
 #pep-sidebar ul a {

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -183,14 +183,6 @@ a img {
     margin: 0 auto;
 }
 
-/* List rules */
-ul {list-style: square}
-ol.arabic {list-style: decimal}
-ol.loweralpha {list-style: lower-alpha}
-ol.upperalpha {list-style: upper-alpha}
-ol.lowerroman {list-style: lower-roman}
-ol.upperroman {list-style: upper-roman}
-
 /* Maths rules */
 sub,
 sup {

--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -13,7 +13,6 @@
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', resource=True) }}" type="text/css" media="(prefers-color-scheme: light)" id="pyg-light">
     <link rel="stylesheet" href="{{ pathto('_static/pygments_dark.css', resource=True) }}" type="text/css" media="(prefers-color-scheme: dark)" id="pyg-dark">
     <link rel="alternate" type="application/rss+xml" title="Latest PEPs" href="https://peps.python.org/peps.rss">
-    <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
     <meta name="description" content="Python Enhancement Proposals (PEPs)">
 </head>
 <body>


### PR DESCRIPTION
Space is important for the readability of any kind of text.

Right now the PEP webpages use a Google font with a lot of custom CSS to pull the text in tighter and with less whitespace.

I find the font, small size and tight spacing hard to read (and my eyes aren't getting any younger!). Using default fonts and spacing feels more readable and loads faster. The Google font causes an annoying initial layout shift after it's loaded and the page is re-rendered.

Readability was brought up when we overhauled the PEPs infra as part of PEP 676. But as the other improvements and benefits of migration were so big, it made sense to press ahead without delaying to discuss this further.

One year on, the overhauled infra has been working really well. Let's now improve the readability :)

# Original comments

Some of the comments from the [original discussion](https://discuss.python.org/t/styling-of-peps/13270/):

> This looks really good to me (I like the higher contrast too), although I had to boost the text to 125%. _[Barry]_

> Its certainly something worth considering bumping up the size a notch or two further; while the text size is one tick bigger (16 px vs 15 px on the old PEPs), preferred text sizes on the web have gotten larger over the years as the viewing habits have changed. Also, I’ve noticed that source code renders much larger than the text, which looks kinda awkward, is much larger than the legacy build system and means that a PEP 8 79-character line will not fit on one line. _[CAM]_

> There’s a strong argument to be made for using the so-called _system font stack_: no extra network requests, no “jump” in rendering as the font loads, more familiar, broad support, up-to-date. _[Hugo]_

> The whitespace (line height + margin) for paragraphs and heading seems… somewhat tight which makes it a bit difficult to read. _[Pradyun]_

# This PR

This PR uses a default "[system font stack](https://systemfontstack.com)", and removes a lot of the custom CSS to use default CSS spacing. Let's compare:

* Original: https://peps.python.org/pep-0703/
* PR: https://pep-previews--3132.org.readthedocs.build/pep-0703/

<details>
<summary>Original</summary>

<img width="1582" alt="image" src="https://user-images.githubusercontent.com/1324225/235449578-8ba059d9-8800-4b93-986c-e2e7f274528c.png">

</details>

<details>
<summary>PR</summary>

<img width="1582" alt="image" src="https://user-images.githubusercontent.com/1324225/235449570-71af4d51-a7d6-4d53-b550-3d53f8914ba3.png">

</details>

Benefits according to https://systemfontstack.com:

* Fast: No network request, no time to parse a font, no flash of an incorrect font.
* Styles & unicode: System fonts have lots of styles and broad language coverage, unlike many webfonts.
* Familiarity: Web apps feel more native when they use system font faces.

Many sites use a system font stack: [GitHub](https://markdotto.com/2018/02/07/github-system-fonts/), [Stack Overflow](https://meta.stackexchange.com/questions/364048/we-are-switching-to-system-fonts-on-may-10-2021), [Booking.com](https://booking.design/implementing-system-fonts-on-booking-com-a-lesson-learned-bdc984df627f), and [Weather.com, Bootstrap, Medium, Ghost, PubMed, and the WordPress dashboard](https://woorkup.com/system-font/). As do the [Furo](https://github.com/pradyunsg/furo/blob/3c4e94897b764a0e25bf6bcf7dd74356009918fe/src/furo/assets/styles/variables/_fonts.scss#L8) (used on the [devguide](https://devguide.python.org/)) and [pydata-sphinx-theme](https://github.com/pydata/pydata-sphinx-theme/pull/285#issuecomment-730571293) themes. See more on the [history and rationale](https://medium.com/towards-more-beautiful-web-typography/survey-system-font-stack-5f73a3b39776).

I looked at sites such as Mozilla's MDN Web Docs (for example: https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching) to compare CSS. Their site is technical writing which I find clearly laid out, with space to breathe. They use a lot of default CSS values.

I've been using this [preview build](https://hugovk-peps.readthedocs.io/en/sfs/pep-0703/) to read recent PEPs and found it much clearer.

# In numbers

Running some numbers on Google's Lighthouse tool (ignore the SEO drop on the PR, that's because RtD rightly hides preview builds via robots.txt) shows better performance with the PR:


<table>
<tr>
<th><a href="https://pagespeed.web.dev/analysis/https-peps-python-org-pep-0703/pemch8p3mu?form_factor=mobile">Original</a>
<th><a href="https://pagespeed.web.dev/analysis/https-hugovk-peps-readthedocs-io-en-sfs-pep-0703/79yh2ymljj?form_factor=mobile">PR</a>
</tr>
<tr>
<td>
<img width="951" alt="image" src="https://user-images.githubusercontent.com/1324225/235443101-73a70762-d6ed-420f-ad56-8fc00abfa504.png">
<img width="951" alt="image" src="https://user-images.githubusercontent.com/1324225/235443224-94230f8d-9b90-4be2-a515-401da7450e64.png">
 <td valign=top>
<img width="960" alt="image" src="https://user-images.githubusercontent.com/1324225/235441661-323f3be1-405b-44ff-81bb-7faeb6d589b7.png">
<img width="951" alt="image" src="https://user-images.githubusercontent.com/1324225/235443271-22af2043-b2eb-4e8a-b8c4-87d1e13660b5.png"> 

</table>

Note:

* First Contentful Paint ("time at which the first text or image is painted"): 2.8s -> 1.1s
* Largest Contentful Paint ("time at which the largest text or image is painted"): 2.8s -> 1.1s
* Cumulative Layout Shift ("the movement of visible elements within the viewport. Learn more about the cumulative layout shift metric"): 0.012 -> 0
* Speed Index ("how quickly the contents of a page are visibly populated"): 2.8s -> 1.5s

And:

* the 1.8s render-blocking resource (i.e. the Google font) has been eliminated
* the large layout shifts have been removed
* the chained critical requests have dropped from 10 chains to 6
* the request counts have dropped from 13 to 8, and transfer size from 101 KiB to 47 KiB
* long main-thread tasks have dropped from 2 to 1

