### PR TITLE
PEP 693: Postpone 3.12.0b1 by two weeks

### DIFF
--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -53,7 +53,7 @@ Actual:
 
 Expected:
 
-- 3.12.0 beta 1: Monday, 2023-05-08
+- 3.12.0 beta 1: Monday, 2023-05-22
   (No new features beyond this point.)
 - 3.12.0 beta 2: Monday, 2023-05-29
 - 3.12.0 beta 3: Monday, 2023-06-19


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

As proposed by release manager @Yhg1s in https://discuss.python.org/t/postponing-3-12-beta-1-feature-freeze/26406/1:

> Considering how many accepted changes are still being worked on (PEPs 684, 687, 688, 695, 697 at least) and still being decided on by the SC (PEPs 649, 702 and 709), I’m planning to postpone feature freeze and beta 1 for 3.12 by two weeks, without changing the rest of the schedule.


