### PR TITLE
PEP 639: fix broken link to SPDX spec

### DIFF
--- a/pep-0639.rst
+++ b/pep-0639.rst
@@ -2756,7 +2756,7 @@ References
 .. _spdx: https://spdx.dev/
 .. _spdxid: https://spdx.dev/ids/
 .. _spdxlist: https://spdx.org/licenses/
-.. _spdxpression: https://spdx.github.io/spdx-spec/SPDX-license-expressions/
+.. _spdxpression: https://spdx.github.io/spdx-spec/v2.2.2/SPDX-license-expressions/
 .. _spdxpy: https://github.com/spdx/tools-python/
 .. _spdxtutorial: https://github.com/david-a-wheeler/spdx-tutorial
 .. _spdxversion: https://github.com/pombredanne/spdx-pypi-pep/issues/6


### PR DESCRIPTION
* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

Addresses #3215 by directly linking to version 2.2.2 of the SPDX specification.


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3216.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->