### PR TITLE
PEP 3145: Resolve unreferenced footnotes

### DIFF
--- a/pep-3145.txt
+++ b/pep-3145.txt
@@ -1,7 +1,5 @@
 PEP: 3145
 Title: Asynchronous I/O For subprocess.Popen
-Version: $Revision$
-Last-Modified: $Date$
 Author: Eric Pruitt, Charles R. McCreary, Josiah Carlson
 Status: Withdrawn
 Type: Standards Track
@@ -110,40 +108,38 @@ References
 ==========
 
 .. [1] [ python-Feature Requests-1191964 ] asynchronous Subprocess
-       https://mail.python.org/pipermail/python-bugs-list/2006-December/
-       036524.html
+       https://mail.python.org/pipermail/python-bugs-list/2006-December/036524.html
 
 .. [2] Daily Life in an Ivory Basement : /feb-07/problems-with-subprocess
-       http://ivory.idyll.org/blog/feb-07/problems-with-subprocess
+       http://ivory.idyll.org/blog/problems-with-subprocess.html
 
 .. [3] How can I run an external command asynchronously from Python? - Stack
        Overflow
-       http://stackoverflow.com/questions/636561/how-can-i-run-an-external-
-       command-asynchronously-from-python
+       https://stackoverflow.com/q/636561
 
 .. [4] 18.1. subprocess - Subprocess management - Python v2.6.2 documentation
-       http://docs.python.org/library/subprocess.html#subprocess.Popen.wait
+       https://docs.python.org/2.6/library/subprocess.html#subprocess.Popen.wait
 
 .. [5] 18.1. subprocess - Subprocess management - Python v2.6.2 documentation
-       http://docs.python.org/library/subprocess.html#subprocess.Popen.kill
+       https://docs.python.org/2.6/library/subprocess.html#subprocess.Popen.kill
 
 .. [6] Issue 1191964: asynchronous Subprocess - Python tracker
-       http://bugs.python.org/issue1191964
+       https://github.com/python/cpython/issues/41922
 
 .. [7] Module to allow Asynchronous subprocess use on Windows and Posix
        platforms - ActiveState Code
-       http://code.activestate.com/recipes/440554/
+       https://code.activestate.com/recipes/440554/
 
-.. [8] subprocess.rst - subprocdev - Project Hosting on Google Code
-       http://code.google.com/p/subprocdev/source/browse/doc/subprocess.rst?spec=svn2c925e935cad0166d5da85e37c742d8e7f609de5&r=2c925e935cad0166d5da85e37c742d8e7f609de5#437
+[8] subprocess.rst - subprocdev - Project Hosting on Google Code
+\   https://web.archive.org/web/20130306074135/http://code.google.com/p/subprocdev/source/browse/doc/subprocess.rst?spec=svn2c925e935cad0166d5da85e37c742d8e7f609de5&r=2c925e935cad0166d5da85e37c742d8e7f609de5
 
 .. [9] subprocdev - Project Hosting on Google Code
-       http://code.google.com/p/subprocdev
+       https://code.google.com/archive/p/subprocdev/
 
 .. [10] Python Subprocess Dev
-        http://subdev.blogspot.com/
+        https://subdev.blogspot.com/
 
-.. [11] https://bugs.python.org/issue18823 -- Idle: use pipes instead of
+.. [11] https://github.com/python/cpython/issues/63023 -- Idle: use pipes instead of
         sockets to talk with user subprocess
 
 Copyright
@@ -151,4 +147,3 @@ Copyright
 
 This P.E.P. is licensed under the Open Publication License;
 http://www.opencontent.org/openpub/.
-


### PR DESCRIPTION
Footnote [8] existed since the first draft, unreferenced -- I've removed the syntax.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3261.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->