### PR TITLE
PEP 492: Resolve unreferenced footnotes

### DIFF
--- a/pep-0492.txt
+++ b/pep-0492.txt
@@ -558,7 +558,7 @@ an asynchronous one.  While this is not a very useful thing to do, the
 code illustrates the relationship between regular and asynchronous
 iterators.
 
-::
+.. code:: python
 
     class AsyncIteratorWrapper:
         def __init__(self, obj):
@@ -584,7 +584,7 @@ Why StopAsyncIteration?
 Coroutines are still based on generators internally.  So, before PEP
 479, there was no fundamental difference between
 
-::
+.. code:: python
 
     def g1():
         yield from fut
@@ -592,7 +592,7 @@ Coroutines are still based on generators internally.  So, before PEP
 
 and
 
-::
+.. code:: python
 
     def g2():
         yield from fut
@@ -602,7 +602,7 @@ And since :pep:`479` is accepted and enabled by default for coroutines,
 the following example will have its ``StopIteration`` wrapped into a
 ``RuntimeError``
 
-::
+.. code:: python
 
     async def a1():
         await fut
@@ -643,7 +643,7 @@ generators are treated as distinct concepts:
    doing so will result in a ``TypeError``.
 
 3. *generator-based coroutines* (for asyncio code must be decorated
-   with ``@asyncio.coroutine``) can ``yield from`` *native coroutine
+   with ``@asyncio.coroutine`` [1]_) can ``yield from`` *native coroutine
    objects*.
 
 4. ``inspect.isgenerator()`` and ``inspect.isgeneratorfunction()``
@@ -1218,7 +1218,7 @@ Overall Impact
 This proposal introduces no observable performance impact.  Here is an
 output of python's official set of benchmarks [4]_:
 
-::
+.. code:: text
 
     python perf.py -r -b default ../cpython/python.exe ../cpython-aw/python.exe
 
@@ -1356,7 +1356,7 @@ Working example
 All concepts proposed in this PEP are implemented [3]_ and can be
 tested.
 
-::
+.. code:: python
 
     import asyncio
 
@@ -1456,12 +1456,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
Footnote [1] was unreferenced following 9d82c29, I've added a reference in what seems a sensible place.

A