### PR TITLE
PEP 3148: Resolve uses of the default role

### DIFF
--- a/pep-3148.txt
+++ b/pep-3148.txt
@@ -57,21 +57,21 @@ in that module, which work across thread and process boundaries.
 Interface
 ---------
 
-The proposed package provides two core classes: `Executor` and
-`Future`. An `Executor` receives asynchronous work requests (in terms
-of a callable and its arguments) and returns a `Future` to represent
+The proposed package provides two core classes: ``Executor`` and
+``Future``. An ``Executor`` receives asynchronous work requests (in terms
+of a callable and its arguments) and returns a ``Future`` to represent
 the execution of that work request.
 
 Executor
 ''''''''
 
-`Executor` is an abstract class that provides methods to execute calls
+``Executor`` is an abstract class that provides methods to execute calls
 asynchronously.
 
 ``submit(fn, *args, **kwargs)``
 
     Schedules the callable to be executed as ``fn(*args, **kwargs)``
-    and returns a `Future` instance representing the execution of the
+    and returns a ``Future`` instance representing the execution of the
     callable.
 
     This is an abstract method and must be implemented by Executor
@@ -81,10 +81,10 @@ asynchronously.
 
     Equivalent to ``map(func, *iterables)`` but func is executed
     asynchronously and several calls to func may be made concurrently.
-    The returned iterator raises a `TimeoutError` if `__next__()` is
+    The returned iterator raises a ``TimeoutError`` if ``__next__()`` is
     called and the result isn't available after *timeout* seconds from
-    the original call to `map()`.  If *timeout* is not specified or
-    `None` then there is no limit to the wait time.  If a call raises
+    the original call to ``map()``.  If *timeout* is not specified or
+    ``None`` then there is no limit to the wait time.  If a call raises
     an exception then that exception will be raised when its value is
     retrieved from the iterator.
 
@@ -92,12 +92,12 @@ asynchronously.
 
     Signal the executor that it should free any resources that it is
     using when the currently pending futures are done executing.
-    Calls to `Executor.submit` and `Executor.map` and made after
-    shutdown will raise `RuntimeError`.
+    Calls to ``Executor.submit`` and ``Executor.map`` and made after
+    shutdown will raise ``RuntimeError``.
 
-    If wait is `True` then this method will not return until all the
+    If wait is ``True`` then this method will not return until all the
     pending futures are done executing and the resources associated
-    with the executor have been freed. If wait is `False` then this
+    with the executor have been freed. If wait is ``False`` then this
     method will return immediately and the resources associated with
     the executor will be freed when all pending futures are done
     executing. Regardless of the value of wait, the entire Python
@@ -107,21 +107,21 @@ asynchronously.
 | ``__enter__()``
 | ``__exit__(exc_type, exc_val, exc_tb)``
 
-    When using an executor as a context manager, `__exit__` will call
+    When using an executor as a context manager, ``__exit__`` will call
     ``Executor.shutdown(wait=True)``.
 
 
 ProcessPoolExecutor
 '''''''''''''''''''
 
-The `ProcessPoolExecutor` class is an `Executor` subclass that uses a
+The ``ProcessPoolExecutor`` class is an ``Executor`` subclass that uses a
 pool of processes to execute calls asynchronously.  The callable
-objects and arguments passed to `ProcessPoolExecutor.submit` must be
+objects and arguments passed to ``ProcessPoolExecutor.submit`` must be
 pickleable according to the same limitations as the multiprocessing
 module.
 
-Calling `Executor` or `Future` methods from within a callable
-submitted to a `ProcessPoolExecutor` will result in deadlock.
+Calling ``Executor`` or ``Future`` methods from within a callable
+submitted to a ``ProcessPoolExecutor`` will result in deadlock.
 
 ``__init__(max_workers)``
 
@@ -132,11 +132,11 @@ submitted to a `ProcessPoolExecutor` will result in deadlock.
 ThreadPoolExecutor
 ''''''''''''''''''
 
-The `ThreadPoolExecutor` class is an `Executor` subclass that uses a
+The ``ThreadPoolExecutor`` class is an ``Executor`` subclass that uses a
 pool of threads to execute calls asynchronously.
 
-Deadlock can occur when the callable associated with a `Future` waits
-on the results of another `Future`.  For example::
+Deadlock can occur when the callable associated with a ``Future`` waits
+on the results of another ``Future``.  For example::
 
     import time
     def wait_on_b():
@@ -173,28 +173,28 @@ And::
 Future Objects
 ''''''''''''''
 
-The `Future` class encapsulates the asynchronous execution of a
-callable. `Future` instances are returned by `Executor.submit`.
+The ``Future`` class encapsulates the asynchronous execution of a
+callable. ``Future`` instances are returned by ``Executor.submit``.
 
 ``cancel()``
 
     Attempt to cancel the call.  If the call is currently being
     executed then it cannot be cancelled and the method will return
