### PR TITLE
PEP 491: Resolve unreferenced footnotes

### DIFF
--- a/pep-0491.txt
+++ b/pep-0491.txt
@@ -1,7 +1,5 @@
 PEP: 491
 Title: The Wheel Binary Package Format 1.9
-Version: $Revision$
-Last-Modified: $Date$
 Author: Daniel Holth <dholth@gmail.com>
 Discussions-To: distutils-sig@python.org
 Status: Deferred

--- a/pep-0491.txt
+++ b/pep-0491.txt
@@ -531,13 +531,6 @@ Is it possible to import Python code directly from a wheel file?
     a fully installed package before accepting it as a genuine bug.
 
 
-References
-==========
-
-.. [1] PEP acceptance
-   (https://mail.python.org/pipermail/python-dev/2013-February/124103.html)
-
-
 Appendix
 ========
 
@@ -558,14 +551,3 @@ Copyright
 =========
 
 This document has been placed into the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
Footnote [1] referenced an email pertaining to PEP 427; I've removed the footnote.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3240.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->