### PR TITLE
Infra: Add Python version to PEP 0 tables

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -232,14 +232,17 @@ table td + td {
 }
 /* Common column widths for PEP status tables  */
 table.pep-zero-table tr td:nth-child(1) {
-    width: 5.5%;
+    width: 5%;
 }
 table.pep-zero-table tr td:nth-child(2) {
-    width: 6.5%;
+    width: 7%;
 }
 table.pep-zero-table tr td:nth-child(3),
 table.pep-zero-table tr td:nth-child(4){
-    width: 44%;
+    width: 41%;
+}
+table.pep-zero-table tr td:nth-child(5) {
+    width: 6%;
 }
 /* Authors & Sponsors table */
 #authors-owners table td,

--- a/pep_sphinx_extensions/pep_zero_generator/parser.py
+++ b/pep_sphinx_extensions/pep_zero_generator/parser.py
@@ -140,6 +140,7 @@ class PEP:
             "shorthand": self.shorthand,
             # the author list as a comma-separated with only last names
             "authors": ", ".join(author.full_name for author in self.authors),
+            # The targeted Python-Version (if present) or the empty string
             "python_version": self.python_version or "",
         }
 

--- a/pep_sphinx_extensions/pep_zero_generator/parser.py
+++ b/pep_sphinx_extensions/pep_zero_generator/parser.py
@@ -140,6 +140,7 @@ class PEP:
             "shorthand": self.shorthand,
             # the author list as a comma-separated with only last names
             "authors": ", ".join(author.full_name for author in self.authors),
+            "python_version": self.python_version or "",
         }
 
     @property

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -74,12 +74,19 @@ class PEPZeroWriter:
         self.output.append(author_table_separator)
 
     def emit_pep_row(
-        self, *, shorthand: str, number: int, title: str, authors: str
+        self,
+        *,
+        shorthand: str,
+        number: int,
+        title: str,
+        authors: str,
+        python_version: str,
     ) -> None:
         self.emit_text(f"   * - {shorthand}")
         self.emit_text(f"     - :pep:`{number} <{number}>`")
         self.emit_text(f"     - :pep:`{title.replace('`', '')} <{number}>`")
         self.emit_text(f"     - {authors}")
+        self.emit_text(f"     - {python_version}")
 
     def emit_column_headers(self) -> None:
         """Output the column headers for the PEP indices."""
@@ -92,6 +99,7 @@ class PEPZeroWriter:
         self.emit_text("     - PEP")
         self.emit_text("     - Title")
         self.emit_text("     - Authors")
+        self.emit_text("     - Python")
 
     def emit_title(self, text: str, *, symbol: str = "=") -> None:
         self.output.append(text)
@@ -109,6 +117,7 @@ class PEPZeroWriter:
         # list-table must have at least one body row
         if len(peps) == 0:
             self.emit_text("   * -")
+            self.emit_text("     -")
             self.emit_text("     -")
             self.emit_text("     -")
             self.emit_text("     -")
@@ -192,7 +201,11 @@ class PEPZeroWriter:
             self.emit_column_headers()
             for number, claimants in sorted(self.RESERVED.items()):
                 self.emit_pep_row(
-                    shorthand="", number=number, title="RESERVED", authors=claimants
+                    shorthand="",
+                    number=number,
+                    title="RESERVED",
+                    authors=claimants,
+                    python_version="",
                 )
 
             self.emit_newline()

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -111,7 +111,7 @@ class PEPZeroWriter:
     def emit_subtitle(self, text: str) -> None:
         self.emit_title(text, symbol="-")
 
-    def emit_table(self, peps: list[PEP]):
+    def emit_table(self, peps: list[PEP]) -> None:
         include_version = any(pep.details["python_version"] for pep in peps)
         self.emit_column_headers(include_version=include_version)
         for pep in peps:

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -99,7 +99,7 @@ class PEPZeroWriter:
         self.emit_text("     - PEP")
         self.emit_text("     - Title")
         self.emit_text("     - Authors")
