### PR TITLE
Infra: Revert "Fix a URL in the PyPA specification banner (#3199)"

### DIFF
--- a/pep_sphinx_extensions/pep_processor/parsing/pep_banner_directive.py
+++ b/pep_sphinx_extensions/pep_processor/parsing/pep_banner_directive.py
@@ -94,7 +94,7 @@ class CanonicalPyPASpecBanner(PEPBanner):
     )
     admonition_post_text = (
         "See the `PyPA specification update process "
-        "<https://www.pypa.io/en/latest/specifications.html#handling-fixes-and-other-minor-updates>`__ "
+        "<https://www.pypa.io/en/latest/specifications/#handling-fixes-and-other-minor-updates>`__ "
         "for how to propose changes."
     )
     admonition_class = nodes.attention


### PR DESCRIPTION
This reverts commit 08124264e6cc590b472d7f4f023ebe3e6ff3071a (https://github.com/python/peps/pull/3199).

Short version: I broke links on pypa.io (https://github.com/pypa/pypa.io/pull/88), but I've now unbroken them (https://github.com/pypa/pypa.io/pull/90) so we can revert this temporary fix.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3218.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->