### PR TITLE
PEP 695: Fix a typo in a type parameter name

### DIFF
--- a/peps/pep-0695.rst
+++ b/peps/pep-0695.rst
@@ -989,7 +989,7 @@ It is however valid at runtime, and it us used here to illustrate the runtime se
 ::
 
    @decorator
-   def f[T: int, U: (int, str), *V, **P](
+   def f[T: int, U: (int, str), *Ts, **P](
        x: T = SOME_CONSTANT,
        y: U,
        *args: *Ts,


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3461.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->