### PR TITLE
PEP 572: Resolve unreferenced footnotes

### DIFF
--- a/pep-0572.rst
+++ b/pep-0572.rst
@@ -290,7 +290,7 @@ The same reason makes these examples invalid too::
 
 While it's technically possible to assign consistent semantics to these cases,
 it's difficult to determine whether those semantics actually make *sense* in the
-absence of real use cases. Accordingly, the reference implementation will ensure
+absence of real use cases. Accordingly, the reference implementation [1]_ will ensure
 that such cases raise ``SyntaxError``, rather than executing with implementation
 defined behaviour.
 
@@ -1326,14 +1326,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
The references to footnote [1] were removed in 5e8b724, I inserted a reference in what seems a sensible place.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3249.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->