### PR TITLE
PEP 393: Replace broken link with an Internet Archive one

### DIFF
--- a/pep-0393.txt
+++ b/pep-0393.txt
@@ -457,7 +457,7 @@ References
 .. [1] PEP 393 branch
        https://bitbucket.org/t0rsten/pep-393
 .. [2] Django measurement results
-       http://www.dcl.hpi.uni-potsdam.de/home/loewis/djmemprof/
+       https://web.archive.org/web/20160911215951/http://www.dcl.hpi.uni-potsdam.de/home/loewis/djmemprof/
 
 Copyright
 =========


### PR DESCRIPTION
Fixes #3205

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3211.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->