### PR TITLE
PEP 715: Fix link to packaging term

### DIFF
--- a/pep-0715.rst
+++ b/pep-0715.rst
@@ -56,7 +56,7 @@ in functionality to the
 :term:`wheel format <packaging:Wheel>`
 first introduced by :pep:`427` in 2012
 as :ref:`the standardized format <packaging:binary-distribution-format>`
-for :term:`packaging:Built Distributions`.
+for :term:`built distributions <packaging:Built Distribution>`.
 
 Despite its longevity, the egg format has had
 `limited adoption on PyPI <https://github.com/pypi/warehouse/issues/10653>`_.


### PR DESCRIPTION
Fix this Sphinx warning:
```
pep-0715.rst:52: WARNING: term not in glossary: 'packaging:Built Distributions'
```

# Before

Also doesn't create the link at https://peps.python.org/pep-0715/#the-bdist-egg-format:

> in 2012 as [the standardized format](https://packaging.python.org/en/latest/specifications/binary-distribution-format/#binary-distribution-format) for packaging:Built Distributions.

# After

Creates a link at https://pep-previews--3188.org.readthedocs.build/pep-0715/#the-bdist-egg-format:

> in 2012 as [the standardized format](https://packaging.python.org/en/latest/specifications/binary-distribution-format/#binary-distribution-format) for [built distributions](https://packaging.python.org/en/latest/glossary/#term-Built-Distribution).

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3188.org.readthedocs.build/pep-0715/

<!-- readthedocs-preview pep-previews end -->