### PR TITLE
PEP 3146: Resolve uses of the default role

### DIFF
--- a/pep-3146.txt
+++ b/pep-3146.txt
@@ -132,10 +132,10 @@ they are used.
 However, if by chance the historically-untaken branch is now taken, or some
 integer-optimized ``a + b`` snippet receives two strings, we must support this.
 We cannot change Python semantics. Each of these sections of optimized machine
-code is preceded by a `guard`, which checks whether the simplifying assumptions
-we made when optimizing still hold. If the assumptions are still valid, we run
-the optimized machine code; if they are not, we revert back to the interpreter
-and pick up where we left off.
+code is preceded by a ``guard``, which checks whether the simplifying
+assumptions we made when optimizing still hold. If the assumptions are still
+valid, we run the optimized machine code; if they are not, we revert back to
+the interpreter and pick up where we left off.
 
 We have chosen to reuse a set of existing compiler libraries called LLVM
 [#llvm]_ for code generation and code optimization. This has saved our small
@@ -848,8 +848,8 @@ Unladen Swallow [#us-oprofile-change]_, other profiling tools should be easy as
 well, provided they support a similar JIT interface [#oprofile-jit-interface]_.
 
 We have documented the process for using oProfile to profile Unladen Swallow
-[#oprofile-workflow]_. This document will be merged into CPython's `Doc/` tree
-in the merge.
+[#oprofile-workflow]_. This document will be merged into CPython's ``Doc/``
+tree in the merge.
 
 
 Addition of C++ to CPython


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3384.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->