### PR TITLE
PEP 323: Resolve unreferenced footnotes

### DIFF
--- a/pep-0323.txt
+++ b/pep-0323.txt
@@ -475,23 +475,14 @@ specific iterator type at the same time.
 References
 ==========
 
-.. [1] Discussion on python-dev starting at post:
-       https://mail.python.org/pipermail/python-dev/2003-October/038969.html
+[1] Discussion on python-dev starting at post:
+\   https://mail.python.org/pipermail/python-dev/2003-October/038969.html
 
-.. [2] Online documentation for the copy module of the standard library:
-       http://docs.python.org/library/copy.html
+[2] Online documentation for the copy module of the standard library:
+\   https://docs.python.org/release/2.6/library/copy.html
 
 
 Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:


### PR DESCRIPTION
Footnotes [1] was never referenced, and the reference to [2] was removed in 36e7a69 -- this commit removes the markup syntax.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3224.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->