### PR TITLE
PEP 644: Resolve unreferenced footnotes

### DIFF
--- a/pep-0644.rst
+++ b/pep-0644.rst
@@ -322,7 +322,7 @@ Debian Buster and Debian Bullseye will be available.
 
 Instead Python 3.10 will gain additional documentation and a new
 ``configure`` option ``--with-openssl-rpath=auto`` to simplify use of custom
-OpenSSL builds [11].
+OpenSSL builds [11]_.
 
 
 Backwards Compatibility
@@ -371,14 +371,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
Fix reST syntax.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3252.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->