### PR TITLE
PEP 277: Resolve unreferenced footnotes

### DIFF
--- a/pep-0277.txt
+++ b/pep-0277.txt
@@ -101,10 +101,10 @@ The implementation is available at [2]_.
 References
 ==========
 
-.. [1] Microsoft Windows APIs
-       http://msdn.microsoft.com/
+[1] Microsoft Windows APIs
+\   https://msdn.microsoft.com/
 
-.. [2] https://bugs.python.org/issue594001
+.. [2] https://github.com/python/cpython/issues/37017
 
 
 Copyright


### PR DESCRIPTION
Footnote [1] doesn't seem to have ever been referenced, I've simply removed the reference markup.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3221.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->