### PR TITLE
PEP 617: Resolve unreferenced footnotes

### DIFF
--- a/pep-0617.rst
+++ b/pep-0617.rst
@@ -1,7 +1,5 @@
 PEP: 617
 Title: New PEG parser for CPython
-Version: $Revision$
-Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>,
         Pablo Galindo <pablogsal@python.org>,
         Lysandros Nikolaou <lisandrosnik@gmail.com>
@@ -12,6 +10,8 @@ Content-Type: text/x-rst
 Created: 24-Mar-2020
 Python-Version: 3.9
 Post-History: 02-Apr-2020
+
+.. highlight:: PEG
 
 ========
 Overview
@@ -40,7 +40,7 @@ and the *follow sets* of the grammar:
 * Given a rule, the *first set* is the collection of all terminals that can occur
   first in a full derivation of that rule. Intuitively, this helps the parser decide
   among the alternatives in a rule. For
-  instance, given the rule ::
+  instance, given the rule::
 
       rule: A | B
 
@@ -298,13 +298,13 @@ and "hidden left-recursion" like::
 Syntax
 ------
 
-The grammar consists of a sequence of rules of the form: ::
+The grammar consists of a sequence of rules of the form::
 
    rule_name: expression
 
 Optionally, a type can be included right after the rule name, which
 specifies the return type of the C or Python function corresponding to
-the rule: ::
+the rule::
 
    rule_name[return_type]: expression
 
@@ -324,7 +324,7 @@ Python-style comments.
 
 Match e1, then match e2.
 
-::
+.. code:: PEG
 
    rule_name: first_rule second_rule
 
@@ -339,7 +339,7 @@ The first alternative can also appear on the line after the rule name
 for formatting purposes. In that case, a \| must be used before the
 first alternative, like so:
 
-::
+.. code:: PEG
 
    rule_name[return_type]:
        | first_alt
@@ -350,14 +350,14 @@ first alternative, like so:
 
 Match e.
 
-::
+.. code:: PEG
 
    rule_name: (e)
 
 A slightly more complex and useful example includes using the grouping
 operator together with the repeat operators:
 
-::
+.. code:: PEG
 
    rule_name: (e1 e2)*
 
@@ -366,14 +366,14 @@ operator together with the repeat operators:
 
 Optionally match e.
 
-::
+.. code:: PEG
 
    rule_name: [e]
 
 A more useful example includes defining that a trailing comma is
 optional:
 
-::
+.. code:: PEG
 
    rule_name: e (',' e)* [',']
 
@@ -384,7 +384,7 @@ optional:
 
 Match zero or more occurrences of e.
 
-::
+.. code:: PEG
 
    rule_name: (e1 e2)*
 
@@ -395,7 +395,7 @@ Match zero or more occurrences of e.
 
 Match one or more occurrences of e.
 
-::
+.. code:: PEG
 
    rule_name: (e1 e2)+
 
@@ -406,7 +406,7 @@ Match one or more occurrences of e, separated by s. The generated parse
 tree does not include the separator. This is otherwise identical to
 ``(e (s e)*)``.
 
-::
+.. code:: PEG
 
    rule_name: ','.e+
 
@@ -428,7 +428,7 @@ An example taken from the proposed Python grammar specifies that a primary
 consists of an atom, which is not followed by a ``.`` or a ``(`` or a
 ``[``:
 
-::
+.. code:: PEG
 
    primary: atom !'.' !'(' !'['
 
@@ -439,7 +439,7 @@ consists of an atom, which is not followed by a ``.`` or a ``(`` or a
 
 Commit to the current alternative, even if it fails to parse.
 
-::
+.. code:: PEG
 
    rule_name: '(' ~ some_rule ')' | some_alt
 
@@ -451,7 +451,7 @@ Variables in the Grammar
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 A subexpression can be named by preceding it with an identifier and an
-``=`` sign. The name can then be used in the action (see below), like this: ::
+``=`` sign. The name can then be used in the action (see below), like this::
 
    rule_name[return_type]: '(' a=some_other_rule ')' { a }
 
@@ -469,7 +469,7 @@ files should be written, each one with a different set of actions, keeping
 everything else apart from said actions identical in both files. As an
 example of a grammar with Python actions, the piece of the parser generator
 that parses grammar files is bootstrapped from a meta-grammar file with
-Python actions that generate the grammar tree as a result of the parsing. 
+Python actions that generate the grammar tree as a result of the parsing.
 
 In the specific case of the new proposed PEG grammar for Python, having
 actions allows directly describing how the AST is composed in the grammar
@@ -496,7 +496,7 @@ with all the parsed expressions gets returned (this is meant for debugging).
 
 The full meta-grammar for the grammars supported by the PEG generator is:
 
-::
+.. code:: PEG
 
     start[Grammar]: grammar ENDMARKER { grammar }
 
@@ -589,25 +589,25 @@ As an illustrative example this simple grammar file allows directly
 generating a full parser that can parse simple arithmetic expressions and that
 returns a valid C-based Python AST:
 
-::
+.. code:: PEG
 
     start[mod_ty]: a=expr_stmt* $ { Module(a, NULL, p->arena) }
     expr_stmt[stmt_ty]: a=expr NEWLINE { _Py_Expr(a, EXTRA) }
-    expr[expr_ty]: 
+    expr[expr_ty]:
         | l=expr '+' r=term { _Py_BinOp(l, Add, r, EXTRA) }
         | l=expr '-' r=term { _Py_BinOp(l, Sub, r, EXTRA) }
         | t=term { t }
 
-    term[expr_ty]: 
+    term[expr_ty]:
         | l=term '*' r=factor { _Py_BinOp(l, Mult, r, EXTRA) }
         | l=term '/' r=factor { _Py_BinOp(l, Div, r, EXTRA) }
         | f=factor { f }
 
-    factor[expr_ty]: 
+    factor[expr_ty]:
         | '(' e=expr ')' { e }
         | a=atom { a }
 
-    atom[expr_ty]: 
+    atom[expr_ty]:
         | n=NAME { n }
         | n=NUMBER { n }
         | s=STRING { s }
@@ -619,7 +619,7 @@ for the parser.
 
 A similar grammar written to target Python AST objects:
 
-::
+.. code:: PEG
 
   start: expr NEWLINE? ENDMARKER { ast.Expression(expr) }
   expr: 
@@ -787,17 +787,16 @@ References
 ==========
 
 .. [1] Ford, Bryan
-   http://pdos.csail.mit.edu/~baford/packrat/thesis
+   https://pdos.csail.mit.edu/~baford/packrat/thesis/
 
 .. [2] Medeiros et al.
    https://arxiv.org/pdf/1207.0443.pdf
 
 .. [3] Warth et al.
-   http://web.cs.ucla.edu/~todd/research/pepm08.pdf
+   https://web.cs.ucla.edu/~todd/research/pepm08.pdf
 
-.. [#GUIDO_PEG]
-   Guido's series on PEG parsing
-   https://medium.com/@gvanrossum_83706/peg-parsing-series-de5d41b2ed60
+[4] Guido's series on PEG parsing
+\   https://medium.com/@gvanrossum_83706/peg-parsing-series-de5d41b2ed60
 
 =========
 Copyright


### PR DESCRIPTION
The final footnote was never referenced; I've removed the syntax.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3250.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->