### PR TITLE
Lint: Enable pre-commit default role checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,15 +79,15 @@ repos:
     hooks:
       - id: rst-backticks
         name: "Check RST: No single backticks"
-        files: '^pep-\d\.txt|\.rst$'
+        files: '^pep-\d+\.(rst|txt)$'
         types: [text]
       - id: rst-inline-touching-normal
         name: "Check RST: No backticks touching text"
-        files: '^pep-\d+\.txt|\.rst$'
+        files: '^pep-\d+\.(rst|txt)$'
         types: [text]
       - id: rst-directive-colons
         name: "Check RST: 2 colons after directives"
-        files: '^pep-\d+\.txt|\.rst$'
+        files: '^pep-\d+\.(rst|txt)$'
         types: [text]
 
   # Manual codespell check


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3415.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->