### PR TITLE
Update references to Alyssa Coghlan

### DIFF
--- a/pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py
+++ b/pep_sphinx_extensions/tests/pep_zero_generator/test_parser.py
@@ -46,7 +46,7 @@ def test_pep_equal():
         (
             "pep-0008.rst",
             {
-                "authors": "Guido van Rossum, Barry Warsaw, Nick Coghlan",
+                "authors": "Guido van Rossum, Barry Warsaw, Alyssa Coghlan",
                 "number": 8,
                 "shorthand": ":abbr:`PA (Process, Active)`",
                 "title": "Style Guide for Python Code",

--- a/peps/pep-0001.rst
+++ b/peps/pep-0001.rst
@@ -1,6 +1,6 @@
 PEP: 1
 Title: PEP Purpose and Guidelines
-Author: Barry Warsaw, Jeremy Hylton, David Goodger, Nick Coghlan
+Author: Barry Warsaw, Jeremy Hylton, David Goodger, Alyssa Coghlan
 Status: Active
 Type: Process
 Created: 13-Jun-2000

--- a/peps/pep-0008.rst
+++ b/peps/pep-0008.rst
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>,
         Barry Warsaw <barry@python.org>,
-        Nick Coghlan <ncoghlan@gmail.com>
+        Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Active
 Type: Process
 Content-Type: text/x-rst

--- a/peps/pep-0306.rst
+++ b/peps/pep-0306.rst
@@ -2,7 +2,7 @@ PEP: 306
 Title: How to Change Python's Grammar
 Version: $Revision$
 Last-Modified: $Date$
-Author: Michael Hudson <mwh@python.net>, Jack Diederich <jackdied@gmail.com>, Nick Coghlan <ncoghlan@gmail.com>, Benjamin Peterson <benjamin@python.org>
+Author: Michael Hudson <mwh@python.net>, Jack Diederich <jackdied@gmail.com>, Alyssa Coghlan <ncoghlan@gmail.com>, Benjamin Peterson <benjamin@python.org>
 Status: Withdrawn
 Type: Informational
 Content-Type: text/x-rst

--- a/peps/pep-0338.rst
+++ b/peps/pep-0338.rst
@@ -2,7 +2,7 @@ PEP: 338
 Title: Executing modules as scripts
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0340.rst
+++ b/peps/pep-0340.rst
@@ -554,7 +554,7 @@ In no useful order: Alex Martelli, Barry Warsaw, Bob Ippolito,
 Brett Cannon, Brian Sabbey, Chris Ryland, Doug Landauer, Duncan
 Booth, Fredrik Lundh, Greg Ewing, Holger Krekel, Jason Diamond,
 Jim Jewett, Josiah Carlson, Ka-Ping Yee, Michael Chermside,
-Michael Hudson, Neil Schemenauer, Nick Coghlan, Paul Moore,
+Michael Hudson, Neil Schemenauer, Alyssa Coghlan, Paul Moore,
 Phillip Eby, Raymond Hettinger, Georg Brandl, Samuele
 Pedroni, Shannon Behrens, Skip Montanaro, Steven Bethard, Terry
 Reedy, Tim Delaney, Aahz, and others.  Thanks all for the valuable

--- a/peps/pep-0343.rst
+++ b/peps/pep-0343.rst
@@ -2,7 +2,7 @@ PEP: 343
 Title: The "with" Statement
 Version: $Revision$
 Last-Modified: $Date$
-Author: Guido van Rossum, Nick Coghlan
+Author: Guido van Rossum, Alyssa Coghlan
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
@@ -25,7 +25,7 @@ Author's Note
 =============
 
 This PEP was originally written in first person by Guido, and
-subsequently updated by Nick Coghlan to reflect later discussion
+subsequently updated by Alyssa (Nick) Coghlan to reflect later discussion
 on python-dev. Any first person references are from Guido's
 original.
 
@@ -938,7 +938,7 @@ References
 .. [6] Proposal to use the PEP 342 enhanced generator API directly
        https://mail.python.org/pipermail/python-dev/2005-October/056969.html
 
-.. [7] Guido lets me (Nick Coghlan) talk him into a bad idea ;)
+.. [7] Guido lets me (Alyssa Coghlan) talk him into a bad idea ;)
        https://mail.python.org/pipermail/python-dev/2005-October/057018.html
 
 .. [8] Guido raises some exception handling questions

--- a/peps/pep-0346.rst
+++ b/peps/pep-0346.rst
@@ -2,7 +2,7 @@ PEP: 346
 Title: User Defined ("``with``") Statements
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0348.rst
+++ b/peps/pep-0348.rst
@@ -436,7 +436,7 @@ was used.
 Acknowledgements
 ================
 
-Thanks to Robert Brewer, Josiah Carlson, Nick Coghlan, Timothy
+Thanks to Robert Brewer, Josiah Carlson, Alyssa Coghlan, Timothy
 Delaney, Jack Diedrich, Fred L. Drake, Jr., Philip J. Eby, Greg Ewing,
 James Y. Knight, MA Lemburg, Guido van Rossum, Stephen J. Turnbull,
 Raymond Hettinger, and everyone else I missed for participating in the

--- a/peps/pep-0359.rst
+++ b/peps/pep-0359.rst
@@ -327,7 +327,7 @@ Keyword
 -------
 
 Does the ``make`` keyword break too much code?  Originally, the make
