### PR TITLE
PEP 458: Resolve uses of the default role

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -339,7 +339,7 @@ of pip going forward SHOULD use TUF by default to download and verify distributi
 from PyPI before installing them. However, there may be unforeseen issues that
 might prevent users from installing or updating distributions, including pip itself,
 via TUF. Therefore, pip SHOULD provide an option e.g.,
-`--unsafely-disable-package-verification`, in order to work around such issues
+``--unsafely-disable-package-verification``, in order to work around such issues
 until they are resolved. Note, the proposed option name is purposefully long,
 because a user must be helped to understand that the action is unsafe and not
 generally recommended.
@@ -722,9 +722,9 @@ overhead for returning and new users would be around 50-54% and 114%
 respectively, assuming that the number of bins stay fixed. If the number of
 bins is increased, then the cost for all users would effectively be the cost
 for new users, because their cost would be dominated by the (once-in-a-while)
-cost of downloading the large number of delegations in the `bins` metadata.
+cost of downloading the large number of delegations in the ``bins`` metadata.
 If the cost for new users should prove to be too much, primarily due to the
-overhead of downloading the `bins` metadata, then this subject SHOULD be
+overhead of downloading the ``bins`` metadata, then this subject SHOULD be
 revisited before that happens.
 
 Note that changes to the number of bins on the server are transparent to the


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3405.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->