### PR TITLE
PEP 697: Mark Final

### DIFF
--- a/pep-0697.rst
+++ b/pep-0697.rst
@@ -2,7 +2,7 @@ PEP: 697
 Title: Limited C API for Extending Opaque Types
 Author: Petr Viktorin <encukou@gmail.com>
 Discussions-To: https://discuss.python.org/t/19743
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 23-Aug-2022
@@ -10,6 +10,14 @@ Python-Version: 3.12
 Post-History: `24-May-2022 <https://mail.python.org/archives/list/capi-sig@python.org/thread/SIP3VP7JU4OBWP62KBOYGOYCVIOTXEFH/>`__,
               `06-Oct-2022 <https://discuss.python.org/t/19743>`__,
 Resolution: https://discuss.python.org/t/19743/30
+
+
+.. canonical-doc::
+   :external+py3.12:c:member:`PyType_Spec.basicsize`,
+   :external+py3.12:c:func:`PyObject_GetTypeData`,
+   :external+py3.12:data:`Py_TPFLAGS_ITEMS_AT_END`,
+   :external+py3.12:c:macro:`Py_RELATIVE_OFFSET`,
+   :external+py3.12:c:func:`PyObject_GetItemData`
 
 
 Abstract


### PR DESCRIPTION
* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [x] (n/a) Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive (or ``pypa-spec``, for packaging PEPs)


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3141.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->