-statement used the keyword ``create`` (a suggestion due to Nick
+statement used the keyword ``create`` (a suggestion due to Alyssa
 Coghlan).  However, investigations into the standard library [8]_ and
 Zope+Plone code [9]_ revealed that ``create`` would break a lot more
 code, so ``make`` was adopted as the keyword instead.  However, there

--- a/peps/pep-0366.rst
+++ b/peps/pep-0366.rst
@@ -2,7 +2,7 @@ PEP: 366
 Title: Main module explicit relative imports
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0369.rst
+++ b/peps/pep-0369.rst
@@ -42,11 +42,11 @@ as post import hooks.
 Use cases
 =========
 
-A use case for a post import hook is mentioned in Nick Coghlan's initial
+A use case for a post import hook is mentioned in Alyssa (Nick) Coghlan's initial
 posting [2]_. about callbacks on module import. It was found during the
 development of Python 3.0 and its ABCs. We wanted to register classes
 like decimal.Decimal with an ABC but the module should not be imported
-on every interpreter startup. Nick came up with this example::
+on every interpreter startup. Alyssa came up with this example::
 
    @imp.when_imported('decimal')
    def register(decimal):
@@ -261,7 +261,7 @@ documentation updates and additional unit tests.
 Acknowledgments
 ===============
 
-Nick Coghlan, for proof reading and the initial discussion
+Alyssa Coghlan, for proof reading and the initial discussion
 Phillip J. Eby, for his implementation in PEAK and help with my own implementation
 
 

--- a/peps/pep-0377.rst
+++ b/peps/pep-0377.rst
@@ -2,7 +2,7 @@ PEP: 377
 Title: Allow __enter__() methods to skip the statement body
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0378.rst
+++ b/peps/pep-0378.rst
@@ -44,8 +44,8 @@ task easier for many users.
 .. _`Babel`: http://babel.edgewall.org/
 
 
-Main Proposal (from Nick Coghlan, originally called Proposal I)
-===============================================================
+Main Proposal (from Alyssa Coghlan, originally called Proposal I)
+=================================================================
 
 A comma will be added to the format() specifier mini-language::
 

--- a/peps/pep-0390.rst
+++ b/peps/pep-0390.rst
@@ -3,7 +3,7 @@ Title: Static metadata for Distutils
 Version: $Revision$
 Last-Modified: $Date$
 Author: Tarek Ziadé <tarek@ziade.org>
-BDFL-Delegate: Nick Coghlan
+BDFL-Delegate: Alyssa Coghlan
 Discussions-To: distutils-sig@python.org
 Status: Rejected
 Type: Standards Track
@@ -25,7 +25,7 @@ Rejection Notice
 ================
 
 As distutils2 is no longer going to be incorporated into the standard
-library, this PEP was rejected by Nick Coghlan in late April, 2013.
+library, this PEP was rejected by Alyssa Coghlan in late April, 2013.
 
 A replacement PEP based on :pep:`426` (metadata 2.0) will be created that
 defines the minimum amount of information needed to generate an sdist

--- a/peps/pep-0394.rst
+++ b/peps/pep-0394.rst
@@ -3,7 +3,7 @@ Title: The "python" Command on Unix-Like Systems
 Version: $Revision$
 Last-Modified: $Date$
 Author: Kerrick Staley <mail@kerrickstaley.com>,
-        Nick Coghlan <ncoghlan@gmail.com>,
+        Alyssa Coghlan <ncoghlan@gmail.com>,
         Barry Warsaw <barry@python.org>,
         Petr Viktorin <encukou@gmail.com>,
         Miro Hrončok <miro@hroncok.cz>,

--- a/peps/pep-0395.rst
+++ b/peps/pep-0395.rst
@@ -2,7 +2,7 @@ PEP: 395
 Title: Qualified Names for Modules
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0403.rst
+++ b/peps/pep-0403.rst
@@ -2,7 +2,7 @@ PEP: 403
 Title: General purpose decorator clause (aka "@in" clause)
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0405.rst
+++ b/peps/pep-0405.rst
@@ -3,7 +3,7 @@ Title: Python Virtual Environments
 Version: $Revision$
 Last-Modified: $Date$
 Author: Carl Meyer <carl@oddbird.net>
-BDFL-Delegate: Nick Coghlan
+BDFL-Delegate: Alyssa Coghlan
 Status: Final
 Type: Standards Track
 Topic: Packaging

--- a/peps/pep-0406.rst
+++ b/peps/pep-0406.rst
@@ -2,7 +2,7 @@ PEP: 406
 Title: Improved Encapsulation of Import State
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>, Greg Slodkowicz <jergosh@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>, Greg Slodkowicz <jergosh@gmail.com>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0408.rst
+++ b/peps/pep-0408.rst
@@ -2,7 +2,7 @@ PEP: 408
 Title: Standard library __preview__ package
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>,
+Author: Alyssa Coghlan <ncoghlan@gmail.com>,
         Eli Bendersky <eliben@gmail.com>
 Status: Rejected
 Type: Standards Track

--- a/peps/pep-0411.rst
+++ b/peps/pep-0411.rst
@@ -2,7 +2,7 @@ PEP: 411
 Title: Provisional packages in the Python standard library
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>,
+Author: Alyssa Coghlan <ncoghlan@gmail.com>,
         Eli Bendersky <eliben@gmail.com>
 Status: Superseded
 Type: Informational

--- a/peps/pep-0413.rst
+++ b/peps/pep-0413.rst
@@ -2,7 +2,7 @@ PEP: 413
 Title: Faster evolution of the Python Standard Library
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Withdrawn
 Type: Process
 Content-Type: text/x-rst

--- a/peps/pep-0414.rst
+++ b/peps/pep-0414.rst
@@ -3,7 +3,7 @@ Title: Explicit Unicode Literal for Python 3.3
 Version: $Revision$
 Last-Modified: $Date$
 Author: Armin Ronacher <armin.ronacher@active-4.com>,
-        Nick Coghlan <ncoghlan@gmail.com>
+        Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
@@ -102,7 +102,7 @@ Author's Note
 This PEP was originally written by Armin Ronacher, and Guido's approval was
 given based on that version.
 
-The currently published version has been rewritten by Nick Coghlan to
+The currently published version has been rewritten by Alyssa Coghlan to
 include additional historical details and rationale that were taken into
 account when Guido made his decision, but were not explicitly documented in
 Armin's version of the PEP.

--- a/peps/pep-0415.rst
+++ b/peps/pep-0415.rst
@@ -3,7 +3,7 @@ Title: Implement context suppression with exception attributes
 Version: $Revision$
 Last-Modified: $Date$
 Author: Benjamin Peterson <benjamin@python.org>
-BDFL-Delegate: Nick Coghlan
+BDFL-Delegate: Alyssa Coghlan
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
@@ -28,7 +28,7 @@ instances.
 PEP Acceptance
 ==============
 
-This PEP was accepted by Nick Coghlan on the 14th of May, 2012.
+This PEP was accepted by Alyssa Coghlan on the 14th of May, 2012.
 
 
 Rationale

--- a/peps/pep-0420.rst
+++ b/peps/pep-0420.rst
@@ -444,7 +444,7 @@ lacking an ``__init__.py`` file.  Such a directory will now be
 imported as a namespace package, whereas in prior Python versions an
 ImportWarning would be raised.
 
-Nick Coghlan presented a list of his objections to this proposal [4]_.
+Alyssa (Nick) Coghlan presented a list of her objections to this proposal [4]_.
 They are:
 
 1. Implicit package directories go against the Zen of Python.
@@ -458,7 +458,7 @@ They are:
 4. Implicit package directories will permanently entrench current
    newbie-hostile behavior in ``__main__``.
 
-Nick later gave a detailed response to his own objections [5]_, which
+Alyssa later gave a detailed response to her own objections [5]_, which
 is summarized here:
 
 1. The practicality of this PEP wins over other proposals and the
@@ -500,7 +500,7 @@ Dynamic path computation
 ------------------------
 
 Guido raised a concern that automatic dynamic path computation was an
-unnecessary feature [8]_.  Later in that thread, PJ Eby and Nick
+unnecessary feature [8]_.  Later in that thread, PJ Eby and Alyssa
 Coghlan presented arguments as to why dynamic computation would
 minimize surprise to Python users.  The conclusion of that discussion
 has been included in this PEP's Rationale section.
@@ -622,10 +622,10 @@ References
 .. [3] PyCon 2012 Namespace Package discussion outcome
        (https://mail.python.org/pipermail/import-sig/2012-March/000421.html)
 
-.. [4] Nick Coghlan's objection to the lack of marker files or directories
+.. [4] Alyssa Coghlan's objection to the lack of marker files or directories
        (https://mail.python.org/pipermail/import-sig/2012-March/000423.html)
 
-.. [5] Nick Coghlan's response to his initial objections
+.. [5] Alyssa Coghlan's response to her initial objections
        (https://mail.python.org/pipermail/import-sig/2012-April/000464.html)
 
 .. [6] Martin v. Löwis's suggestion to make ``encodings`` a namespace

--- a/peps/pep-0421.rst
+++ b/peps/pep-0421.rst
@@ -169,7 +169,7 @@ Non-Required Attributes
 
 Earlier versions of this PEP included a required attribute called
 ``metadata`` that held any non-required, per-implementation data
-[#Nick]_.  However, this proved to be an unnecessary addition
+[#Alyssa]_.  However, this proved to be an unnecessary addition
 considering the purpose of ``sys.implementation``.
 
 Ultimately, non-required attributes are virtually ignored in this PEP.
@@ -502,7 +502,7 @@ References
 .. [#javatest] The use of ``os.name`` as 'java' in the stdlib test suite.
    http://hg.python.org/cpython/file/2f563908ebc5/Lib/test/support.py#l512
 
-.. [#Nick] Nick Coghlan's proposal for ``sys.implementation.metadata``:
+.. [#Alyssa] Alyssa (Nick) Coghlan's proposal for ``sys.implementation.metadata``:
    https://mail.python.org/pipermail/python-ideas/2012-May/014984.html
 
 .. [#Barry] Feedback from Barry Warsaw:

--- a/peps/pep-0422.rst
+++ b/peps/pep-0422.rst
@@ -2,7 +2,7 @@ PEP: 422
 Title: Simpler customisation of class creation
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>,
+Author: Alyssa Coghlan <ncoghlan@gmail.com>,
         Daniel Urban <urban.dani+py@gmail.com>
 Status: Withdrawn
 Type: Standards Track

--- a/peps/pep-0425.rst
+++ b/peps/pep-0425.rst
@@ -3,7 +3,7 @@ Title: Compatibility Tags for Built Distributions
 Version: $Revision$
 Last-Modified: 07-Aug-2012
 Author: Daniel Holth <dholth@gmail.com>
-BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
+BDFL-Delegate: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Final
 Type: Standards Track
 Topic: Packaging
@@ -30,7 +30,7 @@ they will be included in filenames.
 PEP Acceptance
 ==============
 
-This PEP was accepted by Nick Coghlan on 17th February, 2013.
+This PEP was accepted by Alyssa Coghlan on 17th February, 2013.
 
 
 Rationale
@@ -283,7 +283,7 @@ References
 Acknowledgements
 ================
 
-The author thanks Paul Moore, Nick Coghlan, Marc Abramowitz, and
+The author thanks Paul Moore, Alyssa Coghlan, Marc Abramowitz, and
 Mr. Michele Lacchia for their valuable help and advice.
 
 Copyright

--- a/peps/pep-0426.rst
+++ b/peps/pep-0426.rst
@@ -2,7 +2,7 @@ PEP: 426
 Title: Metadata for Python Software Packages 2.0
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>,
+Author: Alyssa Coghlan <ncoghlan@gmail.com>,
         Daniel Holth <dholth@gmail.com>,
         Donald Stufft <donald@stufft.io>
 BDFL-Delegate: Donald Stufft <donald@stufft.io>

--- a/peps/pep-0427.rst
+++ b/peps/pep-0427.rst
@@ -3,7 +3,7 @@ Title: The Wheel Binary Package Format 1.0
 Version: $Revision$
 Last-Modified: $Date$
 Author: Daniel Holth <dholth@gmail.com>
-BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
+BDFL-Delegate: Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: distutils-sig@python.org
 Status: Final
 Type: Standards Track
@@ -35,7 +35,7 @@ PEP Acceptance
 ==============
 
 This PEP was accepted, and the defined wheel version updated to 1.0, by
-Nick Coghlan on 16th February, 2013 [1]_
+Alyssa Coghlan on 16th February, 2013 [1]_
 
 
 Rationale

--- a/peps/pep-0430.rst
+++ b/peps/pep-0430.rst
@@ -2,7 +2,7 @@ PEP: 430
 Title: Migrating to Python 3 as the default online documentation
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 BDFL-Delegate: Georg Brandl
 Status: Final
 Type: Informational

--- a/peps/pep-0432.rst
+++ b/peps/pep-0432.rst
@@ -2,7 +2,7 @@ PEP: 432
 Title: Restructuring the CPython startup sequence
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>,
+Author: Alyssa Coghlan <ncoghlan@gmail.com>,
         Victor Stinner <vstinner@python.org>,
         Eric Snow <ericsnowcurrently@gmail.com>
 Discussions-To: capi-sig@python.org

--- a/peps/pep-0434.rst
+++ b/peps/pep-0434.rst
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Todd Rovito <rovitotv@gmail.com>,
         Terry Reedy <tjreedy@udel.edu>
-BDFL-Delegate: Nick Coghlan
+BDFL-Delegate: Alyssa Coghlan
 Status: Active
 Type: Informational
 Content-Type: text/x-rst

--- a/peps/pep-0436.rst
+++ b/peps/pep-0436.rst
@@ -693,7 +693,7 @@ Notes / TBD
   currently under discussion.  Argument Clinic will add support for
   the prototype when it becomes viable.
 
-* Nick Coghlan suggests that we a) only support at most one left-optional
+* Alyssa Coghlan suggests that we a) only support at most one left-optional
   group per function, and b) in the face of ambiguity, prefer the left
   group over the right group.  This would solve all our existing use cases
   including range().
@@ -757,7 +757,7 @@ The PEP author wishes to thank Ned Batchelder for permission to
 shamelessly rip off his clever design for Cog--"my favorite tool
 that I've never gotten to use".  Thanks also to everyone who provided
 feedback on the [bugtracker issue] and on python-dev.  Special thanks
-to Nick Coglan and Guido van Rossum for a rousing two-hour in-person
+to Alyssa (Nick) Coghlan and Guido van Rossum for a rousing two-hour in-person
 deep dive on the topic at PyCon US 2013.
 
 

--- a/peps/pep-0438.rst
+++ b/peps/pep-0438.rst
@@ -451,7 +451,7 @@ Donald Stufft for pushing away from external hosting and offering to
 implement both a Pull Request for the necessary PyPI changes and the
 analysis tool to drive the transition phase 1.
 
-Marc-Andre Lemburg, Nick Coghlan and catalog-sig in general for
+Marc-Andre Lemburg, Alyssa Coghlan and catalog-sig in general for
 thinking through issues regarding getting rid of "external hosting".
 
 

--- a/peps/pep-0439.rst
+++ b/peps/pep-0439.rst
@@ -3,7 +3,7 @@ Title: Inclusion of implicit pip bootstrap in Python installation
 Version: $Revision$
 Last-Modified: $Date$
 Author: Richard Jones <richard@python.org>
-BDFL-Delegate:  Nick Coghlan <ncoghlan@gmail.com>
+BDFL-Delegate:  Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: distutils-sig@python.org
 Status: Rejected
 Type: Standards Track
@@ -234,7 +234,7 @@ References
 Acknowledgments
 ===============
 
-Nick Coghlan for his thoughts on the proposal and dealing with the Red
+Alyssa Coghlan for her thoughts on the proposal and dealing with the Red
 Hat issue.
 
 Jannis Leidel and Carl Meyer for their thoughts. Marcus Smith for feedback.

--- a/peps/pep-0440.rst
+++ b/peps/pep-0440.rst
@@ -1,8 +1,8 @@
 PEP: 440
 Title: Version Identification and Dependency Specification
-Author: Nick Coghlan <ncoghlan@gmail.com>,
+Author: Alyssa Coghlan <ncoghlan@gmail.com>,
         Donald Stufft <donald@stufft.io>
-BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
+BDFL-Delegate: Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: distutils-sig@python.org
 Status: Final
 Type: Standards Track

--- a/peps/pep-0443.rst
+++ b/peps/pep-0443.rst
@@ -370,7 +370,7 @@ PEAK-Rules, influences include Paul Moore's original issue
 [#issue-5135]_ that proposed exposing ``pkgutil.simplegeneric`` as part
 of the ``functools`` API, Guido van Rossum's article on multimethods
 [#artima2005]_, and discussions with Raymond Hettinger on a general
-pprint rewrite. Huge thanks to Nick Coghlan for encouraging me to create
+pprint rewrite. Huge thanks to Alyssa Coghlan for encouraging me to create
 this PEP and providing initial feedback.
 
 

--- a/peps/pep-0451.rst
+++ b/peps/pep-0451.rst
@@ -3,7 +3,7 @@ Title: A ModuleSpec Type for the Import System
 Version: $Revision$
 Last-Modified: $Date$
 Author: Eric Snow <ericsnowcurrently@gmail.com>
-BDFL-Delegate: Brett Cannon <brett@python.org>, Nick Coghlan <ncoghlan@gmail.com>
+BDFL-Delegate: Brett Cannon <brett@python.org>, Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: import-sig@python.org
 Status: Final
 Type: Standards Track

--- a/peps/pep-0453.rst
+++ b/peps/pep-0453.rst
@@ -1,7 +1,7 @@
 PEP: 453
 Title: Explicit bootstrapping of pip in Python installations
 Author: Donald Stufft <donald@stufft.io>,
-        Nick Coghlan <ncoghlan@gmail.com>
+        Alyssa Coghlan <ncoghlan@gmail.com>
 BDFL-Delegate: Martin von Löwis
 Status: Final
 Type: Standards Track

--- a/peps/pep-0456.rst
+++ b/peps/pep-0456.rst
@@ -3,7 +3,7 @@ Title: Secure and interchangeable hash algorithm
 Version: $Revision$
 Last-Modified: $Date$
 Author: Christian Heimes <christian@python.org>
-BDFL-Delegate: Nick Coghlan
+BDFL-Delegate: Alyssa Coghlan
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0457.rst
+++ b/peps/pep-0457.rst
@@ -242,7 +242,7 @@ Credit for the use of '/' as the separator between positional-only and positiona
 parameters goes to Guido van Rossum, in a proposal from 2012. [#GUIDO]_
 
 Credit for making left option groups higher precedence goes to
-Nick Coghlan. (Conversation in person at PyCon US 2013.)
+Alyssa Coghlan. (Conversation in person at PyCon US 2013.)
 
 .. [#DICT]
     http://docs.python.org/3/library/stdtypes.html#dict

--- a/peps/pep-0458.rst
+++ b/peps/pep-0458.rst
@@ -9,7 +9,7 @@ Author: Trishank Karthik Kuppusamy <karthik@trishank.com>,
         Joshua Lock <jlock@vmware.com>,
         Lois Anne DeLong <lad278@nyu.edu>,
         Justin Cappos <jcappos@nyu.edu>
-Sponsor: Nick Coghlan <ncoghlan@gmail.com>
+Sponsor: Alyssa Coghlan <ncoghlan@gmail.com>
 BDFL-Delegate: Donald Stufft <donald@stufft.io>
 Discussions-To: https://discuss.python.org/t/pep-458-secure-pypi-downloads-with-package-signing/2648
 Status: Accepted
@@ -1380,7 +1380,7 @@ conclusions or recommendations expressed in this material are those of the
 author(s) and do not necessarily reflect the views of the National Science
 Foundation.
 
-We thank Nick Coghlan, Daniel Holth, Donald Stufft, and the distutils-sig
+We thank Alyssa Coghlan, Daniel Holth, Donald Stufft, and the distutils-sig
 community in general for helping us to think about how to usably and
 efficiently integrate TUF with PyPI.
 

--- a/peps/pep-0459.rst
+++ b/peps/pep-0459.rst
@@ -2,8 +2,8 @@ PEP: 459
 Title: Standard Metadata Extensions for Python Software Packages
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
-BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
+BDFL-Delegate: Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: distutils-sig@python.org
 Status: Withdrawn
 Type: Standards Track

--- a/peps/pep-0462.rst
+++ b/peps/pep-0462.rst
@@ -1,6 +1,6 @@
 PEP: 462
 Title: Core development workflow automation for CPython
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Withdrawn
 Type: Process
 Content-Type: text/x-rst

--- a/peps/pep-0466.rst
+++ b/peps/pep-0466.rst
@@ -2,7 +2,7 @@ PEP: 466
 Title: Network Security Enhancements for Python 2.7.x
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>,
+Author: Alyssa Coghlan <ncoghlan@gmail.com>,
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0467.rst
+++ b/peps/pep-0467.rst
@@ -2,7 +2,7 @@ PEP: 467
 Title: Minor API improvements for binary sequences
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>, Ethan Furman <ethan@stoneleaf.us>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>, Ethan Furman <ethan@stoneleaf.us>
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0468.rst
+++ b/peps/pep-0468.rst
@@ -56,8 +56,8 @@ and with this proposal::
    def spam(a, **kwargs):
        ...
 
-Nick Coglan, speaking of some of the uses cases, summed it up well
-[#nick_obvious]_::
+Alyssa (Nick) Coghlan, speaking of some of the uses cases, summed it up well
+[#alyssa_obvious]_::
 
    These *can* all be done today, but *not* by using keyword arguments.
    In my view, the problem to be addressed is that keyword arguments
@@ -80,11 +80,11 @@ constructor for OrderedDict. [#past_threads]_ [#loss_of_order]_
 Use Cases
 =========
 
-As Nick noted, the current behavior of \*\*kwargs is unintuitive in
+As Alyssa noted, the current behavior of \*\*kwargs is unintuitive in
 cases where one would expect order to matter.  Aside from more specific
 cases outlined below, in general "anything else where you want to
 control the iteration order *and* set field names and values in a single
-call will potentially benefit." [#nick_general]_  That matters in the
+call will potentially benefit." [#alyssa_general]_  That matters in the
 case of factories (e.g. __init__()) for ordered types.
 
 Serialization
@@ -92,7 +92,7 @@ Serialization
 
 Obviously OrderedDict would benefit (both __init__() and update()) from
 ordered kwargs.  However, the benefit also extends to serialization
-APIs [#nick_obvious]_::
+APIs [#alyssa_obvious]_::
 
    In the context of serialisation, one key lesson we have learned is
    that arbitrary ordering is a problem when you want to minimise
@@ -365,7 +365,7 @@ Footnotes
 References
 ==========
 
-.. [#nick_obvious]
+.. [#alyssa_obvious]
    https://mail.python.org/pipermail/python-ideas/2014-April/027512.html
 
 .. [#past_threads]
@@ -401,7 +401,7 @@ References
 
      https://mail.python.org/pipermail/python-dev/2013-May/126328.html
 
-.. [#nick_general]
+.. [#alyssa_general]
    https://mail.python.org/pipermail/python-dev/2012-December/123105.html
 
 .. [#raymond_debug]

--- a/peps/pep-0469.rst
+++ b/peps/pep-0469.rst
@@ -2,7 +2,7 @@ PEP: 469
 Title: Migration of dict iteration code to Python 3
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0471.rst
+++ b/peps/pep-0471.rst
@@ -296,7 +296,7 @@ others on the python-dev and python-ideas mailing lists. A sampling:
   scandir and :pep:`471` on `this June 2014 python-dev thread
   <https://mail.python.org/pipermail/python-dev/2014-June/135217.html>`_
 
-* **Nick Coghlan**, a core Python developer: "I've had the local Red
+* **Alyssa Coghlan**, a core Python developer: "I've had the local Red
   Hat release engineering team express their displeasure at having to
   stat every file in a network mounted directory tree for info that is
   present in the dirent structure, so a definite +1 to os.scandir from
@@ -327,7 +327,7 @@ others on the python-dev and python-ideas mailing lists. A sampling:
   it to 3.4."
   [`source6 <https://mail.python.org/pipermail/python-dev/2013-November/130583.html>`_]
 
-Support for this PEP itself (meta-support?) was given by Nick Coghlan
+Support for this PEP itself (meta-support?) was given by Alyssa (Nick) Coghlan
 on python-dev: "A PEP reviewing all this for 3.5 and proposing a
 specific os.scandir API would be a good thing."
 [`source7 <https://mail.python.org/pipermail/python-dev/2013-November/130588.html>`_]
@@ -526,7 +526,7 @@ DirEntry fields being static with an ensure_lstat option
 --------------------------------------------------------
 
 Another seemingly simpler and attractive option was suggested by
-Nick Coghlan in this `June 2014 python-dev message
+Alyssa Coghlan in this `June 2014 python-dev message
 <https://mail.python.org/pipermail/python-dev/2014-June/135261.html>`_:
 make ``DirEntry.is_X`` and ``DirEntry.lstat_result`` properties, and
 populate ``DirEntry.lstat_result`` at iteration time, but only if
@@ -586,12 +586,12 @@ See also some previous discussion:
 
 * `May 2013 python-dev thread
   <https://mail.python.org/pipermail/python-dev/2013-May/126148.html>`_
-  where Nick Coghlan makes the original case for a ``DirEntry``-style
+  where Alyssa Coghlan makes the original case for a ``DirEntry``-style
   object.
 
 * `June 2014 python-dev thread
   <https://mail.python.org/pipermail/python-dev/2014-June/135244.html>`_
-  where Nick Coghlan makes (another) good case against the two-tuple
+  where Alyssa Coghlan makes (another) good case against the two-tuple
   approach.
 
 
@@ -659,7 +659,7 @@ Previous discussion
 
 * `Further May 2013 thread Ben Hoyt started on python-dev
   <https://mail.python.org/pipermail/python-dev/2013-May/126119.html>`_
-  that refined the ``scandir()`` API, including Nick Coghlan's
+  that refined the ``scandir()`` API, including Alyssa Coghlan's
   suggestion of scandir yielding ``DirEntry``-like objects
 
 * `November 2013 thread Ben Hoyt started on python-dev

--- a/peps/pep-0474.rst
+++ b/peps/pep-0474.rst
@@ -2,7 +2,7 @@ PEP: 474
 Title: Creating forge.python.org
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Withdrawn
 Type: Process
 Content-Type: text/x-rst

--- a/peps/pep-0477.rst
+++ b/peps/pep-0477.rst
@@ -1,7 +1,7 @@
 PEP: 477
 Title: Backport ensurepip (PEP 453) to Python 2.7
 Author: Donald Stufft <donald@stufft.io>,
-        Nick Coghlan <ncoghlan@gmail.com>
+        Alyssa Coghlan <ncoghlan@gmail.com>
 BDFL-Delegate: Benjamin Peterson <benjamin@python.org>
 Status: Final
 Type: Standards Track

--- a/peps/pep-0479.rst
+++ b/peps/pep-0479.rst
@@ -210,7 +210,7 @@ implementation of ``groupby`` [5]_ currently has comments "Exit on
 propagate and then be handled.  This will be unusual, but not unknown,
 and such constructs will fail.  Other examples abound, e.g. [6]_, [7]_.
 
-(Nick Coghlan comments: """If you wanted to factor out a helper
+(Alyssa Coghlan comments: """If you wanted to factor out a helper
 function that terminated the generator you'd have to do "return
 yield from helper()" rather than just "helper()".""")
 
@@ -425,7 +425,7 @@ exception.
 Supplying a specific exception to raise on return
 -------------------------------------------------
 
-Nick Coghlan suggested a means of providing a specific
+Alyssa (Nick) Coghlan suggested a means of providing a specific
 ``StopIteration`` instance to the generator; if any other instance of
 ``StopIteration`` is raised, it is an error, but if that particular
 one is raised, the generator has properly completed.  This subproposal
@@ -443,7 +443,7 @@ raising ``StopIteration``, it raises a specific subclass of
 If it is not that subclass, it is an escaping exception rather than a
 return statement.
 
-The inspiration for this alternative proposal was Nick's observation
+The inspiration for this alternative proposal was Alyssa's observation
 [8]_ that if an ``asyncio`` coroutine [9]_ accidentally raises
 ``StopIteration``, it currently terminates silently, which may present
 a hard-to-debug mystery to the developer.  The main proposal turns
@@ -502,7 +502,7 @@ avoid a ``try/except`` block.
 Sub-proposal: decorator to explicitly request current behaviour
 ---------------------------------------------------------------
 
-Nick Coghlan suggested [11]_ that the situations where the current
+Alyssa Coghlan suggested [11]_ that the situations where the current
 behaviour is desired could be supported by means of a decorator::
 
     from itertools import allow_implicit_stop
@@ -598,7 +598,7 @@ References
 .. [7] wrap unbounded generator to restrict its output
    (http://code.activestate.com/recipes/66427-wrap-unbounded-generator-to-restrict-its-output/)
 
-.. [8] Post from Nick Coghlan mentioning asyncio
+.. [8] Post from Alyssa (Nick) Coghlan mentioning asyncio
    (https://mail.python.org/pipermail/python-ideas/2014-November/029961.html)
 
 .. [9] Coroutines in asyncio
@@ -607,7 +607,7 @@ References
 .. [10] Post from Mark Shannon with alternate proposal
    (https://mail.python.org/pipermail/python-dev/2014-November/137129.html)
 
-.. [11] Idea from Nick Coghlan
+.. [11] Idea from Alyssa Coghlan
    (https://mail.python.org/pipermail/python-dev/2014-November/137201.html)
 
 .. [12] Rejection of above idea by GvR

--- a/peps/pep-0480.rst
+++ b/peps/pep-0480.rst
@@ -898,7 +898,7 @@ conclusions or recommendations expressed in this material are those of the
 author(s) and do not necessarily reflect the views of the National Science
 Foundation.
 
-We thank Nick Coghlan, Daniel Holth, Donald Stufft, Sumana
+We thank Alyssa Coghlan, Daniel Holth, Donald Stufft, Sumana
 Harihareswara, and the distutils-sig community in general for helping
 us to think about how to usably and efficiently integrate TUF with
 PyPI.

--- a/peps/pep-0487.rst
+++ b/peps/pep-0487.rst
@@ -455,7 +455,7 @@ This got its own :pep:`520`.
 History
 =======
 
-This used to be a competing proposal to :pep:`422` by Nick Coghlan and Daniel
+This used to be a competing proposal to :pep:`422` by Alyssa Coghlan and Daniel
 Urban. :pep:`422` intended to achieve the same goals as this PEP, but with a
 different way of implementation.  In the meantime, :pep:`422` has been withdrawn
 favouring this approach.

--- a/peps/pep-0489.rst
+++ b/peps/pep-0489.rst
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Petr Viktorin <encukou@gmail.com>,
         Stefan Behnel <stefan_ml@behnel.de>,
-        Nick Coghlan <ncoghlan@gmail.com>
+        Alyssa Coghlan <ncoghlan@gmail.com>
 BDFL-Delegate: Eric Snow <ericsnowcurrently@gmail.com>
 Discussions-To: import-sig@python.org
 Status: Final
@@ -812,8 +812,8 @@ This proposal did not correspond to the (then nonexistent) :pep:`451`,
 where module creation and initialization is broken into distinct steps.
 It also did not support loading an extension into pre-existing module objects.
 
-Nick Coghlan proposed "Create" and "Exec" hooks, and wrote a prototype
-implementation [#nicks-prototype]_.
+Alyssa (Nick) Coghlan proposed "Create" and "Exec" hooks, and wrote a prototype
+implementation [#alyssas-prototype]_.
 At this time :pep:`451` was still not implemented, so the prototype
 does not use ModuleSpec.
 
@@ -837,7 +837,7 @@ References
 .. [#stefans_protopep]
    https://mail.python.org/pipermail/python-dev/2013-August/128087.html
 
-.. [#nicks-prototype]
+.. [#alyssas-prototype]
    https://mail.python.org/pipermail/python-dev/2013-August/128101.html
 
 .. [#gh-repo]

--- a/peps/pep-0492.rst
+++ b/peps/pep-0492.rst
@@ -1444,7 +1444,7 @@ Acknowledgments
 
 I thank Guido van Rossum, Victor Stinner, Elvis Pranskevichus, Andrew
 Svetlov, Łukasz Langa, Greg Ewing, Stephen J. Turnbull, Jim J. Jewett,
-Brett Cannon, Nick Coghlan, Steven D'Aprano, Paul Moore, Nathaniel
+Brett Cannon, Alyssa Coghlan, Steven D'Aprano, Paul Moore, Nathaniel
 Smith, Ethan Furman, Stefan Behnel, Paul Sokolovsky, Victor Petrovykh,
 and many others for their feedback, ideas, edits, criticism, code
 reviews, and discussions around this PEP.

--- a/peps/pep-0493.rst
+++ b/peps/pep-0493.rst
@@ -2,7 +2,7 @@ PEP: 493
 Title: HTTPS verification migration tools for Python 2.7
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>,
+Author: Alyssa Coghlan <ncoghlan@gmail.com>,
         Robert Kuska <rkuska@redhat.com>,
         Marc-André Lemburg <mal@lemburg.com>
 BDFL-Delegate: Barry Warsaw

--- a/peps/pep-0496.rst
+++ b/peps/pep-0496.rst
@@ -3,7 +3,7 @@ Title: Environment Markers
 Version: $Revision$
 Last-Modified: $Date$
 Author: James Polley <jp@jamezpolley.com>
-BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
+BDFL-Delegate: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Rejected
 Type: Informational
 Topic: Packaging

--- a/peps/pep-0499.rst
+++ b/peps/pep-0499.rst
@@ -1,7 +1,7 @@
 PEP: 499
 Title: ``python -m foo`` should also bind ``'foo'`` in ``sys.modules``
 Author: Cameron Simpson <cs@cskk.id.au>, Chris Angelico <rosuav@gmail.com>, Joseph Jevnik <joejev@gmail.com>
-BDFL-Delegate: Nick Coghlan
+BDFL-Delegate: Alyssa Coghlan
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst
@@ -95,7 +95,7 @@ simple change to the way the ``-m`` option is implemented: in addition
 to binding the module object to ``sys.modules['__main__']``, it is also
 bound to ``sys.modules['module.name']``.
 
-Nick Coghlan has suggested that this is as simple as modifying the
+Alyssa (Nick) Coghlan has suggested that this is as simple as modifying the
 ``runpy`` module's ``_run_module_as_main`` function as follows::
 
     main_globals = sys.modules["__main__"].__dict__
@@ -120,7 +120,7 @@ Considerations and Prerequisites
 Pickling Modules
 ----------------
 
-Nick has mentioned `issue 19702`_ which proposes (quoted from the issue):
+Alyssa has mentioned `issue 19702`_ which proposes (quoted from the issue):
 
 - runpy will ensure that when __main__ is executed via the import
   system, it will also be aliased in sys.modules as __spec__.name

--- a/peps/pep-0501.rst
+++ b/peps/pep-0501.rst
@@ -2,7 +2,7 @@ PEP: 501
 Title: General purpose string interpolation
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0504.rst
+++ b/peps/pep-0504.rst
@@ -2,7 +2,7 @@ PEP: 504
 Title: Using the System RNG by default
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0506.rst
+++ b/peps/pep-0506.rst
@@ -141,7 +141,7 @@ The consensus appears to be that there is no need to add a new CSPRNG to
 the ``random`` module to support these uses, ``SystemRandom`` will be
 sufficient.
 
-Some illustrative implementations have been given by Nick Coghlan [#]_
+Some illustrative implementations have been given by Alyssa (Nick) Coghlan [#]_
 and a minimalist API by Tim Peters [#]_. This idea has also been discussed
 on the issue tracker for the "cryptography" module [#]_.  The following
 pseudo-code should be taken as the starting point for the real
@@ -226,7 +226,7 @@ module [#]_.  This received considerable scepticism and outright opposition:
   without a proven attack against Python applications, many people object
   to a backwards-incompatible change.
 
-Nick Coghlan made an :pep:`earlier suggestion <504>`
+Alyssa Coghlan made an :pep:`earlier suggestion <504>`
 for a globally configurable PRNG
 which uses the system CSPRNG by default, but has since withdrawn it
 in favour of this proposal.
@@ -342,7 +342,7 @@ Frequently Asked Questions
   A: No. This is a "batteries included" solution, not a full-featured
   "nuclear reactor".  It is intended to mitigate against some basic
   security errors, not be a solution to all security-related issues. To
-  quote Nick Coghlan referring to his earlier proposal [#]_::
+  quote Alyssa Coghlan referring to her earlier proposal [#]_::
 
       "...folks really are better off learning to use things like
       cryptography.io for security sensitive software, so this change

--- a/peps/pep-0509.rst
+++ b/peps/pep-0509.rst
@@ -345,7 +345,7 @@ There are multiple issues:
 
 Mandatory bikeshedding on the property name:
 
-* ``__cache_token__``: name proposed by Nick Coghlan, name coming from
+* ``__cache_token__``: name proposed by Alyssa Coghlan, name coming from
   `abc.get_cache_token()
   <https://docs.python.org/3/library/abc.html#abc.get_cache_token>`_.
 * ``__version__``

--- a/peps/pep-0513.rst
+++ b/peps/pep-0513.rst
@@ -3,7 +3,7 @@ Title: A Platform Tag for Portable Linux Built Distributions
 Version: $Revision$
 Last-Modified: $Date$
 Author: Robert T. McGibbon <rmcgibbo@gmail.com>, Nathaniel J. Smith <njs@pobox.com>
-BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
+BDFL-Delegate: Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: distutils-sig@python.org
 Status: Superseded
 Type: Informational

--- a/peps/pep-0516.rst
+++ b/peps/pep-0516.rst
@@ -2,7 +2,7 @@ PEP: 516
 Title: Build system abstraction for pip/conda etc
 Author: Robert Collins <rbtcollins@hp.com>,
         Nathaniel J. Smith <njs@pobox.com>
-BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
+BDFL-Delegate: Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: distutils-sig@python.org
 Status: Rejected
 Type: Standards Track

--- a/peps/pep-0517.rst
+++ b/peps/pep-0517.rst
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Nathaniel J. Smith <njs@pobox.com>,
         Thomas Kluyver <thomas@kluyver.me.uk>
-BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
+BDFL-Delegate: Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: distutils-sig@python.org
 Status: Final
 Type: Standards Track

--- a/peps/pep-0518.rst
+++ b/peps/pep-0518.rst
@@ -3,7 +3,7 @@ Title: Specifying Minimum Build System Requirements for Python Projects
 Author: Brett Cannon <brett@python.org>,
         Nathaniel J. Smith <njs@pobox.com>,
         Donald Stufft <donald@stufft.io>
-BDFL-Delegate: Nick Coghlan
+BDFL-Delegate: Alyssa Coghlan
 Discussions-To: distutils-sig@python.org
 Status: Final
 Type: Standards Track

--- a/peps/pep-0520.rst
+++ b/peps/pep-0520.rst
@@ -419,7 +419,7 @@ References
 * `Follow-up 2
   <https://mail.python.org/pipermail/python-dev/2015-May/140137.html>`__
 
-* `Nick Coghlan's concerns about mutability
+* `Alyssa (Nick) Coghlan's concerns about mutability
   <https://mail.python.org/pipermail/python-dev/2016-June/144883.html>`__
 
 Copyright

--- a/peps/pep-0522.rst
+++ b/peps/pep-0522.rst
@@ -2,7 +2,7 @@ PEP: 522
 Title: Allow BlockingIOError in security sensitive APIs
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>, Nathaniel J. Smith <njs@pobox.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>, Nathaniel J. Smith <njs@pobox.com>
 Status: Rejected
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0527.rst
+++ b/peps/pep-0527.rst
@@ -3,7 +3,7 @@ Title: Removing Un(der)used file types/extensions on PyPI
 Version: $Revision$
 Last-Modified: $Date$
 Author: Donald Stufft <donald@stufft.io>
-BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
+BDFL-Delegate: Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: distutils-sig@python.org
 Status: Final
 Type: Standards Track

--- a/peps/pep-0531.rst
+++ b/peps/pep-0531.rst
@@ -2,7 +2,7 @@ PEP: 531
 Title: Existence checking operators
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0532.rst
+++ b/peps/pep-0532.rst
@@ -2,7 +2,7 @@ PEP: 532
 Title: A circuit breaking protocol and binary operators
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>,
+Author: Alyssa Coghlan <ncoghlan@gmail.com>,
         Mark E. Haase <mehaase@gmail.com>
 Status: Deferred
 Type: Standards Track

--- a/peps/pep-0534.rst
+++ b/peps/pep-0534.rst
@@ -2,7 +2,7 @@ PEP: 534
 Title: Improved Errors for Missing Standard Library Modules
 Author: Tomáš Orsava <tomas.n@orsava.cz>,
         Petr Viktorin <encukou@gmail.com>,
-        Nick Coghlan <ncoghlan@gmail.com>
+        Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0535.rst
+++ b/peps/pep-0535.rst
@@ -2,7 +2,7 @@ PEP: 535
 Title: Rich comparison chaining
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0538.rst
+++ b/peps/pep-0538.rst
@@ -2,7 +2,7 @@ PEP: 538
 Title: Coercing the legacy C locale to a UTF-8 based locale
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 BDFL-Delegate: INADA Naoki
 Status: Final
 Type: Standards Track
@@ -1093,7 +1093,7 @@ Implementation
 ==============
 
 The reference implementation is being developed in the
-``pep538-coerce-c-locale`` feature branch [18]_ in Nick Coghlan's fork of the
+``pep538-coerce-c-locale`` feature branch [18]_ in Alyssa Coghlan's fork of the
 CPython repository on GitHub. A work-in-progress PR is available at [20]_.
 
 This reference implementation covers not only the enhancement request in

--- a/peps/pep-0539.rst
+++ b/peps/pep-0539.rst
@@ -3,7 +3,7 @@ Title: A New C-API for Thread-Local Storage in CPython
 Version: $Revision$
 Last-Modified: $Date$
 Author: Erik M. Bray, Masayuki Yamamoto
-BDFL-Delegate: Nick Coghlan
+BDFL-Delegate: Alyssa Coghlan
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0543.rst
+++ b/peps/pep-0543.rst
@@ -1532,7 +1532,7 @@ by:
 * Hynek Schlawack
 * Jim J Jewett
 * Nathaniel J. Smith
-* Nick Coghlan
+* Alyssa Coghlan
 * Paul Kehrer
 * Steve Dower
 * Steven Fackler

--- a/peps/pep-0550.rst
+++ b/peps/pep-0550.rst
@@ -1611,7 +1611,7 @@ Thanks to Nathaniel Smith for proposing the ``ContextVar`` design
 coming up with the idea of having a stack of contexts in the thread
 state.
 
-Thanks to Nick Coghlan for numerous suggestions and ideas on the
+Thanks to Alyssa (Nick) Coghlan for numerous suggestions and ideas on the
 mailing list, and for coming up with a case that cause the complete
 rewrite of the initial PEP version [19]_.
 
@@ -1638,7 +1638,7 @@ Version History
    * Local Context was renamed to Logical Context.  The term "local"
      was ambiguous and conflicted with local name scopes.
 
-   * Context Item was renamed to Context Key, see the thread with Nick
+   * Context Item was renamed to Context Key, see the thread with Alyssa
      Coghlan, Stefan Krah, and Yury Selivanov [23]_ for details.
 
    * Context Item get cache design was adjusted, per Nathaniel Smith's
@@ -1646,7 +1646,7 @@ Version History
 
    * Coroutines are created without a Logical Context; ceval loop
      no longer needs to special case the ``await`` expression
-     (proposed by Nick Coghlan in [24]_.)
+     (proposed by Alyssa Coghlan in [24]_.)
 
 4. V4 posted on 25-Aug-2017 [31]_.
 
@@ -1674,7 +1674,7 @@ Version History
    * All APIs have been placed to the ``contextvars`` module, and
      the factory functions were changed to class constructors
      (``ContextVar``, ``ExecutionContext``, and ``LogicalContext``).
-     Thanks to Nick for the idea [33]_.
+     Thanks to Alyssa for the idea [33]_.
 
    * ``ContextVar.lookup()`` got renamed back to ``ContextVar.get()``
      and gained the ``topmost`` and ``default`` keyword arguments.

--- a/peps/pep-0554.rst
+++ b/peps/pep-0554.rst
@@ -333,7 +333,7 @@ isolation within the same process.  This can be leveraged in a number
 of ways.  Furthermore, subinterpreters provide a well-defined framework
 in which such isolation may extended.  (See :pep:`684`.)
 
-Nick Coghlan explained some of the benefits through a comparison with
+Alyssa (Nick) Coghlan explained some of the benefits through a comparison with
 multi-processing [benefits]_::
 
    [I] expect that communicating between subinterpreters is going

--- a/peps/pep-0558.rst
+++ b/peps/pep-0558.rst
@@ -1,6 +1,6 @@
 PEP: 558
 Title: Defined semantics for locals()
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 BDFL-Delegate: Nathaniel J. Smith
 Discussions-To: python-dev@python.org
 Status: Deferred

--- a/peps/pep-0561.rst
+++ b/peps/pep-0561.rst
@@ -270,7 +270,7 @@ Acknowledgements
 ================
 
 This PEP would not have been possible without the ideas, feedback, and support
-of Ivan Levkivskyi, Jelle Zijlstra, Nick Coghlan, Daniel F Moisset, Andrey
+of Ivan Levkivskyi, Jelle Zijlstra, Alyssa Coghlan, Daniel F Moisset, Andrey
 Vlasovskikh, Nathaniel Smith, and Guido van Rossum.
 
 

--- a/peps/pep-0563.rst
+++ b/peps/pep-0563.rst
@@ -585,7 +585,7 @@ requirement to call ``eval()`` on the annotation with the correct
 ``globals`` and ``locals`` set.
 
 This detail about ``globals`` and ``locals`` having to be correct was
-picked up by a number of commenters.  Nick Coghlan benchmarked turning
+picked up by a number of commenters.  Alyssa (Nick) Coghlan benchmarked turning
 annotations into lambdas instead of strings, sadly this proved to be
 much slower at runtime than the current situation.
 
@@ -597,10 +597,10 @@ and modal support to either perform or not perform evaluation is
 a messy solution.  His biggest concern remained loss of functionality
 stemming from the evaluation restrictions on global and local scope.
 
-Nick Coghlan pointed out that some of those evaluation restrictions from
+Alyssa Coghlan pointed out that some of those evaluation restrictions from
 the PEP could be lifted by a clever implementation of an evaluation
 helper, which could solve self-referencing classes even in the form of a
-class decorator.  He suggested the PEP should provide this helper
+class decorator.  She suggested the PEP should provide this helper
 function in the standard library.
 
 Second draft discussion on python-dev
@@ -617,7 +617,7 @@ linters or programming text editors) will catch this type of error.
 Jukka Lehtosalo added that this situation is analogous to how names in
 function bodies are not resolved until the function is called.
 
-A major topic of discussion was Nick Coghlan's suggestion to store
+A major topic of discussion was Alyssa Coghlan's suggestion to store
 annotations in "thunk form", in other words as a specialized lambda
 which would be able to access class-level scope (and allow for scope
 customization at call time).  He presented a possible design for it
@@ -642,7 +642,7 @@ introspectable as strings.  Most importantly, Guido van Rossum
 explicitly stated interest in gradually restricting the use of
 annotations to static typing (with an optional runtime component).
 
-Nick Coghlan got convinced to :pep:`563`, too, promptly beginning
+Alyssa Coghlan got convinced to :pep:`563`, too, promptly beginning
 the mandatory bike shedding session on the name of the ``__future__``
 import.  Many debaters agreed that ``annotations`` seems like
 an overly broad name for the feature name.  Guido van Rossum briefly

--- a/peps/pep-0565.rst
+++ b/peps/pep-0565.rst
@@ -1,6 +1,6 @@
 PEP: 565
 Title: Show DeprecationWarning in __main__
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0566.rst
+++ b/peps/pep-0566.rst
@@ -175,7 +175,7 @@ This document has been placed in the public domain.
 Acknowledgements
 ================
 
-Thanks to Nick Coghlan and Thomas Kluyver for contributing to this PEP.
+Thanks to Alyssa Coghlan and Thomas Kluyver for contributing to this PEP.
 
 
 ..

--- a/peps/pep-0567.rst
+++ b/peps/pep-0567.rst
@@ -883,7 +883,7 @@ Acknowledgments
 ===============
 
 I thank Guido van Rossum, Nathaniel Smith, Victor Stinner,
-Elvis Pranskevichus, Nick Coghlan, Antoine Pitrou, INADA Naoki,
+Elvis Pranskevichus, Alyssa Coghlan, Antoine Pitrou, INADA Naoki,
 Paul Moore, Eric Snow, Greg Ewing, and many others for their feedback,
 ideas, edits, criticism, code reviews, and discussions around
 this PEP.

--- a/peps/pep-0571.rst
+++ b/peps/pep-0571.rst
@@ -3,7 +3,7 @@ Title: The manylinux2010 Platform Tag
 Author: Mark  Williams <mrw@enotuniq.org>,
         Geoffrey Thomas <geofft@ldpreload.com>,
         Thomas Kluyver <thomas@kluyver.me.uk>
-BDFL-Delegate: Nick Coghlan <ncoghlan@gmail.com>
+BDFL-Delegate: Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: distutils-sig@python.org
 Status: Superseded
 Type: Informational

--- a/peps/pep-0572.rst
+++ b/peps/pep-0572.rst
@@ -967,7 +967,7 @@ benefit of style guides such as :pep:`8`, two recommendations are suggested.
 Acknowledgements
 ================
 
-The authors wish to thank Nick Coghlan and Steven D'Aprano for their
+The authors wish to thank Alyssa Coghlan and Steven D'Aprano for their
 considerable contributions to this proposal, and members of the
 core-mentorship mailing list for assistance with implementation.
 

--- a/peps/pep-0573.rst
+++ b/peps/pep-0573.rst
@@ -3,7 +3,7 @@ Title: Module State Access from C Extension Methods
 Version: $Revision$
 Last-Modified: $Date$
 Author: Petr Viktorin <encukou@gmail.com>,
-        Nick Coghlan <ncoghlan@gmail.com>,
+        Alyssa Coghlan <ncoghlan@gmail.com>,
         Eric Snow <ericsnowcurrently@gmail.com>,
         Marcel Plch <gmarcel.plch@gmail.com>
 BDFL-Delegate: Stefan Behnel

--- a/peps/pep-0574.rst
+++ b/peps/pep-0574.rst
@@ -3,7 +3,7 @@ Title: Pickle protocol 5 with out-of-band data
 Version: $Revision$
 Last-Modified: $Date$
 Author: Antoine Pitrou <solipsis@pitrou.net>
-BDFL-Delegate: Nick Coghlan
+BDFL-Delegate: Alyssa Coghlan
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
@@ -512,7 +512,7 @@ scheme.
 Acknowledgements
 ================
 
-Thanks to the following people for early feedback: Nick Coghlan, Olivier
+Thanks to the following people for early feedback: Alyssa Coghlan, Olivier
 Grisel, Stefan Krah, MinRK, Matt Rocklin, Eric Snow.
 
 Thanks to Pierre Glaser and Olivier Grisel for experimenting with the

--- a/peps/pep-0577.rst
+++ b/peps/pep-0577.rst
@@ -1,6 +1,6 @@
 PEP: 577
 Title: Augmented Assignment Expressions
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-0581.rst
+++ b/peps/pep-0581.rst
@@ -221,7 +221,7 @@ You can post questions on Discourse under the
 Acknowledgements
 ================
 
-Thanks to Guido van Rossum, Brett Cannon, and Nick Coghlan, who were consulted
+Thanks to Guido van Rossum, Brett Cannon, and Alyssa Coghlan, who were consulted
 in the early stage and research of this PEP. Their feedback, concerns, input,
 and ideas have been valuable.
 

--- a/peps/pep-0582.rst
+++ b/peps/pep-0582.rst
@@ -3,7 +3,7 @@ Title: Python local packages directory
 Version: $Revision$
 Last-Modified: $Date$
 Author: Kushal Das <mail@kushaldas.in>, Steve Dower <steve.dower@python.org>,
-        Donald Stufft <donald@stufft.io>, Nick Coghlan <ncoghlan@gmail.com>
+        Donald Stufft <donald@stufft.io>, Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-582-python-local-packages-directory/963/
 Status: Rejected
 Type: Standards Track

--- a/peps/pep-0584.rst
+++ b/peps/pep-0584.rst
@@ -595,7 +595,7 @@ Disadvantages
 
 * It isn't an operator.  Guido discusses `why operators are useful
   <https://mail.python.org/archives/list/python-ideas@python.org/message/52DLME5DKNZYFEETCTRENRNKWJ2B4DD5/>`_.
-  For another viewpoint, see `Nick Coghlan's blog post
+  For another viewpoint, see `Alyssa Coghlan's blog post
   <https://www.curiousefficiency.org/posts/2019/03/what-does-x-equals-a-plus-b-mean.html>`_.
 
 

--- a/peps/pep-0587.rst
+++ b/peps/pep-0587.rst
@@ -1,6 +1,6 @@
 PEP: 587
 Title: Python Initialization Configuration
-Author: Victor Stinner <vstinner@python.org>, Nick Coghlan <ncoghlan@gmail.com>
+Author: Victor Stinner <vstinner@python.org>, Alyssa Coghlan <ncoghlan@gmail.com>
 BDFL-Delegate: Thomas Wouters <thomas@python.org>
 Discussions-To: python-dev@python.org
 Status: Final

--- a/peps/pep-0588.rst
+++ b/peps/pep-0588.rst
@@ -264,7 +264,7 @@ Can the list be shortened?
 Priority list
 -------------
 
-Is the current "priority" list useful? Nick Coghlan noted that perhaps only
+Is the current "priority" list useful? Alyssa Coghlan noted that perhaps only
 ``release blocker`` and ``deferred blocker`` are useful.
 
 
@@ -278,7 +278,7 @@ You can post questions on Discourse under the
 Acknowledgements
 ================
 
-Thanks to Guido van Rossum, Brett Cannon, and Nick Coghlan, who were consulted
+Thanks to Guido van Rossum, Brett Cannon, and Alyssa Coghlan, who were consulted
 in the early stage and research of this PEP. Their feedback, concerns, input,
 and ideas have been valuable.
 

--- a/peps/pep-0594.rst
+++ b/peps/pep-0594.rst
@@ -593,7 +593,7 @@ the ``array`` module could gain support for 24-bit (3-byte) arrays.
 Discussions
 ===========
 
-* Elana Hashman and Nick Coghlan suggested to keep the ``getopt`` module.
+* Elana Hashman and Alyssa Coghlan suggested to keep the ``getopt`` module.
 * Berker Peksag proposed to deprecate and remove ``msilib``.
 * Brett Cannon recommended to delay active deprecation warnings and removal
   of modules like ``imp`` until Python 3.10. Version 3.8 will be released
@@ -603,7 +603,7 @@ Discussions
   To avoid lengthy discussion and delay of the PEP, I decided against dealing
   with distutils. Deprecation of the distutils package will be handled by
   another PEP.
-* Multiple people (Gregory P. Smith, David Beazley, Nick Coghlan, ...)
+* Multiple people (Gregory P. Smith, David Beazley, Alyssa Coghlan, ...)
   convinced me to keep the `wave`_ module. [4]_
 * Gregory P. Smith proposed to deprecate `nntplib`_. [4]_
 * Andrew Svetlov mentioned the ``socketserver`` module is questionable.

--- a/peps/pep-0598.rst
+++ b/peps/pep-0598.rst
@@ -2,7 +2,7 @@ PEP: 598
 Title: Introducing incremental feature releases
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-596-python-3-9-release-schedule-doubling-the-release-cadence/1828
 Status: Withdrawn
 Type: Informational

--- a/peps/pep-0601.rst
+++ b/peps/pep-0601.rst
@@ -1,7 +1,7 @@
 PEP: 601
 Title: Forbid return/break/continue breaking out of finally
 Author: Damien George, Batuhan Taskaya
-Sponsor: Nick Coghlan
+Sponsor: Alyssa Coghlan
 Discussions-To: https://discuss.python.org/t/pep-601-forbid-return-break-continue-breaking-out-of-finally/2239
 Status: Rejected
 Type: Standards Track

--- a/peps/pep-0605.rst
+++ b/peps/pep-0605.rst
@@ -2,7 +2,7 @@ PEP: 605
 Title: A rolling feature release stream for CPython
 Version: $Revision$
 Last-Modified: $Date$
-Author: Steve Dower <steve.dower@python.org>, Nick Coghlan <ncoghlan@gmail.com>
+Author: Steve Dower <steve.dower@python.org>, Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-605-a-rolling-feature-release-stream-for-cpython/2418
 Status: Rejected
 Type: Informational

--- a/peps/pep-0607.rst
+++ b/peps/pep-0607.rst
@@ -4,7 +4,7 @@ Version: $Revision$
 Last-Modified: $Date$
 Author: Łukasz Langa <lukasz@python.org>,
         Steve Dower <steve.dower@python.org>,
-        Nick Coghlan <ncoghlan@gmail.com>
+        Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-607-shared-background-for-the-release-cadence-peps/2528
 Status: Final
 Type: Informational

--- a/peps/pep-0610.rst
+++ b/peps/pep-0610.rst
@@ -1,7 +1,7 @@
 PEP: 610
 Title: Recording the Direct URL Origin of installed distributions
 Author: Stéphane Bidoul <stephane.bidoul@gmail.com>, Chris Jerdonek <chris.jerdonek@gmail.com>
-Sponsor: Nick Coghlan <ncoghlan@gmail.com>
+Sponsor: Alyssa Coghlan <ncoghlan@gmail.com>
 BDFL-Delegate: Pradyun Gedam <pradyunsg@gmail.com>
 Discussions-To: https://discuss.python.org/t/recording-the-source-url-of-an-installed-distribution/1535
 Status: Final
@@ -552,7 +552,7 @@ Acknowledgements
 ================
 
 Various people helped make this PEP a reality. Paul F. Moore provided the
-essence of the abstract. Nick Coghlan suggested the direct_url name.
+essence of the abstract. Alyssa Coghlan suggested the direct_url name.
 
 Copyright
 =========

--- a/peps/pep-0628.rst
+++ b/peps/pep-0628.rst
@@ -2,7 +2,7 @@ PEP: 628
 Title: Add ``math.tau``
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
@@ -27,7 +27,7 @@ PEP Acceptance
 ==============
 
 This PEP is now `accepted`_ and ``math.tau`` will be a part of Python 3.6.
-Happy birthday Nick!
+Happy birthday Alyssa!
 
 The idea in this PEP has been implemented in the auspiciously named
 `issue 12345`_.

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -2771,7 +2771,7 @@ References
 Acknowledgments
 ===============
 
-- Nick Coghlan
+- Alyssa Coghlan
 - Kevin P. Fleming
 - Pradyun Gedam
 - Oleg Grenrus

--- a/peps/pep-0642.rst
+++ b/peps/pep-0642.rst
@@ -2,7 +2,7 @@ PEP: 642
 Title: Explicit Pattern Syntax for Structural Pattern Matching
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 BDFL-Delegate:
 Discussions-To: python-dev@python.org
 Status: Rejected

--- a/peps/pep-0654.rst
+++ b/peps/pep-0654.rst
@@ -1456,7 +1456,7 @@ and elsewhere helped us improve upon the first draft of the PEP in multiple
 ways, both the design and the exposition. For this we appreciate all those who
 contributed ideas and asked good questions:  Ammar Askar, Matthew Barnett,
 Ran Benita, Emily Bowman, Brandt Bucher, Joao Bueno, Baptiste Carvello,
-Rob Cliffe, Nick Coghlan, Steven D'Aprano, Caleb Donovick, Steve Dower,
+Rob Cliffe, Alyssa Coghlan, Steven D'Aprano, Caleb Donovick, Steve Dower,
 Greg Ewing, Ethan Furman, Pablo Salgado, Jonathan Goble, Joe Gottman, Thomas Grainger,
 Larry Hastings, Zac Hatfield-Dodds, Chris Jerdonek, Jim Jewett, Sven Kunze,
 Łukasz Langa, Glenn Linderman, Paul Moore, Antoine Pitrou, Ivan Pozdeev,

--- a/peps/pep-3104.rst
+++ b/peps/pep-3104.rst
@@ -513,7 +513,7 @@ References
 .. [25] Draft PEP for outer scopes (Talin)
    https://mail.python.org/pipermail/python-3000/2006-November/004190.html
 
-.. [26] Draft PEP for outer scopes (Nick Coghlan)
+.. [26] Draft PEP for outer scopes (Alyssa Coghlan)
    https://mail.python.org/pipermail/python-3000/2006-November/004237.html
 
 .. [27] Global variable (version 2006-11-01T01:23:16)

--- a/peps/pep-3144.rst
+++ b/peps/pep-3144.rst
@@ -3,7 +3,7 @@ Title: IP Address Manipulation Library for the Python Standard Library
 Version: $Revision$
 Last-Modified: $Date$
 Author: Peter Moody <pmoody@google.com>
-BDFL-Delegate: Nick Coghlan
+BDFL-Delegate: Alyssa Coghlan
 Discussions-To: ipaddr-py-dev@googlegroups.com
 Status: Final
 Type: Standards Track
@@ -23,7 +23,7 @@ python.
 PEP Acceptance
 ==============
 
-This PEP was accepted by Nick Coghlan on the 15th of May, 2012.
+This PEP was accepted by Alyssa Coghlan on the 15th of May, 2012.
 
 
 Motivation

--- a/peps/pep-3150.rst
+++ b/peps/pep-3150.rst
@@ -2,7 +2,7 @@ PEP: 3150
 Title: Statement local namespaces (aka "given" clause)
 Version: $Revision$
 Last-Modified: $Date$
-Author: Nick Coghlan <ncoghlan@gmail.com>
+Author: Alyssa Coghlan <ncoghlan@gmail.com>
 Status: Deferred
 Type: Standards Track
 Content-Type: text/x-rst

--- a/peps/pep-3151.rst
+++ b/peps/pep-3151.rst
@@ -937,7 +937,7 @@ zipimporter.get_data() can raise IOError.
 Acknowledgments
 ===============
 
-Significant input has been received from Nick Coghlan.
+Significant input has been received from Alyssa Coghlan.
 
 References
 ==========

--- a/peps/pep-3156.rst
+++ b/peps/pep-3156.rst
@@ -2057,7 +2057,7 @@ References
 
 - PyPI: the Python Package Index at http://pypi.python.org/
 
-- Nick Coghlan wrote a nice blog post with some background, thoughts
+- Alyssa Coghlan wrote a nice blog post with some background, thoughts
   about different approaches to async I/O, gevent, and how to use
   futures with constructs like ``while``, ``for`` and ``with``:
   http://python-notes.boredomandlaziness.org/en/latest/pep_ideas/async_programming.html

--- a/peps/pep-8015.rst
+++ b/peps/pep-8015.rst
@@ -471,7 +471,7 @@ their own PEPs.
 * Mailing list: `distutils-sig
   <https://mail.python.org/mm3/mailman3/lists/distutils-sig.python.org/>`_
 * Bug tracker component: ``Distutils``
-* Example of members: Paul Moore, Nick Coghlan, Donald Stuff
+* Example of members: Paul Moore, Alyssa Coghlan, Donald Stuff
 * Stdlib module: ``distutils``
 * Current PEP delegate: Paul Moore
 

--- a/peps/pep-8100.rst
+++ b/peps/pep-8100.rst
@@ -49,7 +49,7 @@ is a core team member, they may nominate themselves.
 Once the nomination period opens, candidates will be listed here:
 
 1. `Brett Cannon <https://discuss.python.org/t/steering-council-nomination-brett-cannon/620>`_
-2. `Nick Coghlan <https://discuss.python.org/t/steering-council-nomination-nick-coghlan/624>`_
+2. `Alyssa (Nick) Coghlan <https://discuss.python.org/t/steering-council-nomination-nick-coghlan/624>`_
 3. `Barry Warsaw <https://discuss.python.org/t/steering-council-nomination-barry-warsaw/629>`__
 4. `Guido van Rossum <https://discuss.python.org/t/steering-council-nomination-guido-van-rossum/628>`__
 5. `Victor Stinner <https://discuss.python.org/t/steering-council-nomination-victor-stinner/635>`_
@@ -141,49 +141,49 @@ The top five vote-getters are:
 * Brett Cannon
 * Carol Willing
 * Guido van Rossum
-* Nick Coghlan
+* Alyssa (Nick) Coghlan
 
 No conflict of interest as defined in :pep:`13` were observed.
 
 The full vote counts are as follows:
 
-+-------------------+----------------+
-| Candidate         | Votes Received |
-+===================+================+
-| Guido van Rossum  | 45             |
-+-------------------+----------------+
-| Brett Cannon      | 44             |
-+-------------------+----------------+
-| Carol Willing     | 33             |
-+-------------------+----------------+
-| Barry Warsaw      | 31             |
-+-------------------+----------------+
-| Nick Coghlan      | 25             |
-+-------------------+----------------+
-| Benjamin Peterson | 22             |
-+-------------------+----------------+
-| Łukasz Langa      | 21             |
-+-------------------+----------------+
-| Victor Stinner    | 21             |
-+-------------------+----------------+
-| Mariatta          | 20             |
-+-------------------+----------------+
-| Emily Morehouse   | 18             |
-+-------------------+----------------+
-| Yury Selivanov    | 15             |
-+-------------------+----------------+
-| Donald Stufft     | 11             |
-+-------------------+----------------+
-| Peter Wang        | 10             |
-+-------------------+----------------+
-| Travis Oliphant   | 8              |
-+-------------------+----------------+
-| Kushal Das        | 7              |
-+-------------------+----------------+
-| Gregory P. Smith  | 6              |
-+-------------------+----------------+
-| David Mertz       | 3              |
-+-------------------+----------------+
++-----------------------+----------------+
+| Candidate             | Votes Received |
++=======================+================+
+| Guido van Rossum      | 45             |
++-----------------------+----------------+
+| Brett Cannon          | 44             |
++-----------------------+----------------+
+| Carol Willing         | 33             |
++-----------------------+----------------+
+| Barry Warsaw          | 31             |
++-----------------------+----------------+
+| Alyssa (Nick) Coghlan | 25             |
++-----------------------+----------------+
+| Benjamin Peterson     | 22             |
++-----------------------+----------------+
+| Łukasz Langa          | 21             |
++-----------------------+----------------+
+| Victor Stinner        | 21             |
++-----------------------+----------------+
+| Mariatta              | 20             |
++-----------------------+----------------+
+| Emily Morehouse       | 18             |
++-----------------------+----------------+
+| Yury Selivanov        | 15             |
++-----------------------+----------------+
+| Donald Stufft         | 11             |
++-----------------------+----------------+
+| Peter Wang            | 10             |
++-----------------------+----------------+
+| Travis Oliphant       | 8              |
++-----------------------+----------------+
+| Kushal Das            | 7              |
++-----------------------+----------------+
+| Gregory P. Smith      | 6              |
++-----------------------+----------------+
+| David Mertz           | 3              |
++-----------------------+----------------+
 
 Copyright
 =========
@@ -265,7 +265,7 @@ Active Python core developers
     Nathaniel J. Smith
     Ned Deily
     Neil Schemenauer
-    Nick Coghlan
+    Alyssa Coghlan
     Pablo Galindo
     Paul Moore
     Petr Viktorin

--- a/peps/pep-8101.rst
+++ b/peps/pep-8101.rst
@@ -238,7 +238,7 @@ Active Python core developers
     Nathaniel J. Smith
     Ned Deily
     Neil Schemenauer
-    Nick Coghlan
+    Alyssa Coghlan
     Pablo Galindo
     Paul Ganssle
     Paul Moore

--- a/peps/pep-8102.rst
+++ b/peps/pep-8102.rst
@@ -257,7 +257,7 @@ Active Python core developers
     Nathaniel J. Smith
     Ned Deily
     Neil Schemenauer
-    Nick Coghlan
+    Alyssa Coghlan
     Pablo Galindo
     Paul Ganssle
     Paul Moore

--- a/peps/pep-8103.rst
+++ b/peps/pep-8103.rst
@@ -244,7 +244,7 @@ Active Python core developers
     Nathaniel J. Smith
     Ned Deily
     Neil Schemenauer
-    Nick Coghlan
+    Alyssa Coghlan
     Pablo Galindo
     Paul Ganssle
     Paul Moore

--- a/peps/pep-8104.rst
+++ b/peps/pep-8104.rst
@@ -240,7 +240,7 @@ Active Python core developers
     Nathaniel J. Smith
     Ned Deily
     Neil Schemenauer
-    Nick Coghlan
+    Alyssa Coghlan
     Pablo Galindo
     Paul Ganssle
     Paul Moore


### PR DESCRIPTION
* For most cases (including all PEP metadata), replace birth name with chosen name
* Birth name has been retained in parentheses when this makes other references substantially clearer (e.g. references to mailing list posts, elected members of the inaugural Steering Council)

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3475.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->