### PR TITLE
PEP 3104: Resolve unreferenced footnotes

### DIFF
--- a/pep-3104.txt
+++ b/pep-3104.txt
@@ -517,10 +517,10 @@ References
    https://mail.python.org/pipermail/python-3000/2006-November/004237.html
 
 .. [27] Global variable (version 2006-11-01T01:23:16)
-   http://en.wikipedia.org/wiki/Global_variable
+   https://en.wikipedia.org/w/index.php?title=Global_variable&oldid=85001451
 
 .. [28] Ruby 2.0 block local variable
-   http://redhanded.hobix.com/inspect/ruby20BlockLocalVariable.html
+   https://web.archive.org/web/20070105131417/http://redhanded.hobix.com/inspect/ruby20BlockLocalVariable.html
 
 .. [29] Issue 4199: combining assignment with global & nonlocal (Guido van Rossum)
    https://mail.python.org/pipermail/python-dev/2013-June/127142.html

--- a/pep-3104.txt
+++ b/pep-3104.txt
@@ -1,7 +1,5 @@
 PEP: 3104
 Title: Access to Names in Outer Scopes
-Version: $Revision$
-Last-Modified: $Date$
 Author: Ka-Ping Yee <ping@zesty.ca>
 Status: Final
 Type: Standards Track
@@ -482,8 +480,8 @@ References
 .. [14] Explicit Lexical Scoping (pre-PEP?) (Guido van Rossum)
    https://mail.python.org/pipermail/python-dev/2006-July/066991.html
 
-.. [15] Explicit Lexical Scoping (pre-PEP?) (Guido van Rossum)
-   https://mail.python.org/pipermail/python-dev/2006-July/066995.html
+[15] Explicit Lexical Scoping (pre-PEP?) (Guido van Rossum)
+\   https://mail.python.org/pipermail/python-dev/2006-July/066995.html
 
 .. [16] Lexical scoping in Python 3k (Guido van Rossum)
    https://mail.python.org/pipermail/python-dev/2006-July/066968.html
@@ -547,13 +545,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
Footnote [15] existed in the first draft of the PEP, I've removed the syntax.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3256.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->