### PR TITLE
PEP 9999: C API Working Group Charter

### DIFF
--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -3,7 +3,8 @@ Title: C API Working Group Charter
 Author: Guido van Rossum <guido@python.org>,
         Petr Viktorin <encukou@gmail.com>,
         Victor Stinner <vstinner@python.org>,
-        Steve Dower <steve.dower@python.org>
+        Steve Dower <steve.dower@python.org>,
+        Irit Katriel <irit@python.org>
 Discussions-To: https://discuss.python.org/t/pep-731-c-api-working-group
 Status: Draft
 Type: Process

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -1,0 +1,220 @@
+PEP: 9999
+Title: C API Working Group Process
+Author: Guido van Rossum <guido@python.org>,
+        Petr Viktorin <encukou@gmail.com>,
+        Victor Stinner <vstinner@python.org>,
+        Steve Dower <steve.dower@python.org>
+Discussions-To: https://discuss.python.org/t/pep-731-c-api-working-group-process
+Status: Draft
+Type: Process
+Topic: Typing
+Created: 11-Oct-2023
+Python-Version: 3.13
+Post-History: `11-Oct-2023 <https://discuss.python.org/t/pep-731-c-api-working-group-process>`__
+
+Abstract
+========
+
+This PEP proposes to establish the C API Working Group:
+a small committee of Python core developers responsible for
+maintaining and developing the Python C API.
+
+The working goup will maintain
+documentation, test suites and tooling related to Python's C API.
+It is the deciding body for changes to the C API,
+from the addition or removal of individual API functions, types, etc.,
+to the the acceptance of new designs of a more or less radical nature.
+
+The working goup's mandate is to represent the interests of all Python users,
+but especially all maintainers of code that uses Python's C API,
+whether in the context of CPython, using an alternate Python implementation,
+or using a binding framework for other languages.
+
+The C API Working Group serves at the pleasure of the Python Steering Council.
+The working group's members are the listed authors of this PEP.
+
+Epigraph
+========
+
+.. |br| raw:: html
+
+   <br />
+
+KEEPER
+|br|
+Stop!
+Who would cross the Bridge of Death must answer me these questions three,
+ere the other side he see.
+
+#. Who invented Python?
+#. In what year did Python 2.7 reach its End-of-Life?
+#. What is the future of the Python C API?
+
+LANCELOT
+|br|
+Auuuuuuuugh!
+
+Motivation
+==========
+
+Despite many discussions and in-person meetings at
+core developer sprints and Language Summits,
+and a thorough inventory of the problems and stakeholders of the C API,
+no consensus has been reached about many contentious issues,
+including, but not limted to:
+
+- Conventions for designing new API functions;
+- how to deal with compatibility;
+- what's the best strategy for handling errors;
+- the future of the Stable ABI and the Limited API;
+- whether to switch to a handle-based API convention (and why).
+
+The general feeling is that there are too many stakeholders,
+proposals, requirements, constraints, and conventions,
+to make any progress without having a small trusted group of deciders.
+
+At the 2023 Language Summit in Salt Lake City it was decided to start work on
+an `inventory of problems <https://github.com/capi-working-group/problems>`__.
+At the 2023 core developer sprint in Brno this work is more or less finished
+(thanks to the great moderation efforts by Irit Katriel)
+and after a discussion it appeared that the next step is to establish
+a working group to ensure that we're not stymied forever.
+
+The Steering Council has
+`indicated <https://github.com/python/steering-council/issues/201#issuecomment-1648848155>`__
+its desire to delegate decisions about the C API
+to the C API working group even before its formal establishment.
+
+Specification
+=============
+
+We propose the creation of a new group, the C API Working Group.
+This group will be responsible for developing and maintaining the Python C API,
+and for solving the above problems.
+
+The "operations and process" section describes how this group would operate and
+be governed.
+
+Mandate
+-------
+
+The C API Working Group's mandate is to ensure that the Python C API is:
+
+* **Blah**: Blah, blah.
+* **Blah**: Blah, blah.
+* **Blah**: Blah, blah.
+
+Operations and process
+----------------------
+
+XXX HIRO TODO XXX
+
+The council would have three members, comprised of prominent community members,
+such as Python core developers and maintainers of major type checkers. The members
+should include people affiliated with a variety of projects related to type checking,
+which may include type checkers, CPython, typeshed, or other projects.
+
+The Steering Council would appoint the initial Typing Council. There is no term
+limit for council members. Council members may resign their position at any time.
+There is an expectation that at least one person will voluntarily resign from the
+Typing Council each year.
+
+To determine replacements, nominations will be collected from the typing
+community. Self-nominations are allowed. The existing Typing Council will then decide
+the replacement member(s) from the nominees. The expectation is that this would
+be done by fiat, but the Typing Council can choose a replacement by any means
+they see fit, including a vote.
+
+The Typing Council remains accountable to the Steering Council. At any point,
+for any reason, the Steering Council could (publicly or privately) make a
+specific change or request a non-specific change to the composition of the
+Typing Council.
+
+We acknowledge that this is a not particularly democratic structure and puts
+a lot of faith in the Typing Council. However, the Python community has a long
+history of success with not particularly democratic structures! We believe
+self-governance, cycling of membership, and accountability to the
+Steering Council will be sufficient to ensure that the Typing Council is meeting
+the needs of the community.
+
+The council would operate primarily through reviews of GitHub PRs. Regular
+meetings are likely not necessary, but the council may set up video calls, a
+private chat, or whatever other mechanism they decide upon internally.
+
+The council should aim for transparency, posting all decisions publicly on
+`discuss.python.org <https://discuss.python.org/c/typing/32>`__, with a
+rationale if possible. Before making a decision, the council should give
+all interested community members a chance to weigh in. There should be at
+least a week between the start of a discussion and the council's decision.
+
+Members of the council will be eligible to sponsor PEPs. If this PEP is accepted,
+:pep:`1` should be amended to note this fact.
+
+Relationship with the Steering Council
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Just like today, the Python Steering Council would remain responsible for the
+overall direction of the Python language and would continue to decide on
+typing-related PEPs. The Typing Council would provide written opinions and
+recommendations to the Steering Council on typing-related PEPs.
+
+However, smaller changes to the type system could be made
+by the Typing Council directly. The Steering Council could also choose
+to delegate decisions on some PEPs to the Typing Council (exactly as any other
+PEP delegation).
+
+Some examples of how past and recent issues could have been handled under this model:
+
+- A PEP like :pep:`695` (type parameter syntax), which changes the language
+  syntax, would need to be decided upon by the Steering Council; the Typing
+  Council would merely provide opinion or endorsement. Similarly, PEPs
+  like :pep:`702` would be decided upon by the Steering
+  Council, because it concerns runtime behaviour beyond pure typing. Other examples
+  that would need to be decided by the SC include :pep:`718` and :pep:`727`.
+- A PEP like :pep:`698` (``@override``), which affects only users of type
+  checkers and does not change the overall language, would also by default
+  be decided upon by the Steering Council. However, such PEPs could be
+  delegated to the Typing Council for a decision (like any other PEP delegation).
+  Other examples of PEPs that could potentially be delegated include
+  :pep:`647`, :pep:`655`, :pep:`673`, and :pep:`675`.
+- Adding a smaller feature, such as :data:`typing.Never` as an alias for
+  :data:`typing.NoReturn`, would be done by means of a PR to the spec and
+  conformance test suite. The Typing
+  Council would then decide whether or not to merge the PR. They may ask for the
+  feature to be specified and discussed in a PEP if they feel that is warranted.
+- If there is confusion about the interpretation of some part of the spec, like
+  happened recently with `partial stubs in PEP
+  561 <https://discuss.python.org/t/pep-561-clarification-regarding-n/32875/27>`_,
+  somebody would make a PR to the typing specification to clarify the
+  spec, and then the Typing Council would decide on the spec change.
+
+The runtime :mod:`typing` module will continue to be maintained by the
+CPython core developer team. However, any changes to the runtime module that
+affect type checker behavior should be made in conjunction with a change
+to the specification (see below) and should be approved by the Typing Council.
+For example, in Python 3.11 the core developers added the new function
+:func:`typing.assert_type`. If the Typing Council had been in place, this
+change would require a matching change to the specification and approval
+by the Typing Council. On the other hand, Python 3.11 also added the
+:func:`typing.get_overloads` introspection helper. As this function does not
+affect type checker behavior, it would not require approval by the Typing
+Council. However, as support for runtime type checkers is within the remit
+of the Council, they should monitor such changes and provide feedback when
+appropriate.
+
+XXX
+
+Amendments
+----------
+
+This PEP serves as a charter for the C API Working Group.
+Changes to its operation can be made either through a new PEP
+or through a change to this PEP.
+In either case, the change would be decided upon
+by the Steering Council after discussion in the community.
+
+Copyright
+=========
+
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -5,13 +5,11 @@ Author: Guido van Rossum <guido@python.org>,
         Victor Stinner <vstinner@python.org>,
         Steve Dower <steve.dower@python.org>,
         Irit Katriel <irit@python.org>
