### PR TITLE
PEP 708: Mark as Provisional

### DIFF
--- a/pep-0708.rst
+++ b/pep-0708.rst
@@ -3,13 +3,36 @@ Title: Extending the Repository API to Mitigate Dependency Confusion Attacks
 Author: Donald Stufft <donald@stufft.io>
 PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/24179
-Status: Draft
+Status: Provisional
 Type: Standards Track
 Topic: Packaging
 Content-Type: text/x-rst
 Created: 20-Feb-2023
 Post-History: `01-Feb-2023 <https://discuss.python.org/t/23414/>`__,
               `23-Feb-2023 <https://discuss.python.org/t/24179>`__
+Resolution: https://discuss.python.org/t/24179/72
+
+
+Provisional Acceptance
+======================
+
+This PEP has been **provisionally accepted**,
+with the following required conditions before the PEP is made Final:
+
+1. An implementation of the PEP in PyPI (Warehouse)
+   including any necessary UI elements
+   to allow project owners to set the tracking data.
+2. An implementation of the PEP in at least one repository other than PyPI,
+   as you can’t really test merging indexes without at least two indexes.
+3. An implementation of the PEP in pip,
+   which supports the intended semantics and can be used to demonstrate
+   that the expected security benefits are achieved.
+   This implementation will need to be "off by default" initially,
+   which means that users will have to opt in to testing it.
+   Ideally, we should collect explicit positive reports from users
+   (both project owners and project users)
+   who have successfully tried out the new feature,
+   rather than just assuming that "no news is good news".
 
 
 Abstract


### PR DESCRIPTION
Congratulations @dstufft!

cc: @pfmoore -- I tried to capture the salient points of your acceptance message, which ended up just being the bullet points -- please suggest any additions or deletions for the provisional acceptance note.

A

----

* [X] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [X] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [X] ``Status`` changed to ``Accepted``/``Rejected``
* [X] ``Resolution`` link points directly to SC/PEP Delegate official acceptance/rejected post
* [X] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [X] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3268.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->