### PR TITLE
PEP 659: Mark as withdrawn

### DIFF
--- a/pep-0659.rst
+++ b/pep-0659.rst
@@ -1,12 +1,19 @@
 PEP: 659
 Title: Specializing Adaptive Interpreter
 Author: Mark Shannon <mark@hotpy.org>
-Status: Draft
+Status: Withdrawn
 Type: Informational
 Content-Type: text/x-rst
 Created: 13-Apr-2021
 Post-History: 11-May-2021
 
+Withdrawal Notice
+=================
+
+`Per the Steering Council <https://github.com/python/steering-council/issues/180>`__:
+
+    We talked this over and we would like you to please withdraw the PEP since,
+    as you mentioned, it's debatable if it should have been a PEP to begin with.
 
 Abstract
 ========
@@ -376,14 +383,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-
-..
-    Local Variables:
-    mode: indented-text
-    indent-tabs-mode: nil
-    sentence-end-double-space: t
-    fill-column: 70
-    coding: utf-8
-    End:


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

* [x] SC/PEP Delegate has formally ~accepted/rejected~ withdrawn the PEP and posted to the ~``Discussions-To`` thread~ Steering Council tracker
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ~``Accepted``/``Rejected``~ ``Withdrawn``
* [ ] ``Resolution`` link points directly to SC/PEP Delegate official acceptance/rejected post 
* [x] ~Acceptance/rejection~ Withdrawn notice added, if the SC/PEP delegate had major conditions or comments
* [ ] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3135.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->