### PR TITLE
PEP 3119: Resolve unreferenced footnotes

### DIFF
--- a/pep-3119.txt
+++ b/pep-3119.txt
@@ -1,7 +1,5 @@
 PEP: 3119
 Title: Introducing Abstract Base Classes
-Version: $Revision$
-Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>, Talin <viridia@gmail.com>
 Status: Final
 Type: Standards Track
@@ -844,65 +842,54 @@ References
 .. [1] An Introduction to ABC's, by Talin
    (https://mail.python.org/pipermail/python-3000/2007-April/006614.html)
 
-.. [2] Incomplete implementation prototype, by GvR
-   (http://svn.python.org/view/sandbox/trunk/abc/)
+[2] Incomplete implementation prototype, by GvR
+\   (https://web.archive.org/web/20170223133820/http://svn.python.org/view/sandbox/trunk/abc/)
 
-.. [3] Possible Python 3K Class Tree?, wiki page created by Bill Janssen
-   (http://wiki.python.org/moin/AbstractBaseClasses)
+[3] Possible Python 3K Class Tree?, wiki page created by Bill Janssen
+\   (https://wiki.python.org/moin/AbstractBaseClasses)
 
 .. [4] Generic Functions implementation, by GvR
-   (http://svn.python.org/view/sandbox/trunk/overload/)
+   (https://web.archive.org/web/20170223135019/http://svn.python.org/view/sandbox/trunk/overload/)
 
 .. [5] Charming Python: Scaling a new PEAK, by David Mertz
-   (http://www-128.ibm.com/developerworks/library/l-cppeak2/)
+   (https://web.archive.org/web/20070515125102/http://www-128.ibm.com/developerworks/library/l-cppeak2/)
 
 .. [6] Implementation of @abstractmethod
-   (https://bugs.python.org/issue1706989)
+   (https://github.com/python/cpython/issues/44895)
 
 .. [7] Unifying types and classes in Python 2.2, by GvR
-   (http://www.python.org/download/releases/2.2.3/descrintro/)
+   (https://www.python.org/download/releases/2.2.3/descrintro/)
 
 .. [8] Putting Metaclasses to Work: A New Dimension in Object-Oriented
    Programming, by Ira R. Forman and Scott H. Danforth
-   (http://www.amazon.com/gp/product/0201433052)
+   (https://archive.org/details/PuttingMetaclassesToWork)
 
-.. [9] Partial order, in Wikipedia
-   (http://en.wikipedia.org/wiki/Partial_order)
+[9] Partial order, in Wikipedia
+\   (https://en.wikipedia.org/wiki/Partial_order)
 
-.. [10] Total order, in Wikipedia
-   (http://en.wikipedia.org/wiki/Total_order)
+[10] Total order, in Wikipedia
+\   (https://en.wikipedia.org/wiki/Total_order)
 
 .. [11] Finite set, in Wikipedia
-   (http://en.wikipedia.org/wiki/Finite_set)
+   (https://en.wikipedia.org/wiki/Finite_set)
 
 .. [12] Make isinstance/issubclass overloadable
    (https://bugs.python.org/issue1708353)
 
 .. [13] ABCMeta sample implementation
-   (http://svn.python.org/view/sandbox/trunk/abc/xyz.py)
+   (https://web.archive.org/web/20170224195724/http://svn.python.org/view/sandbox/trunk/abc/xyz.py)
 
 .. [14] python-dev email ("Comparing heterogeneous types")
    https://mail.python.org/pipermail/python-dev/2004-June/045111.html
 
 .. [15] Function ``frozenset_hash()`` in Object/setobject.c
-   (http://svn.python.org/view/python/trunk/Objects/setobject.c)
+   (https://web.archive.org/web/20170224204758/http://svn.python.org/view/python/trunk/Objects/setobject.c)
 
 .. [16] Multiple interpreters in mod_python
-   (http://www.modpython.org/live/current/doc-html/pyapi-interps.html)
+   (https://web.archive.org/web/20070515132123/http://www.modpython.org/live/current/doc-html/pyapi-interps.html)
 
 
 Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
Footnote [2] existed in the first draft, unreferenced. Footnote [3] was added in e06f400 and had its only reference removed in 3ff288b. Footnotes [9] and [10] were added in ac9a270 and had their references removed in 842b40e, when the Ordering ABCs were removed from the PEP. I've retained all four, removing the markup.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3259.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->