-        self.emit_text("     - Python")
+        self.emit_text("     - ")
 
     def emit_title(self, text: str, *, symbol: str = "=") -> None:
         self.output.append(text)

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -111,8 +111,7 @@ class PEPZeroWriter:
     def emit_subtitle(self, text: str) -> None:
         self.emit_title(text, symbol="-")
 
-    def emit_pep_category(self, category: str, peps: list[PEP]) -> None:
-        self.emit_subtitle(category)
+    def emit_table(self, peps: list[PEP]):
         include_version = any(pep.details["python_version"] for pep in peps)
         self.emit_column_headers(include_version=include_version)
         for pep in peps:
@@ -120,6 +119,10 @@ class PEPZeroWriter:
             if not include_version:
                 details.pop("python_version")
             self.emit_pep_row(**details)
+
+    def emit_pep_category(self, category: str, peps: list[PEP]) -> None:
+        self.emit_subtitle(category)
+        self.emit_table(peps)
         # list-table must have at least one body row
         if len(peps) == 0:
             self.emit_text("   * -")
@@ -195,13 +198,7 @@ class PEPZeroWriter:
 
         # PEPs by number
         self.emit_title("Numerical Index")
-        include_version = any(pep.details["python_version"] for pep in peps)
-        self.emit_column_headers(include_version=include_version)
-        for pep in peps:
-            details = pep.details
-            if not include_version:
-                details.pop("python_version")
-            self.emit_pep_row(**details)
+        self.emit_table(peps)
 
         self.emit_newline()
 

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -99,7 +99,7 @@ class PEPZeroWriter:
         self.emit_text("     - PEP")
         self.emit_text("     - Title")
         self.emit_text("     - Authors")
-        self.emit_text("     - ")
+        self.emit_text("     - ")  # for Python-Version
 
     def emit_title(self, text: str, *, symbol: str = "=") -> None:
         self.output.append(text)

--- a/pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py
+++ b/pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py
@@ -40,16 +40,35 @@ def test_pep_equal():
     assert pep_a == pep_b
 
 
-def test_pep_details(monkeypatch):
-    pep8 = parser.PEP(PEP_ROOT / "pep-0008.rst")
+@pytest.mark.parametrize(
+    ("test_input", "expected"),
+    [
+        (
+            "pep-0008.rst",
+            {
+                "authors": "Guido van Rossum, Barry Warsaw, Nick Coghlan",
+                "number": 8,
+                "shorthand": ":abbr:`PA (Process, Active)`",
+                "title": "Style Guide for Python Code",
+                "python_version": "",
+            },
+        ),
+        (
+            "pep-0719.rst",
+            {
+                "authors": "Thomas Wouters",
+                "number": 719,
+                "shorthand": ":abbr:`IA (Informational, Active)`",
+                "title": "Python 3.13 Release Schedule",
+                "python_version": "3.13",
+            },
+        ),
+    ],
+)
+def test_pep_details(test_input, expected):
+    pep = parser.PEP(PEP_ROOT / test_input)
 
-    assert pep8.details == {
-        "authors": "Guido van Rossum, Barry Warsaw, Nick Coghlan",
-        "number": 8,
-        "shorthand": ":abbr:`PA (Process, Active)`",
-        "title": "Style Guide for Python Code",
-        "python_version": "",
-    }
+    assert pep.details == expected
 
 
 @pytest.mark.parametrize(

--- a/pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py
+++ b/pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py
@@ -48,6 +48,7 @@ def test_pep_details(monkeypatch):
         "number": 8,
         "shorthand": ":abbr:`PA (Process, Active)`",
         "title": "Style Guide for Python Code",
+        "python_version": "",
     }
 
 


### PR DESCRIPTION
For https://github.com/python/peps/issues/1012.

Came up today in https://discuss.python.org/t/list-of-future-commitments/33785/4?u=hugovk.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3434.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->