### PR TITLE
PEP 696: Add note about lazy eval with PEP 695

### DIFF
--- a/pep-0696.rst
+++ b/pep-0696.rst
@@ -435,8 +435,8 @@ of the square brackets like so:
    type Rab[U, T = str] = Bar[T, U]
 
 :ref:`Similarly to the bound for a type parameter <695-scoping-behavior>`,
-defaults should be lazily evaluated to avoid the unnecessary usage of
-quotes around them.
+defaults should be lazily evaluated, with the same scoping rules to
+avoid the unnecessary usage of quotes around them.
 
 This functionality was included in the initial draft of :pep:`695` but
 was removed due to scope creep.

--- a/pep-0696.rst
+++ b/pep-0696.rst
@@ -413,9 +413,9 @@ Pyright currently supports this functionality.
 Interaction with PEP 695
 ------------------------
 
-If this PEP is accepted, the syntax proposed in :pep:`695` will be
-extended to introduce a way to specify defaults for type parameters
-using the "=" operator inside of the square brackets like so:
+The syntax proposed in :pep:`695` will be extended to introduce a 
+way to specify defaults for type parameters using the "=" operator
+inside of the square brackets like so:
 
 .. code-block:: py
 
@@ -433,6 +433,10 @@ using the "=" operator inside of the square brackets like so:
    type Baz[**P = [int, str]] = Spam[**P]
    type Qux[*Ts = *tuple[str]] = Ham[*Ts]
    type Rab[U, T = str] = Bar[T, U]
+
+Similarly to the bound for a type parameter, defaults should be
+lazily evaluated to avoid the unnecessary useage of quotes around 
+them.
 
 This functionality was included in the initial draft of :pep:`695` but
 was removed due to scope creep.

--- a/pep-0696.rst
+++ b/pep-0696.rst
@@ -413,9 +413,9 @@ Pyright currently supports this functionality.
 Interaction with PEP 695
 ------------------------
 
-The syntax proposed in :pep:`695` will be extended to introduce a 
-way to specify defaults for type parameters using the "=" operator
-inside of the square brackets like so:
+The syntax proposed in :pep:`695` will be extended to introduce a way
+to specify defaults for type parameters using the "=" operator inside
+of the square brackets like so:
 
 .. code-block:: py
 
@@ -434,9 +434,9 @@ inside of the square brackets like so:
    type Qux[*Ts = *tuple[str]] = Ham[*Ts]
    type Rab[U, T = str] = Bar[T, U]
 
-Similarly to the bound for a type parameter, defaults should be
-lazily evaluated to avoid the unnecessary useage of quotes around 
-them.
+:ref:`Similarly to the bound for a type parameter <695-scoping-behavior>`,
+defaults should be lazily evaluated to avoid the unnecessary usage of
+quotes around them.
 
 This functionality was included in the initial draft of :pep:`695` but
 was removed due to scope creep.


### PR DESCRIPTION
* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3145.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->