-Discussions-To: https://discuss.python.org/t/pep-731-c-api-working-group
 Status: Draft
 Type: Process
 Topic: Typing
 Created: 11-Oct-2023
 Python-Version: 3.13
-Post-History: `11-Oct-2023 <https://discuss.python.org/t/pep-731-c-api-working-group>`__
 
 Abstract
 ========

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -1,16 +1,16 @@
 PEP: 9999
-Title: C API Working Group Process
+Title: C API Working Group Charter
 Author: Guido van Rossum <guido@python.org>,
         Petr Viktorin <encukou@gmail.com>,
         Victor Stinner <vstinner@python.org>,
         Steve Dower <steve.dower@python.org>
-Discussions-To: https://discuss.python.org/t/pep-731-c-api-working-group-process
+Discussions-To: https://discuss.python.org/t/pep-731-c-api-working-group
 Status: Draft
 Type: Process
 Topic: Typing
 Created: 11-Oct-2023
 Python-Version: 3.13
-Post-History: `11-Oct-2023 <https://discuss.python.org/t/pep-731-c-api-working-group-process>`__
+Post-History: `11-Oct-2023 <https://discuss.python.org/t/pep-731-c-api-working-group>`__
 
 Abstract
 ========
@@ -30,8 +30,9 @@ but especially all maintainers of code that uses Python's C API,
 whether in the context of CPython, using an alternate Python implementation,
 or using a binding framework for other languages.
 
