### PR TITLE
PEP 703: typo fix, "with with" -> "with"

### DIFF
--- a/peps/pep-0703.rst
+++ b/peps/pep-0703.rst
@@ -1767,7 +1767,7 @@ an open issue, but a possible path might look like the following:
    CPython, one with the GIL and one without.  Extension authors
    target both ABIs.
 #. After 2--3 releases, (i.e., in 2026--2027), CPython is released
-   with with the GIL controlled by a runtime environment variable or
+   with the GIL controlled by a runtime environment variable or
    flag. The GIL is enabled by default.  There is only a single ABI.
 #. After another 2--3 release (i.e., 2028--2030), CPython switches to
    the GIL being disabled by default.  The GIL can still be enabled


### PR DESCRIPTION
* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3456.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->