### PR TITLE
PEP 3135: Resolve unreferenced footnotes

### DIFF
--- a/pep-3135.txt
+++ b/pep-3135.txt
@@ -1,7 +1,5 @@
 PEP: 3135
 Title: New Super
-Version: $Revision$
-Last-Modified: $Date$
 Author: Calvin Spealman <ironfroggy@gmail.com>,
         Tim Delaney <timothy.c.delaney@gmail.com>,
         Lie Ryan <lie.1296@gmail.com>
@@ -16,11 +14,13 @@ Post-History: `28-Apr-2007 <https://mail.python.org/pipermail/python-dev/2007-Ap
               `14-May-2007 <https://mail.python.org/pipermail/python-dev/2007-May/073127.html>`__,
               `12-Mar-2009 <https://mail.python.org/pipermail/python-bugs-list/2009-March/072665.html>`__
 
+
 Numbering Note
 ==============
 
 This PEP started its life as :pep:`367`.  Since it is now targeted
 for Python 3000, it has been moved into the 3xxx space.
+
 
 Abstract
 ========
@@ -37,6 +37,7 @@ The premise of the new super usage suggested is as follows::
 to replace the old::
 
     super(Foo, self).foo(1, 2)
+
 
 Rationale
 =========
@@ -83,6 +84,7 @@ of ``super`` in a method definition and only passes in the
 ``__class__`` cell when this is found.  Thus, calling a global alias
 of ``super`` without arguments will not necessarily work.
 
+
 Closed Issues
 =============
 
@@ -107,7 +109,7 @@ However, this was found to be false, because calling an object only looks up
 the __call__ method directly on the object's type. The following example shows
 this in action.
 
-::
+.. code:: python
 
     class A(object):
         def __call__(self):
@@ -121,6 +123,7 @@ this in action.
 
 In any case, this issue goes away entirely because classic calls to
 ``super(<class>, <instance>)`` are still supported with the same meaning.
+
 
 Alternative Proposals
 =====================
@@ -182,12 +185,12 @@ be equivalent to calling the method on the ``super`` object with the same name
 as the method currently being executed i.e. the following two methods would be
 equivalent:
 
-::
+.. code:: python
 
     def f(self, *p, **kw):
         super.f(*p, **kw)
 
-::
+.. code:: python
 
     def f(self, *p, **kw):
         super(*p, **kw)
@@ -197,41 +200,33 @@ concerns are obvious. Guido has suggested that this should be excluded from
 this PEP on the principle of KISS (Keep It Simple Stupid).
 
 
-
 History
 =======
-12-Mar-2009 - Updated to reflect the current state of implementation.
+12-Mar-2009
+  - Updated to reflect the current state of implementation.
 
-29-Apr-2007 - Changed title from "Super As A Keyword" to "New Super"
-            - Updated much of the language and added a terminology section
-              for clarification in confusing places.
-            - Added reference implementation and history sections.
+29-Apr-2007
+  - Changed title from "Super As A Keyword" to "New Super"
+  - Updated much of the language and added a terminology section
+    for clarification in confusing places.
+  - Added reference implementation and history sections.
 
-06-May-2007 - Updated by Tim Delaney to reflect discussions on the python-3000
-              and python-dev mailing lists.
+06-May-2007
+  - Updated by Tim Delaney to reflect discussions on the python-3000
+    and python-dev mailing lists.
+
 
 References
 ==========
 
-.. [1] Fixing super anyone?
-   (https://mail.python.org/pipermail/python-3000/2007-April/006667.html)
+[1] Fixing super anyone?
+\   (https://mail.python.org/pipermail/python-3000/2007-April/006667.html)
 
-.. [2] PEP 3130: Access to Module/Class/Function Currently Being Defined (this)
-   (https://mail.python.org/pipermail/python-ideas/2007-April/000542.html)
+[2] PEP 3130: Access to Module/Class/Function Currently Being Defined (this)
+\   (https://mail.python.org/pipermail/python-ideas/2007-April/000542.html)
 
 
 Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-3135.txt
+++ b/pep-3135.txt
@@ -202,8 +202,6 @@ this PEP on the principle of KISS (Keep It Simple Stupid).
 
 History
 =======
-12-Mar-2009
-  - Updated to reflect the current state of implementation.
 
 29-Apr-2007
   - Changed title from "Super As A Keyword" to "New Super"
@@ -214,6 +212,9 @@ History
 06-May-2007
   - Updated by Tim Delaney to reflect discussions on the python-3000
     and python-dev mailing lists.
+
+12-Mar-2009
+  - Updated to reflect the current state of implementation.
 
 
 References


### PR DESCRIPTION
Footnotes [1] and [2] existed since the re-numbering of PEP 3135, but had their references removed in 8e2ffa3. This removes the markup (and also fixes the markup of [*History*](https://peps.python.org/pep-3135/#history)).

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3260.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->