### PR TITLE
PEP 695: __type_params__ attribute is writable

### DIFF
--- a/peps/pep-0695.rst
+++ b/peps/pep-0695.rst
@@ -602,7 +602,7 @@ is a generator or coroutine.
 Accessing Type Parameters at Runtime
 ------------------------------------
 
-A new read-only attribute called ``__type_params__`` is available on generic classes,
+A new attribute called ``__type_params__`` is available on generic classes,
 functions, and type aliases. This attribute is a tuple of the
 type parameters that parameterize the class, function, or alias.
 The tuple contains ``TypeVar``, ``ParamSpec``, and ``TypeVarTuple`` instances.


### PR DESCRIPTION
Fixes python/cpython#104600.

We realized that the attribute should be writable on functions and
classes for the benefit of wrappers such as @functools.wraps.

cc @erictraut 

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3457.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->