-    `False`, otherwise the call will be cancelled and the method will
-    return `True`.
+    ``False``, otherwise the call will be cancelled and the method will
+    return ``True``.
 
 ``cancelled()``
 
-    Return `True` if the call was successfully cancelled.
+    Return ``True`` if the call was successfully cancelled.
 
 ``running()``
 
-    Return `True` if the call is currently being executed and cannot
+    Return ``True`` if the call is currently being executed and cannot
     be cancelled.
 
 ``done()``
 
-    Return `True` if the call was successfully cancelled or finished
+    Return ``True`` if the call was successfully cancelled or finished
     running.
 
 ``result(timeout=None)``
@@ -202,10 +202,10 @@ callable. `Future` instances are returned by `Executor.submit`.
     Return the value returned by the call.  If the call hasn't yet
     completed then this method will wait up to *timeout* seconds.  If
     the call hasn't completed in *timeout* seconds then a
-    `TimeoutError` will be raised.  If *timeout* is not specified or
-    `None` then there is no limit to the wait time.
+    ``TimeoutError`` will be raised.  If *timeout* is not specified or
+    ``None`` then there is no limit to the wait time.
 
-    If the future is cancelled before completing then `CancelledError`
+    If the future is cancelled before completing then ``CancelledError``
     will be raised.
 
     If the call raised then this method will raise the same exception.
@@ -215,13 +215,13 @@ callable. `Future` instances are returned by `Executor.submit`.
     Return the exception raised by the call.  If the call hasn't yet
     completed then this method will wait up to *timeout* seconds.  If
     the call hasn't completed in *timeout* seconds then a
-    `TimeoutError` will be raised.  If *timeout* is not specified or
+    ``TimeoutError`` will be raised.  If *timeout* is not specified or
     ``None`` then there is no limit to the wait time.
 
-    If the future is cancelled before completing then `CancelledError`
+    If the future is cancelled before completing then ``CancelledError``
     will be raised.
 
-    If the call completed without raising then `None` is returned.
+    If the call completed without raising then ``None`` is returned.
 
 ``add_done_callback(fn)``
 
@@ -231,9 +231,9 @@ callable. `Future` instances are returned by `Executor.submit`.
 
     Added callables are called in the order that they were added and
     are always called in a thread belonging to the process that added
-    them.  If the callable raises an `Exception` then it will be
+    them.  If the callable raises an ``Exception`` then it will be
     logged and ignored.  If the callable raises another
-    `BaseException` then behavior is not defined.
+    ``BaseException`` then behavior is not defined.
 
     If the future has already completed or been cancelled then *fn*
     will be called immediately.
@@ -241,43 +241,43 @@ callable. `Future` instances are returned by `Executor.submit`.
 Internal Future Methods
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The following `Future` methods are meant for use in unit tests and
-`Executor` implementations.
+The following ``Future`` methods are meant for use in unit tests and
+``Executor`` implementations.
 
 ``set_running_or_notify_cancel()``
 
-    Should be called by `Executor` implementations before executing
-    the work associated with the `Future`.
+    Should be called by ``Executor`` implementations before executing
+    the work associated with the ``Future``.
 
-    If the method returns `False` then the `Future` was cancelled,
-    i.e.  `Future.cancel` was called and returned `True`.  Any threads
-    waiting on the `Future` completing (i.e. through `as_completed()`
-    or `wait()`) will be woken up.
+    If the method returns ``False`` then the ``Future`` was cancelled,
+    i.e.  ``Future.cancel`` was called and returned ``True``.  Any threads
+    waiting on the ``Future`` completing (i.e. through ``as_completed()``
+    or ``wait()``) will be woken up.
 
-    If the method returns `True` then the `Future` was not cancelled
+    If the method returns ``True`` then the ``Future`` was not cancelled
     and has been put in the running state, i.e. calls to
-    `Future.running()` will return `True`.
+    ``Future.running()`` will return ``True``.
 
     This method can only be called once and cannot be called after
-    `Future.set_result()` or `Future.set_exception()` have been
+    ``Future.set_result()`` or ``Future.set_exception()`` have been
     called.
 
 ``set_result(result)``
 
-    Sets the result of the work associated with the `Future`.
+    Sets the result of the work associated with the ``Future``.
 
 ``set_exception(exception)``
 
