### PR TITLE
PEP 425: Resolve unreferenced footnotes

### DIFF
--- a/pep-0425.txt
+++ b/pep-0425.txt
@@ -274,11 +274,11 @@ Why is the ABI tag (the second tag) sometimes "none" in the reference implementa
 References
 ==========
 
-.. [1] Egg Filename-Embedded Metadata
-   (http://peak.telecommunity.com/DevCenter/EggFormats#filename-embedded-metadata)
+[1] Egg Filename-Embedded Metadata
+\   (http://peak.telecommunity.com/DevCenter/EggFormats#filename-embedded-metadata)
 
-.. [2] Creating Built Distributions
-   (http://docs.python.org/distutils/builtdist.html)
+[2] Creating Built Distributions
+\   (https://docs.python.org/3.4/distutils/builtdist.html)
 
 Acknowledgements
 ================
@@ -290,14 +290,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
Footnotes [1] and [2] have existed since the initial draft; both never referenced. I've removed the syntax.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3236.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->