### PR TITLE
PEP 1/PEP 12: Update PEP number assignment guidance

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -185,8 +185,11 @@ corrected by the editors).
 The standard PEP workflow is:
 
 * You, the PEP author, fork the `PEP repository`_, and create a file named
-  ``pep-9999.rst`` that contains your new PEP.  Use "9999" as your draft PEP
-  number.
+  ``pep-NNNN.rst`` that contains your new PEP.  ``NNNN`` should be the next
+  available PEP number not used by a published or in-PR PEP.
+
+* In the "PEP:" header field, enter the PEP number that matches your filename
+  as your draft PEP number.
 
 * In the "Type:" header field, enter "Standards Track",
   "Informational", or "Process" as appropriate, and for the "Status:"

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -794,8 +794,9 @@ problem, ask the author(s) to use :pep:`12` as a template and resubmit.
 
 Once the PEP is ready for the repository, a PEP editor will:
 
-* Assign a PEP number (almost always just the next available number,
-  but sometimes it's a special/joke number, like 666 or 3141).
+* Check that the author has selected a valid PEP number or assign them a
+  number if they have not (almost always just the next available number, but
+  sometimes it's a special/joke number, like 666 or 3141).
   (Clarification: For Python 3, numbers in the 3000s were used for
   Py3k-specific proposals.  But now that all new features go into
   Python 3 only, the process is back to using numbers in the 100s again.

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -797,10 +797,8 @@ Once the PEP is ready for the repository, a PEP editor will:
 * Check that the author has selected a valid PEP number or assign them a
   number if they have not (almost always just the next available number, but
   sometimes it's a special/joke number, like 666 or 3141).
-  (Clarification: For Python 3, numbers in the 3000s were used for
-  Py3k-specific proposals.  But now that all new features go into
-  Python 3 only, the process is back to using numbers in the 100s again.
-  Remember that numbers below 100 are meta-PEPs.)
+
+  Remember that numbers below 100 are meta-PEPs.
 
 * Check that the author has correctly labeled the PEP's type
   ("Standards Track", "Informational", or "Process"), and marked its

--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -185,7 +185,7 @@ corrected by the editors).
 The standard PEP workflow is:
 
 * You, the PEP author, fork the `PEP repository`_, and create a file named
-  ``pep-NNNN.rst`` that contains your new PEP.  ``NNNN`` should be the next
+  :file:`pep-{NNNN}.rst` that contains your new PEP.  :samp:`{NNNN}` should be the next
   available PEP number not used by a published or in-PR PEP.
 
 * In the "PEP:" header field, enter the PEP number that matches your filename

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -60,14 +60,12 @@ Once you've decided which type of PEP yours is going to be, follow the
 directions below.
 
 - Make a copy of this file (the ``.rst`` file, **not** the HTML!) and
-  perform the following edits. Name the new file ``pep-9999.rst`` if
-  you don't yet have a PEP number assignment, or ``pep-NNNN.rst`` if
-  you do. Those with push permissions are welcome to claim the next
-  available number (ignoring the special blocks 3000 and 8000, and a
-  handful of special allocations - currently 666, 754, and 801) and
-  push it directly.
+  perform the following edits. Name the new file ``pep-NNNN.rst``, using
+  the next available number (not used by a published or in-PR PEP, ignoring
+  the special blocks 3000 and 8000, and a handful of special allocations -
+  currently 666, 754, and 801).
 
-- Replace the "PEP: 12" header with "PEP: 9999" or "PEP: NNNN",
+- Replace the "PEP: 12" header with "PEP: NNNN",
   matching the file name. Note that the file name should be padded with
   zeros (eg ``pep-0012.rst``), but the header should not (``PEP: 12``).
 
@@ -158,7 +156,7 @@ directions below.
   non-inline link targets referenced by the text.
 
 - Run ``./build.py`` to ensure the PEP is rendered without errors,
-  and check that the output in ``build/pep-9999.html`` looks as you intend.
+  and check that the output in ``build/pep-NNNN.html`` looks as you intend.
 
 - Create a pull request against the `PEPs repository`_.
 

--- a/pep-0012.rst
+++ b/pep-0012.rst
@@ -60,10 +60,8 @@ Once you've decided which type of PEP yours is going to be, follow the
 directions below.
 
 - Make a copy of this file (the ``.rst`` file, **not** the HTML!) and
-  perform the following edits. Name the new file ``pep-NNNN.rst``, using
-  the next available number (not used by a published or in-PR PEP, ignoring
-  the special blocks 3000 and 8000, and a handful of special allocations -
-  currently 666, 754, and 801).
+  perform the following edits. Name the new file :file:`pep-{NNNN}.rst`, using
+  the next available number (not used by a published or in-PR PEP).
 
 - Replace the "PEP: 12" header with "PEP: NNNN",
   matching the file name. Note that the file name should be padded with
@@ -156,7 +154,7 @@ directions below.
   non-inline link targets referenced by the text.
 
 - Run ``./build.py`` to ensure the PEP is rendered without errors,
-  and check that the output in ``build/pep-NNNN.html`` looks as you intend.
+  and check that the output in :file:`build/pep-{NNNN}.html` looks as you intend.
 
 - Create a pull request against the `PEPs repository`_.
 


### PR DESCRIPTION
Ref: https://github.com/python/peps/pull/3161#issuecomment-1579857385

> Hey ... could you please avoid renaming the file back and forth? It obsoletes all reviewer comments and suggestions, and will furthermore make comments on in-flight reviews completely disappear into the void, which I've had happen to my half-dozen review suggestions so far twice now (which is, as you might imagine, rather frustrating 🙂).
> 
> This is why we've switched to specifically asking in the new PEP checklist (in your OP) that instead of using a placeholder number, you just give the PEP the next available number that it would be assigned anyway (not used by a published or in-PR PEP) yourself from the get go, to avoid the need for a file name, etc. change in all but the unlikely event that your PEP number happens to conflict with another submitted around the same time, or your PEP is not approved for draft publication in its current form—in which case it is no worse than the previous situation of always having to rename at least once. Thanks.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3163.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->