### PR TITLE
PEP 299: Resolve unreferenced footnotes

### DIFF
--- a/pep-0299.txt
+++ b/pep-0299.txt
@@ -100,7 +100,7 @@ Open Issues
 Rejection
 =========
 
-In a short discussion on python-dev [1], two major backwards
+In a short discussion on python-dev [1]_, two major backwards
 compatibility problems were brought up and Guido pronounced that he
 doesn't like the idea anyway as it's "not worth the change (in docs,
 user habits, etc.) and there's nothing particularly broken."
@@ -117,12 +117,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:


### PR DESCRIPTION
This one is fixing incorrect reStructuredText.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3223.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->