### PR TITLE
PEP 355: Resolve unreferenced footnotes

### DIFF
--- a/pep-0355.txt
+++ b/pep-0355.txt
@@ -570,12 +570,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0355.txt
+++ b/pep-0355.txt
@@ -167,7 +167,7 @@ for brevity; see the reference implementation for more detail)::
             """p.splitpath() -> Return (p.parent, p.name)."""
         def stripext(self) => Path
             """p.stripext() -> Remove one file extension from the path."""
-        def splitunc(self): ...  [1]_
+        def splitunc(self): ...  # See footnote [1]
         def splitall(self): ...
         def relpath(self): ...
         def relpathto(self, dest): ...
@@ -219,7 +219,7 @@ for brevity; see the reference implementation for more detail)::
         def isfile(self): ...
         def islink(self): ...
         def ismount(self): ...
-        def samefile(self, other): ...  [1]_
+        def samefile(self, other): ...  # See footnote [1]
         def atime(self): ...
             """Last access time of the file."""
         def mtime(self): ...
@@ -231,17 +231,17 @@ for brevity; see the reference implementation for more detail)::
             Windows), is the creation time for path.
             """
         def size(self): ...
-        def access(self, mode): ...  [1]_
+        def access(self, mode): ...  # See footnote [1]
         def stat(self): ...
         def lstat(self): ...
-        def statvfs(self): ...  [1]_
-        def pathconf(self, name): ...  [1]_
+        def statvfs(self): ...  # See footnote [1]
+        def pathconf(self, name): ...  # See footnote [1]
 
         # Methods for manipulating information about the filesystem
         # path.
         def utime(self, times) => None
         def chmod(self, mode) => None
-        def chown(self, uid, gid) => None [1]_
+        def chown(self, uid, gid) => None # See footnote [1]
         def rename(self, new) => None
         def renames(self, new) => None
 
@@ -273,8 +273,8 @@ for brevity; see the reference implementation for more detail)::
         def rmtree(self, ignore_errors = False, onerror = None): ...
 
         # Special stuff from os
-        def chroot(self): ...  [1]_
-        def startfile(self): ...  [1]_
+        def chroot(self): ...  # See footnote [1]
+        def startfile(self): ...  # See footnote [1]
 
 
 Replacing older functions with the Path class
@@ -546,7 +546,7 @@ replacement for a.
 References and Footnotes
 ========================
 
-.. [1] Method is not guaranteed to be available on all platforms.
+[1] Method is not guaranteed to be available on all platforms.
 
 .. [2] "(idea) subclassable string: path object?", van Rossum, 2001
        https://mail.python.org/pipermail/python-dev/2001-August/016663.html


### PR DESCRIPTION
Another instance of footnote references from within a code block -- I've removed the footnote markup from [1] and updated the comments in the Specification.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3231.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->