### PR TITLE
Meta: Format `pep_sphinx_extensions` with `black` and `isort`, and some touch-ups.

### DIFF
--- a/pep_sphinx_extensions/__init__.py
+++ b/pep_sphinx_extensions/__init__.py
@@ -7,11 +7,15 @@ from typing import TYPE_CHECKING
 from docutils.writers.html5_polyglot import HTMLTranslator
 from sphinx import environment
 
-from pep_sphinx_extensions.pep_processor.html import pep_html_builder
-from pep_sphinx_extensions.pep_processor.html import pep_html_translator
-from pep_sphinx_extensions.pep_processor.parsing import pep_banner_directive
-from pep_sphinx_extensions.pep_processor.parsing import pep_parser
-from pep_sphinx_extensions.pep_processor.parsing import pep_role
+from pep_sphinx_extensions.pep_processor.html import (
+    pep_html_builder,
+    pep_html_translator,
+)
+from pep_sphinx_extensions.pep_processor.parsing import (
+    pep_banner_directive,
+    pep_parser,
+    pep_role,
+)
 from pep_sphinx_extensions.pep_processor.transforms import pep_references
 from pep_sphinx_extensions.pep_zero_generator.pep_index_generator import create_pep_zero
 
@@ -56,29 +60,38 @@ def setup(app: Sphinx) -> dict[str, bool]:
 
     app.add_source_parser(pep_parser.PEPParser)  # Add PEP transforms
 
-    app.set_translator("html", pep_html_translator.PEPTranslator)  # Docutils Node Visitor overrides (html builder)
-    app.set_translator("dirhtml", pep_html_translator.PEPTranslator)  # Docutils Node Visitor overrides (dirhtml builder)
+    app.set_translator(
+        "html", pep_html_translator.PEPTranslator
+    )  # Docutils Node Visitor overrides (html builder)
+    app.set_translator(
+        "dirhtml", pep_html_translator.PEPTranslator
+    )  # Docutils Node Visitor overrides (dirhtml builder)
 
-    app.add_role("pep", pep_role.PEPRole(), override=True)  # Transform PEP references to links
+    app.add_role(
+        "pep", pep_role.PEPRole(), override=True
+    )  # Transform PEP references to links
 
     app.add_post_transform(pep_references.PEPReferenceRoleTitleText)
 
     # Register custom directives
+    app.add_directive("pep-banner", pep_banner_directive.PEPBanner)
+    app.add_directive("canonical-doc", pep_banner_directive.CanonicalDocBanner)
     app.add_directive(
-        "pep-banner", pep_banner_directive.PEPBanner)
-    app.add_directive(
-        "canonical-doc", pep_banner_directive.CanonicalDocBanner)
-    app.add_directive(
-        "canonical-pypa-spec", pep_banner_directive.CanonicalPyPASpecBanner)
+        "canonical-pypa-spec", pep_banner_directive.CanonicalPyPASpecBanner
+    )
 
     # Register event callbacks
-    app.connect("builder-inited", _update_config_for_builder)  # Update configuration values for builder used
+    app.connect(
+        "builder-inited", _update_config_for_builder
+    )  # Update configuration values for builder used
     app.connect("env-before-read-docs", create_pep_zero)  # PEP 0 hook
 
     # Mathematics rendering
     inline_maths = HTMLTranslator.visit_math, _depart_maths
     block_maths = HTMLTranslator.visit_math_block, _depart_maths
-    app.add_html_math_renderer("maths_to_html", inline_maths, block_maths)  # Render maths to HTML
+    app.add_html_math_renderer(
+        "maths_to_html", inline_maths, block_maths
+    )  # Render maths to HTML
 
     # Parallel safety: https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata
     return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/pep_sphinx_extensions/pep_processor/html/pep_html_builder.py
+++ b/pep_sphinx_extensions/pep_processor/html/pep_html_builder.py
@@ -2,10 +2,9 @@ from pathlib import Path
 
 from docutils import nodes
 from docutils.frontend import OptionParser
+from sphinx.builders.dirhtml import DirectoryHTMLBuilder
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.writers.html import HTMLWriter
-
-from sphinx.builders.dirhtml import DirectoryHTMLBuilder
 
 
 class FileBuilder(StandaloneHTMLBuilder):
