### PR TITLE
PEP 713: Mark as Rejected

### DIFF
--- a/pep-0713.rst
+++ b/pep-0713.rst
@@ -3,7 +3,7 @@ Title: Callable Modules
 Author: Amethyst Reese <amethyst at n7.gg>
 Sponsor: Łukasz Langa <lukasz at python.org>
 Discussions-To: https://discuss.python.org/t/pep-713-callable-modules/26127
-Status: Draft
+Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 20-Apr-2023

--- a/pep-0713.rst
+++ b/pep-0713.rst
@@ -9,6 +9,17 @@ Content-Type: text/x-rst
 Created: 20-Apr-2023
 Python-Version: 3.12
 Post-History: `23-Apr-2023 <https://discuss.python.org/t/pep-713-callable-modules/26127>`__
+Resolution: https://discuss.python.org/t/26127/86
+
+
+Rejection Notice
+================
+
+The Steering Council didn't feel that there was a compelling reason to
+have this PEP, even though it clearly could be done from a consistency
+point of view.
+If this idea comes up again in the future, this is a useful prior
+discussion to refer to.
 
 
 Abstract


### PR DESCRIPTION
* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [X] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [X] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` link points directly to SC/PEP Delegate official acceptance/rejected post
* [x] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [X] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3423.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->