### PR TITLE
Ensure the ``:pep:`` role works properly with the dirhtml builder

### DIFF
--- a/pep_sphinx_extensions/__init__.py
+++ b/pep_sphinx_extensions/__init__.py
@@ -28,7 +28,7 @@ def _update_config_for_builder(app: Sphinx) -> None:
     app.env.document_ids = {}  # For PEPReferenceRoleTitleText
     app.env.settings["builder"] = app.builder.name
     if app.builder.name == "dirhtml":
-        app.env.settings["pep_url"] = "pep-{:0>4}"
+        app.env.settings["pep_url"] = "pep-{:0>4}/"
 
     app.connect("build-finished", _post_build)  # Post-build tasks
 

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -149,7 +149,7 @@ class PEPZeroWriter:
                 target = (
                     f"topic/{subindex}.html"
                     if builder == "html"
-                    else f"../topic/{subindex}"
+                    else f"../topic/{subindex}/"
                 )
                 self.emit_text(f"* `{subindex.title()} PEPs <{target}>`_")
                 self.emit_newline()


### PR DESCRIPTION
Closes #3321

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3322.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->