### PR TITLE
PEP 419: Resolve unreferenced footnotes

### DIFF
--- a/pep-0419.txt
+++ b/pep-0419.txt
@@ -508,6 +508,11 @@ References
 .. [3] Twisted: inlineCallbacks
    https://twisted.org/documents/8.1.0/api/twisted.internet.defer.html
 
+[4] Original discussion
+\   https://mail.python.org/pipermail/python-ideas/2012-April/014705.html
+
+[5] Implementation of PEP 419
+\   https://github.com/python/cpython/issues/58935
 
 Copyright
 =========

--- a/pep-0419.txt
+++ b/pep-0419.txt
@@ -506,27 +506,10 @@ References
    https://github.com/sampsyo/bluelet
 
 .. [3] Twisted: inlineCallbacks
-   http://twistedmatrix.com/documents/8.1.0/api/twisted.internet.defer.html
-
-.. [4] Original discussion
-   https://mail.python.org/pipermail/python-ideas/2012-April/014705.html
-
-.. [5] Issue #14730: Implementation of the PEP 419
-   http://bugs.python.org/issue14730
+   https://twisted.org/documents/8.1.0/api/twisted.internet.defer.html
 
 
 Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 70
-  coding: utf-8
-  End:


### PR DESCRIPTION
Footnote [4] referenced the initial email to Python-Dev, and [5] referenced https://github.com/python/cpython/issues/58935, both of which seem severable from the main text.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3235.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->