### PR TITLE
Infra: Improve print style

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -157,4 +157,9 @@
         margin: 0;
         padding: 0;
     }
+
+    /* This blocks a small portion on each page. */
+    readthedocs-flyout {
+        display: none;
+    }
 }

--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -89,7 +89,7 @@
         max-width: 100% !important;
     }
     @page {
-        margin: 0.5cm;
+        margin: 2.5cm;
     }
     p,
     h2,
@@ -101,5 +101,56 @@
     h2,
     h3 {
         page-break-after: avoid;
+    }
+    h1 {
+        font-size: 18pt;
+        font-weight: bold;
+        text-align: center;
+    }
+    h2, details > summary {
+        font-size: 15pt;
+        font-weight: normal;
+    }
+    h3 {
+        font-size: 13pt;
+        font-weight: normal;
+    }
+    h4 {
+        font-size: 10pt;
+        font-weight: 600;
+    }
+    a, abbr {
+        text-decoration: none;
+    }
+
+    details {
+        display: none;
+    }
+    details[open] {
+        display: block;
+    }
+
+    h1.page-title:first-child {
+        margin-top: 0;
+    }
+
+    section#pep-page-section {
+        display: flex;
+        justify-content: center;
+        padding: 0;
+        margin: 0 auto;
+    }
+
+    section#pep-page-section > header,
+    nav#pep-sidebar {
+        display: none;
+    }
+
+    section#pep-page-section > article {
+        float: none;
+        max-width: 17.5cm;
+        width: auto;
+        margin: 0;
+        padding: 0;
     }
 }

--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -88,8 +88,18 @@
     img {
         max-width: 100% !important;
     }
+    /* Page margins according to DIN 5008, leaves space for punched holes. */
     @page {
-        margin: 2.5cm;
+        margin-top: 2cm;
+        margin-bottom: 2cm;
+    }
+    @page :right {
+        margin-left: 2.5cm;
+        margin-right: 2cm;
+    }
+    @page :left {
+        margin-left: 2cm;
+        margin-right: 2.5cm;
     }
     p,
     h2,

--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -92,13 +92,7 @@
     @page {
         margin-top: 2cm;
         margin-bottom: 2cm;
-    }
-    @page :right {
         margin-left: 2.5cm;
-        margin-right: 2cm;
-    }
-    @page :left {
-        margin-left: 2cm;
         margin-right: 2.5cm;
     }
     p,


### PR DESCRIPTION
* Remove header.
* Remove TOC sidebar.
* Remove TOC header if closed.
* Use appropriate page margins and max-width.
* Remove underlines from links and abbreviations.
* Use more compact headings.

Closes: #3480

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3486.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->