### PR TITLE
PEP 654: Resolve unreferenced footnotes

### DIFF
--- a/pep-0654.rst
+++ b/pep-0654.rst
@@ -46,7 +46,7 @@ together as the stack unwinds. Several real world use cases are listed below.
   are proposing (see also the `Programming Without 'except \*'`_ section.)
 
   Implementing a better task spawning API in asyncio, inspired by Trio
-  nurseries, was the main motivation for this PEP.  That work is currently
+  nurseries [13]_, was the main motivation for this PEP.  That work is currently
   blocked on Python not having native language level support for exception
   groups.
 
@@ -1474,7 +1474,7 @@ References
 
 .. [3] https://github.com/python-trio/trio/issues/611
 
-.. [4] https://bugs.python.org/issue29980
+.. [4] https://github.com/python/cpython/issues/74166
 
 .. [5] https://docs.python.org/3/library/atexit.html#atexit.register
 
@@ -1482,7 +1482,7 @@ References
 
 .. [7] https://hypothesis.readthedocs.io/en/latest/settings.html#hypothesis.settings.report_multiple_bugs
 
-.. [8] https://bugs.python.org/issue40857
+.. [8] https://github.com/python/cpython/issues/85034
 
 .. [9] https://trio.readthedocs.io/en/stable/reference-core.html#trio.MultiError
 
@@ -1499,13 +1499,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
Footnote [13] was added in cef697a, which also added the stanza on "Implementing a better task spawning API..." to which I've added a reference to [13].

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3254.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->