### PR TITLE
PEPs 729, 731: Apply Governance topic

### DIFF
--- a/peps/pep-0729.rst
+++ b/peps/pep-0729.rst
@@ -4,7 +4,7 @@ Author: Jelle Zijlstra <jelle.zijlstra@gmail.com>, Shantanu Jain <hauntsaninja a
 Discussions-To: https://discuss.python.org/t/pep-729-typing-governance-process/35362
 Status: Draft
 Type: Process
-Topic: Typing
+Topic: Governance, Typing
 Created: 19-Sep-2023
 Post-History: `04-Oct-2023 <https://discuss.python.org/t/pep-729-typing-governance-process/35362>`__,
               `20-Sep-2023 <https://discuss.python.org/t/proposed-new-typing-governance-process/34244>`__

--- a/peps/pep-0731.rst
+++ b/peps/pep-0731.rst
@@ -8,6 +8,7 @@ Author: Guido van Rossum <guido@python.org>,
 Discussions-To: https://discuss.python.org/t/pep-731-c-api-working-group-charter/36117
 Status: Draft
 Type: Process
+Topic: Governance
 Created: 11-Oct-2023
 Post-History: `13-Oct-2023 <https://discuss.python.org/t/pep-731-c-api-working-group-charter/36117>`__
 


### PR DESCRIPTION
This will list them on the https://peps.python.org/topic/governance/ page.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3487.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->