@@ -20,7 +19,9 @@ class FileBuilder(StandaloneHTMLBuilder):
 
     def prepare_writing(self, _doc_names: set[str]) -> None:
         self.docwriter = HTMLWriter(self)
-        _opt_parser = OptionParser([self.docwriter], defaults=self.env.settings, read_config_files=True)
+        _opt_parser = OptionParser(
+            [self.docwriter], defaults=self.env.settings, read_config_files=True
+        )
         self.docsettings = _opt_parser.get_default_values()
 
     def get_doc_context(self, docname: str, body: str, _metatags: str) -> dict:
@@ -40,7 +41,7 @@ class FileBuilder(StandaloneHTMLBuilder):
             toc_tree = toc_tree[0][1]  # don't include document title
             del toc_tree[0]  # remove contents node
             for node in toc_tree.findall(nodes.reference):
-                node["refuri"] = node["anchorname"] or '#'  # fix targets
+                node["refuri"] = node["anchorname"] or "#"  # fix targets
             toc = self.render_partial(toc_tree)["fragment"]
         else:
             toc = ""  # PEPs with no sections -- 9, 210

--- a/pep_sphinx_extensions/pep_processor/html/pep_html_translator.py
+++ b/pep_sphinx_extensions/pep_processor/html/pep_html_translator.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from docutils import nodes
 import sphinx.writers.html5 as html5
+from docutils import nodes
 
 if TYPE_CHECKING:
     from sphinx.builders import html
@@ -38,7 +38,11 @@ class PEPTranslator(html5.HTML5Translator):
 
         # Only first paragraph can be compact (ignoring initial label & invisible nodes)
         first = isinstance(node.parent[0], nodes.label)
-        visible_siblings = [child for child in node.parent.children[first:] if not isinstance(child, nodes.Invisible)]
+        visible_siblings = [
+            child
+            for child in node.parent.children[first:]
+            if not isinstance(child, nodes.Invisible)
+        ]
         if visible_siblings[0] is not node:
             return False
 
@@ -58,13 +62,18 @@ class PEPTranslator(html5.HTML5Translator):
         self.body.append(self.context.pop())
 
     def visit_footnote_reference(self, node):
-        self.body.append(self.starttag(node, "a", suffix="[",
-            CLASS=f"footnote-reference {self.settings.footnote_references}",
-            href=f"#{node['refid']}"
-        ))
+        self.body.append(
+            self.starttag(
+                node,
+                "a",
+                suffix="[",
+                CLASS=f"footnote-reference {self.settings.footnote_references}",
+                href=f"#{node['refid']}",
+            )
+        )
 
     def depart_footnote_reference(self, node):
-        self.body.append(']</a>')
+        self.body.append("]</a>")
 
     def visit_label(self, node):
         # pass parent node to get id into starttag:
@@ -83,21 +92,29 @@ class PEPTranslator(html5.HTML5Translator):
         self.body.append(self.context.pop())
         back_refs = node.parent["backrefs"]
         if self.settings.footnote_backlinks and len(back_refs) > 1:
-            back_links = ", ".join(f"<a href='#{ref}'>{i}</a>" for i, ref in enumerate(back_refs, start=1))
+            back_links = ", ".join(
+                f"<a href='#{ref}'>{i}</a>" for i, ref in enumerate(back_refs, start=1)
+            )
             self.body.append(f"<em> ({back_links}) </em>")
 
         # Close the def tags
         self.body.append("</dt>\n<dd>")
 
     def visit_bullet_list(self, node):
-        if isinstance(node.parent, nodes.section) and "contents" in node.parent["names"]:
+        if (
+            isinstance(node.parent, nodes.section)
+            and "contents" in node.parent["names"]
+        ):
             self.body.append("<details><summary>Table of Contents</summary>")
             self.context.append("</details>")
         super().visit_bullet_list(node)
 
     def depart_bullet_list(self, node):
         super().depart_bullet_list(node)
-        if isinstance(node.parent, nodes.section) and "contents" in node.parent["names"]:
+        if (
+            isinstance(node.parent, nodes.section)
+            and "contents" in node.parent["names"]
+        ):
             self.body.append(self.context.pop())
 
     def unknown_visit(self, node: nodes.Node) -> None:

