### PR TITLE
PEP721: fixing a typo

### DIFF
--- a/pep-0721.rst
+++ b/pep-0721.rst
@@ -51,7 +51,7 @@ Another consideration is ease of implementation for non-Python tools.
 Unpatched versions of Python
 ----------------------------
 
-Tools are allowed to ignore this PEP when running on Python pithout tarfile
+Tools are allowed to ignore this PEP when running on Python without tarfile
 filters.
 
 The feature has been backported to all versions of Python supported by


### PR DESCRIPTION
Fixed a typo in the sentence "Tools are allowed to ignore this PEP when running on Python **p**ithout tarfile filters."

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3200.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->