### PR TITLE
PEP 468: Resolve uses of the default role

### DIFF
--- a/pep-0468.txt
+++ b/pep-0468.txt
@@ -201,7 +201,7 @@ idea regardless.  (There is a reason those discussions were brief.)
 Relationship to inspect.Signature
 ---------------------------------
 
-Signature objects should need no changes.  The `kwargs` parameter of
+Signature objects should need no changes.  The ``kwargs`` parameter of
 inspect.BoundArguments (returned by Signature.bind() and
 Signature.bind_partial()) will change from a dict to an OrderedDict.
 
@@ -321,7 +321,7 @@ application-level use of annotations.
 dict.__order__
 --------------
 
-dict objects would have a new attribute, `__order__` that would default
+dict objects would have a new attribute, ``__order__`` that would default
 to None and that in the kwargs case the interpreter would use in the
 same way as described above for __kworder__.
 
@@ -329,13 +329,13 @@ Prognosis:
 
 It would mean zero impact on kwargs performance but the change would be
 pretty intrusive (Python uses dict a lot).  Also, for the wrapper case
-the interpreter would have to be careful to preserve `__order__`.
+the interpreter would have to be careful to preserve ``__order__``.
 
 KWArgsDict.__order__
 --------------------
 
-This is the same as the `dict.__order__` idea, but kwargs would be an
-instance of a new minimal dict subclass that provides the `__order__`
+This is the same as the ``dict.__order__`` idea, but kwargs would be an
+instance of a new minimal dict subclass that provides the ``__order__``
 attribute.  dict would instead be unchanged.
 
 Prognosis:


### PR DESCRIPTION
* Change is:
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3408.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->