### PR TITLE
PEP 1: Cease recommending Typing-SIG (it has ceased to be!)

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -37,8 +37,8 @@ which don't significantly impair meaning and understanding.
 
 If you're still unsure, we encourage you to reach out first before opening a
 PR here. For example, you could contact the PEP author(s), propose your idea in
-a discussion venue appropriate to the PEP (such as `Typing-SIG
-<https://mail.python.org/archives/list/typing-sig@python.org/>`__ for static
+a discussion venue appropriate to the PEP (such as `Typing Discourse
+<https://discuss.python.org/c/typing/>`__ for static
 typing, or `Packaging Discourse <https://discuss.python.org/c/packaging/>`__
 for packaging), or `open an issue <https://github.com/python/peps/issues>`__.
 

--- a/peps/pep-0001.rst
+++ b/peps/pep-0001.rst
@@ -136,8 +136,8 @@ forums, and attempts to build community consensus around the idea.  The PEP
 champion (a.k.a. Author) should first attempt to ascertain whether the idea is
 PEP-able.  Posting to the `Ideas category`_ of the `Python Discourse`_ is usually
 the best way to go about this, unless a more specialized venue is appropriate,
-such as `Typing-SIG`_ for static typing or the `Packaging category`_ of the
-Python Discourse for packaging issues.
+such as the `Typing category`_ (for static typing ideas)
+or `Packaging category`_ (for packaging ideas) on the Python Discourse.
 
 Vetting an idea publicly before going as far as writing a PEP is meant
 to save the potential author time. Many ideas have been brought
@@ -284,8 +284,9 @@ The `PEPs category`_ of the `Python Discourse`_
 is the preferred choice for most new PEPs,
 whereas historically the `Python-Dev`_ mailing list was commonly used.
 Some specialized topics have specific venues, such as
-`Typing-SIG`_ for typing PEPs or the `Packaging category`_ on the Python
-Discourse for packaging PEPs. If the PEP authors are unsure of the best venue,
+the `Typing category`_ and the `Packaging category`_ on the Python
+Discourse for typing and packaging PEPs, respectively.
+If the PEP authors are unsure of the best venue,
 the PEP Sponsor and PEP editors can advise them accordingly.
 
 If a PEP undergoes a significant re-write or other major, substantive
@@ -859,7 +860,7 @@ Footnotes
 
 .. _PEPs category: https://discuss.python.org/c/peps/
 
-.. _Typing-SIG: https://mail.python.org/mailman3/lists/typing-sig.python.org/
+.. _Typing category: https://discuss.python.org/c/typing/
 
 .. _Packaging category: https://discuss.python.org/c/packaging/
 


### PR DESCRIPTION
As noted [by Hugo](https://discuss.python.org/t/29129/28).

A

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3453.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->