### PR TITLE
PEP 658: fix typo

### DIFF
--- a/peps/pep-0658.rst
+++ b/peps/pep-0658.rst
@@ -128,7 +128,7 @@ Expose more files in the distribution
 -------------------------------------
 
 It was proposed to provide the entire ``.dist-info`` directory as a
-separate part, instead of only the metadata file. However, searving
+separate part, instead of only the metadata file. However, serving
 multiple files in one entity through HTTP requires re-archiving them
 separately after they are extracted from the original distribution
 by the repository server, and there are no current use cases for files


### PR DESCRIPTION
I noticed while I was reading it

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3479.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->