### PR TITLE
PEP 722: Add parsing imports as a rejected idea

### DIFF
--- a/pep-0722.rst
+++ b/pep-0722.rst
@@ -533,7 +533,7 @@ Third, even if repositories did offer this information, the same import
 name may correspond to several packages on PyPI. One might object that
 disambiguating which package is wanted would only be needed if there are
 several projects providing the same import name. However, this would
-make it easy for anyone to unintentionally or malveolently break working
+make it easy for anyone to unintentionally or malevolently break working
 scripts, by uploading a package to PyPI providing an import name that is
 the same as an existing project. The alternative where, among the
 candidates, the first package to have been registered on the index is


### PR DESCRIPTION
This idea has come up repeatedly in the discussion, but suffers from fatal flaws. I propose to add it as rejected idea to the PEP so that people who don't have the time to read the whole thread can avoid bringing it up again.

If this PR is accepted, possibly with edits, it could make sense to copy the same text to PEP 723.

@pfmoore @ofek 

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3276.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->