### PR TITLE
PEP 724: Add the Rationale section

### DIFF
--- a/peps/pep-0724.rst
+++ b/peps/pep-0724.rst
@@ -87,7 +87,7 @@ Rationale
 =========
 
 There are a number of issues where a ``stricter`` ``TypeGuard`` would have
-solved a user's problem:
+been a solution:
 
 * `Python typing issue <https://github.com/python/typing/issues/1351>`__
 * `Pyright issue <https://github.com/microsoft/pyright/issues/3450>`__

--- a/peps/pep-0724.rst
+++ b/peps/pep-0724.rst
@@ -93,6 +93,8 @@ solved a user's problem:
 * `Pyright issue <https://github.com/microsoft/pyright/issues/3450>`__
 * `Pyright issue <https://github.com/microsoft/pyright/issues/3466>`__
 * `Mypy issue <https://github.com/python/mypy/issues/15305>`__
+* `Mypy issue <https://github.com/python/mypy/issues/15520>`__
+* `Typeshed issue <https://github.com/python/typeshed/issues/8009>`__
 
 
 Specification

--- a/peps/pep-0724.rst
+++ b/peps/pep-0724.rst
@@ -86,7 +86,7 @@ return ``TypeGuard`` type was not a subtype of the input type. Refer to
 Rationale
 =========
 
-There are a number of issues where a ``stricter`` ``TypeGuard`` would have
+There are a number of issues where a stricter ``TypeGuard`` would have
 been a solution:
 
 * `Python typing issue <https://github.com/python/typing/issues/1351>`__

--- a/peps/pep-0724.rst
+++ b/peps/pep-0724.rst
@@ -86,7 +86,7 @@ return ``TypeGuard`` type was not a subtype of the input type. Refer to
 Rationale
 =========
 
-There were a number of cases where a ``stricter`` ``TypeGuard`` would have
+There are a number of issues where a ``stricter`` ``TypeGuard`` would have
 solved a user's problem:
 
 * `Python typing issue <https://github.com/python/typing/issues/1351>`__

--- a/peps/pep-0724.rst
+++ b/peps/pep-0724.rst
@@ -89,12 +89,12 @@ Rationale
 There are a number of issues where a stricter ``TypeGuard`` would have
 been a solution:
 
-* `Python typing issue <https://github.com/python/typing/issues/1351>`__
-* `Pyright issue <https://github.com/microsoft/pyright/issues/3450>`__
-* `Pyright issue <https://github.com/microsoft/pyright/issues/3466>`__
-* `Mypy issue <https://github.com/python/mypy/issues/15305>`__
-* `Mypy issue <https://github.com/python/mypy/issues/15520>`__
-* `Typeshed issue <https://github.com/python/typeshed/issues/8009>`__
+* `Python typing issue - TypeGuard doesn't intersect like isinstance <https://github.com/python/typing/issues/1351>`__
+* `Pyright issue - TypeGuard not eliminating possibility on branch <https://github.com/microsoft/pyright/issues/3450>`__
+* `Pyright issue - Type narrowing for Literal doesn't work <https://github.com/microsoft/pyright/issues/3466>`__
+* `Mypy issue - TypeGuard is incompatible with exhaustive check <https://github.com/python/mypy/issues/15305>`__
+* `Mypy issue - Incorrect type narrowing for inspect.isawaitable <https://github.com/python/mypy/issues/15520>`__
+* `Typeshed issue - asyncio.iscoroutinefunction is not a TypeGuard <https://github.com/python/typeshed/issues/8009>`__
 
 
 Specification

--- a/peps/pep-0724.rst
+++ b/peps/pep-0724.rst
@@ -12,7 +12,6 @@ Content-Type: text/x-rst
 Created: 28-Jul-2023
 Python-Version: 3.13
 Post-History: `30-Dec-2021 <https://mail.python.org/archives/list/typing-sig@python.org/thread/EMUD2D424OI53DCWQ4H5L6SJD2IXBHUL/>`__,
-              `18-Feb-2023 <https://github.com/python/typing/issues/1351>`__,
               `19-Sep-2023 <https://discuss.python.org/t/pep-724-stricter-type-guards/34124>`__,
 
 Abstract
@@ -83,6 +82,17 @@ The following code sample demonstrates both of these limitations.
 :pep:`647` imposed these limitations so it could support use cases where the
 return ``TypeGuard`` type was not a subtype of the input type. Refer to
 :pep:`647` for examples.
+
+Rationale
+=========
+
+There were a number of cases where a ``stricter`` ``TypeGuard`` would have
+solved a user's problem:
+
+* `Python typing issue <https://github.com/python/typing/issues/1351>`__
+* `Pyright issue <https://github.com/microsoft/pyright/issues/3450>`__
+* `Pyright issue <https://github.com/microsoft/pyright/issues/3466>`__
+* `Mypy issue <https://github.com/python/mypy/issues/15305>`__
 
 
 Specification

--- a/peps/pep-0724.rst
+++ b/peps/pep-0724.rst
@@ -12,6 +12,7 @@ Content-Type: text/x-rst
 Created: 28-Jul-2023
 Python-Version: 3.13
 Post-History: `30-Dec-2021 <https://mail.python.org/archives/list/typing-sig@python.org/thread/EMUD2D424OI53DCWQ4H5L6SJD2IXBHUL/>`__,
+              `18-Feb-2023 <https://github.com/python/typing/issues/1351>`__,
               `19-Sep-2023 <https://discuss.python.org/t/pep-724-stricter-type-guards/34124>`__,
 
 Abstract


### PR DESCRIPTION
@neilgirdhar [pointed out](https://discuss.python.org/t/pep-724-stricter-type-guards/34124/8) this other thread that seems relevant as well.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3447.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->