### PR TITLE
Update the link to pyprocessing from PEP-0371.

### DIFF
--- a/pep-0371.txt
+++ b/pep-0371.txt
@@ -403,8 +403,8 @@ Closed Issues
 References
 ==========
 
-.. [1] PyProcessing home page
-       http://pyprocessing.berlios.de/
+.. [1] The 2008 era PyProcessing project (the pyprocessing name was since repurposed)
+       https://web.archive.org/web/20080914113946/https://pyprocessing.berlios.de/
 
 .. [2] See Adam Olsen's "safe threading" project
        http://code.google.com/p/python-safethread/


### PR DESCRIPTION
The project name and URL were since repurposed for a different purpose. Linking to the archived version from the PEP's timeframe is important to avoid confusion when doing historical research.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3166.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->