### PR TITLE
PEP 617: Fix expression typo in rationale

### DIFF
--- a/pep-0617.rst
+++ b/pep-0617.rst
@@ -163,7 +163,7 @@ an LL(1) parser) several rules are not LL(1) and several workarounds are
 implemented in the grammar and in other parts of CPython to deal with this. For
 example, consider the rule for assignment expressions::
 
-    namedexpr_test: NAME [':=' test]
+    namedexpr_test: [NAME ':='] test
 
 This simple rule is not compatible with the Python grammar as *NAME* is among the
 elements of the *first set* of the rule *test*. To work around this limitation the


### PR DESCRIPTION
In the rationale section, the expression for the intended rule for assignment expressions has brackets around the wrong part, making the logic hard to follow.

For reference, here's an excerpt of [Guido's post](https://discuss.python.org/t/preparing-for-new-python-parsing/1550/5) which was likely the source for the section:

> The first case is that of assignment expressions. The Grammar says:
> 
> ```
> namedexpr_test: test [':=' test]
> ```
> 
> but what we really want to say is:
> 
> ```
> namedexpr_test: [NAME ':='] test
> ```
> Unfortunately that’s not LL(1) since NAME is also in the FIRST set of test. (You can think of test as the pre-PEP-572 top-level expression rule, named test for historical reasons.)

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3244.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->