### PR TITLE
PEP 232: Resolve unreferenced footnotes

### DIFF
--- a/pep-0232.txt
+++ b/pep-0232.txt
@@ -174,7 +174,9 @@ the 2.1 release.
   syntactic support for conveniently setting.  It may be
   worthwhile to eventually enhance the language for supporting
   easy function attribute setting.  Here are some syntaxes
-  suggested by PEP reviewers::
+  suggested by PEP reviewers: [3]_
+
+  .. code:: python
 
       def a {
           'publish' : 1,
@@ -243,12 +245,12 @@ References
 ==========
 
 .. [1] Aycock, "Compiling Little Languages in Python",
-   http://www.foretec.com/python/workshops/1998-11/proceedings/papers/aycock-little/aycock-little.html
+   https://legacy.python.org/workshops/1998-11/proceedings/papers/aycock-little/aycock-little.html
 
-.. [2] http://classic.zope.org:8080/Documentation/Reference/ORB
+.. [2] http://web.archive.org/web/20010307022153/http://classic.zope.org:8080/Documentation/Reference/ORB
 
 .. [3] Hudson, Michael, SourceForge patch implementing this syntax,
-   http://sourceforge.net/tracker/index.php?func=detail&aid=403441&group_id=5470&atid=305470
+   http://web.archive.org/web/20010901050535/http://sourceforge.net/tracker/index.php?func=detail&aid=403441&group_id=5470&atid=305470
 
 
 Copyright

--- a/pep-0232.txt
+++ b/pep-0232.txt
@@ -247,10 +247,10 @@ References
 .. [1] Aycock, "Compiling Little Languages in Python",
    https://legacy.python.org/workshops/1998-11/proceedings/papers/aycock-little/aycock-little.html
 
-.. [2] http://web.archive.org/web/20010307022153/http://classic.zope.org:8080/Documentation/Reference/ORB
+.. [2] https://web.archive.org/web/20010307022153/http://classic.zope.org:8080/Documentation/Reference/ORB
 
 .. [3] Hudson, Michael, SourceForge patch implementing this syntax,
-   http://web.archive.org/web/20010901050535/http://sourceforge.net/tracker/index.php?func=detail&aid=403441&group_id=5470&atid=305470
+   https://web.archive.org/web/20010901050535/http://sourceforge.net/tracker/index.php?func=detail&aid=403441&group_id=5470&atid=305470
 
 
 Copyright

--- a/pep-0232.txt
+++ b/pep-0232.txt
@@ -257,13 +257,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
The footnote was referenced from within a code block example, so I've lifted the reference up. I also updated the links.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3219.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->