### PR TITLE
PEP 262: Resolve unreferenced footnotes

### DIFF
--- a/pep-0262.txt
+++ b/pep-0262.txt
@@ -319,8 +319,8 @@ for Windows.
 References
 ==========
 
-.. [1] Michael Muller's patch (posted to the Distutils-SIG around 28
-       Dec 1999) generates a list of installed files.
+[1] Michael Muller's patch (posted to the Distutils-SIG around 28
+\   Dec 1999) generates a list of installed files.
 
 .. [2] A patch to implement this PEP will be tracked as
        patch #562100 on SourceForge.
@@ -344,9 +344,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   End:


### PR DESCRIPTION
Footnote [1] doesn't seem to have ever been referenced, I've simply removed the reference markup.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3220.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->