### PR TITLE
PEP 698: Add missing "self" parameters to methods and a colon to a class

### DIFF
--- a/peps/pep-0698.rst
+++ b/peps/pep-0698.rst
@@ -196,7 +196,7 @@ method or attribute in some ancestor class.
             return 2
 
         @override
-        def baz() -> int:  # Type check error: no matching signature in ancestor
+        def baz(self) -> int:  # Type check error: no matching signature in ancestor
             return 1
 
 
@@ -240,7 +240,7 @@ Consider the following code:
         pass
 
     class Child(Parent):
-        def foo() -> int:
+        def foo(self) -> int:
             return 2
 
 Imagine we refactor it as follows:
@@ -248,12 +248,12 @@ Imagine we refactor it as follows:
 
 .. code-block:: python
 
-    class Parent
-        def foo() -> int:   # This method is new
+    class Parent:
+        def foo(self) -> int:   # This method is new
             return 1
 
     class Child(Parent):
-        def foo() -> int:  # This is now an override!
+        def foo(self) -> int:  # This is now an override!
             return 2
 
     def call_foo(parent: Parent) -> int:
@@ -416,22 +416,22 @@ ancestor class where the overridden method should be defined:
 .. code-block:: python
 
     class Parent0:
-        def foo() -> int:
+        def foo(self) -> int:
             return 1
 
 
     class Parent1:
-        def bar() -> int:
+        def bar(self) -> int:
             return 1
 
 
     class Child(Parent0, Parent1):
         @override(Parent0)  # okay, Parent0 defines foo
-        def foo() -> int:
+        def foo(self) -> int:
             return 2
 
         @override(Parent0)  # type error, Parent0 does not define bar
-        def bar() -> int:
+        def bar(self) -> int:
             return 2
 
 


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3490.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->