--- a/pep_sphinx_extensions/pep_processor/parsing/pep_banner_directive.py
+++ b/pep_sphinx_extensions/pep_processor/parsing/pep_banner_directive.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from docutils import nodes
 from docutils.parsers import rst
 
-
 PYPA_SPEC_BASE_URL = "https://packaging.python.org/en/latest/specifications/"
 
 
@@ -25,13 +24,11 @@ class PEPBanner(rst.Directive):
     admonition_class = nodes.important
     css_classes = []
 
-
     def run(self) -> list[nodes.admonition]:
 
         if self.arguments:
             link_content = self.arguments[0]
-            pre_text = self.admonition_pre_template.format(
-                link_content=link_content)
+            pre_text = self.admonition_pre_template.format(link_content=link_content)
         else:
             pre_text = self.admonition_pre_text
 
@@ -48,12 +45,12 @@ class PEPBanner(rst.Directive):
 
         source_lines = [pre_text] + list(self.content or []) + [post_text]
         admonition_node = self.admonition_class(
-            "\n".join(source_lines), classes=["pep-banner"] + self.css_classes)
+            "\n".join(source_lines), classes=["pep-banner"] + self.css_classes
+        )
 
         admonition_node.append(pre_text_node)
         if self.content:
-            self.state.nested_parse(
-                self.content, self.content_offset, admonition_node)
+            self.state.nested_parse(self.content, self.content_offset, admonition_node)
         admonition_node.append(post_text_node)
 
         return [admonition_node]
@@ -71,12 +68,9 @@ class CanonicalDocBanner(PEPBanner):
         "This PEP is a historical document. "
         "The up-to-date, canonical documentation can now be found elsewhere."
     )
-    admonition_post_text = (
-        "See :pep:`1` for how to propose changes."
-    )
+    admonition_post_text = "See :pep:`1` for how to propose changes."
 
     css_classes = ["canonical-doc", "sticky-banner"]
-
 
 
 class CanonicalPyPASpecBanner(PEPBanner):

--- a/pep_sphinx_extensions/pep_processor/parsing/pep_parser.py
+++ b/pep_sphinx_extensions/pep_processor/parsing/pep_parser.py
@@ -4,10 +4,12 @@ from typing import TYPE_CHECKING
 
 from sphinx import parsers
 
-from pep_sphinx_extensions.pep_processor.transforms import pep_contents
-from pep_sphinx_extensions.pep_processor.transforms import pep_footer
-from pep_sphinx_extensions.pep_processor.transforms import pep_headers
-from pep_sphinx_extensions.pep_processor.transforms import pep_title
+from pep_sphinx_extensions.pep_processor.transforms import (
+    pep_contents,
+    pep_footer,
+    pep_headers,
+    pep_title,
+)
 
 if TYPE_CHECKING:
     from docutils import transforms

--- a/pep_sphinx_extensions/pep_processor/parsing/pep_role.py
+++ b/pep_sphinx_extensions/pep_processor/parsing/pep_role.py
@@ -11,7 +11,9 @@ class PEPRole(roles.ReferenceRole):
         try:
             pep_num = int(pep_str)
         except ValueError:
-            msg = self.inliner.reporter.error(f'invalid PEP number {self.target}', line=self.lineno)
+            msg = self.inliner.reporter.error(
+                f"invalid PEP number {self.target}", line=self.lineno
+            )
             prb = self.inliner.problematic(self.rawtext, self.rawtext, msg)
             return [prb], [msg]
         pep_base = self.inliner.document.settings.pep_url.format(pep_num)
@@ -30,10 +32,11 @@ class PEPRole(roles.ReferenceRole):
 
         return [
             nodes.reference(
-                "", title,
+                "",
+                title,
                 internal=True,
                 refuri=ref_uri,
                 classes=["pep"],
-                _title_tuple=(pep_num, fragment)
+                _title_tuple=(pep_num, fragment),
             )
         ], []

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_contents.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_contents.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from docutils import nodes
-from docutils import transforms
+from docutils import nodes, transforms
 from docutils.transforms import parts
 
 
@@ -37,6 +36,7 @@ class PEPContents(transforms.Transform):
 
 class Contents(parts.Contents):
     """Build Table of Contents from document."""
+
     def __init__(self, document: nodes.document, startnode: nodes.Node | None = None):
         super().__init__(document, startnode)
 
