### PR TITLE
PEP 336: Resolve unreferenced footnotes

### DIFF
--- a/pep-0336.txt
+++ b/pep-0336.txt
@@ -24,7 +24,7 @@ This PEP is rejected.  It is considered a feature that ``None`` raises
 an error when called.  The proposal falls short in tests for
 obviousness, clarity, explicitness, and necessity.  The provided Switch
 example is nice but easily handled by a simple lambda definition.
-See python-dev discussion on 17 June 2005 [2]_.
+See python-dev discussion on 17 June 2005 [1]_.
 
 
 Motivation
@@ -119,10 +119,7 @@ After::
 References
 ==========
 
-.. [1] Python Reference Manual, Section 3.2,
-       http://docs.python.org/reference/
-
-.. [2] Raymond Hettinger, Propose to reject PEP 336 -- Make None Callable
+.. [1] Raymond Hettinger, Propose to reject PEP 336 -- Make None Callable
        https://mail.python.org/pipermail/python-dev/2005-June/054280.html
 
 
@@ -130,13 +127,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 70
-  End:


### PR DESCRIPTION
Footnote [1] was never referenced, and doesn't provide any value to the PEP, so better to remove than convert to text.

A