### PR TITLE
Infra: Call sphinx-build directly in Makefile instead of via build.py wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,13 @@ SOURCES      =
 OUTPUT_DIR   = build
 SPHINXERRORHANDLING =
 
-ALLSPHINXOPTS = -b $(BUILDER) -t internal_builder -j $(JOBS) \
+ALLSPHINXOPTS = -b $(BUILDER) -j $(JOBS) \
                 $(SPHINXOPTS) $(SPHINXERRORHANDLING) . $(OUTPUT_DIR) $(SOURCES)
 
 ## html           to render PEPs to "pep-NNNN.html" files
 .PHONY: html
 html: venv
 	$(SPHINXBUILD) $(ALLSPHINXOPTS)
-	$(VENVDIR)/bin/python3 -c "import build; from pathlib import Path; build.create_index_file(Path('$(OUTPUT_DIR)'), '$(BUILDER)')"
 
 ## htmlview       to open the index page built by the html target in your browser
 .PHONY: htmlview
@@ -29,13 +28,11 @@ htmlview: html
 dirhtml: BUILDER = dirhtml
 dirhtml: venv rss
 	$(SPHINXBUILD) $(ALLSPHINXOPTS)
-	$(VENVDIR)/bin/python3 -c "import build; from pathlib import Path; build.create_index_file(Path('$(OUTPUT_DIR)'), '$(BUILDER)')"
 
 ## fail-warning   to render PEPs to "pep-NNNN.html" files and fail the Sphinx build on any warning
 .PHONY: fail-warning
 fail-warning: venv
 	$(SPHINXBUILD) $(ALLSPHINXOPTS) -W
-	$(VENVDIR)/bin/python3 -c "import build; from pathlib import Path; build.create_index_file(Path('$(OUTPUT_DIR)'), '$(BUILDER)')"
 
 ## check-links    to check validity of links within PEP sources
 .PHONY: check-links

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,23 @@
 # Builds PEP files to HTML using sphinx
 
-PYTHON=python3
-VENVDIR=.venv
-JOBS=8
-OUTPUT_DIR=build
-RENDER_COMMAND=$(VENVDIR)/bin/python3 build.py -j $(JOBS) -o $(OUTPUT_DIR)
+# You can set these variables from the command line.
+PYTHON       = python3
+VENVDIR      = .venv
+SPHINXBUILD  = PATH=$(VENVDIR)/bin:$$PATH sphinx-build
+BUILDER      = html
+JOBS         = 8
+SOURCES      =
+OUTPUT_DIR   = build
+SPHINXERRORHANDLING =
+
+ALLSPHINXOPTS = -b $(BUILDER) -t internal_builder -j $(JOBS) \
+                $(SPHINXOPTS) $(SPHINXERRORHANDLING) . $(OUTPUT_DIR) $(SOURCES)
 
 ## html           to render PEPs to "pep-NNNN.html" files
 .PHONY: html
 html: venv
-	$(RENDER_COMMAND)
+	$(SPHINXBUILD) $(ALLSPHINXOPTS)
+	$(VENVDIR)/bin/python3 -c "import build; from pathlib import Path; build.create_index_file(Path('$(OUTPUT_DIR)'), '$(BUILDER)')"
 
 ## htmlview       to open the index page built by the html target in your browser
 .PHONY: htmlview
@@ -18,18 +26,22 @@ htmlview: html
 
 ## dirhtml        to render PEPs to "index.html" files within "pep-NNNN" directories
 .PHONY: dirhtml
+dirhtml: BUILDER = dirhtml
 dirhtml: venv rss
-	$(RENDER_COMMAND) --build-dirs
+	$(SPHINXBUILD) $(ALLSPHINXOPTS)
+	$(VENVDIR)/bin/python3 -c "import build; from pathlib import Path; build.create_index_file(Path('$(OUTPUT_DIR)'), '$(BUILDER)')"
 
 ## fail-warning   to render PEPs to "pep-NNNN.html" files and fail the Sphinx build on any warning
 .PHONY: fail-warning
 fail-warning: venv
-	$(RENDER_COMMAND) --fail-on-warning
+	$(SPHINXBUILD) $(ALLSPHINXOPTS) -W
+	$(VENVDIR)/bin/python3 -c "import build; from pathlib import Path; build.create_index_file(Path('$(OUTPUT_DIR)'), '$(BUILDER)')"
 
 ## check-links    to check validity of links within PEP sources
 .PHONY: check-links
+check-links: BUILDER = linkcheck
 check-links: venv
-	$(RENDER_COMMAND) --check-links
+	$(SPHINXBUILD) $(ALLSPHINXOPTS)
 
 ## rss            to generate the peps.rss file
 .PHONY: rss

--- a/conf.py
+++ b/conf.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 import sys
 
-sys.path.append(str(Path("pep_sphinx_extensions").absolute()))
+sys.path.append(str(Path(".").absolute()))
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
It's come up a couple of times that `build.py` is wrapping `sphinx-build`.

This PR replaces all calls of `build.py` in `Makefile` with direct calls to `sphinx-build`, and follows the [CPython `Makefile`](https://github.com/python/cpython/blob/main/Doc/Makefile) where possible to minimise differences and ease maintenance across repos. 

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3195.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->