### PR TITLE
PEP 371: Resolve unreferenced footnotes

### DIFF
--- a/pep-0371.txt
+++ b/pep-0371.txt
@@ -144,7 +144,7 @@ All of the code for this can be downloaded from
 http://jessenoller.com/code/bench-src.tgz
 
 The basic method of execution for these benchmarks is in the
-run_benchmarks.py script, which is simply a wrapper to execute a
+run_benchmarks.py [6]_ script, which is simply a wrapper to execute a
 target function through a single threaded (linear), multi-threaded
 (via threading), and multi-process (via pyprocessing) function for
 a static number of iterations with increasing numbers of execution
@@ -431,13 +431,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0371.txt
+++ b/pep-0371.txt
@@ -9,7 +9,7 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 06-May-2008
 Python-Version: 2.6, 3.0
-Post-History:
+Post-History: `03-Jun-2008 <https://mail.python.org/pipermail/python-dev/2008-June/080011.html>`__
 
 
 Abstract
@@ -407,15 +407,15 @@ References
        https://web.archive.org/web/20080914113946/https://pyprocessing.berlios.de/
 
 .. [2] See Adam Olsen's "safe threading" project
-       http://code.google.com/p/python-safethread/
+       https://code.google.com/archive/p/python-safethread/
 
 .. [3] See: Addition of "pyprocessing" module to standard lib.
        https://mail.python.org/pipermail/python-dev/2008-May/079417.html
 
-.. [4] http://mpi4py.scipy.org/
+.. [4] https://mpi4py.readthedocs.io/
 
 .. [5] See "Cluster Computing"
-       http://wiki.python.org/moin/ParallelProcessing
+       https://wiki.python.org/moin/ParallelProcessing#Cluster_Computing
 
 .. [6] The original run_benchmark.py code was published in Python
        Magazine in December 2007: "Python Threads and the Global
@@ -423,9 +423,6 @@ References
        this PEP.
 
 .. [7] http://groups.google.com/group/python-dev2/msg/54cf06d15cbcbc34
-
-.. [8] Addition Python-Dev discussion
-       https://mail.python.org/pipermail/python-dev/2008-June/080011.html
 
 Copyright
 =========


### PR DESCRIPTION
Footnote [6] has existed since the initial draft of the PEP; I've added a reference in a sensible place. Footnote [8] was added in 351a920, and is really a post-history update.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3234.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->