### PR TITLE
PEP 693: note release of beta 1 and delay beta 2 by a day

### DIFF
--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -50,12 +50,12 @@ Actual:
 - 3.12.0 alpha 5: Tuesday, 2023-02-07
 - 3.12.0 alpha 6: Tuesday, 2023-03-07
 - 3.12.0 alpha 7: Tuesday, 2023-04-04
+- 3.12.0 beta 1: Monday, 2023-05-22
+  (No new features beyond this point.)
 
 Expected:
 
-- 3.12.0 beta 1: Monday, 2023-05-22
-  (No new features beyond this point.)
-- 3.12.0 beta 2: Monday, 2023-05-29
+- 3.12.0 beta 2: Tuesday, 2023-05-30
 - 3.12.0 beta 3: Monday, 2023-06-19
 - 3.12.0 beta 4: Monday, 2023-07-10
 - 3.12.0 candidate 1: Monday, 2023-07-31


### PR DESCRIPTION
Update PEP 693 with the actual date of 3.12 beta 1, and delay beta 2 by a day to not conflict with Memorial Day and Pentecost.


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3153.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->