### PR TITLE
PEP 703: Remove blank ``Resolution`` header

### DIFF
--- a/pep-0703.rst
+++ b/pep-0703.rst
@@ -10,7 +10,6 @@ Created: 09-Jan-2023
 Python-Version: 3.13
 Post-History: `09-Jan-2023 <https://discuss.python.org/t/22606>`__,
               `04-May-2023 <https://discuss.python.org/t/26503>`__
-Resolution:
 
 
 Abstract


### PR DESCRIPTION
xref #3275

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3323.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->