### PR TITLE
PEP 719: The first alpha of 3.13 was released on Friday 13th

### DIFF
--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -43,10 +43,10 @@ in a 12-month release cadence between feature versions, as defined by
 Actual:
 
 - 3.13 development begins: Monday, 2023-05-22
+- 3.13.0 alpha 1: Friday, 2023-10-13
 
 Expected:
 
-- 3.13.0 alpha 1: Tuesday, 2023-10-17
 - 3.13.0 alpha 2: Tuesday, 2023-11-21
 - 3.13.0 alpha 3: Tuesday, 2023-12-19
 - 3.13.0 alpha 4: Tuesday, 2024-01-16


### PR DESCRIPTION
https://discuss.python.org/t/python-3-13-0-alpha-1/36109

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3485.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->