### PR TITLE
PEP 702: Tools may clean up the deprecation message

### DIFF
--- a/peps/pep-0702.rst
+++ b/peps/pep-0702.rst
@@ -115,6 +115,8 @@ The decorator takes the following arguments:
 
 The positional-only argument is of type ``str`` and contains a message that should
 be shown by the type checker when it encounters a usage of the decorated object.
+Tools may clean up the deprecation message for display, for example
+by using :func:`inspect.cleandoc` or equivalent logic.
 The message must be a string literal.
 The content of deprecation messages is up to the user, but it may include the version
 in which the deprecated object is to be removed, and information about suggested


### PR DESCRIPTION
See https://discuss.python.org/t/pep-702-marking-deprecations-using-the-type-system/23036/53?u=jelle

I don't want to prescribe the exact behavior on tools and IDEs; they
can figure out for themselves what works best. This change is intended
to make it so they can adjust the message without worrying that they
are breaking the specification.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3482.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->