### PR TITLE
PEP 8: Move selected operator whitespace examples from "Wrong" to "Acceptable" section

### DIFF
--- a/peps/pep-0008.rst
+++ b/peps/pep-0008.rst
@@ -560,12 +560,16 @@ Other Recommendations
 
   ::
 
-      # Wrong:
-      i=i+1
-      submitted +=1
+      # Acceptable:
       x = x * 2 - 1
       hypot2 = x * x + y * y
       c = (a + b) * (a - b)
+
+  ::
+
+      # Wrong:
+      i=i+1
+      submitted +=1
 
 - Function annotations should use the normal rules for colons and
   always have spaces around the ``->`` arrow if present.  (See


### PR DESCRIPTION
See #3448 for rationale.

Closes #3448.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3449.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->