### PR TITLE
PEP 418: Standardise authors

### DIFF
--- a/pep-0418.txt
+++ b/pep-0418.txt
@@ -1,8 +1,9 @@
 PEP: 418
 Title: Add monotonic time, performance counter, and process time functions
-Version: $Revision$
-Last-Modified: $Date$
-Author: Cameron Simpson <cs@cskk.id.au>, Jim Jewett <jimjjewett@gmail.com>, Stephen J. Turnbull <stephen@xemacs.org>, Victor Stinner <vstinner@python.org>
+Author: Cameron Simpson <cs@cskk.id.au>,
+        Jim J. Jewett <jimjjewett@gmail.com>,
+        Stephen J. Turnbull <stephen@xemacs.org>,
+        Victor Stinner <vstinner@python.org>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
@@ -1640,14 +1641,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

In support of #3295.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3327.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->