-    Sets the result of the work associated with the `Future` to the
-    given `Exception`.
+    Sets the result of the work associated with the ``Future`` to the
+    given ``Exception``.
 
 Module Functions
 ''''''''''''''''
 
 ``wait(fs, timeout=None, return_when=ALL_COMPLETED)``
 
-    Wait for the `Future` instances (possibly created by different
-    `Executor` instances) given by *fs* to complete.  Returns a named
+    Wait for the ``Future`` instances (possibly created by different
+    ``Executor`` instances) given by *fs* to complete.  Returns a named
     2-tuple of sets.  The first set, named "done", contains the
     futures that completed (finished or were cancelled) before the
     wait completed.  The second set, named "not_done", contains
@@ -293,27 +293,27 @@ Module Functions
     ============================= ==================================================
      Constant                      Description
     ============================= ==================================================
-    `FIRST_COMPLETED`             The method will return when any future finishes or
+    ``FIRST_COMPLETED``           The method will return when any future finishes or
                                   is cancelled.
-    `FIRST_EXCEPTION`             The method will return when any future finishes by
+    ``FIRST_EXCEPTION``           The method will return when any future finishes by
                                   raising an exception. If not future raises an
                                   exception then it is equivalent to ALL_COMPLETED.
-    `ALL_COMPLETED`               The method will return when all calls finish.
+    ``ALL_COMPLETED``             The method will return when all calls finish.
     ============================= ==================================================
 
 ``as_completed(fs, timeout=None)``
 
-    Returns an iterator over the `Future` instances given by *fs* that
+    Returns an iterator over the ``Future`` instances given by *fs* that
     yields futures as they complete (finished or were cancelled).  Any
-    futures that completed before `as_completed()` was called will be
-    yielded first.  The returned iterator raises a `TimeoutError` if
-    `__next__()` is called and the result isn't available after
-    *timeout* seconds from the original call to `as_completed()`.  If
-    *timeout* is not specified or `None` then there is no limit to the
+    futures that completed before ``as_completed()`` was called will be
+    yielded first.  The returned iterator raises a ``TimeoutError`` if
+    ``__next__()`` is called and the result isn't available after
+    *timeout* seconds from the original call to ``as_completed()``.  If
+    *timeout* is not specified or ``None`` then there is no limit to the
     wait time.
 
-    The `Future` instances can have been created by different
-    `Executor` instances.
+    The ``Future`` instances can have been created by different
+    ``Executor`` instances.
 
 Check Prime Example
 -------------------
@@ -408,7 +408,7 @@ list [3]_.
 
 The proposed design is explicit, i.e. it requires that clients be
 aware that they are consuming Futures.  It would be possible to design
-a module that would return proxy objects (in the style of `weakref`)
+a module that would return proxy objects (in the style of ``weakref``)
 that could be used transparently.  It is possible to build a proxy
 implementation on top of the proposed explicit mechanism.
 
@@ -425,13 +425,13 @@ the API has been discussed in some detail on stdlib-sig [6]_.
 The proposed design was discussed on the Python-Dev mailing list [7]_.
 Following those discussions, the following changes were made:
 
-* The `Executor` class was made into an abstract base class
-* The `Future.remove_done_callback` method was removed due to a lack
+* The ``Executor`` class was made into an abstract base class
+* The ``Future.remove_done_callback`` method was removed due to a lack
   of convincing use cases
-* The `Future.add_done_callback` method was modified to allow the
+* The ``Future.add_done_callback`` method was modified to allow the
   same callable to be added many times
-* The `Future` class's mutation methods were better documented to
-  indicate that they are private to the `Executor` that created them
+* The ``Future`` class's mutation methods were better documented to
+  indicate that they are private to the ``Executor`` that created them
 
 ========================
 Reference Implementation
@@ -445,7 +445,7 @@ References
 ==========
 
 .. [1]
-   `java.util.concurrent` package documentation
+   ``java.util.concurrent`` package documentation
    http://java.sun.com/j2se/1.5.0/docs/api/java/util/concurrent/package-summary.html
 
 .. [2]
@@ -453,15 +453,15 @@ References
    http://code.activestate.com/recipes/84317/
 
 .. [3]
-   `Python-3000` thread, "mechanism for handling asynchronous concurrency"
+   ``Python-3000`` thread, "mechanism for handling asynchronous concurrency"
    https://mail.python.org/pipermail/python-3000/2006-April/000960.html
 
 .. [4]
-   `Python 3000` thread, "Futures in Python 3000 (was Re: mechanism for handling asynchronous concurrency)"
+   ``Python 3000`` thread, "Futures in Python 3000 (was Re: mechanism for handling asynchronous concurrency)"
    https://mail.python.org/pipermail/python-3000/2006-April/000970.html
 
 .. [5]
-   A discussion of `stream`, a similar concept proposed by Anh Hai Trinh
+   A discussion of ``stream``, a similar concept proposed by Anh Hai Trinh
    http://www.mail-archive.com/stdlib-sig@python.org/msg00480.html
 
 .. [6]
@@ -473,7 +473,7 @@ References
    https://mail.python.org/pipermail/python-dev/2010-March/098169.html
 
 .. [8]
-   Reference `futures` implementation
+   Reference ``futures`` implementation
    http://code.google.com/p/pythonfutures/source/browse/#svn/branches/feedback
 
 =========


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3386.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->