### PR TITLE
PEP 693: Update 3.12.0rc1 release date

### DIFF
--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -55,10 +55,10 @@ Actual:
 - 3.12.0 beta 2: Tuesday, 2023-06-06
 - 3.12.0 beta 3: Monday, 2023-06-19
 - 3.12.0 beta 4: Tuesday, 2023-07-11
+- 3.12.0 candidate 1: Sunday, 2023-08-06
 
 Expected:
 
-- 3.12.0 candidate 1: Monday, 2023-07-31
 - 3.12.0 candidate 2: Monday, 2023-09-04
 - 3.12.0 final:  Monday, 2023-10-02
 


### PR DESCRIPTION
Re: https://www.python.org/downloads/release/python-3120rc1/

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3283.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->