### PR TITLE
PEP 719: Add to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -596,6 +596,7 @@ pep-0712.rst  @ericvsmith
 pep-0713.rst  @ambv
 pep-0714.rst  @dstufft
 pep-0715.rst  @dstufft
+pep-0719.rst  @Yhg1s
 # ...
 # pep-0754.txt
 # ...


### PR DESCRIPTION
Follow on from https://github.com/python/peps/pull/3184, thanks for the reminder @JelleZijlstra.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3185.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->