### PR TITLE
PEP 544: Fix a typo in an example

### DIFF
--- a/pep-0544.txt
+++ b/pep-0544.txt
@@ -781,8 +781,8 @@ For example::
   class C:
       def meth(self, x: int) -> int: ...
 
-  a: ProtoA = C  # Type check error, signatures don't match!
-  b: ProtoB = C  # OK
+  a: ProtoA = C  # OK
+  b: ProtoB = C  # Type check error, signatures don't match!
 
 
 ``NewType()`` and type aliases


### PR DESCRIPTION
As noted in #3208, it looks like `C.meth` matches the signature of `ProtoA.meth` and should be the "compatible" example.

Closes #3208

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3209.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->