### PR TITLE
PEP 703: Use 't' for proposed ABI tag

### DIFF
--- a/peps/pep-0703.rst
+++ b/peps/pep-0703.rst
@@ -330,8 +330,8 @@ and python.org downloads. A new build configuration flag,
 CPython with support for running without the global interpreter lock.
 
 When built with ``--disable-gil``, CPython will define the ``Py_NOGIL``
-macro in Python/patchlevel.h.  The ABI tag will include the letter "n"
-(for "nogil").
+macro in Python/patchlevel.h.  The ABI tag will include the letter "t"
+(for "threading").
 
 The ``--disable-gil`` builds of CPython will still support optionally
 running with the GIL enabled at runtime (see `PYTHONGIL Environment


### PR DESCRIPTION
As requested by @brettcannon (in https://discuss.python.org/t/pep-703-making-the-global-interpreter-lock-optional-3-12-updates/26503/99) and more recently by @gpshead (https://discuss.python.org/t/nogil-installers-on-windows/34049/3)

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3445.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->