@@ -45,7 +45,9 @@ class Contents(parts.Contents):
         self.backlinks = None
 
     def apply(self) -> None:
-        contents = self.build_contents(self.document[0][4:])  # skip PEP title, headers, <hr/>, and contents
+        contents = self.build_contents(
+            self.document[0][4:]
+        )  # skip PEP title, headers, <hr/>, and contents
         if contents:
             self.startnode.replace_self(contents)
         else:
@@ -65,7 +67,7 @@ class Contents(parts.Contents):
             # remove all pre-existing hyperlinks in the title (e.g. PEP references)
             while (link_node := title.next_node(nodes.reference)) is not None:
                 link_node.replace_self(link_node[0])
-            ref_id = section['ids'][0]
+            ref_id = section["ids"][0]
             title["refid"] = ref_id  # Add a link to self
             entry_text = self.copy_and_filter(title)
             reference = nodes.reference("", "", refid=ref_id, *entry_text)
@@ -74,5 +76,5 @@ class Contents(parts.Contents):
             item += self.build_contents(section)  # recurse to add sub-sections
             entries.append(item)
         if entries:
-            return nodes.bullet_list('', *entries)
+            return nodes.bullet_list("", *entries)
         return []

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_footer.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_footer.py
@@ -1,9 +1,8 @@
 import datetime as dt
-from pathlib import Path
 import subprocess
+from pathlib import Path
 
-from docutils import nodes
-from docutils import transforms
+from docutils import nodes, transforms
 
 
 class PEPFooter(transforms.Transform):
@@ -83,7 +82,9 @@ def _get_last_modified_timestamps():
             return {}
 
     # set up the dictionary with the *current* files
-    last_modified = {path.name: 0 for path in Path().glob("pep-*") if path.suffix in {".txt", ".rst"}}
+    last_modified = {
+        path.name: 0 for path in Path().glob("pep-*") if path.suffix in {".txt", ".rst"}
+    }
 
     # iterate through newest to oldest, updating per file timestamps
     change_sets = all_modified.removeprefix("#").split("#")

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_references.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_references.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
-from docutils import nodes
-from docutils import transforms
+from docutils import nodes, transforms
 
 
 class PEPReferenceRoleTitleText(transforms.Transform):

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_title.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_title.py
@@ -1,10 +1,7 @@
 from pathlib import Path
 
-from docutils import nodes
-from docutils import transforms
-from docutils import utils
-from docutils.parsers.rst import roles
-from docutils.parsers.rst import states
+from docutils import nodes, transforms, utils
+from docutils.parsers.rst import roles, states
 
 
 class PEPTitle(transforms.Transform):
@@ -27,7 +24,9 @@ class PEPTitle(transforms.Transform):
         for field in self.document[0]:
             # Hold details of the attribute's tag against its details
             row_attributes = {sub.tagname: sub.rawsource for sub in field}
-            pep_header_details[row_attributes["field_name"]] = row_attributes["field_body"]
+            pep_header_details[row_attributes["field_name"]] = row_attributes[
+                "field_body"
+            ]
 
             # Store the redundant fields in the table for removal
             if row_attributes["field_name"] in desired_fields:
@@ -40,11 +39,17 @@ class PEPTitle(transforms.Transform):
         # Create the title string for the PEP
         pep_number = int(pep_header_details["PEP"])
         pep_title = pep_header_details["Title"]
-        pep_title_string = f"PEP {pep_number} -- {pep_title}"  # double hyphen for en dash
+        pep_title_string = (
+            f"PEP {pep_number} -- {pep_title}"  # double hyphen for en dash
+        )
 
         # Generate the title section node and its properties
         title_nodes = _line_to_nodes(pep_title_string)
-        pep_title_node = nodes.section("", nodes.title("", "", *title_nodes, classes=["page-title"]), names=["pep-content"])
+        pep_title_node = nodes.section(
+            "",
+            nodes.title("", "", *title_nodes, classes=["page-title"]),
+            names=["pep-content"],
+        )
 
         # Insert the title node as the root element, move children down
         document_children = self.document.children
@@ -60,7 +65,15 @@ class PEPTitle(transforms.Transform):
 def _line_to_nodes(text: str) -> list[nodes.Node]:
     """Parse RST string to nodes."""
     document = utils.new_document("<inline-rst>")
