### PR TITLE
PEP 693: Update 3.12.0b4 release date

### DIFF
--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -54,10 +54,10 @@ Actual:
   (No new features beyond this point.)
 - 3.12.0 beta 2: Tuesday, 2023-06-06
 - 3.12.0 beta 3: Monday, 2023-06-19
+- 3.12.0 beta 4: Tuesday, 2023-07-11
 
 Expected:
 
-- 3.12.0 beta 4: Monday, 2023-07-10
 - 3.12.0 candidate 1: Monday, 2023-07-31
 - 3.12.0 candidate 2: Monday, 2023-09-04
 - 3.12.0 final:  Monday, 2023-10-02


### PR DESCRIPTION
Re: https://www.python.org/downloads/release/python-3120b4/

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3203.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->