### PR TITLE
PEP 1: Resolve uses of the default role

### DIFF
--- a/pep-0001.txt
+++ b/pep-0001.txt
@@ -296,7 +296,7 @@ pointing to this new thread.
 
 If it is not chosen as the discussion venue,
 a brief announcement post should be made to the `PEPs category`_
-with at least a link to the rendered PEP and the `Discussions-To` thread
+with at least a link to the rendered PEP and the ``Discussions-To`` thread
 when the draft PEP is committed to the repository
 and if a major-enough change is made to trigger a new thread.
 


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3366.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->