### PR TITLE
PEP 724: Add the current Discussions-To thread

### DIFF
--- a/peps/pep-0724.rst
+++ b/peps/pep-0724.rst
@@ -11,8 +11,8 @@ Topic: Typing
 Content-Type: text/x-rst
 Created: 28-Jul-2023
 Python-Version: 3.13
-Post-History: `30-Dec-2021 <https://mail.python.org/archives/list/typing-sig@python.org/thread/EMUD2D424OI53DCWQ4H5L6SJD2IXBHUL/>`__
-
+Post-History: `30-Dec-2021 <https://mail.python.org/archives/list/typing-sig@python.org/thread/EMUD2D424OI53DCWQ4H5L6SJD2IXBHUL/>`__,
+              `19-Sep-2023 <https://discuss.python.org/t/pep-724-stricter-type-guards/34124>`__,
 
 Abstract
 ========

--- a/peps/pep-0724.rst
+++ b/peps/pep-0724.rst
@@ -4,7 +4,7 @@ Author: Rich Chiodo <rchiodo at microsoft.com>,
         Eric Traut <erictr at microsoft.com>,
         Erik De Bonte <erikd at microsoft.com>,
 Sponsor: Jelle Zijlstra <jelle.zijlstra@gmail.com>
-Discussions-To: https://mail.python.org/archives/list/typing-sig@python.org/thread/7KZ2VUDXZ5UKAUHRNXBJYBENAYMT6WXN/
+Discussions-To: https://discuss.python.org/t/pep-724-stricter-type-guards/34124
 Status: Draft
 Type: Standards Track
 Topic: Typing


### PR DESCRIPTION
@erictraut pointed out the discussions to location was the wrong spot. Updating to the new peps discussion location.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3446.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->