### PR TITLE
PEP 693: Update the Python 3.12.0rc2 release date.

### DIFF
--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -56,10 +56,10 @@ Actual:
 - 3.12.0 beta 3: Monday, 2023-06-19
 - 3.12.0 beta 4: Tuesday, 2023-07-11
 - 3.12.0 candidate 1: Sunday, 2023-08-06
+- 3.12.0 candidate 2: Wednesday, 2023-09-06
 
 Expected:
 
-- 3.12.0 candidate 2: Monday, 2023-09-04
 - 3.12.0 final:  Monday, 2023-10-02
 
 Subsequent bugfix releases every two months.


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3426.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->