### PR TITLE
PEP 448: Resolve unreferenced footnotes

### DIFF
--- a/pep-0448.txt
+++ b/pep-0448.txt
@@ -227,24 +227,13 @@ References
    (https://mail.python.org/pipermail/python-dev/2015-February/138564.html)
 
 .. [2] Issue 2292, "Missing `*`-unpacking generalizations", Thomas Wouters
-   (http://bugs.python.org/issue2292)
+   (https://github.com/python/cpython/issues/46545)
 
-.. [3] Discussion on Python-ideas list,
-   "list / array comprehensions extension", Alexander Heger
-   (https://mail.python.org/pipermail/python-ideas/2011-December/013097.html)
+[3] Discussion on Python-ideas list,
+\   "list / array comprehensions extension", Alexander Heger
+\  (https://mail.python.org/pipermail/python-ideas/2011-December/013097.html)
 
 Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
Footnote [3] has been present since the beginning (originally as [2]) -- whilst unreferened, it provides useful background to the PEP. I've removed the syntax, but I'm on the fence about just removing it.

A