### PR TITLE
PEP 292: Resolve unreferenced footnotes

### DIFF
--- a/pep-0292.txt
+++ b/pep-0292.txt
@@ -190,10 +190,10 @@ References
 ==========
 
 .. [1] String Formatting Operations
-       http://docs.python.org/library/stdtypes.html#string-formatting-operations
+       https://docs.python.org/release/2.6/library/stdtypes.html#string-formatting-operations
 
 .. [2] Identifiers and Keywords
-       http://docs.python.org/reference/lexical_analysis.html#identifiers-and-keywords
+       https://docs.python.org/release/2.6/reference/lexical_analysis.html#identifiers-and-keywords
 
 .. [3] https://mail.python.org/pipermail/python-dev/2002-June/025652.html
 

--- a/pep-0292.txt
+++ b/pep-0292.txt
@@ -114,7 +114,7 @@ library documentation.
 Why ``$`` and Braces?
 =====================
 
-The BDFL said it best [4]_: "The ``$`` means "substitution" in so many
+The BDFL said it best [3]_: "The ``$`` means "substitution" in so many
 languages besides Perl that I wonder where you've been. [...]
 We're copying this from the shell."
 
@@ -184,8 +184,7 @@ string/unicode like ``%``-operator substitution syntax.
 Reference Implementation
 ========================
 
-The implementation has been committed to the Python 2.4 source tree.
-
+The implementation [4]_ has been committed to the Python 2.4 source tree.
 
 References
 ==========
@@ -196,12 +195,9 @@ References
 .. [2] Identifiers and Keywords
        http://docs.python.org/reference/lexical_analysis.html#identifiers-and-keywords
 
-.. [3] Guido's python-dev posting from 21-Jul-2002
-       https://mail.python.org/pipermail/python-dev/2002-July/026397.html
+.. [3] https://mail.python.org/pipermail/python-dev/2002-June/025652.html
 
-.. [4] https://mail.python.org/pipermail/python-dev/2002-June/025652.html
-
-.. [5] Reference Implementation
+.. [4] Reference Implementation
        http://sourceforge.net/tracker/index.php?func=detail&aid=1014055&group_id=5470&atid=305470
 
 Copyright


### PR DESCRIPTION
Footnote [3] was added in 1ac7cab, to a section entitled *BDFL Weathervane*; the section was later removed in fa6ff92, but the footnote remained. I've therefore removed footnote [3] and added a reference to old footnote [5] (now [4]).

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3222.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->