### PR TITLE
PEP 340: Resolve unreferenced footnotes

### DIFF
--- a/pep-0340.txt
+++ b/pep-0340.txt
@@ -563,11 +563,11 @@ contributions!
 References
 ==========
 
-.. [1] https://mail.python.org/pipermail/python-dev/2005-April/052821.html
+[1] https://mail.python.org/pipermail/python-dev/2005-April/052821.html
 
-.. [2] http://msdn.microsoft.com/vcsharp/programming/language/ask/withstatement/
+.. [2] https://web.archive.org/web/20060719195933/http://msdn.microsoft.com/vcsharp/programming/language/ask/withstatement/
 
-.. [3] http://effbot.org/zone/asyncore-generators.htm
+.. [3] https://web.archive.org/web/20050204062901/http://effbot.org/zone/asyncore-generators.htm
 
 Copyright
 =========


### PR DESCRIPTION
Footnote [1] was originally referenced in the introduction to the PEP as background of why it came into being, before being removed in 45c25ac. I've removed the syntax and updated links to archive.org versions.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3228.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->