### PR TITLE
Lint: Update Ruff config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ concurrency:
 
 env:
   FORCE_COLOR: 1
+  RUFF_FORMAT: github
 
 jobs:
   pre-commit:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,6 @@ repos:
         args:
           - '--exit-non-zero-on-fix'
           - '--diff'
-          - '--format=github'
         files: '^pep_sphinx_extensions/tests/'
 
   - repo: https://github.com/tox-dev/tox-ini-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,6 @@ repos:
         name: "Lint with Ruff"
         args:
           - '--exit-non-zero-on-fix'
-          - '--diff'
         files: '^pep_sphinx_extensions/tests/'
 
   - repo: https://github.com/tox-dev/tox-ini-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,16 @@ repos:
       - id: check-yaml
         name: "Check YAML"
 
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        name: "Format with Black"
+        args:
+          - '--target-version=py39'
+          - '--target-version=py310'
+        files: 'pep_sphinx_extensions/tests/.*'
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.287
     hooks:
@@ -52,16 +62,6 @@ repos:
           - '--diff'
           - '--format=github'
         files: '^pep_sphinx_extensions/tests/'
-
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
-    hooks:
-      - id: black
-        name: "Format with Black"
-        args:
-          - '--target-version=py39'
-          - '--target-version=py310'
-        files: 'pep_sphinx_extensions/tests/.*'
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
     rev: 1.3.1


### PR DESCRIPTION
I didn't get a chance to review https://github.com/python/peps/pull/3429 before merge, so here are some suggestions.

https://github.com/astral-sh/ruff-pre-commit says (emphasis mine):

> _Ruff's pre-commit hook should be placed after other formatting tools, such as Black_ and isort, unless you enable autofix, in which case, Ruff's pre-commit hook should run before Black, isort, and other formatting tools, as Ruff's autofix behavior can output code changes that require reformatting.

Also only enable GitHub formatting for GitHub Actions, not the user's local console.

And also remove `--diff`, it prevents the formatting and annotation.


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3433.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->