### PR TITLE
PEP 257: update code example to Python 3

### DIFF
--- a/pep-0257.txt
+++ b/pep-0257.txt
@@ -252,7 +252,7 @@ therefore 3 lines long.  The first and last lines are blank::
 
 To illustrate::
 
-    >>> print repr(foo.__doc__)
+    >>> print(repr(foo.__doc__))
     '\n    This is the second line of the docstring.\n    '
     >>> foo.__doc__.splitlines()
     ['', '    This is the second line of the docstring.', '    ']


### PR DESCRIPTION
Replace `print` keyword with call to `print()` function in "Handling Docstring Indentation" example.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3207.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->