### PR TITLE
PEP 705 Link to new discussion thread

### DIFF
--- a/peps/pep-0705.rst
+++ b/peps/pep-0705.rst
@@ -2,7 +2,7 @@ PEP: 705
 Title: TypedDict: Read-only and other keys
 Author: Alice Purcell <alicederyn@gmail.com>
 Sponsor: Pablo Galindo <pablogsal@gmail.com>
-Discussions-To: https://discuss.python.org/t/pep-705-typedmapping/24827
+Discussions-To: https://discuss.python.org/t/pep-705-typeddict-read-only-and-other-keys/36457
 Status: Draft
 Type: Standards Track
 Topic: Typing
@@ -12,6 +12,7 @@ Python-Version: 3.13
 Post-History: `30-Sep-2022 <https://mail.python.org/archives/list/typing-sig@python.org/thread/6FR6RKNUZU4UY6B6RXC2H4IAHKBU3UKV/>`__,
               `02-Nov-2022 <https://mail.python.org/archives/list/python-dev@python.org/thread/2P26R4VH2ZCNNNOQCBZWEM4RNF35OXOW/>`__,
               `14-Mar-2023 <https://discuss.python.org/t/pep-705-typedmapping/24827>`__,
+              `17-Oct-2023 <https://discuss.python.org/t/pep-705-typeddict-read-only-and-other-keys/36457>`__,
 
 
 Abstract

--- a/peps/pep-0705.rst
+++ b/peps/pep-0705.rst
@@ -263,8 +263,8 @@ The optional boolean ``readonly`` flag to ``TypedDict``, when ``True``, indicate
 
 The ``readonly`` flag defaults to ``False``.
 
-``typing.ReadOnly`` flag
-------------------------
+``typing.ReadOnly`` type qualifier
+----------------------------------
 
 The ``typing.ReadOnly`` type qualifier is used to indicate that a variable declared in a ``TypedDict`` definition may not be mutated by any operation performed on instances of the ``TypedDict``::
 


### PR DESCRIPTION
I also noticed a mistake in one heading as I was putting the discussion post together (`ReadOnly` is a type qualifier, not a flag).

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3492.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->