### PR TITLE
Meta: Instruct linguist to include PEPs in the statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,7 @@
 *.png binary
 *.pptx binary
 *.odp binary
+
+# Instruct linguist not to ignore the PEPs
+# https://github.com/github-linguist/linguist/blob/master/docs/overrides.md
+peps/*.rst text linguist-detectable


### PR DESCRIPTION
See https://github.com/github-linguist/linguist/blob/master/docs/overrides.md for context.

The updated 'languages' widget would look like:

![image](https://github.com/python/peps/assets/9087854/cf5c115e-e669-42e0-9d8b-3304e4fc6995)

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3430.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->