### PR TITLE
PEP 343: Resolve unreferenced footnotes

### DIFF
--- a/pep-0343.txt
+++ b/pep-0343.txt
@@ -30,7 +30,7 @@ on python-dev. Any first person references are from Guido's
 original.
 
 Python's alpha release cycle revealed terminology problems in this
-PEP and in the associated documentation and implementation [14]_.
+PEP and in the associated documentation and implementation [13]_.
 The PEP stabilised around the time of the first Python 2.5 beta
 release.
 
@@ -558,7 +558,7 @@ of any major objections on python-dev).
 3. Objects with ``__enter__/__exit__`` methods are called "context
    managers" and the decorator to convert a generator function
    into a context manager factory is ``contextlib.contextmanager``.
-   There were some other suggestions [16]_ during the 2.5 release
+   There were some other suggestions [15]_ during the 2.5 release
    cycle but no compelling arguments for switching away from the
    terms that had been used in the PEP implementation were made.
 
@@ -569,14 +569,14 @@ Rejected Options
 For several months, the PEP prohibited suppression of exceptions
 in order to avoid hidden flow control. Implementation
 revealed this to be a right royal pain, so Guido restored the
-ability [13]_.
+ability [12]_.
 
 Another aspect of the PEP that caused no end of questions and
 terminology debates was providing a ``__context__()`` method that
 was analogous to an iterable's ``__iter__()`` method [5]_ [7]_ [9]_.
-The ongoing problems [10]_ [13]_ with explaining what it was and why
+The ongoing problems [10]_ [12]_ with explaining what it was and why
 it was and how it was meant to work eventually lead to Guido
-killing the concept outright [15]_ (and there was much rejoicing!).
+killing the concept outright [14]_ (and there was much rejoicing!).
 
 The notion of using the :pep:`342` generator API directly to define
 the with statement was also briefly entertained [6]_, but quickly
@@ -953,32 +953,19 @@ References
 .. [11] Guido says AttributeError is fine for missing special methods
         https://mail.python.org/pipermail/python-dev/2005-October/057625.html
 
-.. [12] Original PEP 342 implementation patch
-        http://sourceforge.net/tracker/index.php?func=detail&aid=1223381&group_id=5470&atid=305470
-
-.. [13] Guido restores the ability to suppress exceptions
+.. [12] Guido restores the ability to suppress exceptions
         https://mail.python.org/pipermail/python-dev/2006-February/061909.html
 
-.. [14] A simple question kickstarts a thorough review of PEP 343
+.. [13] A simple question kickstarts a thorough review of PEP 343
         https://mail.python.org/pipermail/python-dev/2006-April/063859.html
 
-.. [15] Guido kills the __context__() method
+.. [14] Guido kills the __context__() method
         https://mail.python.org/pipermail/python-dev/2006-April/064632.html
 
-.. [16] Proposal to use 'context guard' instead of 'context manager'
+.. [15] Proposal to use 'context guard' instead of 'context manager'
         https://mail.python.org/pipermail/python-dev/2006-May/064676.html
 
 Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
Footnote [12] was added in f860cb2 with no reference -- I can't find a working archive.org link (all say that the patch is private), so I've removed [12] and re-numbered the remaining footnotes.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3230.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->