-The C API Working Group serves at the pleasure of the Python Steering Council.
+The working group serves at the pleasure of the Python Steering Council.
 The working group's members are the listed authors of this PEP.
+This document serves as the working group's charter.
 
 Epigraph
 ========
@@ -57,8 +58,8 @@ Auuuuuuuugh!
 Motivation
 ==========
 
-Despite many discussions and in-person meetings at
-core developer sprints and Language Summits,
+Despite many discussions and in-person meetings
+at core developer sprints and Language Summits,
 and a thorough inventory of the problems and stakeholders of the C API,
 no consensus has been reached about many contentious issues,
 including, but not limted to:
@@ -98,57 +99,77 @@ be governed.
 Mandate
 -------
 
-The C API Working Group's mandate is to ensure that the Python C API is:
+The working group's mandate is to ensure that the Python C API is:
 
-* **Blah**: Blah, blah.
-* **Blah**: Blah, blah.
-* **Blah**: Blah, blah.
+* **Useful**: It should provide access to all relevant functionality.
+* **Ergonomic**: It should be easy to use.
+* **Fair**: It should serve the purposes of a variety of stakeholders.
+* **Stable**: It should avoid requiring users to update their code more than necessary.
+* **Evolvable**: It should give Python implementers enough freedom to change implementation details.
+* **Maintainable**: It should be easy to maintain and extend.
+
+For several of these items, a more comprehensive listing of constraints
+can be found in the PEP being drafted by Irit Katriel on the basis of the
+`inventory of C API problems <https://github.com/capi-working-group/problems>`__.
+
+The stability requirement is not meant to prevent sweeping C API changes ---
+one of the working group's initial tasks is to settle the question of
+whether we intend any landmark changes to the C API in the coming five years,
+and if so, to select or write a suitable proposal.
+However, the working group is required to carefully consider the migration
+efforts required of package maintainers and other stakeholders.
 
 Operations and process
 ----------------------
 
