### PR TITLE
PEP 440: Resolve uses of the default role

### DIFF
--- a/pep-0440.txt
+++ b/pep-0440.txt
@@ -93,10 +93,10 @@ this scheme but MUST also include the normalizations specified below.
 Installation tools MAY warn the user when non-compliant or ambiguous versions
 are detected.
 
-See also `Appendix B : Parsing version strings with regular expressions` which
-provides a regular expression to check strict conformance with the canonical
-format, as well as a more permissive regular expression accepting inputs that
-may require subsequent normalization.
+See also ``Appendix B : Parsing version strings with regular expressions``
+which provides a regular expression to check strict conformance with the
+canonical format, as well as a more permissive regular expression accepting
+inputs that may require subsequent normalization.
 
 Public version identifiers are separated into up to five segments:
 
@@ -650,10 +650,10 @@ are permitted and MUST be ordered as shown::
 
    .devN, aN, bN, rcN, <no suffix>, .postN
 
-Note that `c` is considered to be semantically equivalent to `rc` and must be
-sorted as if it were `rc`. Tools MAY reject the case of having the same ``N``
-for both a ``c`` and a ``rc`` in the same release segment as ambiguous and
-remain in compliance with the PEP.
+Note that ``c`` is considered to be semantically equivalent to ``rc`` and must
+be sorted as if it were ``rc``. Tools MAY reject the case of having the same
+``N`` for both a ``c`` and a ``rc`` in the same release segment as ambiguous
+and remain in compliance with the PEP.
 
 Within an alpha (``1.0a1``), beta (``1.0b1``), or release candidate
 (``1.0rc1``, ``1.0c1``), the following suffixes are permitted and MUST be
@@ -1296,7 +1296,7 @@ trailing ``\n`` character were found on PyPI.
 Various other normalisation rules were also added as described in the
 separate section on version normalisation below.
 
-`Appendix A` shows detailed results of an analysis of PyPI distribution
+``Appendix A`` shows detailed results of an analysis of PyPI distribution
 version information, as collected on 8th August, 2014. This analysis
 compares the behavior of the explicitly ordered version scheme defined in
 this PEP with the de facto standard defined by the behavior of setuptools.
@@ -1599,7 +1599,7 @@ Metadata v2.0 guidelines versus setuptools::
 Appendix B : Parsing version strings with regular expressions
 =============================================================
 
-As noted earlier in the `Public version identifiers` section, published
+As noted earlier in the ``Public version identifiers`` section, published
 version identifiers SHOULD use the canonical format. This section provides
 regular expressions that can be used to test whether a version is already
 in that form, and if it's not, extract the various components for subsequent


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3395.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->