### PR TITLE
PEP 329: Resolve unreferenced footnotes

### DIFF
--- a/pep-0329.txt
+++ b/pep-0329.txt
@@ -244,7 +244,7 @@ Here is a sample implementation for codetweaks.py::
 
 
 Note the automatic detection of a non-CPython environment that does not
-have bytecodes [3]_.  In that situation, the bind functions would simply
+have bytecodes [2]_.  In that situation, the bind functions would simply
 return the original function unchanged.  This assures that the two
 line additions to library modules do not impact other implementations.
 
@@ -255,23 +255,13 @@ The final code should add a flag to make it easy to disable binding.
 References
 ==========
 
-.. [2] ASPN Recipe for a non-private implementation
-       http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/277940
+[1] ASPN Recipe for a non-private implementation
+\   https://code.activestate.com/recipes/277940/
 
-.. [3] Differences between CPython and Jython
-       http://www.jython.org/cgi-bin/faqw.py?req=show&file=faq01.003.htp
+.. [2] Differences between CPython and Jython
+       https://web.archive.org/web/20031018014238/http://www.jython.org/cgi-bin/faqw.py?req=show&file=faq01.003.htp
 
 Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:


### PR DESCRIPTION
Footnote [2] was never referenced, remove the markup.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3226.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->