### PR TITLE
PEP 571: Resolve unreferenced footnotes

### DIFF
--- a/pep-0571.rst
+++ b/pep-0571.rst
@@ -1,7 +1,5 @@
 PEP: 571
 Title: The manylinux2010 Platform Tag
-Version: $Revision$
-Last-Modified: $Date$
 Author: Mark  Williams <mrw@enotuniq.org>,
         Geoffrey Thomas <geofft@ldpreload.com>,
         Thomas Kluyver <thomas@kluyver.me.uk>
@@ -61,7 +59,7 @@ from CentOS 6 and that the ``manylinux`` toolchain, PyPI, and ``pip``
 be updated to support it.
 
 This was originally proposed as ``manylinux2``, but the versioning has
-been changed to use calendar years (also known as CalVer [23]_). This
+been changed to use calendar years (also known as CalVer [22]_). This
 makes it easier to define future *manylinux* tags out of order: for
 example, a hypothetical ``manylinux2017`` standard may be defined via
 a new PEP before ``manylinux2014``, or a ``manylinux2007`` standard
@@ -238,11 +236,11 @@ distribution's upcoming releases. [17]_ If Travis CI, for example,
 begins running jobs under
 a kernel that does not provide the ``vsyscall`` interface, Python
 packagers will not be able to use our Docker images there to build
-``manylinux`` wheels. [19]_
+``manylinux`` wheels. [18]_
 
 We have derived a patch from the ``glibc`` git repository that
 backports the removal of all dependencies on ``vsyscall`` to the
-version of ``glibc`` included with our ``manylinux2010`` image. [20]_
+version of ``glibc`` included with our ``manylinux2010`` image. [19]_
 Rebuilding ``glibc``, and thus building ``manylinux2010`` image itself,
 still requires a host kernel that provides the ``vsyscall`` mechanism,
 but the resulting image can be both run on hosts that provide it and
@@ -257,7 +255,7 @@ Auditwheel
 ----------
 
 The ``auditwheel`` tool has also been updated to produce
-``manylinux2010`` wheels. [21]_ Its behavior and purpose are otherwise
+``manylinux2010`` wheels. [20]_ Its behavior and purpose are otherwise
 unchanged from :pep:`513`.
 
 
@@ -305,7 +303,7 @@ this PEP.  As a result, ``manylinux1`` wheels are considered
 ``manylinux2010`` wheels.  A ``pip`` that recognizes the ``manylinux2010``
 platform tag will thus install ``manylinux1`` wheels for
 ``manylinux2010`` platforms -- even when explicitly set -- when no
-``manylinux2010`` wheels are available. [22]_
+``manylinux2010`` wheels are available. [21]_
 
 PyPI Support
 ============
@@ -358,28 +356,18 @@ References
    (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=852620)
 .. [17] [Wheel-builders] Heads-up re: new kernel configurations breaking the manylinux docker image
    (https://mail.python.org/pipermail/wheel-builders/2016-December/000239.html)
-.. [18] No longer used
-.. [19] Travis CI
+.. [18] Travis CI
    (https://travis-ci.org/)
-.. [20] remove-vsyscall.patch
+.. [19] remove-vsyscall.patch
    https://github.com/markrwilliams/manylinux/commit/e9493d55471d153089df3aafca8cfbcb50fa8093#diff-3eda4130bdba562657f3ec7c1b3f5720
-.. [21] auditwheel manylinux2 branch
+.. [20] auditwheel manylinux2 branch
    (https://github.com/markrwilliams/auditwheel/tree/manylinux2)
-.. [22] pip manylinux2 branch
+.. [21] pip manylinux2 branch
    https://github.com/markrwilliams/pip/commits/manylinux2
-.. [23] Calendar Versioning
+.. [22] Calendar Versioning
    http://calver.org/
 
 Copyright
 =========
 
 This document has been placed into the public domain.
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
Re-numbered, as footnote [18] was unused.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3248.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->