### PR TITLE
PEP 701: Clarify that newlines also end format specifier mode

### DIFF
--- a/peps/pep-0701.rst
+++ b/peps/pep-0701.rst
@@ -373,8 +373,8 @@ tokens:
 2. Keep consuming tokens until a one of the following is encountered:
 
    * A closing quote equal to the opening quote.
-   * If in "format specifier mode" (see step 3), an opening brace (``{``) or a
-     closing brace (``}``).
+   * If in "format specifier mode" (see step 3), an opening brace (``{``), a
+     closing brace (``}``) or a newline token (``\n``).
    * If not in "format specifier mode" (see step 3), an opening brace (``{``) or
      a closing brace (``}``) that is not immediately followed by another opening/closing
      brace.

--- a/peps/pep-0701.rst
+++ b/peps/pep-0701.rst
@@ -374,7 +374,7 @@ tokens:
 
    * A closing quote equal to the opening quote.
    * If in "format specifier mode" (see step 3), an opening brace (``{``), a
-     closing brace (``}``) or a newline token (``\n``).
+     closing brace (``}``), or a newline token (``\n``).
    * If not in "format specifier mode" (see step 3), an opening brace (``{``) or
      a closing brace (``}``) that is not immediately followed by another opening/closing
      brace.


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3460.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->