### PR TITLE
PEP 715: Mark as final

### DIFF
--- a/pep-0715.rst
+++ b/pep-0715.rst
@@ -4,7 +4,7 @@ Author: William Woodruff <william@yossarian.net>
 Sponsor: Donald Stufft <donald@stufft.io>
 PEP-Delegate: Donald Stufft <donald@stufft.io>
 Discussions-To: https://discuss.python.org/t/27610
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Packaging
 Content-Type: text/x-rst


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [ ] Canonical docs/spec linked with a ``canonical-doc`` directive (or ``canonical-pypa-spec``, for packaging PEPs)

I believe this can be marked as final because the PEP has been fully implemented and eggs can no longer be updated to PyPI:

* https://github.com/pypi/warehouse/pull/14017
* https://blog.pypi.org/posts/2023-06-26-deprecate-egg-uploads/
* https://github.com/pypi/warehouse/pull/14118
* https://github.com/pypa/packaging.python.org/pull/1278

cc @woodruffw @di 


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3302.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->