### PR TITLE
PEP 695: Edit for valid Julia Syntax

### DIFF
--- a/pep-0695.rst
+++ b/pep-0695.rst
@@ -1495,16 +1495,22 @@ upper and lower bounds on a type.
 
 .. code-block:: julia
 
-    // Generic struct; type parameter with upper and lower bounds
-    struct StructA{T} where Int <: T <: Number
+    # Generic struct; type parameter with upper and lower bounds
+    # Valid for T in (Int64, Signed, Integer, Real, Number)
+    struct Container{Int <: T <: Number}
         x::T
     end
 
-    // Generic function
-    function func1{T <: Real}(v::Container{T})
+    # Generic function
+    function func1(v::Container{T}) where T <: Real end
 
-    // Alternate form of generic function
-    function func2(v::Container{T} where T <: Real)
+    # Alternate forms of generic function
+    function func2(v::Container{T} where T <: Real) end
+    function func3(v::Container{<: Real}) end
+
+    # Tuple types are covariant
+    # Valid for func4((2//3, 3.5))
+    function func4(t::Tuple{Real,Real}) end
 
 Dart
 ----


### PR DESCRIPTION
Edit for valid Julia syntax

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

The syntax for Julia is incorrect. This edit changes the Julia syntax to exhibit valid Julia syntax

```julia
julia> struct StructA{T} where Int <: T <: Number
           x::T
       end
ERROR: syntax: invalid type signature around REPL[1]:1

julia> function func1{T <: Real}(v::Container{T}) end
ERROR: UndefVarError: `func1` not defined
```

The edited syntax is valid.


The edited syntax is completely valid Julia code as of Julia 1.9.2.

```julia
julia> begin

       # Generic struct; type parameter with upper and lower bounds
       # Valid for T in (Int64, Signed, Integer, Real, Number)
       struct Container{Int <: T <: Number}
           x::T
       end

       # Generic function
       function func1(v::Container{T}) where T <: Real end

       # Alternate forms of generic function
       function func2(v::Container{T} where T <: Real) end
       function func3(v::Container{<: Real}) end

       # Tuple types are covariant
       # Valid for func4((2//3, 3.5))
       function func4(t::Tuple{Real,Real}) end

       end
func4 (generic function with 1 method)

julia> Container(5)
Container{Int64}(5)

julia> func1(Container(5))

julia> func2(Container{Signed}(5))

julia> func3(Container{Integer}(0x3))

julia> func4((3.5, 9))
```


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3300.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->