### PR TITLE
PEP 693: Add Python 3.12.0rc3 release date

### DIFF
--- a/peps/pep-0693.rst
+++ b/peps/pep-0693.rst
@@ -57,6 +57,7 @@ Actual:
 - 3.12.0 beta 4: Tuesday, 2023-07-11
 - 3.12.0 candidate 1: Sunday, 2023-08-06
 - 3.12.0 candidate 2: Wednesday, 2023-09-06
+- 3.12.0 candidate 3: Tuesday, 2023-09-19
 
 Expected:
 


### PR DESCRIPTION
Fixes https://github.com/python/peps/issues/3444.
<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3443.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->