### PR TITLE
PEP 3147: Resolve unreferenced footnotes

### DIFF
--- a/pep-3147.txt
+++ b/pep-3147.txt
@@ -1,7 +1,5 @@
 PEP: 3147
 Title: PYC Repository Directories
-Version: $Revision$
-Last-Modified: $Date$
 Author: Barry Warsaw <barry@python.org>
 Status: Final
 Type: Standards Track
@@ -567,44 +565,44 @@ References
 ==========
 
 .. [2] The marshal module:
-   https://docs.python.org/dev/library/marshal.html
+   https://docs.python.org/3.1/library/marshal.html
 
 .. [3] import.c:
-   http://svn.python.org/view/python/branches/py3k/Python/import.c?view=markup
+   https://github.com/python/cpython/blob/v3.2a1/Python/import.c
 
-.. [4] Ubuntu: <http://www.ubuntu.com>
+.. [4] Ubuntu: https://www.ubuntu.com
 
-.. [5] Debian: <http://www.debian.org>
+.. [5] Debian: https://www.debian.org
 
 .. [6] Debian Python Policy:
-   http://www.debian.org/doc/packaging-manuals/python-policy/
+   https://www.debian.org/doc/packaging-manuals/python-policy/
 
 .. [8] python-support:
-   http://wiki.debian.org/DebianPythonFAQ#Whatispython-support.3F
+   https://web.archive.org/web/20100110123824/http://wiki.debian.org/DebianPythonFAQ#Whatispython-support.3F
 
 .. [9] python-central:
-   http://wiki.debian.org/DebianPythonFAQ#Whatispython-central.3F
+   https://web.archive.org/web/20100110123824/http://wiki.debian.org/DebianPythonFAQ#Whatispython-central.3F
 
 .. [10] binascii.hexlify():
-   http://www.python.org/doc/current/library/binascii.html#binascii.hexlify
+   https://docs.python.org/3.1/library/binascii.html#binascii.hexlify
 
 .. [11] Jython: http://www.jython.org/
 
 .. [12] IronPython: http://ironpython.net/
 
-.. [13] PyPy: http://codespeak.net/pypy/dist/pypy/doc/
+.. [13] PyPy: https://web.archive.org/web/20100310130136/http://codespeak.net/pypy/dist/pypy/doc/
 
-.. [14] Pynie: http://code.google.com/p/pynie/
+.. [14] Pynie: https://code.google.com/archive/p/pynie/
 
-.. [15] py_compile: http://docs.python.org/library/py_compile.html
+.. [15] py_compile: https://docs.python.org/3.1/library/py_compile.html
 
-.. [16] compileall: http://docs.python.org/library/compileall.html
+.. [16] compileall: https://docs.python.org/3.1/library/compileall.html
 
-.. [17] imp: http://www.python.org/doc/current/library/imp.html
+.. [17] imp: https://docs.python.org/3.1/library/imp.html
 
-.. [20] http://www.mail-archive.com/python-dev@python.org/msg45203.html
+.. [20] https://www.mail-archive.com/python-dev@python.org/msg45203.html
 
-.. [21] importlib: http://docs.python.org/3.1/library/importlib.html
+[21] importlib: https://docs.python.org/3.1/library/importlib.html
 
 .. [22] https://code.launchpad.net/~barry/python/pep3147
 
@@ -636,14 +634,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
Footnote [21] was added in bac0ec1 and removed in c80d1ae -- this removes the markup.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3262.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->