### PR TITLE
PEP 569, 596, 619, 664, 693: Fix days for release dates

### DIFF
--- a/pep-0569.rst
+++ b/pep-0569.rst
@@ -55,7 +55,7 @@ Release Schedule
 - 3.8.0 beta 1: Tuesday, 2019-06-04
   (No new features beyond this point.)
 
-- 3.8.0 beta 2: Monday, 2019-07-04
+- 3.8.0 beta 2: Thursday, 2019-07-04
 - 3.8.0 beta 3: Monday, 2019-07-29
 - 3.8.0 beta 4: Friday, 2019-08-30
 - 3.8.0 candidate 1: Tuesday, 2019-10-01

--- a/pep-0596.rst
+++ b/pep-0596.rst
@@ -68,8 +68,8 @@ Actual:
 
 - 3.9.1 candidate 1: Tuesday, 2020-11-24
 - 3.9.1 final: Monday, 2020-12-07
-- 3.9.2 candidate 1: Monday, 2021-02-16
-- 3.9.2 final: Monday, 2021-02-19
+- 3.9.2 candidate 1: Tuesday, 2021-02-16
+- 3.9.2 final: Friday, 2021-02-19
 - 3.9.3: Friday, 2021-04-02 (security hotfix; recalled due to bpo-43710)
 - 3.9.4: Sunday, 2021-04-04 (ABI compatibility hotfix)
 - 3.9.5: Monday, 2021-05-03
@@ -77,7 +77,7 @@ Actual:
 - 3.9.7: Monday, 2021-08-30
 - 3.9.8: Friday, 2021-11-05 (recalled due to bpo-45235)
 - 3.9.9: Monday, 2021-11-15
