### PR TITLE
PEP 1 and 12: Remove optional Content-Type from templates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,14 +109,14 @@ repos:
       - id: check-required-headers
         name: "PEPs must have all required headers"
         language: pygrep
-        entry: '(?-m:^PEP:(?=[\s\S]*\nTitle:)(?=[\s\S]*\nAuthor:)(?=[\s\S]*\nStatus:)(?=[\s\S]*\nType:)(?=[\s\S]*\nContent-Type:)(?=[\s\S]*\nCreated:))'
+        entry: '(?-m:^PEP:(?=[\s\S]*\nTitle:)(?=[\s\S]*\nAuthor:)(?=[\s\S]*\nStatus:)(?=[\s\S]*\nType:)(?=[\s\S]*\nCreated:))'
         args: ['--negate', '--multiline']
         files: '^peps/pep-\d+\.rst$'
 
       - id: check-header-order
         name: "PEP header order must follow PEP 12"
         language: pygrep
-        entry: '^PEP:[^\n]+\nTitle:[^\n]+\n(Version:[^\n]+\n)?(Last-Modified:[^\n]+\n)?Author:[^\n]+\n( +\S[^\n]+\n)*(Sponsor:[^\n]+\n)?((PEP|BDFL)-Delegate:[^\n]*\n)?(Discussions-To:[^\n]*\n)?Status:[^\n]+\nType:[^\n]+\n(Topic:[^\n]+\n)?Content-Type:[^\n]+\n(Requires:[^\n]+\n)?Created:[^\n]+\n(Python-Version:[^\n]*\n)?(Post-History:[^\n]*\n( +\S[^\n]*\n)*)?(Replaces:[^\n]+\n)?(Superseded-By:[^\n]+\n)?(Resolution:[^\n]*\n)?\n'
+        entry: '^PEP:[^\n]+\nTitle:[^\n]+\n(Version:[^\n]+\n)?(Last-Modified:[^\n]+\n)?Author:[^\n]+\n( +\S[^\n]+\n)*(Sponsor:[^\n]+\n)?((PEP|BDFL)-Delegate:[^\n]*\n)?(Discussions-To:[^\n]*\n)?Status:[^\n]+\nType:[^\n]+\n(Topic:[^\n]+\n)?(Content-Type:[^\n]+\n)?(Requires:[^\n]+\n)?Created:[^\n]+\n(Python-Version:[^\n]*\n)?(Post-History:[^\n]*\n( +\S[^\n]*\n)*)?(Replaces:[^\n]+\n)?(Superseded-By:[^\n]+\n)?(Resolution:[^\n]*\n)?\n'
         args: ['--negate', '--multiline']
         files: '^peps/pep-\d+\.rst$'
 

--- a/peps/pep-0001.rst
+++ b/peps/pep-0001.rst
@@ -3,7 +3,6 @@ Title: PEP Purpose and Guidelines
 Author: Barry Warsaw, Jeremy Hylton, David Goodger, Nick Coghlan
 Status: Active
 Type: Process
-Content-Type: text/x-rst
 Created: 13-Jun-2000
 Post-History: 21-Mar-2001, 29-Jul-2002, 03-May-2003, 05-May-2012,
               07-Apr-2013
@@ -610,7 +609,6 @@ optional and are described below.  All other headers are required.
              Withdrawn | Final | Superseded>
     Type: <Standards Track | Informational | Process>
   * Topic: <Governance | Packaging | Release | Typing>
-  * Content-Type: text/x-rst
   * Requires: <pep numbers>
     Created: <date created on, in dd-mmm-yyyy format>
   * Python-Version: <version number>
@@ -649,7 +647,7 @@ out.
 The PEP-Delegate field is used to record the individual appointed by the
 Steering Council to make the final decision on whether or not to approve or
 reject a PEP. (The delegate's email address is currently omitted due to a
-limitation in the email address masking for reStructuredText PEPs)
+limitation in the email address masking for reStructuredText PEPs.)
 
 *Note: The Resolution header is required for Standards Track PEPs
 only.  It contains a URL that should point to an email message or
@@ -667,11 +665,6 @@ Informational, or Process.
 The optional Topic header lists the special topic, if any,
 the PEP belongs under.
 See the :ref:`topic-index` for the existing topics.
-
-The format of a PEP is specified with a Content-Type header.
-All PEPs must use reStructuredText (see :pep:`12`),
-and have a value of ``text/x-rst``, the default.
-Previously, plaintext PEPs used ``text/plain`` (see :pep:`9`).
 
 The Created header records the date that the PEP was assigned a
 number, while Post-History is used to record the dates of and corresponding
@@ -878,13 +871,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/peps/pep-0012.rst
+++ b/peps/pep-0012.rst
@@ -5,7 +5,6 @@ Author: David Goodger <goodger@python.org>,
         Brett Cannon <brett@python.org>
 Status: Active
 Type: Process
-Content-Type: text/x-rst
 Created: 05-Aug-2002
 Post-History: `30-Aug-2002 <https://mail.python.org/archives/list/python-dev@python.org/thread/KX3AS7QAY26QH3WIUAEOCCNXQ4V2TGGV/>`__
 
@@ -174,7 +173,6 @@ your PEP):
   Status: Draft
   Type: [Standards Track | Informational | Process]
   Topic: *[Governance | Packaging | Release | Typing]
-  Content-Type: text/x-rst
   Requires: *[NNN]
   Created: [DD-MMM-YYYY]
   Python-Version: *[M.N]

--- a/peps/pep-0012/pep-NNNN.rst
+++ b/peps/pep-0012/pep-NNNN.rst
@@ -7,7 +7,6 @@ Discussions-To: <REQUIRED: URL of current canonical discussion thread>
 Status: <REQUIRED: Draft | Active | Accepted | Provisional | Deferred | Rejected | Withdrawn | Final | Superseded>
 Type: <REQUIRED: Standards Track | Informational | Process>
 Topic: <Governance | Packaging | Release | Typing>
-Content-Type: text/x-rst
 Requires: <pep numbers>
 Created: <date created on, in dd-mmm-yyyy format>
 Python-Version: <version number>


### PR DESCRIPTION
Fixes https://github.com/python/peps/issues/2500.

* There are three 👍s on https://github.com/python/peps/issues/2500#issuecomment-1090883413, for removing the optional `Content-Type` header from the PEP 1 and 12 templates: @JelleZijlstra, @encukou, @hugovk, @CAM-Gerlach.

* @AA-Turner was -0 in https://github.com/python/peps/issues/2500#issuecomment-1100617332

But following issue https://github.com/python/peps/issues/10 / PR https://github.com/python/peps/pull/3418, all PEPs now have an `.rst` extension, so we no longer need the optional header for new PEPs.
