### PR TITLE
PEP 282: update the log4j link in references

### DIFF
--- a/peps/pep-0282.rst
+++ b/peps/pep-0282.rst
@@ -613,7 +613,7 @@ References
        http://java.sun.com/j2se/1.4/docs/guide/util/logging/
 
 .. [2] log4j: a Java logging package
-       http://jakarta.apache.org/log4j/docs/index.html
+       https://logging.apache.org/log4j/
 
 .. [3] Protomatter's Syslog
        http://protomatter.sourceforge.net/1.1.6/index.html


### PR DESCRIPTION
fix issue #3465 

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3470.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->