### PR TITLE
PEP 703: fix some typos

### DIFF
--- a/pep-0703.rst
+++ b/pep-0703.rst
@@ -708,7 +708,7 @@ Additionally, ``PyObject_Malloc`` should be used only for allocating
 Python objects; it should not be used for allocating buffers,
 storages, or other data structures that are not PyObjects. 
 
-This PEP also imposes restrictions on the plugable allocator API
+This PEP also imposes restrictions on the pluggable allocator API
 (``PyMem_SetAllocator``). When compiling without the GIL, allocators
 set using this API must eventually delegate the allocation to the
 corresponding underlying allocator, such as ``PyObject_Malloc``, for

--- a/pep-0703.rst
+++ b/pep-0703.rst
@@ -474,7 +474,7 @@ field.
 Default (``0b00``)
 """"""""""""""""""
 
-Objects are intitially created in the default state.  This is the only
+Objects are initially created in the default state.  This is the only
 state that allows for the quick deallocation code path.  Otherwise, the
 thread must merge the local and shared reference count fields, which
 requires an atomic compare-and-swap.
@@ -708,7 +708,7 @@ Additionally, ``PyObject_Malloc`` should be used only for allocating
 Python objects; it should not be used for allocating buffers,
 storages, or other data structures that are not PyObjects. 
 
-This PEP also imposes restrictions on the pluggable allocator API
+This PEP also imposes restrictions on the plugable allocator API
 (``PyMem_SetAllocator``). When compiling without the GIL, allocators
 set using this API must eventually delegate the allocation to the
 corresponding underlying allocator, such as ``PyObject_Malloc``, for
@@ -1311,7 +1311,7 @@ The ``PYTHONGIL=0`` override is important because extensions that are
 not thread-safe can still be useful in multi-threaded applications. For
 example, one may want to use the extension from only a single thread or
 guard access by locks.  For context, there are already some extensions
-that aren not thread-safe even with the GIL, and users already have to
+that are not thread-safe even with the GIL, and users already have to
 take these sorts of steps.
 
 The ``PYTHONGIL=1`` override is sometimes useful for debugging.


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3298.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->