### PR TITLE
Infra: Ignore certain commits when calculating the last modified date

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,328 @@
+# .git-blame-ignore-revs
+# Commits listed in this file are ignored by default in GitHub's
+# interactive 'blame' view.
+# Lines beginning with a '#' character are ignored, and may be used as comments.
+
+# Commits should be listed as one unabbreviated SHA-1 per line, with an
+# explanatory comment above the entry. Maintain graph ordering, with later
+# commits listed after earlier commits in this file.
+
+# To use locally, run either of the following commands:
+#     git blame --ignore-revs-file .git-blame-ignore-revs
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# For more details, see https://git-scm.com/docs/git-blame
+
+
+# 2003-05-03: Convert PEPs to reStructuredText
+0a690292ffe2cdc547dbad3bdbdb46672012b536
+
+# 2006-02-09: Add missing ``Type``
+09b08ab91b295a00f4f0738d9cb64032046827a0
+
+# 2006-02-09: Normalise ``Type``
+929fdb2d4be0a5c83793226d62ab0ed1c22128eb
+
+# 2006-03-23: Add ``Last-Modified``
+c5b5d3c83d80930da7ccccbfc7f503632eceb670
+
+# 2007-04-28: Spelling, punctuation, and grammar
+532382f5dcbcd637d1d6e244c8586f18b4b07135
+
+# 2007-06-19: Fix header order & ensure all required headings exist
+cdf5d3ce68d236d99eb8cc39128b63e6de48f230
+
+# 2007-04-15: Normalise ``Type``
+e801b28e4258781d56ef13f48aad12c27bad9cc3
+
+# 2007-06-19: Normalise ``Type`` for the meta-PEPs
+9fe45a32c38d4c9a6999f9c8a76186a36b37fb73
+
+# 2009-01-18: Change the PEPs URL to ``/dev/peps/``
+08ea236bbb57c110138837bac1950c8f03b405aa
+
+# 2011-03-04: Rename ``Replaced`` to ``Superseded``
+8740ed374690706f4240b4637977e0f85bc55521
+
+# 2012-03-12: Convert PEPs to reStructuredText
+a0091dca9dc130d236b1fc21befa485029641cf4
+
+# 2012-03-15: Convert PEPs to reStructuredText
+3153cd2e373bf456a1f278c8bb1d50f1ed553031
+
+# 2012-11-07: Convert PEPs to reStructuredText
+a138604e5637ae37794108f39fa1524217f2c9ba
+
+# 2015-02-14: Fix reStructuredText syntax
+d277ad711adca18c434471c5fe1e4b54b753f337
+475b6f0c4e7b7125890c7c600a57b8d16ca5ff0b
+
+# 2016-05-03: Fix reStructuredText list syntax
+936292e0c425dc62e9dc72f546dcb461d96296ba
+4d8ea1d0fe22d2af25119822c5c1c257e759b895
+af904307761406ca3bcdf399556130d919d517d6
+5999b23389513e9ca9c2ae07dfafe02b2f30c784
+
+# 2016-05-03: Spelling, punctuation, and grammar
+3dad43887227cfd08b2204effedc1750c1cfb6f8
+e54e86b1633ead62422333771a042dc3062cb097
+cc1c73488674324698aa430f4d50577f72ab113c
+
+# 2016-06-18: Convert PEPs to reStructuredText
+cce5754f2817e4b91729aa506bf636fceab6cfac
+
+# 2016-06-19: Convert PEPs to reStructuredText
+56b99522221441800528c99bd149267f50392bbf
+bf195b69e39b05c2720434c519ff9651fdb56ece
+cae235ae454511ea6dd830e17f60fe0b07c6daa9
+
+# 2016-06-21: Convert PEPs to reStructuredText
+8bc43986e74b1bae25599c344ce5aa45110f244b
+
+# 2016-06-22: Convert PEPs to reStructuredText
+db16082f58ae48c57794bacee9c32fa68e8b83ab
+483d4abd3dac958654ee21199d8cc48e78aa73e6
+
+# 2016-07-07: Convert PEPs to reStructuredText
+1255af25a07587bae29ab1144be9c45aafba42cc
+
+# 2016-07-09: Convert PEPs to reStructuredText
+99722904ba6c64f4783999d7eed8469a38db38eb
+
+# 2016-07-11: Spelling, punctuation, and grammar
+04a6af2ab1b19a56db74d5ae85a96656cc04bfa6
+
+# 2016-07-19: Convert PEPs to reStructuredText
+8eff8067cff1a19281bea5388dc7e9d3ef30cce0
+
+# 2016-10-23: Convert PEPs to reStructuredText
+ae7020c262638c25a55efc6198b197eb41351282
+
+# 2016-11-28: Convert PEPs to reStructuredText
+84de20b55dbd2bdb00405ded6e35b7a9c1096680
+c6fbead696390720817600cd84e18561f4a708d6
+
+# 2016-11-29: Convert PEPs to reStructuredText
+a6f1efa5ff64390cae9d9de6b8c8e66df65ac7fb
+
+# 2016-12-03: Convert PEPs to reStructuredText
+4e21b23c38d1b75509dfe3286677b4812e421c93
+
+# 2017-01-01: Convert PEPs to reStructuredText
+e3de43f0ae41569c538de9c5fbeecc09e93e5f1f
+
+# 2017-01-07: Convert PEPs to reStructuredText
+927e704d7e9a439fe127fcefbbb5330adfc49c4a
+
+# 2017-01-10: Convert PEPs to reStructuredText
+b54f01e13fd43e4d31803b19eeba859da6364212
+08282fe6a52dc81e18eeb7e54435c806f10f3985
+
+# 2017-01-19: Convert PEPs to reStructuredText
+87dc92a34ee68c6875b6959f3b4ce6e2d9b9b008
+
+# 2017-01-19: Fix reStructuredText syntax
+f67dd4a7594b0988847192f3e12d6d53925f086e
+
+# 2017-01-24: Convert PEPs to reStructuredText
+4598c39b78b727f77e3f6a747a6de18ad3da2dac
+
+# 2017-02-02: Convert PEPs to reStructuredText
+9b58a292ea42b87fcc26fffa0c59400c4c01c297
+96d2e59aa497f52cce355ea8ed5f3ed4ec8a1bc0
+
+# 2017-02-06: Convert PEPs to reStructuredText
+f9a66fe5118b5e08e1a7c2f546188afa9db4d0c2
+
+# 2017-02-10: Convert PEPs to reStructuredText
+c5881cf2b5b13c1af8f9e59d5d8c0e806b1182da
+9c9560962a57295d0ed41f39c3a10f602371c96c
+
+# 2017-02-24: Convert PEPs to reStructuredText
+73e6ac628e1ad384751a91b901d735bb0581d013
+
+# 2017-03-24 Replace tabs with spaces
+07c157552d11d4cd84a61e5e8fd10ea22939168b
+
+# 2017-03-24: Remove trailing spaces
+a53392a0f080e42a13a2be0f054d9d98e899b067
+
+# 2017-03-27: Convert PEPs to reStructuredText
+a3062a87440bef64e0ccdff930230cc3c1fa6990
+
+# 2017-04-02: Spelling, punctuation, and grammar
+d67517552028611c338e9f8adcc40aaea9d97b2e
+
+# 2017-04-05: Fix reStructuredText syntax
+7ca8985b8f09aed8b46903f0b5e4d45d2ffc1d93
+
+# 2017-05-26: Convert PEPs to reStructuredText
+d66124f5987f086315ba0695a79354afc44e46db
+
+# 2017-05-27: Convert PEPs to reStructuredText
+e15c2c15eb778edbbeae273c358779539496b1ce
+
+# 2017-06-01: Convert PEPs to reStructuredText
+5d3ac8912e9bea11111be7f67b12fc4c982440e7
+
+# 2017-06-02: Convert PEPs to reStructuredText
+329ed7e935e420f4433217ac067e969d6d90bdc7
+
+# 2017-06-11: Use ``https://`` for m.p.o
+60d9b24542d0ece923f46a2afb976e005932ab3d
+
+# 2017-06-16: Convert PEPs to reStructuredText
+ad339c1e27ac55c599391660d11b8215acedf512
+
+# 2017-07-12: Spelling, punctuation, and grammar
+b61bb7d343c660a2abe3e37fb325d21bc2a19c6e
+
+# 2017-08-11: Convert PEPs to reStructuredText
+e889fa82a547ece4e9e92ccc21a4f7c4d1441d9f
+7f682626096b65e3f8b1cb6e98170e6ddd71f5c1
+75b53a7813f6bfede49364879a177b7465f733f7
+f9865e18fd5b451ee3dab428a6c5918d8c92867f
+
+# 2017-08-14: Convert PEPs to reStructuredText
+0d93a6344c388213ac1fbad09772ebaf9841231e
+
+# 2017-08-15: Convert PEPs to reStructuredText
+a600f25404c83e358a947f7a182d3ba8514498fa
+
+# 2017-08-16: Convert PEPs to reStructuredText
+0f7b74537fea06df76fb32f4fd5b5ccce83edb69
+dd454efb3a938983a642ed62b8e914abe33ef012
+7f8e97ca3f154bd4dbade5781307a36ca463dab4
+a5e937ea43f01a48a97d114b50fc23050a62437e
+cc56b43dcb78d29a1fba13252b6c05bb8c7ecae8
+
+# 2017-08-18: Convert PEPs to reStructuredText
+86a462a7b416cab3338000d9a8b1ea2733c61e5b
+5aea3b9792518b8acf66bae8f79aa333bac19136
+e6fe4f377fbd2c25a467c7400e20145dbe0c210d
+3ea921ba72bc1284f96a4126d774e265f14a470f
+
+# 2017-08-21: Convert PEPs to reStructuredText
+a5101b19883a297217a3bee0d1a8a86732626ea8
+f22e81b2558d8e3f375fce45b9e99aadb1128801
+
+# 2017-08-28: Convert PEPs to reStructuredText
+5a1b908205861f15e4fc14932cc9b29fd6c7d350
+b474b4f27fab680ac4c92a4995b64f76b5e015ec
+
+# 2017-08-29: Convert PEPs to reStructuredText
+60a42552a9578a5b8329e3290a295a940ea56776
+
+# 2017-08-31: Convert PEPs to reStructuredText
+89b839265d2b0451bb2e67fac780c1db46c75d0a
+
+# 2017-09-05: Convert PEPs to reStructuredText
+1809c78dd43531450d1e49a5330ab790e8cc4814
+
+# 2017-09-12: Convert PEPs to reStructuredText
+c510df9ac8000d412a49859861bd55a2f574adc1
+916f0862cf0fa7958cc9c8a8537dbfee8d16590f
+58037ff3004962bc036ddd38e6c2c010c631272b
+ca41d18043e7a64b8a733f8eef33df7e4c6fe4bc
+3f83280386e95f72819619b078d7ce55417fc770
+0f008dd22908785c60fb6ee59e5b126f68589ce8
+3035a38e555661bee778015070aecbfb35bf8b3c
+27d218f1bbd3ad718cdcffd348cbc314f1abdfa2
+b596c6abe3c2b61560f64771cff66097e88772a3
+a49551d35bd25860550451868645c14bf9005a55
+d80d5be22338217ef4a1908ee6cf953c13fbe3f8
+
+# 2017-10-24: Convert PEPs to reStructuredText
+5a15c92dcf11af515112d35a6164a2539c1dba84
+0fcce00dada3184137b260a590d5791b4e4f0ab5
+
+# 2017-11-11: Initial rename & revert of ``.txt.`` to ``.rst``
+bb0e518ed3b39bc0bf01c1f2761c37fb2b6876bb
+cf3bad5ab34381fd5c57787c9716be22f7805414
+
+# 2018-07-21: Replace sourceforge links with b.p.o
+ce5590c1c1559499310b805083da5dc8bb5821fe
+
+# 2019-04-16: Remove trailing spaces
+ad7f2b2f6c0e75a3b371c05b9e2efc14fbd3aac4
+
+# 2019-06-24: Spelling, punctuation, and grammar
+e54097d3c413730e68b3c3af153a887cf4985c22
+
+# 2019-07-03: Spelling, punctuation, and grammar
+cfb7bd74dba6357a73be1f1e0614a1a3cc6b69cb
+
+# 2019-08-11: Spelling, punctuation, and grammar
+19b5d9586af8a3eb05af620488d71b2bdb0dd898
+
+# 2020-06-24: Spelling, punctuation, and grammar
+a4a3b8f1dc81795167165487097585c51a18ab80
+
+# 2020-08-07: Fix reStructuredText syntax
+ba36cccc2dd0a9370e6b299b86ffa1e7abd92d6f
+
+# 2020-12-04: Spelling, punctuation, and grammar
+45fdc844ddb817ff9cd4eb6f35e4c1e13ddb8068
+
+# 2021-02-03: Spelling, punctuation, and grammar
+9b64c6ea756098fae9a30f4b47715b2071d66acb
+
+# 2021-02-09: Normalise ``Created``
+bb4751379a95b0843db4b85fcfe7bb7e9f2a580a
+
+# 2021-03-22: Normalise ``Created``
+e6fb0d8ca63bfee38afbf17fb23b145ab9f7e8b7
+
+# 2021-03-23: Normalise various headers
+d548fdfb61ec288b882442511e7734f450e7789e
+
+# 2021-07-14: Fix reStructuredText syntax
+5cedff40082e1e30c8c737a03fa1318aa873d753
+
+# 2021-09-17: Spelling, punctuation, and grammar
+57d9baf04dbdca279210d3e57b58c3801ff78f85
+
+# 2022-01-03: Spelling, punctuation, and grammar
+ace871d870666deb13dbc1a7cda5c6dc5313faaa
+
+# 2022-01-21: Use ``:pep:`` and ``:rfc:`` roles
+113e4907014a8b201d2367aea9644498eb577b04
+
+# 2022-02-27: Display list names in ``Resolution`` and ``Discussions-To``
+42f88f1ce2062ec49db8e07c8b79d7ed62c1bfbc
+
+# 2022-03-09: Normalise ``Post-History``
+b0329c31b3da7b6f60c7215e4db1593014782299
+
+# 2022-04-20: Normalise various headers
+a6336e9d74d355f2beb2c5f83f21dd227b1b4612
+
+# 2022-06-14: Add ``Topic: Packaging``
+19f2582774070b86cc4f8866d5c751f8cb7c56ee
+
+# 2022-08-24: Add ``Python-Version`` headers
+df0c276128734f0b0da47b32fbb9c1d01c0fa458
+
+# 2022-10-05: Normalise ``Author``
+5fb8b28a066de90154c72007c762787b0882b3e2
+
+# 2022-10-06: Fix reStructuredText syntax
+7fa80c34d7b748600eb0d7421430f5af87dc42db
+
+# 2022-10-06: Add ``Topic: Typing``
+83b976da185a797ba187dd79e02bb4c5c2a8c9f7
+
+# 2022-10-06: Add ``Topic: Release``
+e46b83661dd2d80bf7970f30311805119a1d859a
+
+# 2023-02-02: Add ``Topic: Governance``
+5bdec964dafe1f7d63f17822171eace92190d60f
+
+# 2023-05-01: Spelling, punctuation, and grammar
+b9ca714a43af79244e8d0b919025db7c6786aaab
+
+# 2023-07-31: Resolve reference warnings
+b199a29c8af3ca8b73cbb6648610300d670869f4
+
+# 2023-09-09: Move PEPs to the ``peps/`` folder
+08d688fdcafc1557bf7fc53573e5c84b31b78b5d

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,7 @@ peps/contents.rst       @AA-Turner
 check-peps.py           @AA-Turner @CAM-Gerlach @hugovk
 
 # Git infrastructure
+.git-blame-ignore-revs  @AA-Turner
 .gitattributes          @CAM-Gerlach
 .gitignore              @CAM-Gerlach
 


### PR DESCRIPTION
Depends on #3431.

Due to #3418, all dates in the footers of PEPs report that the PEP was last modified on 9 September 2023. Whilst this was expected, and is superficially correct, we really want to report the last *substantive* modification time.

This uses the comprehensive list of ignored commits from #3431 to display the most recent substantive modification of each PEP, which is what readers would expect.

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3432.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->