### PR TITLE
PEP 696: Use list for ParamSpec default [Fix]

### DIFF
--- a/pep-0696.rst
+++ b/pep-0696.rst
@@ -150,7 +150,7 @@ literal "``...``" or another in-scope ``ParamSpec`` (see :ref:`696-scoping-rules
 
 .. code-block:: py
 
-   DefaultP = ParamSpec("DefaultP", default=(str, int))
+   DefaultP = ParamSpec("DefaultP", default=[str, int])
 
    class Foo(Generic[DefaultP]): ...
 


### PR DESCRIPTION
Support for tuples for `ParamSpec` default values was removed in #3052.

From the PEP
```rst
``ParamSpec`` defaults are defined using the same syntax as
``TypeVar`` \ s but use a ``list`` of types or an ellipsis
literal "``...``" or another in-scope ``ParamSpec`` (see :ref:`696-scoping-rules`).
```

/CC: @Gobot1234

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3133.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->