### PR TITLE
PEP 693: delay 3.12 beta 2 by a week

### DIFF
--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -55,7 +55,7 @@ Actual:
 
 Expected:
 
-- 3.12.0 beta 2: Tuesday, 2023-05-30
+- 3.12.0 beta 2: Tuesday, 2023-06-06
 - 3.12.0 beta 3: Monday, 2023-06-19
 - 3.12.0 beta 4: Monday, 2023-07-10
 - 3.12.0 candidate 1: Monday, 2023-07-31


### PR DESCRIPTION
Announced by release manager @Yhg1s in https://discuss.python.org/t/delaying-3-12-beta-2-by-a-week/27232:

> Because there are a number of important bugs being worked on that impede the testing of 3.12, it would be a shame to delay all that by a month, and it’s only been a week since beta 1, I’m delaying beta 2 until next week. (In retrospect I should have realised a week is not enough for third parties to find bugs *and* us to fix them, so lesson learned).
> 
> (See [Type object's ob_type does not get set when tp_bases is set before PyType_Ready · Issue #104614 · python/cpython · GitHub ](https://github.com/python/cpython/issues/104614), [`tp_bases` of `object` is `NULL`: undocumented or unintentional behavior change in 3.12? · Issue #105020 · python/cpython · GitHub ](https://github.com/python/cpython/issues/105020), [3.12.0b1 includes backwards incompatible change to operation of `super()` · Issue #105035 · python/cpython · GitHub ](https://github.com/python/cpython/issues/105035), [object.h includes C++ incompatible code · Issue #105059 · python/cpython · GitHub ](https://github.com/python/cpython/issues/105059) for some of the bugs in talking about.)



<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3157.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->