### PR TITLE
Warn on all missing references in PEPs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -45,6 +45,9 @@ exclude_patterns = [
     "pep-0012/pep-NNNN.rst",
 ]
 
+# Warn on missing references
+nitpicky = True
+
 # Intersphinx configuration
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),


### PR DESCRIPTION
The final PR in this series -- once all the "Resolve unreferenced footnotes" PRs are merged, we can enable [Sphinx's nit-picky mode](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-nitpicky).

A

This also closes #3213.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3263.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->