### PR TITLE
PEP 527: Recategorize as "Standards Track"

### DIFF
--- a/pep-0527.txt
+++ b/pep-0527.txt
@@ -6,7 +6,7 @@ Author: Donald Stufft <donald@stufft.io>
 BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
 Discussions-To: distutils-sig@python.org
 Status: Final
-Type: Process
+Type: Standards Track
 Topic: Packaging
 Content-Type: text/x-rst
 Created: 23-Aug-2016


### PR DESCRIPTION
See https://github.com/python/peps/pull/3180#pullrequestreview-1496861545.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3181.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->