### PR TITLE
PEP 510: Resolve uses of the default role

### DIFF
--- a/pep-0510.txt
+++ b/pep-0510.txt
@@ -125,11 +125,11 @@ Hypothetical myoptimizer module
 Examples in this PEP uses a hypothetical ``myoptimizer`` module which
 provides the following functions and types:
 
-* ``specialize(func, code, guards)``: add the specialized code `code`
-  with guards `guards` to the function `func`
+* ``specialize(func, code, guards)``: add the specialized code ``code``
+  with guards ``guards`` to the function ``func``
 * ``get_specialized(func)``: get the list of specialized codes as a list
-  of ``(code, guards)`` tuples where `code` is a callable or code object
-  and `guards` is a list of a guards
+  of ``(code, guards)`` tuples where ``code`` is a callable or code object
+  and ``guards`` is a list of a guards
 * ``GuardBuiltins(name)``: guard watching for
   ``builtins.__dict__[name]`` and ``globals()[name]``. The guard fails
   if ``builtins.__dict__[name]`` is replaced, or if ``globals()[name]``
@@ -323,7 +323,7 @@ The ``check()`` function checks a guard:
 *stack* is an array of arguments: indexed arguments followed by (*key*,
 *value*) pairs of keyword arguments. *na* is the number of indexed
 arguments. *nk* is the number of keyword arguments: the number of (*key*,
-*value*) pairs. `stack` contains ``na + nk * 2`` objects.
+*value*) pairs. ``stack`` contains ``na + nk * 2`` objects.
 
 
 Specialized code


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3398.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->