### PR TITLE
PEP 561: Clarify `\n`

### DIFF
--- a/pep-0561.rst
+++ b/pep-0561.rst
@@ -238,15 +238,15 @@ typeshed folder and type checking the combined directory structure. Thus type
 checkers MUST maintain the normal resolution order of checking ``*.pyi`` before
 ``*.py`` files.
 
-If a stub package distribution is partial it MUST include ``partial\n`` in a
-``py.typed`` file.  For stub-packages distributing within a namespace
-package (see :pep:`420`), the ``py.typed`` file should be in the
-submodules of the namespace.
+If a stub package distribution is partial it MUST include ``partial`` in a
+``py.typed`` file. The word ``partial`` should be on a line by itself. For
+stub-packages distributing within a namespace package (see :pep:`420`), the
+``py.typed`` file should be in the submodules of the namespace.
 
 Type checkers should treat namespace packages within stub-packages as
 incomplete since multiple distributions may populate them.
 Regular packages within namespace packages in stub-package distributions
-are considered complete unless a ``py.typed`` with ``partial\n`` is included.
+are considered complete unless a ``py.typed`` with ``partial`` is included.
 
 
 Implementation


### PR DESCRIPTION
Stemming from this python discussion:

https://discuss.python.org/t/pep-561-clarification-regarding-n/32875/35

The purpose of this commit is to clarify the wording of the PEP where `partial\n` is concerned to state that the `py.typed` must contain the word `partial` and that `partial` should be on a line by itself.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3428.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->