### PR TITLE
PEP 3114: Resolve unreferenced footnotes

### DIFF
--- a/pep-3114.txt
+++ b/pep-3114.txt
@@ -1,7 +1,5 @@
 PEP: 3114
 Title: Renaming iterator.next() to iterator.__next__()
-Version: $Revision$
-Last-Modified: $Date$
 Author: Ka-Ping Yee <ping@zesty.ca>
 Status: Final
 Type: Standards Track
@@ -177,7 +175,7 @@ following conditions [5]_:
 Approval
 ========
 
-This PEP was accepted by Guido on March 6, 2007 [5]_.
+This PEP was accepted by Guido on March 6, 2007 [6]_.
 
 
 Implementation
@@ -197,7 +195,7 @@ References
    https://mail.python.org/pipermail/python-3000/2007-March/005965.html
 
 .. [3] 2to3 refactoring tool
-   http://svn.python.org/view/sandbox/trunk/2to3/
+   https://github.com/python/cpython/tree/ef04c44e29a8276a484f58d03a75a2dec516302d/Lib/lib2to3
 
 .. [4] PEP: rename it.next() to it.__next__()... (Collin Winter)
    https://mail.python.org/pipermail/python-3000/2007-March/006020.html
@@ -213,14 +211,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
Footnote [5] was renumbered to [6] in 28566de, but the reference wasn't also re-numbered.

A