### PR TITLE
PEP 715: clarify which types are still supported

### DIFF
--- a/pep-0715.rst
+++ b/pep-0715.rst
@@ -20,7 +20,10 @@ This PEP recommends deprecating and then disabling new uploads of the
 deprecating and then disabling new uploads of distribution filenames that have
 the ``.egg`` suffix.
 
-It does not recommend removing or otherwise affecting any previously
+After this PEP, PyPI will only accept new uploads of the ``sdist``
+and ``bdist_wheel`` types.
+
+This PEP does not recommend removing or otherwise affecting any previously
 uploaded ``bdist_egg`` distributions or files with the ``.egg`` suffix.
 
 Rationale


### PR DESCRIPTION
Raised by @pfmoore: https://discuss.python.org/t/pep-715-disabling-bdist-egg-distribution-uploads-on-pypi/27610/2?u=woodruffw

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3168.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->