### PR TITLE
PEP 632: Mark as final

### DIFF
--- a/peps/pep-0632.rst
+++ b/peps/pep-0632.rst
@@ -2,7 +2,7 @@ PEP: 632
 Title: Deprecate distutils module
 Author: Steve Dower <steve.dower@python.org>
 Discussions-To: https://discuss.python.org/t/pep-632-deprecate-distutils-module/5134
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 03-Sep-2020


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [ ] Canonical docs/spec linked with a ``canonical-doc`` directive (or ``canonical-pypa-spec``, for packaging PEPs)


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3468.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->