### PR TITLE
PEP 554: Convert unreferenced footnote to bullet point

### DIFF
--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -1332,10 +1332,6 @@ References
 .. [caveats]
    https://docs.python.org/3/c-api/init.html#bugs-and-caveats
 
-.. [petr-c-ext]
-   https://mail.python.org/pipermail/import-sig/2016-June/001062.html
-   https://mail.python.org/pipermail/python-ideas/2016-April/039748.html
-
 .. [cryptography]
    https://github.com/pyca/cryptography/issues/2299
 

--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -1388,14 +1388,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0554.rst
+++ b/pep-0554.rst
@@ -1380,6 +1380,10 @@ References
     https://mail.python.org/pipermail/python-ideas/2017-September/047144.html
     https://mail.python.org/pipermail/python-dev/2017-September/149566.html
 
+* petr-c-ext
+    https://mail.python.org/pipermail/import-sig/2016-June/001062.html
+    https://mail.python.org/pipermail/python-ideas/2016-April/039748.html
+
 Copyright
 =========
 


### PR DESCRIPTION
Fix this warning:
```
pep-0554.rst:1335: WARNING: Citation [petr-c-ext] is not referenced.
```

The reference to the footnote was removed in https://github.com/python/peps/pull/3067, let's also remove the footnote itself. Alternatively, we could convert it a bulleted footnote, there's already a couple of those.

Also remove redundant emacs metadata.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3189.org.readthedocs.build/pep-0554/

<!-- readthedocs-preview pep-previews end -->