### PR TITLE
PEP 3115: Resolve unreferenced footnotes

### DIFF
--- a/pep-3115.txt
+++ b/pep-3115.txt
@@ -1,7 +1,5 @@
 PEP: 3115
 Title: Metaclasses in Python 3000
-Version: $Revision$
-Last-Modified: $Date$
 Author: Talin <viridia@gmail.com>
 Status: Final
 Type: Standards Track
@@ -297,29 +295,19 @@ the new syntax.
 References
 ==========
 
-.. [1] [Python-3000] Metaclasses in Py3K (original proposal)
-       https://mail.python.org/pipermail/python-3000/2006-December/005030.html
+[1] [Python-3000] Metaclasses in Py3K (original proposal)
+\   https://mail.python.org/pipermail/python-3000/2006-December/005030.html
 
-.. [2] [Python-3000] Metaclasses in Py3K (Guido's suggested syntax)
-       https://mail.python.org/pipermail/python-3000/2006-December/005033.html
+[2] [Python-3000] Metaclasses in Py3K (Guido's suggested syntax)
+\   https://mail.python.org/pipermail/python-3000/2006-December/005033.html
 
-.. [3] [Python-3000] Metaclasses in Py3K (Objections to two-phase init)
-       https://mail.python.org/pipermail/python-3000/2006-December/005108.html
+[3] [Python-3000] Metaclasses in Py3K (Objections to two-phase init)
+\   https://mail.python.org/pipermail/python-3000/2006-December/005108.html
 
-.. [4] [Python-3000] Metaclasses in Py3K (Always use an ordered dict)
-       https://mail.python.org/pipermail/python-3000/2006-December/005118.html
+[4] [Python-3000] Metaclasses in Py3K (Always use an ordered dict)
+\   https://mail.python.org/pipermail/python-3000/2006-December/005118.html
 
 Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 70
-  coding: utf-8
-  End:


### PR DESCRIPTION
All four footnotes existed since the first draft of the PEP, and all were never referenced---I've removed the syntax.

A