### PR TITLE
PEP 6: Resolve uses of the default role

### DIFF
--- a/pep-0006.txt
+++ b/pep-0006.txt
@@ -45,7 +45,7 @@ Prohibitions
 
 Bug fix releases are required to adhere to the following restrictions:
 
-1. There must be zero syntax changes.  All `.pyc` and `.pyo` files must
+1. There must be zero syntax changes.  All ``.pyc`` and ``.pyo`` files must
    work (no regeneration needed) with all bugfix releases forked off
    from a major release.
 


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3367.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->