### PR TITLE
PEP 722: Correct a spelling error

### DIFF
--- a/pep-0722.rst
+++ b/pep-0722.rst
@@ -640,7 +640,7 @@ detail.
 So in order to make a standard, two things would be required:
 
 1. A standardised replacement for the requirements file format.
-2. A standard for how to locate the requiements file for a given script.
+2. A standard for how to locate the requirements file for a given script.
 
 The first item is a significant undertaking. It has been discussed on a number
 of occasions, but so far no-one has attempted to actually do it. The most likely


### PR DESCRIPTION
Noticed when reviewing the PEP 723 finalisation just now.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3299.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->