### PR TITLE
PEP 431: Resolve uses of the default role

### DIFF
--- a/pep-0431.txt
+++ b/pep-0431.txt
@@ -188,13 +188,13 @@ This function takes a name string that must be a string specifying a
 valid zoneinfo time zone, i.e. "US/Eastern", "Europe/Warsaw" or "Etc/GMT".
 If not given, the local time zone will be looked up. If an invalid zone name
 is given, or the local time zone can not be retrieved, the function raises
-`UnknownTimeZoneError`.
+``UnknownTimeZoneError``.
 
 The function also takes an optional path to the location of the zoneinfo
 database which should be used. If not specified, the function will look for
 databases in the following order:
 
-1. Check if the `tzdata-update` module is installed, and then use that
+1. Check if the ``tzdata-update`` module is installed, and then use that
    database.
 
 2. Use the database in ``/usr/share/zoneinfo``, if it exists.


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3394.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->