### PR TITLE
PEP 393: Standardise authors

### DIFF
--- a/pep-0393.txt
+++ b/pep-0393.txt
@@ -1,8 +1,6 @@
 PEP: 393
 Title: Flexible String Representation
-Version: $Revision$
-Last-Modified: $Date$
-Author: Martin v. Löwis <martin@v.loewis.de>
+Author: Martin von Löwis <martin@v.loewis.de>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
@@ -463,13 +461,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

In support of #3295.

A


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3337.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->