### PR TITLE
PEP 621, 668: Fix name spelling

### DIFF
--- a/pep-0621.rst
+++ b/pep-0621.rst
@@ -469,7 +469,7 @@ Example
   keywords = ["egg", "bacon", "sausage", "tomatoes", "Lobster Thermidor"]
   authors = [
     {email = "hi@pradyunsg.me"},
-    {name = "Tzu-Ping Chung"}
+    {name = "Tzu-ping Chung"}
   ]
   maintainers = [
     {name = "Brett Cannon", email = "brett@python.org"}

--- a/pep-0668.rst
+++ b/pep-0668.rst
@@ -4,7 +4,7 @@ Author: Geoffrey Thomas <geofft@ldpreload.com>,
         Matthias Klose <doko@ubuntu.com>,
         Filipe Laíns <lains@riseup.net>,
         Donald Stufft <donald@stufft.io>,
-        Tzu-Ping Chung <uranusjr@gmail.com>,
+        Tzu-ping Chung <uranusjr@gmail.com>,
         Stefano Rivera <stefanor@debian.org>,
         Elana Hashman <ehashman@debian.org>,
         Pradyun Gedam <pradyunsg@gmail.com>


### PR DESCRIPTION
Re: https://discuss.python.org/t/meta-should-the-peps-page-index-by-not-just-the-last-name/27918/6?u=hugovk

Fix Tzu-ping Chung's name to be spelled per his preference, and remove the duplication at https://peps.python.org/#authors-owners:

![image](https://github.com/python/peps/assets/1324225/84756bff-0b56-4a2d-bbac-46972763333f)

@uranusjr How does this look?

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3176.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->