-    document.settings.pep_references = document.settings.rfc_references = False  # patch settings
-    states.RSTStateMachine(state_classes=states.state_classes, initial_state="Body").run([text], document)  # do parsing
-    roles._roles.pop("", None)  # restore the "default" default role after parsing a document
+    document.settings.pep_references = (
+        document.settings.rfc_references
+    ) = False  # patch settings
+    states.RSTStateMachine(
+        state_classes=states.state_classes, initial_state="Body"
+    ).run(
+        [text], document
+    )  # do parsing
+    roles._roles.pop(
+        "", None
+    )  # restore the "default" default role after parsing a document
     return document[0].children

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_zero.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_zero.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from docutils import nodes
-from docutils import transforms
+from docutils import nodes, transforms
 
 
 class PEPZero(transforms.Transform):

--- a/pep_sphinx_extensions/pep_zero_generator/constants.py
+++ b/pep_sphinx_extensions/pep_zero_generator/constants.py
@@ -1,39 +1,46 @@
 """Holds type and status constants for PEP 0 generation."""
 
-STATUS_ACCEPTED = "Accepted"
-STATUS_ACTIVE = "Active"
-STATUS_DEFERRED = "Deferred"
-STATUS_DRAFT = "Draft"
-STATUS_FINAL = "Final"
-STATUS_PROVISIONAL = "Provisional"
-STATUS_REJECTED = "Rejected"
-STATUS_SUPERSEDED = "Superseded"
-STATUS_WITHDRAWN = "Withdrawn"
+from enum import Enum
+
+
+class PEPStatus(Enum):
+    ACCEPTED = "Accepted"
+    ACTIVE = "Active"
+    DEFERRED = "Deferred"
+    DRAFT = "Draft"
+    FINAL = "Final"
+    PROVISIONAL = "Provisional"
+    REJECTED = "Rejected"
+    SUPERSEDED = "Superseded"
+    WITHDRAWN = "Withdrawn"
+
 
 # Valid values for the Status header.
-STATUS_VALUES = {
-    STATUS_ACCEPTED, STATUS_PROVISIONAL, STATUS_REJECTED, STATUS_WITHDRAWN,
-    STATUS_DEFERRED, STATUS_FINAL, STATUS_ACTIVE, STATUS_DRAFT, STATUS_SUPERSEDED,
-}
-# Map of invalid/special statuses to their valid counterparts
+STATUS_VALUES = frozenset((status.value for status in PEPStatus))
+# Map of invalid/special statuses to their valid counterparts.
 SPECIAL_STATUSES = {
-    "April Fool!": STATUS_REJECTED,  # See PEP 401 :)
+    "April Fool!": PEPStatus.REJECTED.value,  # See PEP 401 :)
 }
-# Draft PEPs have no status displayed
-HIDE_STATUS = {STATUS_DRAFT}
-# Dead PEP statuses
-DEAD_STATUSES = {STATUS_REJECTED, STATUS_WITHDRAWN, STATUS_SUPERSEDED}
+# Draft PEPs have no status displayed.
+HIDE_STATUS = frozenset({PEPStatus.DRAFT.value})
+# Dead PEP statuses.
+DEAD_STATUSES = frozenset(
+    {PEPStatus.REJECTED.value, PEPStatus.WITHDRAWN.value, PEPStatus.SUPERSEDED.value}
+)
 
-TYPE_INFO = "Informational"
-TYPE_PROCESS = "Process"
-TYPE_STANDARDS = "Standards Track"
+
+class PEPType(Enum):
+    INFO = "Informational"
+    PROCESS = "Process"
+    STANDARDS = "Standards Track"
+
 
 # Valid values for the Type header.
-TYPE_VALUES = {TYPE_STANDARDS, TYPE_INFO, TYPE_PROCESS}
+TYPE_VALUES = frozenset((type_.value for type_ in PEPType))
 # Active PEPs can only be for Informational or Process PEPs.
-ACTIVE_ALLOWED = {TYPE_PROCESS, TYPE_INFO}
+ACTIVE_ALLOWED = frozenset({PEPType.PROCESS.value, PEPType.INFO.value})
 
