### PR TITLE
PEP 3100: Resolve unreferenced footnotes

### DIFF
--- a/pep-3100.txt
+++ b/pep-3100.txt
@@ -1,7 +1,5 @@
 PEP: 3100
 Title: Miscellaneous Python 3.0 Plans
-Version: $Revision$
-Last-Modified: $Date$
 Author: Brett Cannon <brett@python.org>
 Status: Final
 Type: Process
@@ -123,7 +121,7 @@ To be removed:
 * ``x``: use ``repr(x)`` [2]_ [done]
 * The ``<>`` operator: use ``!=`` instead [3]_ [done]
 * The __mod__ and __divmod__ special methods on float. [they should stay] [21]_
-* Drop unbound methods [7]_ [25]_ [done]
+* Drop unbound methods [7]_ [26]_ [done]
 * METH_OLDARGS [done]
 * WITH_CYCLE_GC [done]
 * __getslice__, __setslice__, __delslice__ [#sequence-types]_;
@@ -246,13 +244,13 @@ To be removed:
   in favor of always using threading.py.)
 * UserXyz classes, in favour of XyzMixins.
 
-* Remove the unreliable empty() and full() methods from Queue.py?
-* Remove jumpahead() from the random API?
+* Remove the unreliable empty() and full() methods from Queue.py? [25]_
+* Remove jumpahead() from the random API? [25]_
 * Make the primitive for random be something generating random bytes
-  rather than random floats?
-* Get rid of Cookie.SerialCookie and Cookie.SmartCookie?
+  rather than random floats? [25]_
+* Get rid of Cookie.SerialCookie and Cookie.SmartCookie? [25]_
 * Modify the heapq.heapreplace() API to compare the new value to the top
-  of the heap?
+  of the heap? [25]_
 
 Outstanding Issues
 ==================
@@ -268,13 +266,13 @@ References
 ==========
 
 .. [1] PyCon 2003 State of the Union:
-   http://www.python.org/doc/essays/ppt/pycon2003/pycon2003.ppt
+   https://legacy.python.org/doc/essays/ppt/pycon2003/pycon2003.ppt
 
 .. [2] Python Regrets:
-   http://www.python.org/doc/essays/ppt/regrets/PythonRegrets.pdf
+   https://legacy.python.org/doc/essays/ppt/regrets/PythonRegrets.pdf
 
 .. [3] Python Wiki:
-   http://www.python.org/moin/Python3.0
+   https://wiki.python.org/moin/Python3.0
 
 .. [4] python-dev email ("Constancy of None")
    https://mail.python.org/pipermail/python-dev/2004-July/046294.html
@@ -293,10 +291,10 @@ References
    https://mail.python.org/pipermail/python-dev/2005-February/051674.html
 
 .. [9] Guido's blog ("The fate of reduce() in Python 3000")
-   http://www.artima.com/weblogs/viewpost.jsp?thread=98196
+   https://www.artima.com/weblogs/viewpost.jsp?thread=98196
 
 .. [10] Guido's blog ("Python Optional Typechecking Redux")
-   http://www.artima.com/weblogs/viewpost.jsp?thread=89161
+   https://www.artima.com/weblogs/viewpost.jsp?thread=89161
 
 .. [11] python-dev email ("anonymous blocks")
    https://mail.python.org/pipermail/python-dev/2005-April/053060.html
@@ -350,19 +348,19 @@ References
    https://mail.python.org/pipermail/python-dev/2008-February/076818.html
 
 .. [#sys-module] Python docs (sys -- System-specific parameters and functions)
-   http://docs.python.org/library/sys.html
+   https://docs.python.org/release/2.6/library/sys.html
 
 .. [#operator-module] Python docs (operator -- Standard operators as functions)
-   http://docs.python.org/library/operator.html
+   https://docs.python.org/release/2.6/library/operator.html
 
 .. [#array-module] Python docs (array -- Efficient arrays of numeric values)
-   http://docs.python.org/library/array.html
+   https://docs.python.org/release/2.6/library/array.html
 
 .. [#file-object] Python docs (File objects)
-   http://docs.python.org/library/stdtypes.html
+   https://docs.python.org/release/2.6/library/stdtypes.html
 
 .. [#sequence-types] Python docs (Additional methods for emulation of sequence types)
-   http://docs.python.org/reference/datamodel.html#additional-methods-for-emulation-of-sequence-types
+   https://docs.python.org/release/2.6/reference/datamodel.html#additional-methods-for-emulation-of-sequence-types
 
 .. [#builtin] Approach to resolving __builtin__ vs __builtins__
    https://mail.python.org/pipermail/python-3000/2007-March/006161.html
@@ -371,22 +369,12 @@ References
    https://mail.python.org/pipermail/python-dev/2007-November/075388.html
 
 .. [#exitfunc-patch] Patch to remove sys.exitfunc
-   https://bugs.python.org/issue1680961
+   https://github.com/python/cpython/issues/44715
 
 .. [#remove-operator-funcs] Remove deprecated functions from operator
-   https://bugs.python.org/issue1516309
+   https://github.com/python/cpython/issues/43602
 
 Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:


### PR DESCRIPTION
Footnote [26] was unreferenced -- it was added in c47893b, but it seems there was a typo with the reference -- footnote [25] was added in 91f95b4 and relates to the lines that I've added a reference to [25] in.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3255.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->