### PR TITLE
PEP 729, 731: Remove Python-Version

### DIFF
--- a/peps/pep-0729.rst
+++ b/peps/pep-0729.rst
@@ -6,7 +6,6 @@ Status: Draft
 Type: Process
 Topic: Typing
 Created: 19-Sep-2023
-Python-Version: 3.13
 Post-History: `04-Oct-2023 <https://discuss.python.org/t/pep-729-typing-governance-process/35362>`__,
               `20-Sep-2023 <https://discuss.python.org/t/proposed-new-typing-governance-process/34244>`__
 

--- a/peps/pep-0731.rst
+++ b/peps/pep-0731.rst
@@ -9,7 +9,6 @@ Discussions-To: https://discuss.python.org/t/pep-731-c-api-working-group-charter
 Status: Draft
 Type: Process
 Created: 11-Oct-2023
-Python-Version: 3.13
 Post-History: `13-Oct-2023 <https://discuss.python.org/t/pep-731-c-api-working-group-charter/36117>`__
 
 Abstract


### PR DESCRIPTION
As these PEPs don't propose changes to Python, the Python-Version
header doesn't really make sense. I had assumed the header was required
but it's not.


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3484.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->