### PR TITLE
PEP 715: Typo in header

### DIFF
--- a/pep-0715.rst
+++ b/pep-0715.rst
@@ -9,7 +9,7 @@ Type: Process
 Topic: Packaging
 Content-Type: text/x-rst
 Created: 06-Jun-2023
-Post-History: `09-Aug-2023 <https://discuss.python.org/t/27610>`__
+Post-History: `09-Jun-2023 <https://discuss.python.org/t/27610>`__
 Resolution:
 
 Abstract


### PR DESCRIPTION
@pfmoore

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3175.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->