### PR TITLE
PEP 505: Resolve unreferenced footnotes

### DIFF
--- a/pep-0505.rst
+++ b/pep-0505.rst
@@ -1,7 +1,5 @@
 PEP: 505
 Title: None-aware operators
-Version: $Revision$
-Last-Modified: $Date$
 Author: Mark E. Haase <mehaase@gmail.com>, Steve Dower <steve.dower@python.org>
 Status: Deferred
 Type: Standards Track

--- a/pep-0505.rst
+++ b/pep-0505.rst
@@ -236,7 +236,7 @@ conversion to use ``None``-aware operators may look like.
 Standard Library
 ----------------
 
-Using the ``find-pep505.py`` script[5]_ an analysis of the Python 3.7 standard
+Using the ``find-pep505.py`` script [5]_ an analysis of the Python 3.7 standard
 library discovered up to 678 code snippets that could be replaced with use of
 one of the ``None``-aware operators::
 
@@ -844,7 +844,7 @@ References
 ==========
 
 .. [1] C# Reference: Operators
-   (https://msdn.microsoft.com/en-us/library/6a71f45d.aspx)
+   (https://learn.microsoft.com/en/dotnet/csharp/language-reference/operators/)
 
 .. [2] A Tour of the Dart Language: Operators
    (https://www.dartlang.org/docs/dart-up-and-running/ch02.html#operators)
@@ -862,14 +862,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
Fixed a whitespace issue.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3243.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->