### PR TITLE
PEP 706: Add changes found in review, Mark Final

### DIFF
--- a/pep-0706.rst
+++ b/pep-0706.rst
@@ -2,7 +2,7 @@ PEP: 706
 Title: Filter for tarfile.extractall
 Author: Petr Viktorin <encukou@gmail.com>
 Discussions-To: https://discuss.python.org/t/23903
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 09-Feb-2023
@@ -271,8 +271,6 @@ of the following strings:
     * Set the owner read and write permissions (:external+py3.11:data:`S_IRUSR|S_IWUSR <stat.S_IRUSR>`).
     * Remove the group & other *executable* permission (:external+py3.11:data:`S_IXGRP|S_IXOTH <stat.S_IXGRP>`)
       if the owner doesn't have it (:external+py3.11:data:`~stat.S_IXUSR`).
-    * Remove the group & other *read* permission (:external+py3.11:data:`S_IRGRP|S_IROTH <stat.S_IRGRP>`)
-      if the owner doesn't have it (:external+py3.11:data:`~stat.S_IRUSR`).
 
   * For other files (directories), ignore mode entirely (set it to ``None``).
   * Ignore user and group info (set ``uid``, ``gid``, ``uname``, ``gname``
@@ -331,6 +329,52 @@ is 1 or more, this will abort the extraction; with ``errorlevel=0`` the error
 will be logged and the member will be ignored, but extraction will continue.
 Note that ``extractall()`` may leave the archive partially extracted;
 it is the user's responsibility to clean up.
+
+
+Errorlevel, and fatal/non-fatal errors
+--------------------------------------
+
+Currently, :external+py3.11:class:`~tarfile.TarFile` has an *errorlevel*
+argument/attribute, which specifies how errors are handled:
+
+- With ``errorlevel=0``, documentation says that “all errors are ignored
+  when using :external+py3.11:meth:`~tarfile.TarFile.extract` and
+  :external+py3.11:meth:`~tarfile.TarFile.extractall`”.
+  The code only ignores *non-fatal* and *fatal* errors (see below),
+  so, for example, you still get ``TypeError`` if you pass ``None`` as the
+  destination path.
+- With ``errorlevel=1`` (the default), all *non-fatal* errors are ignored.
+  (They may be logged to ``sys.stderr`` by setting the *degug*
+  argument/attribute.)
+  Which errors are *non-fatal* is not defined in documentation, but code treats
+  ``ExtractionError`` as such. Specifically, it's these issues:
+
+  - “unable to resolve link inside archive” (raised on systems that do not
+    support symlinks)
+  - “fifo/special devices not supported by system” (not used for failures if
+    the system supports these, e.g. for a ``PermissionError``)
+  - “could not change owner/mode/modification time”
+
+  Note that, for example, *file name too long* or *out of disk space* don't
+  qualify.
+  The *non-fatal* errors are not very likely to appear on a Unix-like system.
+- With ``errorlevel=2``, all errors are raised, including *fatal* ones.
+  Which errors are *fatal* is, again, not defined; in practice it's
+  ``OSError``.
+
+A filter refusing to extract a member does not fit neatly into the
+*fatal*/*non-fatal* categories.
+
+- This PEP does not change existing behavior. (Ideas for improvements are
+  welcome in `Discourse topic 25970 <https://discuss.python.org/t/25970>`_.)
+- When a filter refuses to extract a member, the error should not pass
+  silently by default.
+
+To satisfy this, ``FilterError`` will be considered a *fatal* error, that is,
+it'll be ignored only with ``errorlevel=0``.
+
+Users that want to ignore ``FilterError`` but not other *fatal* errors should
+create a custom filter function, and call another filter in a ``try`` block.
 
 
 Hints for further verification

--- a/pep-0706.rst
+++ b/pep-0706.rst
@@ -11,6 +11,8 @@ Post-History: `25-Jan-2023 <https://discuss.python.org/t/23149>`__,
               `15-Feb-2023 <https://discuss.python.org/t/23903>`__,
 Resolution: https://discuss.python.org/t/23903/10
 
+.. canonical-doc:: :ref:`tarfile documentation <python:tarfile-extraction-filter>`
+
 
 Abstract
 ========


### PR DESCRIPTION

* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [x] Any substantial changes since the accepted version approved by the SC/PEP delegate
  * https://discuss.python.org/t/23149/27
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive (or ``pypa-spec``, for packaging PEPs)


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3134.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->