### PR TITLE
PEP 721: Mark Final

### DIFF
--- a/pep-0721.rst
+++ b/pep-0721.rst
@@ -2,7 +2,7 @@ PEP: 721
 Title: Using tarfile.data_filter for source distribution extraction
 Author: Petr Viktorin <encukou@gmail.com>
 PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Packaging
 Content-Type: text/x-rst
@@ -12,6 +12,7 @@ Python-Version: 3.12
 Post-History: `04-Jul-2023 <https://discuss.python.org/t/28928>`__,
 Resolution: https://discuss.python.org/t/28928/13
 
+.. canonical-pypa-spec:: :ref:`packaging:sdist-archive-features`
 
 Abstract
 ========


### PR DESCRIPTION
* [x] Final implementation has been merged (including tests and docs)
  - it's only a [spec addition](https://packaging.python.org/en/latest/specifications/source-distribution-format/#sdist-archive-features)
* [x] PEP matches the final implementation
* [x] Any substantial changes since the accepted version approved by the SC/PEP delegate
  - the only changes were formatting, linking, typo fixes
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive (or ``pypa-spec``, for packaging PEPs)


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3285.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->