### PR TITLE
PEP 3151: Resolve uses of the default role

### DIFF
--- a/pep-3151.txt
+++ b/pep-3151.txt
@@ -695,7 +695,7 @@ Handling of PYTHONSTARTUP raises IOError (but the error gets discarded)::
     IOError: [Errno 2] No such file or directory: 'foox'
 
 ``PyObject_Print()`` raises IOError when ferror() signals an error on the
-`FILE *` parameter (which, in the source tree, is always either stdout or
+``FILE *`` parameter (which, in the source tree, is always either stdout or
 stderr).
 
 Unicode encoding and decoding using the ``mbcs`` encoding can raise


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3402.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->