### PR TITLE
PEP 284: Standardise authors

### DIFF
--- a/pep-0284.txt
+++ b/pep-0284.txt
@@ -1,9 +1,7 @@
 PEP: 284
 Title: Integer for-loops
-Version: $Revision$
-Last-Modified: $Date$
 Author: David Eppstein <eppstein@ics.uci.edu>,
-        Greg Ewing <greg.ewing@canterbury.ac.nz>
+        Gregory Ewing <greg.ewing@canterbury.ac.nz>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
@@ -264,12 +262,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  fill-column: 70
-  End:


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

In support of #3295.

A


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3328.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->