### PR TITLE
PEP 502: Resolve unreferenced footnotes

### DIFF
--- a/pep-0502.txt
+++ b/pep-0502.txt
@@ -22,7 +22,7 @@ To recap that PEP,
 a string prefix was introduced that marks the string as a template to be
 rendered.
 These formatted strings may contain one or more expressions
-built on `the existing syntax`_ of ``str.format()``.
+built on `the existing syntax`_ of ``str.format()``. [10]_ [11]_
 The formatted string expands at compile-time into a conventional string format
 operation,
 with the given expressions from its text extracted and passed instead as
@@ -650,78 +650,52 @@ References
 ==========
 
 .. [1] Briefer String Format
-
-   (https://mail.python.org/pipermail/python-ideas/2015-July/034659.html)
+       (https://mail.python.org/pipermail/python-ideas/2015-July/034659.html)
 
 .. [2] Briefer String Format
-
-   (https://mail.python.org/pipermail/python-ideas/2015-July/034669.html)
+       (https://mail.python.org/pipermail/python-ideas/2015-July/034669.html)
 
 .. [3] Briefer String Format
-
-   (https://mail.python.org/pipermail/python-ideas/2015-July/034701.html)
+       (https://mail.python.org/pipermail/python-ideas/2015-July/034701.html)
 
 .. [4] Bash Docs
-
-   (http://www.tldp.org/LDP/abs/html/arithexp.html)
+       (https://tldp.org/LDP/abs/html/arithexp.html)
 
 .. [5] Bash Docs
-
-   (http://www.tldp.org/LDP/abs/html/commandsub.html)
+       (https://tldp.org/LDP/abs/html/commandsub.html)
 
 .. [6] Perl Cookbook
-
-   (http://docstore.mik.ua/orelly/perl/cookbook/ch01_11.htm)
+       (https://docstore.mik.ua/orelly/perl/cookbook/ch01_11.htm)
 
 .. [7] Perl Docs
-
-   (http://perl6maven.com/perl6-scalar-array-and-hash-interpolation)
+       (https://web.archive.org/web/20121025185907/https://perl6maven.com/perl6-scalar-array-and-hash-interpolation)
 
 .. [8] Ruby Docs
-
-   (http://ruby-doc.org/core-2.1.1/doc/syntax/literals_rdoc.html#label-Strings)
+       (http://ruby-doc.org/core-2.1.1/doc/syntax/literals_rdoc.html#label-Strings)
 
 .. [9] Ruby Docs
-
-   (https://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Literals#Interpolation)
+       (https://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Literals#Interpolation)
 
 .. [10] Python Str.Format Syntax
-
-   (https://docs.python.org/3/library/string.html#format-string-syntax)
+        (https://docs.python.org/3.6/library/string.html#format-string-syntax)
 
 .. [11] Python Format-Spec Mini Language
-
-   (https://docs.python.org/3/library/string.html#format-specification-mini-language)
+        (https://docs.python.org/3.6/library/string.html#format-specification-mini-language)
 
 .. [12]  Escaping of Input Variables
-
-    (https://mail.python.org/pipermail/python-ideas/2015-August/035532.html)
+        (https://mail.python.org/pipermail/python-ideas/2015-August/035532.html)
 
 .. [13]  Environment Access and Command Substitution
-
-    (https://mail.python.org/pipermail/python-ideas/2015-August/035554.html)
+        (https://mail.python.org/pipermail/python-ideas/2015-August/035554.html)
 
 .. [14]  Extensible String Prefixes
-
-    (https://mail.python.org/pipermail/python-ideas/2015-August/035336.html)
-
+        (https://mail.python.org/pipermail/python-ideas/2015-August/035336.html)
 
 .. [15] Literal String Formatting
-
-    (https://mail.python.org/pipermail/python-dev/2015-August/141289.html)
+        (https://mail.python.org/pipermail/python-dev/2015-August/141289.html)
 
 
 Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0502.txt
+++ b/pep-0502.txt
@@ -1,7 +1,5 @@
 PEP: 502
 Title: String Interpolation - Extended Discussion
-Version: $Revision$
-Last-Modified: $Date$
 Author: Mike G. Miller
 Status: Rejected
 Type: Informational


### PR DESCRIPTION
The references to footnotes [10] and [11] were removed in 1bd2f20; I've added references in what seems a sensible place.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3242.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->