-- 3.9.10: Monday, 2022-01-14
+- 3.9.10: Friday, 2022-01-14
 - 3.9.11: Wednesday, 2022-03-16
 - 3.9.12: Wednesday, 2022-03-23
 - 3.9.13: Tuesday, 2022-05-17 (final regular bugfix release with binary

--- a/pep-0619.rst
+++ b/pep-0619.rst
@@ -42,7 +42,7 @@ Actual:
 
 - 3.10 development begins: Monday, 2020-05-18
 - 3.10.0 alpha 1: Monday, 2020-10-05
-- 3.10.0 alpha 2: Monday, 2020-11-03
+- 3.10.0 alpha 2: Tuesday, 2020-11-03
 - 3.10.0 alpha 3: Monday, 2020-12-07
 - 3.10.0 alpha 4: Monday, 2021-01-04
 - 3.10.0 alpha 5: Wednesday, 2021-02-03
@@ -63,7 +63,7 @@ Bugfix releases
 Actual:
 
 - 3.10.1: Monday, 2021-12-06
-- 3.10.2: Monday, 2022-01-14
+- 3.10.2: Friday, 2022-01-14
 - 3.10.3: Wednesday, 2022-03-16
 - 3.10.4: Thursday, 2022-03-24
 - 3.10.5: Monday, 2022-06-06
@@ -72,7 +72,7 @@ Actual:
 - 3.10.8: Tuesday, 2022-10-11
 - 3.10.9: Tuesday, 2022-12-06
 - 3.10.10: Wednesday, 2023-02-08
-- 3.10.11: Tuesday, 2023-04-05 (final regular bugfix release with binary
+- 3.10.11: Wednesday, 2023-04-05 (final regular bugfix release with binary
   installers)
 
 

--- a/pep-0664.rst
+++ b/pep-0664.rst
@@ -44,10 +44,10 @@ in a 12-month release cadence between major versions, as defined by
 Actual:
 
 - 3.11 development begins: Monday, 2021-05-03
-- 3.11.0 alpha 1: Monday, 2021-10-05
+- 3.11.0 alpha 1: Tuesday, 2021-10-05
 - 3.11.0 alpha 2: Tuesday, 2021-11-02
 - 3.11.0 alpha 3: Wednesday, 2021-12-08
-- 3.11.0 alpha 4: Monday, 2022-01-14
+- 3.11.0 alpha 4: Friday, 2022-01-14
 - 3.11.0 alpha 5: Thursday, 2022-02-03
 - 3.11.0 alpha 6: Monday, 2022-03-07
 - 3.11.0 alpha 7: Tuesday, 2022-04-05
@@ -68,7 +68,7 @@ Actual:
 
 - 3.11.1: Tuesday, 2022-12-06
 - 3.11.2: Wednesday, 2023-02-08
-- 3.11.3: Tuesday, 2023-04-05
+- 3.11.3: Wednesday, 2023-04-05
 
 Expected:
 

--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -42,7 +42,7 @@ in a 12-month release cadence between major versions, as defined by
 
 Actual:
 
-- 3.12 development begins: Monday, 2022-05-08
+- 3.12 development begins: Sunday, 2022-05-08
 - 3.12.0 alpha 1: Monday, 2022-10-24
 - 3.12.0 alpha 2: Monday, 2022-11-14
 - 3.12.0 alpha 3: Tuesday, 2022-12-06


### PR DESCRIPTION
Occasionally releases happen a bit later than originally planned. And sometimes the `yyyy-mm-dd` date is updated in the release PEP, but not the day name (eg. Monday -> Tuesday).

Mismatches identified using this script, that finds date strings of the format "Xxxday, yyyy-mm-dd", parses the string into a `datetime`, then formats it back to a string and compares to the original: is the PEP's day name different from the real one for that date?

Then checked the date against the python.org release announcements, or in the case of "3.12 development begins", against the branching commit.

<details>
<summary>date_validator.py</summary>

```python
"""
Check PEPs have valid date strings of the format "Xxxday, yyyy-mm-dd"

Catches yyyy-mm-dd dates that have the wrong day.
"""
import argparse
import datetime as dt
import logging
import os
import re
import sys
from pathlib import Path

from termcolor import cprint  # pip install termcolor

try:
    from rich.logging import RichHandler  # pip install rich
except ImportError:
    RichHandler = None

DATE_REGEX = re.compile(r"[A-Z][a-z]+day, \d\d\d\d-\d\d-\d\d")


def validate_date_string(date_text: str, date_format: str) -> bool:
    normalised = None
    try:
        # Parse the string into a datetime, then format it back to a string
        # and compare to the original: the day name might have changed.
        normalised = dt.datetime.strptime(date_text, date_format).strftime(date_format)
        if normalised != date_text:
            raise ValueError

        cprint(date_text, "green")
        return True

    except ValueError:
        cprint(date_text, "red")
        if normalised:
            cprint(f"    Did you mean {normalised}?", "yellow")

        return False


def do_file(filename: str) -> bool:
    with open(filename) as f:
        lines = f.readlines()

    valid = True
    for line in lines:
        m = DATE_REGEX.search(line.strip())
        if m:
            date_text = m[0]
            valid &= validate_date_string(date_text, "%A, %Y-%m-%d")

    if valid:
        logging.info("%s has valid dates", filename)
    else:
        cprint(f"{filename} has invalid dates\n", "red")
        logging.info("%s has invalid dates", filename)

    return valid


def main() -> int:
    parser = argparse.ArgumentParser(
        description=__doc__,
        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
    )
    parser.add_argument(
        "input",
        default=".",
        nargs="?",
        help="PEPs to check",
    )
    parser.add_argument(
        "-v",
        "--verbose",
        action="store_const",
        dest="loglevel",
        const=logging.INFO,
        default=logging.WARNING,
        help="Print extra messages to stderr",
    )
    args = parser.parse_args()
    if RichHandler:
        logging.basicConfig(
            level=args.loglevel, format="%(message)s", handlers=[RichHandler()]
        )
    else:
        logging.basicConfig(level=args.loglevel, format="%(message)s")

    valid = True
    if os.path.isfile(args.input):
        valid &= do_file(args.input)
    else:
        for path in sorted(Path(args.input).glob("pep-*.*")):
            if path.suffix in (".rst", ".txt"):
                # logging.info(path)
                valid &= do_file(str(path))
                # print()

    return 0 if valid else 1


if __name__ == "__main__":
    sys.exit(main())
```


</details>

## Python 3.8.0b2
Release Date: July 4, 2019
https://www.python.org/downloads/release/python-380b2/

https://en.wikipedia.org/wiki/Portal:Current_events/2019_July_4 -> Thursday

## Python 3.9.2rc1
Release Date: Feb. 16, 2021
https://www.python.org/downloads/release/python-392rc1/

https://en.wikipedia.org/wiki/Portal:Current_events/2021_February_16 -> Tuesday

## Python 3.9.2
Release Date: Feb. 19, 2021
https://www.python.org/downloads/release/python-392/

https://en.wikipedia.org/wiki/Portal:Current_events/2021_February_19 -> Friday

## Python 3.9.10
Release Date: Jan. 14, 2022
https://www.python.org/downloads/release/python-3910/

https://en.wikipedia.org/wiki/Portal:Current_events/2022_January_14 -> Friday

## Python 3.10.0a2
Release Date: Nov. 3, 2020
https://www.python.org/downloads/release/python-3100a2/

https://en.wikipedia.org/wiki/Portal:Current_events/2020_November_3 -> Tuesday

## Python 3.10.2
Release Date: Jan. 14, 2022
https://www.python.org/downloads/release/python-3102/

https://en.wikipedia.org/wiki/Portal:Current_events/2022_January_14 -> Friday

## Python 3.10.11
Release Date: April 5, 2023
https://www.python.org/downloads/release/python-31011/

https://en.wikipedia.org/wiki/Portal:Current_events/2023_April_5 -> Wednesday

## Python 3.11.0a1
Release Date: Oct. 5, 2021
https://www.python.org/downloads/release/python-3110a1/

https://en.wikipedia.org/wiki/Portal:Current_events/2021_October_5 -> Tuesday

## Python 3.11.0a4
Release Date: Jan. 14, 2022
https://www.python.org/downloads/release/python-3110a4/

https://en.wikipedia.org/wiki/Portal:Current_events/2022_January_14 -> Friday

## Python 3.11.3
Release Date: April 5, 2023
https://www.python.org/downloads/release/python-3113/

https://en.wikipedia.org/wiki/Portal:Current_events/2023_April_5 -> Wednesday

## Python 3.12.0a0
pablogsal committed on May 8, 2022
https://github.com/python/cpython/commit/e851177536b44ebc616ddbe51aebcd1f30857f34

https://en.wikipedia.org/wiki/Portal:Current_events/2022_May_8 -> Sunday

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3136.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->