### PR TITLE
PEP 448: Resolve uses of the default role

### DIFF
--- a/pep-0448.txt
+++ b/pep-0448.txt
@@ -198,7 +198,7 @@ are already valid.  These could be extended to::
     f(**x for x in it) == f({**x for x in it})
 
 However, it wasn't clear if this was the best behaviour or if it should
-unpack into the arguments of the call to `f`. Since this is likely to be
+unpack into the arguments of the call to ``f``. Since this is likely to be
 confusing and is of only very marginal utility, it is not included in this
 PEP.  Instead, these will throw a ``SyntaxError`` and comprehensions with
 explicit brackets should be used instead.
@@ -224,7 +224,7 @@ References
 .. [1] PEP accepted, "PEP 448 review", Guido van Rossum
    (https://mail.python.org/pipermail/python-dev/2015-February/138564.html)
 
-.. [2] Issue 2292, "Missing `*`-unpacking generalizations", Thomas Wouters
+.. [2] Issue 2292, "Missing ``*``-unpacking generalizations", Thomas Wouters
    (https://github.com/python/cpython/issues/46545)
 
 [3] Discussion on Python-ideas list,


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3403.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->