### PR TITLE
PEP 710: Fix RFC 2119 reference

### DIFF
--- a/pep-0710.rst
+++ b/pep-0710.rst
@@ -415,7 +415,7 @@ Making the hashes key optional
 
 :pep:`610` and :ref:`its corresponding canonical PyPA spec <direct-url>`
 recommend including the ``hashes`` key of the ``archive_info`` in the
-``direct_url.json`` file but it is not required (per the :rfc:`21119` language):
+``direct_url.json`` file but it is not required (per the :rfc:`2119` language):
 
   A hashes key SHOULD be present as a dictionary mapping a hash name to a hex
   encoded digest of the file.


### PR DESCRIPTION
[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) deals with SHOULD etc. language, and [RFC 21119](https://www.rfc-editor.org/rfc/rfc21119) doesn't exist.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3147.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->