### PR TITLE
PEP 386: Resolve uses of the default role

### DIFF
--- a/pep-0386.txt
+++ b/pep-0386.txt
@@ -25,9 +25,9 @@ Motivation
 In Python there are no real restrictions yet on how a project should manage its
 versions, and how they should be incremented.
 
-Distutils provides a `version` distribution meta-data field but it is freeform and
+Distutils provides a ``version`` distribution meta-data field but it is freeform and
 current users, such as PyPI usually consider the latest version pushed as the
-`latest` one, regardless of the expected semantics.
+``latest`` one, regardless of the expected semantics.
 
 Distutils will soon extend its capabilities to allow distributions to express a
 dependency on other distributions through the ``Requires-Dist`` metadata field
@@ -271,8 +271,8 @@ a particular package was using and to provide tools on top of PyPI.
 
 Distutils classes are not really used in Python projects, but the
 Setuptools function is quite widespread because it's used by tools like
-`easy_install` [#ezinstall]_, `pip` [#pip]_ or `zc.buildout` [#zc.buildout]_
-to install dependencies of a given project.
+``easy_install`` [#ezinstall]_, ``pip`` [#pip]_ or ``zc.buildout``
+[#zc.buildout]_ to install dependencies of a given project.
 
 While Setuptools *does* provide a mechanism for comparing/sorting versions,
 it is much preferable if the versioning spec is such that a human can make a
@@ -292,7 +292,7 @@ The new versioning algorithm
 During Pycon, members of the Python, Ubuntu and Fedora community worked on
 a version standard that would be acceptable for everyone.
 
-It's currently called `verlib` and a prototype lives at [#prototype]_.
+It's currently called ``verlib`` and a prototype lives at [#prototype]_.
 
 The pseudo-format supported is::
 
@@ -362,9 +362,9 @@ Note that ``c`` is the preferred marker for third party projects.
 NormalizedVersion
 -----------------
 
-The `NormalizedVersion` class is used to hold a version and to compare it with
-others. It takes a string as an argument, that contains the representation of
-the version::
+The ``NormalizedVersion`` class is used to hold a version and to compare it
+with others. It takes a string as an argument, that contains the representation
+of the version::
 
     >>> from verlib import NormalizedVersion
     >>> version = NormalizedVersion('1.0')


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3376.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->