### PR TITLE
PEP 654, 678, 680: Mark as final

### DIFF
--- a/pep-0654.rst
+++ b/pep-0654.rst
@@ -3,7 +3,7 @@ Title: Exception Groups and except*
 Author: Irit Katriel <iritkatriel@gmail.com>,
         Yury Selivanov <yury@edgedb.com>,
         Guido van Rossum <guido@python.org>
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 22-Feb-2021

--- a/pep-0678.rst
+++ b/pep-0678.rst
@@ -3,7 +3,7 @@ Title: Enriching Exceptions with Notes
 Author: Zac Hatfield-Dodds <zac@zhd.dev>
 Sponsor: Irit Katriel
 Discussions-To: https://discuss.python.org/t/pep-678-enriching-exceptions-with-notes/13374
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Requires: 654

--- a/pep-0680.rst
+++ b/pep-0680.rst
@@ -3,7 +3,7 @@ Title: tomllib: Support for Parsing TOML in the Standard Library
 Author: Taneli Hukkinen, Shantanu Jain <hauntsaninja at gmail.com>
 Sponsor: Petr Viktorin <encukou@gmail.com>
 Discussions-To: https://discuss.python.org/t/13040
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 01-Jan-2022


### PR DESCRIPTION
These three PEPs were all implemented and released in Python 3.11:

* https://docs.python.org/3/whatsnew/3.11.html

Thanks to @CAM-Gerlach for noting these.