### PR TITLE
PEP 370: Resolve unreferenced footnotes

### DIFF
--- a/pep-0370.txt
+++ b/pep-0370.txt
@@ -203,21 +203,21 @@ References
    http://peak.telecommunity.com/DevCenter/EasyInstall#creating-a-virtual-python
 
 .. [2]  Working Env
-   http://pypi.python.org/pypi/workingenv.py
-   http://blog.ianbicking.org/workingenv-revisited.html
+   https://pypi.org/project/workingenv.py/
+   https://ianbicking.org/archive/workingenv-revisited.html
 
 .. [3] Virtual Env
-   http://pypi.python.org/pypi/virtualenv
+   https://pypi.org/project/virtualenv/
 
 .. [4] reference implementation
    http://bugs.python.org/issue1799
    http://svn.python.org/view/sandbox/trunk/pep370
 
 .. [5] MSDN: CSIDL
-   http://msdn2.microsoft.com/en-us/library/bb762494.aspx
+   https://learn.microsoft.com/en/windows/win32/shell/csidl
 
-.. [6] Initial suggestion for a per user site-packages directory
-   http://permalink.gmane.org/gmane.comp.python.devel/90902
+[6] Initial suggestion for a per user site-packages directory
+\   http://permalink.gmane.org/gmane.comp.python.devel/90902
 
 .. [7] Suggestion of ~/.local/
    http://permalink.gmane.org/gmane.comp.python.devel/90925
@@ -232,19 +232,10 @@ References
    http://permalink.gmane.org/gmane.comp.python.devel/91095
 
 .. [11] freedesktop.org XGD basedir specs mentions ~/.local
-   http://www.freedesktop.org/wiki/Specifications/basedir-spec
+   https://www.freedesktop.org/wiki/Specifications/basedir-spec/
 
 .. [12] ~/.local for Mac and usercustomize file
    http://permalink.gmane.org/gmane.comp.python.devel/91167
 
 .. [13] Roaming profile on Windows
    http://permalink.gmane.org/gmane.comp.python.devel/91187
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0370.txt
+++ b/pep-0370.txt
@@ -1,7 +1,5 @@
 PEP: 370
 Title: Per user site-packages directory
-Version: $Revision$
-Last-Modified: $Date$
 Author: Christian Heimes <christian@python.org>
 Status: Final
 Type: Standards Track

--- a/pep-0370.txt
+++ b/pep-0370.txt
@@ -208,32 +208,32 @@ References
    https://pypi.org/project/virtualenv/
 
 .. [4] reference implementation
-   http://bugs.python.org/issue1799
+   https://github.com/python/cpython/issues/46132
    http://svn.python.org/view/sandbox/trunk/pep370
 
 .. [5] MSDN: CSIDL
    https://learn.microsoft.com/en/windows/win32/shell/csidl
 
 [6] Initial suggestion for a per user site-packages directory
-\   http://permalink.gmane.org/gmane.comp.python.devel/90902
+\   https://mail.python.org/archives/list/python-dev@python.org/message/V23CUKRH3VCHFLV33ADMHJSM53STPA7I/
 
 .. [7] Suggestion of ~/.local/
-   http://permalink.gmane.org/gmane.comp.python.devel/90925
+   https://mail.python.org/pipermail/python-dev/2008-January/075985.html
 
 .. [8] APPDATA discussion
-   http://permalink.gmane.org/gmane.comp.python.devel/90932
+   https://mail.python.org/pipermail/python-dev/2008-January/075993.html
 
 .. [9] Security concerns and -s option
-   http://permalink.gmane.org/gmane.comp.python.devel/91063
+   https://mail.python.org/pipermail/python-dev/2008-January/076130.html
 
 .. [10] Discussion about the bin directory
-   http://permalink.gmane.org/gmane.comp.python.devel/91095
+   https://mail.python.org/pipermail/python-dev/2008-January/076162.html
 
 .. [11] freedesktop.org XGD basedir specs mentions ~/.local
    https://www.freedesktop.org/wiki/Specifications/basedir-spec/
 
 .. [12] ~/.local for Mac and usercustomize file
-   http://permalink.gmane.org/gmane.comp.python.devel/91167
+   https://mail.python.org/pipermail/python-dev/2008-January/076236.html
 
 .. [13] Roaming profile on Windows
-   http://permalink.gmane.org/gmane.comp.python.devel/91187
+   https://mail.python.org/pipermail/python-dev/2008-January/076256.html


### PR DESCRIPTION
Footnote [6] existed from the beginning of the PEP, but was never referenced. ``permalink.gmane.org`` doesn't seem to work anymore so I can't evaluate if the reference *was* useful -- removed the syntax for now, but this one is more of a judgement call.

Is there a way to map ``gmane.comp.python.devel/<number>`` to ``mail.python.org``?

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3233.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->