-# map of topic -> additional description
+# Map of topic -> additional description.
 SUBINDICES_BY_TOPIC = {
     "governance": """\
 These PEPs detail Python's governance, including governance model proposals

--- a/pep_sphinx_extensions/pep_zero_generator/errors.py
+++ b/pep_sphinx_extensions/pep_zero_generator/errors.py
@@ -9,8 +9,7 @@ class PEPError(Exception):
         self.filename = pep_file
         self.number = pep_number
 
-    def __str__(self):
-        error_msg = super(PEPError, self).__str__()
-        error_msg = f"({self.filename}): {error_msg}"
+    def __str__(self) -> str:
+        error_msg = f"({self.filename}): {super().__str__()}"
         pep_str = f"PEP {self.number}"
         return f"{pep_str} {error_msg}" if self.number is not None else error_msg

--- a/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
+++ b/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
@@ -21,10 +21,8 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from pep_sphinx_extensions.pep_zero_generator import parser, subindices, writer
 from pep_sphinx_extensions.pep_zero_generator.constants import SUBINDICES_BY_TOPIC
-from pep_sphinx_extensions.pep_zero_generator import parser
-from pep_sphinx_extensions.pep_zero_generator import subindices
-from pep_sphinx_extensions.pep_zero_generator import writer
 
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
@@ -32,7 +30,7 @@ if TYPE_CHECKING:
 
 
 def _parse_peps() -> list[parser.PEP]:
-    # Read from root directory
+    # Read from root directory.
     path = Path(".")
     peps: list[parser.PEP] = []
 
@@ -40,7 +38,7 @@ def _parse_peps() -> list[parser.PEP]:
         if not file_path.is_file():
             continue  # Skip directories etc.
         if file_path.match("pep-0000*"):
-            continue  # Skip pre-existing PEP 0 files
+            continue  # Skip pre-existing PEP 0 files.
         if file_path.match("pep-????.???") and file_path.suffix in {".txt", ".rst"}:
             pep = parser.PEP(path.joinpath(file_path).absolute())
             peps.append(pep)
@@ -61,7 +59,7 @@ def create_pep_zero(app: Sphinx, env: BuildEnvironment, docnames: list[str]) -> 
 
     subindices.generate_subindices(SUBINDICES_BY_TOPIC, peps, docnames, env)
 
-    # Create peps.json
+    # Create peps.json.
     json_path = Path(app.outdir, "api", "peps.json").resolve()
     json_path.parent.mkdir(exist_ok=True)
     json_path.write_text(create_pep_json(peps), encoding="utf-8")

--- a/pep_sphinx_extensions/pep_zero_generator/subindices.py
+++ b/pep_sphinx_extensions/pep_zero_generator/subindices.py
@@ -13,14 +13,16 @@ if TYPE_CHECKING:
     from pep_sphinx_extensions.pep_zero_generator.parser import PEP
 
 
-def update_sphinx(filename: str, text: str, docnames: list[str], env: BuildEnvironment) -> Path:
+def update_sphinx(
+    filename: str, text: str, docnames: list[str], env: BuildEnvironment
+) -> Path:
     file_path = Path(f"{filename}.rst").resolve()
     file_path.parent.mkdir(parents=True, exist_ok=True)
     file_path.write_text(text, encoding="utf-8")
 
-    # Add to files for builder
+    # Add to files for builder.
     docnames.append(filename)
-    # Add to files for writer
+    # Add to files for writer.
     env.found_docs.add(filename)
 
     return file_path
@@ -32,7 +34,7 @@ def generate_subindices(
     docnames: list[str],
     env: BuildEnvironment,
 ) -> None:
-    # Create sub index page
+    # Create sub index page.
     generate_topic_contents(docnames, env)
 
     for subindex, additional_description in subindices.items():
@@ -50,13 +52,18 @@ the PEP index.
 {additional_description}
 """
         subindex_text = writer.PEPZeroWriter().write_pep0(
-            filtered_peps, header, subindex_intro, is_pep0=False,
+            filtered_peps,
+            header,
+            subindex_intro,
+            is_pep0=False,
         )
         update_sphinx(f"topic/{subindex}", subindex_text, docnames, env)
 
 
 def generate_topic_contents(docnames: list[str], env: BuildEnvironment):
-    update_sphinx("topic/index", """\
+    update_sphinx(
+        "topic/index",
+        """\
 .. _topic-index:
 
 Topic Index
@@ -70,4 +77,7 @@ PEPs are indexed by topic on the pages below:
    :glob:
 
    *
-""", docnames, env)
+""",
+        docnames,
+        env,
+    )

--- a/pep_sphinx_extensions/tests/pep_processor/transform/test_pep_headers.py
+++ b/pep_sphinx_extensions/tests/pep_processor/transform/test_pep_headers.py
@@ -1,20 +1,7 @@
 import pytest
 
 from pep_sphinx_extensions.pep_processor.transforms import pep_headers
-from pep_sphinx_extensions.pep_zero_generator.constants import (
-    STATUS_ACCEPTED,
-    STATUS_ACTIVE,
-    STATUS_DEFERRED,
-    STATUS_DRAFT,
-    STATUS_FINAL,
-    STATUS_PROVISIONAL,
-    STATUS_REJECTED,
-    STATUS_SUPERSEDED,
-    STATUS_WITHDRAWN,
-    TYPE_INFO,
-    TYPE_PROCESS,
-    TYPE_STANDARDS,
-)
+from pep_sphinx_extensions.pep_zero_generator.constants import PEPStatus, PEPType
 
 
 @pytest.mark.parametrize(
@@ -131,16 +118,28 @@ def test_make_link_pretty(test_input, expected):
 @pytest.mark.parametrize(
     "test_input, expected",
     [
-        (STATUS_ACCEPTED, "Normative proposal accepted for implementation"),
-        (STATUS_ACTIVE, "Currently valid informational guidance, or an in-use process"),
-        (STATUS_DEFERRED, "Inactive draft that may be taken up again at a later time"),
-        (STATUS_DRAFT, "Proposal under active discussion and revision"),
-        (STATUS_FINAL, "Accepted and implementation complete, or no longer active"),
-        (STATUS_REJECTED, "Formally declined and will not be accepted"),
+        (PEPStatus.ACCEPTED.value, "Normative proposal accepted for implementation"),
+        (
+            PEPStatus.ACTIVE.value,
+            "Currently valid informational guidance, or an in-use process",
+        ),
+        (
+            PEPStatus.DEFERRED.value,
+            "Inactive draft that may be taken up again at a later time",
+        ),
+        (PEPStatus.DRAFT.value, "Proposal under active discussion and revision"),
+        (
+            PEPStatus.FINAL.value,
+            "Accepted and implementation complete, or no longer active",
+        ),
+        (PEPStatus.REJECTED.value, "Formally declined and will not be accepted"),
         ("April Fool!", "Formally declined and will not be accepted"),
-        (STATUS_SUPERSEDED, "Replaced by another succeeding PEP"),
-        (STATUS_WITHDRAWN, "Removed from consideration by sponsor or authors"),
-        (STATUS_PROVISIONAL, "Provisionally accepted but additional feedback needed"),
+        (PEPStatus.SUPERSEDED.value, "Replaced by another succeeding PEP"),
+        (PEPStatus.WITHDRAWN.value, "Removed from consideration by sponsor or authors"),
+        (
+            PEPStatus.PROVISIONAL.value,
+            "Provisionally accepted but additional feedback needed",
+        ),
     ],
 )
 def test_abbreviate_status(test_input, expected):
@@ -158,17 +157,17 @@ def test_abbreviate_status_unknown():
     "test_input, expected",
     [
         (
-            TYPE_INFO,
+            PEPType.INFO.value,
             "Non-normative PEP containing background, guidelines or other information "
             "relevant to the Python ecosystem",
         ),
         (
-            TYPE_PROCESS,
+            PEPType.PROCESS.value,
             "Normative PEP describing or proposing a change to a Python community "
             "process, workflow or governance",
         ),
         (
-            TYPE_STANDARDS,
+            PEPType.STANDARDS.value,
             "Normative PEP with a new feature for Python, implementation change for "
             "CPython or interoperability standard for the ecosystem",
         ),

--- a/pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py
+++ b/pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py
@@ -4,20 +4,7 @@ import pytest
 
 from pep_sphinx_extensions.pep_zero_generator import parser
 from pep_sphinx_extensions.pep_zero_generator.author import Author
-from pep_sphinx_extensions.pep_zero_generator.constants import (
-    STATUS_ACCEPTED,
-    STATUS_ACTIVE,
-    STATUS_DEFERRED,
-    STATUS_DRAFT,
-    STATUS_FINAL,
-    STATUS_PROVISIONAL,
-    STATUS_REJECTED,
-    STATUS_SUPERSEDED,
-    STATUS_WITHDRAWN,
-    TYPE_INFO,
-    TYPE_PROCESS,
-    TYPE_STANDARDS,
-)
+from pep_sphinx_extensions.pep_zero_generator.constants import PEPStatus, PEPType
 from pep_sphinx_extensions.pep_zero_generator.errors import PEPError
 from pep_sphinx_extensions.tests.utils import AUTHORS_OVERRIDES
 
@@ -97,18 +84,18 @@ def test_parse_authors_invalid():
 @pytest.mark.parametrize(
     "test_type, test_status, expected",
     [
-        (TYPE_INFO, STATUS_DRAFT, ":abbr:`I (Informational, Draft)`"),
-        (TYPE_INFO, STATUS_ACTIVE, ":abbr:`IA (Informational, Active)`"),
-        (TYPE_INFO, STATUS_ACCEPTED, ":abbr:`IA (Informational, Accepted)`"),
-        (TYPE_INFO, STATUS_DEFERRED, ":abbr:`ID (Informational, Deferred)`"),
-        (TYPE_PROCESS, STATUS_ACCEPTED, ":abbr:`PA (Process, Accepted)`"),
-        (TYPE_PROCESS, STATUS_ACTIVE, ":abbr:`PA (Process, Active)`"),
-        (TYPE_PROCESS, STATUS_FINAL, ":abbr:`PF (Process, Final)`"),
-        (TYPE_PROCESS, STATUS_SUPERSEDED, ":abbr:`PS (Process, Superseded)`"),
-        (TYPE_PROCESS, STATUS_WITHDRAWN, ":abbr:`PW (Process, Withdrawn)`"),
-        (TYPE_STANDARDS, STATUS_ACCEPTED, ":abbr:`SA (Standards Track, Accepted)`"),
-        (TYPE_STANDARDS, STATUS_REJECTED, ":abbr:`SR (Standards Track, Rejected)`"),
-        (TYPE_STANDARDS, STATUS_PROVISIONAL, ":abbr:`SP (Standards Track, Provisional)`"),  # fmt: skip
+        (PEPType.INFO.value, PEPStatus.DRAFT.value, ":abbr:`I (Informational, Draft)`"),
+        (PEPType.INFO.value, PEPStatus.ACTIVE.value, ":abbr:`IA (Informational, Active)`"),
+        (PEPType.INFO.value, PEPStatus.ACCEPTED.value, ":abbr:`IA (Informational, Accepted)`"),
+        (PEPType.INFO.value, PEPStatus.DEFERRED.value, ":abbr:`ID (Informational, Deferred)`"),
+        (PEPType.PROCESS.value, PEPStatus.ACCEPTED.value, ":abbr:`PA (Process, Accepted)`"),
+        (PEPType.PROCESS.value, PEPStatus.ACTIVE.value, ":abbr:`PA (Process, Active)`"),
+        (PEPType.PROCESS.value, PEPStatus.FINAL.value, ":abbr:`PF (Process, Final)`"),
+        (PEPType.PROCESS.value, PEPStatus.SUPERSEDED.value, ":abbr:`PS (Process, Superseded)`"),
+        (PEPType.PROCESS.value, PEPStatus.WITHDRAWN.value, ":abbr:`PW (Process, Withdrawn)`"),
+        (PEPType.STANDARDS.value, PEPStatus.ACCEPTED.value, ":abbr:`SA (Standards Track, Accepted)`"),
+        (PEPType.STANDARDS.value, PEPStatus.REJECTED.value, ":abbr:`SR (Standards Track, Rejected)`"),
+        (PEPType.STANDARDS.value, PEPStatus.PROVISIONAL.value, ":abbr:`SP (Standards Track, Provisional)`"),  # fmt: skip
     ],
 )
 def test_abbreviate_type_status(test_type, test_status, expected):


### PR DESCRIPTION
This PR is a bit more subjective, I formatted the `pep_sphinx_extensions` directory with `black` and `isort` (line-length 120).
And some additional touch-ups, like putting all the PEP statuses and types in enums instead of floating globals.
Parts of this PR are subject to discussion, if anyone would like to even discuss it, otherwise it's just a will to maybe make some things a it prettier, at least in my opinion.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3206.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->