### PR TITLE
PEP 512: Resolve uses of the default role

### DIFF
--- a/pep-0512.txt
+++ b/pep-0512.txt
@@ -44,7 +44,7 @@ the basic steps were:
    Rietveld code review tool [#rietveld]_.
 6. Download the patch to make sure it still applies cleanly.
 7. Run the test suite manually.
-8. Update the `NEWS`, `ACKS`, and "What's New" document as necessary
+8. Update the ``NEWS``, ``ACKS``, and "What's New" document as necessary
 9. Pull changes to avoid a merge race.
 10. Commit the change manually.
 11. If the change was for a bugfix release, merge into the
@@ -240,7 +240,7 @@ in the Knights Who Say Ni project [#ni]_.
 Make old repository read-only
 '''''''''''''''''''''''''''''
 
-Updating `.hg/hgrc` in the now-old Mercurial repository in the `[hooks]`
+Updating ``.hg/hgrc`` in the now-old Mercurial repository in the ``[hooks]``
 section with::
 
   pretxnchangegroup.reject = echo " * This repo has been migrated to github.com/python/peps and does not accept new commits in Mercurial!" 2>&1; exit 1
@@ -435,7 +435,7 @@ http://docs.openstack.org/developer/reno/.
 
 Discussions at the Sep 2016 Python core-dev sprints led to this
 decision compared to the rejected approaches outlined in the
-`Rejected Ideas` section of this PEP. The separate files approach
+``Rejected Ideas`` section of this PEP. The separate files approach
 seems to have the right balance of flexibility and potential tooling
 out of the various options while solving the motivating problem.
 
@@ -772,7 +772,7 @@ Optional features:
   - `Link web content back to files that it is generated from`_
   - `Handling Misc/NEWS`_
   - `Bot to generate cherry-pick pull requests`_
-  - Write `.github/CONTRIBUTING.md`
+  - Write ``.github/CONTRIBUTING.md``
     (to prevent PRs that are inappropriate from even showing up and pointing to the devguide)
 
 


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3399.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->