### PR TITLE
PEP-3121: Mark as Final

### DIFF
--- a/peps/pep-3121.rst
+++ b/peps/pep-3121.rst
@@ -3,12 +3,15 @@ Title: Extension Module Initialization and Finalization
 Version: $Revision$
 Last-Modified: $Date$
 Author: Martin von Löwis <martin@v.loewis.de>
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 27-Apr-2007
 Python-Version: 3.0
 Post-History:
+
+.. canonical-doc:: :external+python:c:func:`PyInit_modulename` and
+                   :external+python:c:type:`PyModuleDef`
 
 Abstract
 ========


### PR DESCRIPTION
* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [n/a] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive (or ``canonical-pypa-spec``, for packaging PEPs)

(There have been changes since 3.0, and the 3.0 docs for this were in a [different place](https://docs.python.org/3.0/extending/newtypes.html), but the feature was implemented as specified.)

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3471.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->