+The working group has at least three members,
+comprised of prominent Python core developers.
+The members should consider the needs of the various stakeholders carefully.
+
+The Steering Council would appoint the initial working group.
+There is no term limit for working group members.
+Working group members may resign their position at any time, for any reason.
+There is an expectation that the membership will change over time.
+
+To determine replacements,
+nominations will be collected from the core developer community.
+Self-nominations are allowed.
+The existing working group will then decide the replacement member(s)
+from the nominees.
+The expectation is that this would be done by fiat,
+but the working group can choose a replacement by any means they see fit,
+including a vote.
+
+The working group remains accountable to the Steering Council.
+At any point, for any reason, the Steering Council could
+(publicly or privately) make a specific change
+or request a non-specific change to the composition of the working group.
+
+We acknowledge that this is a not particularly democratic structure
+and puts a lot of faith in the working group.
+However, the Python community has a long history of success
+with not particularly democratic structures!
+We believe that self-governance, cycling of membership,
+and accountability to the Steering Council will be sufficient
+to ensure that the Typing Council is meeting the needs of the community.
+
+The working group may operate primarily through reviews of GitHub issues and PRs.
+Regular meetings are likely not necessary,
+but the working group may set up video calls,
+a private chat, or whatever other mechanism they decide upon internally.
+
+The working group should aim for transparency,
+posting all decisions publicly on
+`discuss.python.org <https://discuss.python.org>`__,
+with a rationale if possible.
+Before making a decision, the council should give
+all interested community members
+(as examples of different categories of stakeholders)
+a chance to weigh in.
+There should be at least a week between the start of a discussion
+and the council's decision.
+
 XXX HIRO TODO XXX
-
-The council would have three members, comprised of prominent community members,
-such as Python core developers and maintainers of major type checkers. The members
-should include people affiliated with a variety of projects related to type checking,
-which may include type checkers, CPython, typeshed, or other projects.
-
-The Steering Council would appoint the initial Typing Council. There is no term
-limit for council members. Council members may resign their position at any time.
-There is an expectation that at least one person will voluntarily resign from the
-Typing Council each year.
-
-To determine replacements, nominations will be collected from the typing
-community. Self-nominations are allowed. The existing Typing Council will then decide
-the replacement member(s) from the nominees. The expectation is that this would
-be done by fiat, but the Typing Council can choose a replacement by any means
-they see fit, including a vote.
-
-The Typing Council remains accountable to the Steering Council. At any point,
-for any reason, the Steering Council could (publicly or privately) make a
-specific change or request a non-specific change to the composition of the
-Typing Council.
-
-We acknowledge that this is a not particularly democratic structure and puts
-a lot of faith in the Typing Council. However, the Python community has a long
-history of success with not particularly democratic structures! We believe
-self-governance, cycling of membership, and accountability to the
-Steering Council will be sufficient to ensure that the Typing Council is meeting
-the needs of the community.
-
-The council would operate primarily through reviews of GitHub PRs. Regular
-meetings are likely not necessary, but the council may set up video calls, a
-private chat, or whatever other mechanism they decide upon internally.
-
-The council should aim for transparency, posting all decisions publicly on
-`discuss.python.org <https://discuss.python.org/c/typing/32>`__, with a
-rationale if possible. Before making a decision, the council should give
-all interested community members a chance to weigh in. There should be at
-least a week between the start of a discussion and the council's decision.
-
-Members of the council will be eligible to sponsor PEPs. If this PEP is accepted,
-:pep:`1` should be amended to note this fact.
 
 Relationship with the Steering Council
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -202,12 +223,12 @@ Council. However, as support for runtime type checkers is within the remit
 of the Council, they should monitor such changes and provide feedback when
 appropriate.
 
-XXX
+XXX END TODO XXX
 
 Amendments
 ----------
 
