### PR TITLE
PEP 361: Resolve unreferenced footnotes

### DIFF
--- a/pep-0361.txt
+++ b/pep-0361.txt
@@ -151,7 +151,7 @@ Warnings for features removed in Py3k:
 Other major features:
 
 - ``with``/``as`` will be keywords
-- a ``__dir__()`` special method to control ``dir()`` was added [1]
+- a ``__dir__()`` special method to control ``dir()`` was added [1]_
 - AtheOS support stopped.
 - ``warnings`` module implemented in C
 - ``compile()`` takes an AST and can convert to byte code
@@ -281,14 +281,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 70
-  coding: utf-8
-  End:


### PR DESCRIPTION
Update to correct reStructuredText format.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3232.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->