### PR TITLE
PEP 602: Restore Post-History header

### DIFF
--- a/peps/pep-0602.rst
+++ b/peps/pep-0602.rst
@@ -10,6 +10,7 @@ Type: Informational
 Content-Type: text/x-rst
 Created: 04-Jun-2019
 Python-Version: 3.9
+Post-History: `09-Oct-2023 <https://discuss.python.org/t/27002>`__
 
 
 Abstract


### PR DESCRIPTION
Thanks to @hugovk for [finding](https://github.com/python/peps/pull/3467#issuecomment-1754423150) an appropriate thread URL.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3472.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->