### PR TITLE
PEP 701: Correct handling of format specifiers and nested expressions

### DIFF
--- a/pep-0701.rst
+++ b/pep-0701.rst
@@ -228,12 +228,27 @@ for details on the syntax):
 The new tokens (``FSTRING_START``, ``FSTRING_MIDDLE``, ``FSTRING_END``) are defined
 :ref:`later in this document <701-new-tokens>`.
 
-This PEP leaves up to the implementation the level of f-string nesting allowed but
-**specifies a lower bound of 5 levels of nesting**. This is to ensure that users can
-have a reasonable expectation of being able to nest f-strings with "reasonable" depth.
+This PEP leaves up to the implementation the level of f-string nesting allowed
+(f-strings withing the expression parts of other f-strings) but **specifies a
+lower bound of 5 levels of nesting**. This is to ensure that users can have a
+reasonable expectation of being able to nest f-strings with "reasonable" depth.
 This PEP implies that limiting nesting is **not part of the language
 specification** but also the language specification **doesn't mandate arbitrary
 nesting**.
+
+Similarly, this PEP leaves up to the implementation the level of expression nesting
+in format specifiers but **specifies a lower bound of 2 levels of nesting**. This means
+that the following should always be valid:
+
+.. code-block:: python
+
+    f"{'':*^{1:{1}}}"
+
+but the following can be valid or not depending on the implementation:
+
+.. code-block:: python
+
+    f"{'':*^{1:{1:{1}}}}"
 
 The new grammar will preserve the Abstract Syntax Tree (AST) of the current
 implementation. This means that no semantic changes will be introduced by this
@@ -362,8 +377,11 @@ tokens:
 2. Keep consuming tokens until a one of the following is encountered:
 
    * A closing quote equal to the opening quote.
-   * An opening brace (``{``) or a closing brace (``}``) that is not immediately
-     followed by another opening/closing brace.
+   * If in "format specifier mode" (see step 3), an opening brace (``{``) or a
+     closing brace (``}``).
+   * If not in "format specifier mode" (see step 3), an opening brace (``{``) or
+     a closing brace (``}``) that is not immediately followed by another opening/closing
+     brace.
 
    In all cases, if the character buffer is not empty, emit a ``FSTRING_MIDDLE``
    token with the contents captured so far but transform any double
@@ -375,16 +393,15 @@ tokens:
      is encountered, go to step 3.
    * If a closing bracket (not immediately followed by another closing bracket)
      is encountered, emit a token for the closing bracket and go to step 2.
-
 3. Push a new tokenizer mode to the tokenizer mode stack for "Regular Python
-   tokenization within f-string" and proceed to tokenize with it. This mode
-   tokenizes as the "Regular Python tokenization" until a ``!``, ``:``, ``=``
-   character is encountered or if a ``}`` character is encountered with the same
-   level of nesting as the opening bracket token that was pushed when we enter the
-   f-string part. Using this mode, emit tokens until one of the stop points are
-   reached. When this happens, emit the corresponding token for the stopping
-   character encountered and, pop the current tokenizer mode from the tokenizer mode
-   stack and go to step 2.
+   tokenization withing f-string" and proceed to tokenize with it. This mode
+   tokenizes as the "Regular Python tokenization" until a ``:`` or a ``}``
+   character is encountered with the same level of nesting as the opening
+   bracket token that was pushed when we enter the f-string part. Using this mode,
+   emit tokens until one of the stop points are reached. When this happens, emit
+   the corresponding token for the stopping character encountered and, pop the
+   current tokenizer mode from the tokenizer mode stack and go to step 2. If the
+   stopping point is a ``:`` character, enter step 2 in "format specifier" mode.
 4. Emit a ``FSTRING_END`` token with the contents captured and pop the current
    tokenizer mode (corresponding to "F-string tokenization") and go back to
    "Regular Python mode".
@@ -561,7 +578,7 @@ Rejected Ideas
     >>> f'Useless use of lambdas: { lambda x: x*2 }'
     SyntaxError: unexpected EOF while parsing
 
-   The reason is that this will introduce a considerable amount of
+  The reason is that this will introduce a considerable amount of
    complexity for no real benefit. This is due to the fact that the ``:`` character
    normally separates the f-string format specification. This format specification
    is currently tokenized as a string. As the tokenizer MUST tokenize what's on the

--- a/pep-0701.rst
+++ b/pep-0701.rst
@@ -394,7 +394,7 @@ tokens:
    * If a closing bracket (not immediately followed by another closing bracket)
      is encountered, emit a token for the closing bracket and go to step 2.
 3. Push a new tokenizer mode to the tokenizer mode stack for "Regular Python
-   tokenization withing f-string" and proceed to tokenize with it. This mode
+   tokenization within f-string" and proceed to tokenize with it. This mode
    tokenizes as the "Regular Python tokenization" until a ``:`` or a ``}``
    character is encountered with the same level of nesting as the opening
    bracket token that was pushed when we enter the f-string part. Using this mode,


### PR DESCRIPTION
<!--
You can use the following checklist when double-checking your PEP,
and you can help complete some of it yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about anything, just leave it blank and we'll take a look.

If your PEP is not Standards Track, remove the corresponding section.
-->

## Basic requirements (all PEP Types)

* [ ] Read and followed [PEP 1](https://peps.python.org/1) & [PEP 12](https://peps.python.org/12)
* [ ] File created from the [latest PEP template](https://github.com/python/peps/blob/main/pep-0012/pep-NNNN.rst?plain=1)
* [ ] PEP has next available number, & set in filename (``pep-NNNN.rst``), PR title (``PEP 123: <Title of PEP>``) and ``PEP`` header
* [ ] Title clearly, accurately and concisely describes the content in 79 characters or less
* [ ] Core dev/PEP editor listed as ``Author`` or ``Sponsor``, and formally confirmed their approval
* [ ] ``Author``, ``Status`` (``Draft``), ``Type`` and ``Created`` headers filled out correctly
* [ ] ``PEP-Delegate``, ``Topic``, ``Requires`` and ``Replaces`` headers completed if appropriate
* [ ] Required sections included
    * [ ] Abstract (first section)
    * [ ] Copyright (last section; exact wording from template required)
* [ ] Code is well-formatted (PEP 7/PEP 8) and is in [code blocks, with the right lexer names](https://peps.python.org/pep-0012/#literal-blocks) if non-Python
* [ ] PEP builds with no warnings, pre-commit checks pass and content displays as intended in the rendered HTML
* [ ] Authors/sponsor added to ``.github/CODEOWNERS`` for the PEP


## Standards Track requirements

* [ ] PEP topic [discussed in a suitable venue](https://peps.python.org/pep-0001/#start-with-an-idea-for-python) with general agreement that a PEP is appropriate
* [ ] [Suggested sections](https://peps.python.org/pep-0012/#suggested-sections) included (unless not applicable)
    * [ ] Motivation
    * [ ] Rationale
    * [ ] Specification
    * [ ] Backwards Compatibility
    * [ ] Security Implications
    * [ ] How to Teach This
    * [ ] Reference Implementation
    * [ ] Rejected Ideas
    * [ ] Open Issues
* [ ] ``Python-Version`` set to valid (pre-beta) future Python version, if relevant
* [ ] Any project stated in the PEP as supporting/endorsing/benefiting from the PEP formally confirmed such
* [ ] Right before or after initial merging, [PEP discussion thread](https://peps.python.org/pep-0001/#discussing-a-pep) created and linked to in ``Discussions-To`` and ``Post-History``


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3151.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->