### PR TITLE
PEP 499: Shorten the title

### DIFF
--- a/pep-0499.txt
+++ b/pep-0499.txt
@@ -1,7 +1,5 @@
 PEP: 499
 Title: ``python -m foo`` should also bind ``'foo'`` in ``sys.modules``
-Version: $Revision$
-Last-Modified: $Date$
 Author: Cameron Simpson <cs@cskk.id.au>, Chris Angelico <rosuav@gmail.com>, Joseph Jevnik <joejev@gmail.com>
 BDFL-Delegate: Nick Coghlan
 Status: Deferred
@@ -237,13 +235,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/pep-0499.txt
+++ b/pep-0499.txt
@@ -1,5 +1,5 @@
 PEP: 499
-Title: ``python -m foo`` should bind ``sys.modules['foo']`` in addition to ``sys.modules['__main__']``
+Title: ``python -m foo`` should also bind ``'foo'`` in ``sys.modules``
 Version: $Revision$
 Last-Modified: $Date$
 Author: Cameron Simpson <cs@cskk.id.au>, Chris Angelico <rosuav@gmail.com>, Joseph Jevnik <joejev@gmail.com>


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

Dear @cameron-simpson @Rosuav @llllllllll,

In pursuit of #3275 (more maintainable PEP checks), I found that PEP 499 is the only PEP with a title longer than 80 characters. I've proposed a re-wording in this PR, but clearly this should have the blessing of the authors before we go ahead.

Feel free to reject my proposed re-wording, but ideally we can come up with something within the limit.

Thanks,
Adam

*Adding the DO-NOT-MERGE tag until at least one of the authors approves.*

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3325.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->