### PR TITLE
PEP 1: Add a missing word in "Submitting a PEP"

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -207,7 +207,7 @@ The standard PEP workflow is:
   It also provides a complete introduction to reST markup that is used
   in PEPs.  Approval criteria are:
 
-  * It sound and complete.  The ideas must make technical sense.  The
+  * It is sound and complete.  The ideas must make technical sense.  The
     editors do not consider whether they seem likely to be accepted.
   * The title accurately describes the content.
   * The PEP's language (spelling, grammar, sentence structure, etc.)


### PR DESCRIPTION
✏️ Fix typo in PEP 1

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3311.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->