### PR TITLE
PEP 545: Resolve unreferenced footnotes

### DIFF
--- a/pep-0545.txt
+++ b/pep-0545.txt
@@ -1,7 +1,5 @@
 PEP: 545
 Title: Python Documentation Translations
-Version: $Revision$
-Last-Modified: $Date$
 Author: Julien Palard <julien@palard.fr>,
         Inada Naoki <songofacandy@gmail.com>,
         Victor Stinner <vstinner@python.org>
@@ -330,7 +328,7 @@ involves creativity in the expression of the ideas.
 There's multiple solutions, quoting Van Lindberg from the PSF asked
 about the subject:
 
-  1. Docs should either have the copyright​ assigned or be under CCO. A
+  1. Docs should either have the copyright assigned or be under CCO. A
      permissive software license (like Apache or MIT) would also get the
      job done, although it is not quite fit for task.
 
@@ -548,19 +546,14 @@ the translation can be added to the language switcher.
 Previous Discussions
 ====================
 
-- `[Python-ideas] Cross link documentation translations (January, 2016)`_
-- `[Python-ideas] Cross link documentation translations (January, 2016)`_
-- `[Python-ideas] https://docs.python.org/fr/ ? (March 2016)`_
+`[Python-ideas] Cross link documentation translations (January, 2016)
+<https://mail.python.org/pipermail/python-ideas/2016-January/038010.html>`__
 
+`[Python-Dev] Translated Python documentation (February 2016)
+<https://mail.python.org/pipermail/python-dev/2017-February/147416.html>`__
 
-.. _[Python-ideas] Cross link documentation translations (January, 2016):
-   https://mail.python.org/pipermail/python-ideas/2016-January/038010.html
-
-.. _[Python-Dev] Translated Python documentation (February 2016):
-   https://mail.python.org/pipermail/python-dev/2017-February/147416.html
-
-.. _[Python-ideas] https://docs.python.org/fr/ ? (March 2016):
-   https://mail.python.org/pipermail/python-ideas/2016-March/038879.html
+`[Python-ideas] https://docs.python.org/fr/ ? (March 2016)
+<https://mail.python.org/pipermail/python-ideas/2016-March/038879.html>`__
 
 
 References
@@ -570,8 +563,8 @@ References
    Python documents?
    (https://mail.python.org/pipermail/i18n-sig/2013-September/002130.html)
 
-.. [2] [Doc-SIG] Localization of Python docs
-   (https://mail.python.org/pipermail/doc-sig/2013-September/003948.html)
+[2] [Doc-SIG] Localization of Python docs
+\   (https://mail.python.org/pipermail/doc-sig/2013-September/003948.html)
 
 .. [4] IETF language tag
    (https://en.wikipedia.org/wiki/IETF_language_tag)
@@ -580,7 +573,7 @@ References
    (https://www.gnu.org/software/gettext/manual/html_node/Locale-Names.html)
 
 .. [6] Semantic URL: Slug
-   (https://en.wikipedia.org/wiki/Semantic_URL#Slug)
+   (https://en.wikipedia.org/wiki/Clean_URL#Slug)
 
 .. [8] Docsbuild-scripts GitHub repository
    (https://github.com/python/docsbuild-scripts/)
@@ -609,8 +602,8 @@ References
 .. [16] French translation
    (https://www.afpy.org/doc/python/)
 
-.. [17] French translation on GitHub
-   (https://github.com/AFPy/python_doc_fr)
+.. [17] French translation on Gitea
+   (https://git.afpy.org/AFPy/python-docs-fr)
 
 .. [18] French mailing list
    (http://lists.afpy.org/mailman/listinfo/traductions)
@@ -622,7 +615,7 @@ References
    (https://github.com/python-doc-ja/python-doc-ja)
 
 .. [21] Spanish translation
-   (http://docs.python.org.ar/tutorial/3/index.html)
+   (https://docs.python.org/es/3/tutorial/index.html)
 
 .. [22] [Python-Dev] Translated Python documentation: doc vs docs
    (https://mail.python.org/pipermail/python-dev/2017-February/147472.html)
@@ -637,7 +630,7 @@ References
    (http://python-lab.ru/documentation/index.html)
 
 .. [26] Python-oktató
-   (http://harp.pythonanywhere.com/python_doc/tutorial/index.html)
+   (http://web.archive.org/web/20170526080729/http://harp.pythonanywhere.com/python_doc/tutorial/index.html)
 
 .. [27] The Python-hu Archives
    (https://mail.python.org/pipermail/python-hu/)
@@ -650,15 +643,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
Footnote [2] has never been referenced; I removed the markup.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3247.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->