### PR TITLE
PEP 383: Standardise authors

### DIFF
--- a/pep-0383.txt
+++ b/pep-0383.txt
@@ -1,6 +1,6 @@
 PEP: 383
 Title: Non-decodable Bytes in System Character Interfaces
-Author: Martin v. Löwis <martin@v.loewis.de>
+Author: Martin von Löwis <martin@v.loewis.de>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

In support of #3295.

A


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3335.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->