### PR TITLE
Infra: Remove resolved warning filters

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,11 +3,6 @@ addopts = -r a --strict-config --strict-markers --import-mode=importlib --cov pe
 empty_parameter_set_mark = fail_at_collect
 filterwarnings =
     error
-    # Awaiting release of https://github.com/python-babel/babel/issues/873
-    # in Babel 2.11, due 2022-08-01 https://github.com/python-babel/babel/milestone/6?closed=1
-    ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning
-    # Awaiting https://github.com/sphinx-doc/sphinx/issues/10440
-    ignore:'imghdr' is deprecated and slated for removal in Python 3.13:DeprecationWarning
 minversion = 6.0
 testpaths = pep_sphinx_extensions
 xfail_strict = True


### PR DESCRIPTION
https://github.com/python-babel/babel/issues/873 and https://github.com/sphinx-doc/sphinx/issues/10440 have been fixed and released. 🚀 

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3296.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->