### PR TITLE
PEP 326: Remore unreferenced footnotes and renumber

### DIFF
--- a/pep-0326.txt
+++ b/pep-0326.txt
@@ -15,10 +15,10 @@ Post-History: 20-Dec-2003, 03-Jan-2004, 05-Jan-2004, 07-Jan-2004,
 Results
 =======
 
-This PEP has been rejected by the BDFL [12]_.  As per the
-pseudo-sunset clause [13]_, :pep:`326` is being updated one last time
+This PEP has been rejected by the BDFL [8]_.  As per the
+pseudo-sunset clause [9]_, :pep:`326` is being updated one last time
 with the latest suggestions, code modifications, etc., and includes a
-link to a module [14]_ that implements the behavior described in the
+link to a module [10]_ that implements the behavior described in the
 PEP.  Users who desire the behavior listed in this PEP are encouraged
 to use the module for the reasons listed in
 `Independent Implementations?`_.
@@ -177,7 +177,7 @@ potential problems with numeric overflows.
 
 .. _DijkstraSP_table_node:
 
-Gustavo Niemeyer [9]_ points out that using a more Pythonic data
+Gustavo Niemeyer [7]_ points out that using a more Pythonic data
 structure than tuples, to store information about node distances,
 increases readability.  Two equivalent node structures (one using
 ``None``, the other using ``Max``) and their use in a suitably
@@ -253,7 +253,7 @@ A ``Min`` Example
 -----------------
 
 An example of usage for ``Min`` is an algorithm that solves the
-following problem [6]_:
+following problem [5]_:
 
     Suppose you are given a directed graph, representing a
     communication network.  The vertices are the nodes in the network,
@@ -305,7 +305,7 @@ translations are left as an exercise to the reader.
 Other Examples
 --------------
 
-Andrew P. Lentvorski, Jr. [7]_ has pointed out that various data
+Andrew P. Lentvorski, Jr. [6]_ has pointed out that various data
 structures involving range searching have immediate use for ``Max``
 and ``Min`` values.  More specifically; Segment trees, Range trees,
 k-d trees and database keys:
@@ -365,7 +365,7 @@ seek to show how inconsistent they can be.
   could result in incorrect output by passing in secondary versions of
   ``Max``.
 
-It has been pointed out [9]_ that the reference implementation given
+It has been pointed out [7]_ that the reference implementation given
 below would be incompatible with independent implementations of
 ``Max``/``Min``.  The point of this PEP is for the introduction of
 "The One True Implementation" of "The One True Maximum" and "The One
@@ -445,36 +445,27 @@ References
 .. [4] [Python-Dev] Re: PEP 326 now online, Reedy, Terry
    (https://mail.python.org/pipermail/python-dev/2004-January/041685.html)
 
-.. [5] [Python-Dev] PEP 326 now online, Chermside, Michael
-   (https://mail.python.org/pipermail/python-dev/2004-January/041704.html)
-
-.. [6] Homework 6, Problem 7, Dillencourt, Michael
+.. [5] Homework 6, Problem 7, Dillencourt, Michael
    (link may not be valid in the future)
    (http://www.ics.uci.edu/~dillenco/ics161/hw/hw6.pdf)
 
-.. [7] RE: [Python-Dev] PEP 326 now online, Lentvorski, Andrew P., Jr.
+.. [6] RE: [Python-Dev] PEP 326 now online, Lentvorski, Andrew P., Jr.
    (https://mail.python.org/pipermail/python-dev/2004-January/041727.html)
 
-.. [8] Re: It's not really Some is it?, Ippolito, Bob
-   (http://www.livejournal.com/users/chouyu_31/138195.html?thread=274643#t274643)
-
-.. [9] [Python-Dev] Re: PEP 326 now online, Niemeyer, Gustavo
+.. [7] [Python-Dev] Re: PEP 326 now online, Niemeyer, Gustavo
    (https://mail.python.org/pipermail/python-dev/2004-January/042261.html);
    [Python-Dev] Re: PEP 326 now online, Carlson, Josiah
    (https://mail.python.org/pipermail/python-dev/2004-January/042272.html)
 
-.. [11] [Python-Dev] PEP 326 (quick location possibility), Carlson, Josiah
-   (https://mail.python.org/pipermail/python-dev/2004-January/042275.html)
-
-.. [12] [Python-Dev] PEP 326 (quick location possibility), van Rossum, Guido
+.. [8] [Python-Dev] PEP 326 (quick location possibility), van Rossum, Guido
    (https://mail.python.org/pipermail/python-dev/2004-January/042306.html)
 
-.. [13] [Python-Dev] PEP 326 (quick location possibility), Carlson, Josiah
+.. [9] [Python-Dev] PEP 326 (quick location possibility), Carlson, Josiah
    (https://mail.python.org/pipermail/python-dev/2004-January/042300.html)
 
-.. [14] Recommended standard implementation of PEP 326, extremes.py,
+.. [10] Recommended standard implementation of PEP 326, extremes.py,
    Carlson, Josiah
-   (http://www.ics.uci.edu/~jcarlson/pep326/extremes.py)
+   (https://web.archive.org/web/20040410135029/http://www.ics.uci.edu:80/~jcarlson/pep326/extremes.py)
 
 
 Changes
@@ -508,19 +499,10 @@ Changes
 
 - Added some `References`_.
 
-- BDFL rejects [12]_ :pep:`326`
+- BDFL rejects [8]_ :pep:`326`
 
 
 Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:


### PR DESCRIPTION
Footnote [10] does not exist.  Footnotes [5], [8], and [11] are unreferenced. Commit 778f8da removed the reference to [5] (then numbered [6]) and added [8] with no reference. [11] was added in 64497e6 with no reference. Without an apparent need for these three, they are removed. The remaining footnotes and their text references are re-numbered.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3225.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->