-This PEP serves as a charter for the C API Working Group.
+This PEP serves as a charter for the working group.
 Changes to its operation can be made either through a new PEP
 or through a change to this PEP.
 In either case, the change would be decided upon

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -94,8 +94,8 @@ We propose the creation of a new group, the C API Working Group.
 This group will be responsible for developing and maintaining the Python C API,
 and for solving the above problems.
 
-The "operations and process" section describes how this group would operate and
-be governed.
+The "operations and process" section below describes
+how the working group operates and how it is governed.
 
 Mandate
 -------
@@ -170,61 +170,19 @@ a chance to weigh in.
 There should be at least a week between the start of a discussion
 and the council's decision.
 
-XXX HIRO TODO XXX
-
 Relationship with the Steering Council
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Just like today, the Python Steering Council would remain responsible for the
-overall direction of the Python language and would continue to decide on
-typing-related PEPs. The Typing Council would provide written opinions and
-recommendations to the Steering Council on typing-related PEPs.
+Just like today, the Python Steering Council remains responsible
+for the overall direction of the Python C API
+and continues to decide on PEPs related to the C API,
+using the standard PEP review process (community discussion, etc.).
+The C API working group provides written opinions and
+recommendations to the Steering Council on PEPs related to the C API.
 
-However, smaller changes to the type system could be made
-by the Typing Council directly. The Steering Council could also choose
-to delegate decisions on some PEPs to the Typing Council (exactly as any other
-PEP delegation).
-
-Some examples of how past and recent issues could have been handled under this model:
-
-- A PEP like :pep:`695` (type parameter syntax), which changes the language
-  syntax, would need to be decided upon by the Steering Council; the Typing
-  Council would merely provide opinion or endorsement. Similarly, PEPs
-  like :pep:`702` would be decided upon by the Steering
-  Council, because it concerns runtime behaviour beyond pure typing. Other examples
-  that would need to be decided by the SC include :pep:`718` and :pep:`727`.
-- A PEP like :pep:`698` (``@override``), which affects only users of type
-  checkers and does not change the overall language, would also by default
-  be decided upon by the Steering Council. However, such PEPs could be
-  delegated to the Typing Council for a decision (like any other PEP delegation).
-  Other examples of PEPs that could potentially be delegated include
-  :pep:`647`, :pep:`655`, :pep:`673`, and :pep:`675`.
-- Adding a smaller feature, such as :data:`typing.Never` as an alias for
-  :data:`typing.NoReturn`, would be done by means of a PR to the spec and
-  conformance test suite. The Typing
-  Council would then decide whether or not to merge the PR. They may ask for the
-  feature to be specified and discussed in a PEP if they feel that is warranted.
-- If there is confusion about the interpretation of some part of the spec, like
-  happened recently with `partial stubs in PEP
-  561 <https://discuss.python.org/t/pep-561-clarification-regarding-n/32875/27>`_,
-  somebody would make a PR to the typing specification to clarify the
-  spec, and then the Typing Council would decide on the spec change.
-
-The runtime :mod:`typing` module will continue to be maintained by the
-CPython core developer team. However, any changes to the runtime module that
-affect type checker behavior should be made in conjunction with a change
-to the specification (see below) and should be approved by the Typing Council.
-For example, in Python 3.11 the core developers added the new function
-:func:`typing.assert_type`. If the Typing Council had been in place, this
-change would require a matching change to the specification and approval
-by the Typing Council. On the other hand, Python 3.11 also added the
-:func:`typing.get_overloads` introspection helper. As this function does not
-affect type checker behavior, it would not require approval by the Typing
-Council. However, as support for runtime type checkers is within the remit
-of the Council, they should monitor such changes and provide feedback when
-appropriate.
-
-XXX END TODO XXX
+However, the working group can make smaller C API changes directly.
+The Steering Council may also choose to delegate decisions on some PEPs
+to the working group (exactly as any other PEP delegation).
 
 Amendments
 ----------


### PR DESCRIPTION
This is not ready for review by the general public. I will invite specific reviewers (all co-authors) and once we reach consensus here I will submit it to the PEP editors. I might figure out which PEP number to use at that point (currently it looks like 731).