### PR TITLE
PEP 649, 652, 653, 665, 684, 690, 713, 727: fix typos

### DIFF
--- a/pep-0649.rst
+++ b/pep-0649.rst
@@ -932,7 +932,7 @@ will also require constructing a matching "fake locals"
 dictionary, which for ``FORWARDREF`` format will be
 pre-populated with the relevant locals dict.  The
 "fake globals" environment will also have to create
-a fake "closure", a tuple of ``FowardRef`` objects
+a fake "closure", a tuple of ``ForwardRef`` objects
 pre-created with the names of the free variables
 referenced by the ``__annotate__`` method.
 
@@ -1330,7 +1330,7 @@ These codebases examined the annotation strings *without
 evaluating them,* instead relying on identity checks or
 simple lexical analysis on the strings.
 
-This PEP supports these technqiues too.  But users will need
+This PEP supports these techniques too.  But users will need
 to port their code to it.  First, user code will need to use
 ``inspect.get_annotations`` or ``typing.get_type_hints`` to
 access the annotations; they won't be able to simply get the

--- a/pep-0652.rst
+++ b/pep-0652.rst
@@ -210,7 +210,7 @@ The following will be generated from the ABI manifest:
 
 * Source for the Windows shared library, ``PC/python3dll.c``.
 * Input for documentation (see below).
-* Test case that checks the runtime availablility of symbols (see below).
+* Test case that checks the runtime availability of symbols (see below).
 
 The following will be checked against the Stable ABI manifest as part of
 continuous integration:

--- a/pep-0653.rst
+++ b/pep-0653.rst
@@ -156,7 +156,7 @@ Semantics of the matching process
 
 In the following, all variables of the form ``$var`` are temporary variables and are not visible to the Python program.
 They may be visible via introspection, but that is an implementation detail and should not be relied on.
-The psuedo-statement ``FAIL`` is used to signify that matching failed for this pattern and that matching should move to the next pattern.
+The pseudo-statement ``FAIL`` is used to signify that matching failed for this pattern and that matching should move to the next pattern.
 If control reaches the end of the translation without reaching a ``FAIL``, then it has matched, and following patterns are ignored.
 
 Variables of the form ``$ALL_CAPS`` are meta-variables holding a syntactic element, they are not normal variables.
@@ -165,7 +165,7 @@ but an unpacking of ``$items`` into the variables that ``$VARS`` holds.
 For example, with the abstract syntax ``case [$VARS]:``, and the concrete syntax ``case[a, b]:`` then ``$VARS`` would hold the variables ``(a, b)``,
 not the values of those variables.
 
-The psuedo-function ``QUOTE`` takes a variable and returns the name of that variable.
+The pseudo-function ``QUOTE`` takes a variable and returns the name of that variable.
 For example, if the meta-variable ``$VAR`` held the variable ``foo`` then ``QUOTE($VAR) == "foo"``.
 
 All additional code listed below that is not present in the original source will not trigger line events, conforming to :pep:`626`.

--- a/pep-0665.rst
+++ b/pep-0665.rst
@@ -740,7 +740,7 @@ Second, consumers of requirements files like cloud providers would
 also accept lock files.
 
 At this point the PEP would have permeated out far enough to be on
-par with requirements files in terms of general accpetance and
+par with requirements files in terms of general acceptance and
 potentially more if projects had dropped their own lock files for this
 PEP.
 

--- a/pep-0684.rst
+++ b/pep-0684.rst
@@ -682,7 +682,7 @@ Open Issues
   (isolation) but doesn't work under a per-interpreter GIL?
   (See `Extension Module Thread Safety`_.)
 * If it is likely enough, what can we do to help extension maintainers
-  mitigate the problem and enjoy use under a per-intepreter GIL?
+  mitigate the problem and enjoy use under a per-interpreter GIL?
 * What would be a better (scarier-sounding) name
   for ``allow_all_extensions``?
 

--- a/pep-0690.rst
+++ b/pep-0690.rst
@@ -507,7 +507,7 @@ For authors of C extension modules, the proposed public C API is as follows:
 
 * ``PyDict_NextWithError()``, works the same way as ``PyDict_Next()``, with
   the exception it propagates any errors to the caller by returning ``0`` and
-  setting an exception. The caller should use ``PyErr_Ocurred()`` to check for any
+  setting an exception. The caller should use ``PyErr_Occurred()`` to check for any
   errors.
 
 

--- a/pep-0713.rst
+++ b/pep-0713.rst
@@ -61,7 +61,7 @@ without further hooks from the author, even with ``from module import member``.
 It also results in a "module" object that is missing all of the special module
 attributes, including ``__doc__``, ``__package__``, ``__path__``, etc.
 
-Alteratively, a module author can choose to override the module's ``__class__``
+Alternatively, a module author can choose to override the module's ``__class__``
 property with a custom type that provides a callable interface::
 
     # fancy.py

--- a/pep-0727.rst
+++ b/pep-0727.rst
@@ -372,7 +372,7 @@ A way to declare additional information could still be useful in the future,
 but taking early feedback on this document, all that was postponed to future
 proposals.
 
-This also shifts the focus from an all-encompasing function ``doc()``
+This also shifts the focus from an all-encompassing function ``doc()``
 with multiple parameters to multiple composable functions, having ``doc()``
 handle one single use case: additional documentation in ``Annotated``.
 


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3313.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->