### PR TITLE
PEP 480: Resolve unreferenced footnotes

### DIFF
--- a/pep-0480.txt
+++ b/pep-0480.txt
@@ -882,16 +882,16 @@ References
 ==========
 
 .. [2] https://theupdateframework.io/papers/survivable-key-compromise-ccs2010.pdf
-.. [3] https://github.com/theupdateframework/tuf/blob/develop/docs/tuf-spec.txt
-.. [4] https://packaging.python.org/glossary
+.. [3] https://theupdateframework.github.io/specification/latest/index.html
+.. [4] https://packaging.python.org/en/latest/glossary/
 .. [5] https://github.com/theupdateframework/pip/wiki/Attacks-on-software-repositories
 .. [6] https://mail.python.org/pipermail/distutils-sig/2013-September/022773.html
 .. [7] https://theupdateframework.io/papers/attacks-on-package-managers-ccs2008.pdf
 .. [8] https://mail.python.org/pipermail/distutils-sig/2013-September/022755.html
-.. [9] https://pypi.python.org/security
+.. [9] https://pypi.org/security/
 .. [10] https://mail.python.org/pipermail/distutils-sig/2013-August/022154.html
-.. [11] https://en.wikipedia.org/wiki/RSA_%28algorithm%29
-.. [12] http://ed25519.cr.yp.to/
+.. [11] https://en.wikipedia.org/wiki/RSA_(cryptosystem)
+.. [12] https://ed25519.cr.yp.to/
 
 
 Acknowledgements

--- a/pep-0480.txt
+++ b/pep-0480.txt
@@ -78,7 +78,7 @@ TUF metadata available on PyPI to download distributions more securely.
 the minimum security model, which supports continuous delivery of projects and
 uses online cryptographic keys to sign the distributions uploaded by
 developers.  Although the minimum security model guards against most attacks on
-software updaters [5]_ [7]_, such as mix-and-match and extraneous dependencies
+software updaters [5]_ [6]_, such as mix-and-match and extraneous dependencies
 attacks, it can be improved to support end-to-end signing and to prohibit
 forged distributions in the event that PyPI is compromised.
 
@@ -299,12 +299,12 @@ The package manager (pip) shipped with CPython MUST work on non-CPython
 interpreters and cannot have dependencies that have to be compiled (i.e., the
 PyPI+TUF integration MUST NOT require compilation of C extensions in order to
 verify cryptographic signatures).  Verification of signatures MUST be done in
-Python, and verifying RSA [11]_ signatures in pure-Python may be impractical due
+Python, and verifying RSA [8]_ signatures in pure-Python may be impractical due
 to speed.  Therefore, PyPI MAY use the `Ed25519`__ signature scheme.
 
 __ http://ed25519.cr.yp.to/
 
-Ed25519 [12]_ is a public-key signature system that uses small cryptographic
+Ed25519 [9]_ is a public-key signature system that uses small cryptographic
 signatures and keys.  A `pure-Python implementation`__ of the Ed25519 signature
 scheme is available.  Verification of Ed25519 signatures is fast even when
 performed in Python.
@@ -728,7 +728,7 @@ attacks, or metadata inconsistency attacks.
 Table 1: Attacks that are possible by compromising certain combinations of role
 keys.  In `September 2013`__, it was shown how the latest version (at the time)
 of pip was susceptible to these attacks and how TUF could protect users against
-them [8]_.  Roles signed by offline keys are in **bold**.
+them [7]_.  Roles signed by offline keys are in **bold**.
 
 __ https://mail.python.org/pipermail/distutils-sig/2013-September/022755.html
 
@@ -885,13 +885,10 @@ References
 .. [3] https://theupdateframework.github.io/specification/latest/index.html
 .. [4] https://packaging.python.org/en/latest/glossary/
 .. [5] https://github.com/theupdateframework/pip/wiki/Attacks-on-software-repositories
-.. [6] https://mail.python.org/pipermail/distutils-sig/2013-September/022773.html
-.. [7] https://theupdateframework.io/papers/attacks-on-package-managers-ccs2008.pdf
-.. [8] https://mail.python.org/pipermail/distutils-sig/2013-September/022755.html
-.. [9] https://pypi.org/security/
-.. [10] https://mail.python.org/pipermail/distutils-sig/2013-August/022154.html
-.. [11] https://en.wikipedia.org/wiki/RSA_(cryptosystem)
-.. [12] https://ed25519.cr.yp.to/
+.. [6] https://theupdateframework.io/papers/attacks-on-package-managers-ccs2008.pdf
+.. [7] https://mail.python.org/pipermail/distutils-sig/2013-September/022755.html
+.. [8] https://en.wikipedia.org/wiki/RSA_(cryptosystem)
+.. [9] https://ed25519.cr.yp.to/
 
 
 Acknowledgements

--- a/pep-0480.txt
+++ b/pep-0480.txt
@@ -1,7 +1,5 @@
 PEP: 480
 Title: Surviving a Compromise of PyPI: End-to-end signing of packages
-Version: $Revision$
-Last-Modified: $Date$
 Author: Trishank Karthik Kuppusamy <karthik@trishank.com>,
         Vladimir Diaz <vladimir.diaz@nyu.edu>,
         Justin Cappos <jcappos@nyu.edu>, Marina Moore <mm9693@nyu.edu>


### PR DESCRIPTION
Footnotes [6], [9], and [10] were introduced in 2689835, when PEP 480 was cleaved from 458, all unreferenced. I've read through the PEP and can't identify a useful place that references could be added, so I've removed the footnotes and renumbered.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3238.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->