### PR TITLE
PEP 696: Update the discussions to link

### DIFF
--- a/peps/pep-0696.rst
+++ b/peps/pep-0696.rst
@@ -2,7 +2,7 @@ PEP: 696
 Title: Type defaults for TypeVarLikes
 Author: James Hilton-Balfe <gobot1234yt@gmail.com>
 Sponsor: Jelle Zijlstra <jelle.zijlstra@gmail.com>
-Discussions-To: https://discuss.python.org/t/pep-696-type-defaults-for-typevarlikes/22569https://mail.python.org/archives/list/typing-sig@python.org/thread/7VWBZWXTCX6RAJO6GG67BAXUPFZ24NTC
+Discussions-To: https://discuss.python.org/t/pep-696-type-defaults-for-typevarlikes/22569
 Status: Draft
 Type: Standards Track
 Topic: Typing

--- a/peps/pep-0696.rst
+++ b/peps/pep-0696.rst
@@ -2,7 +2,7 @@ PEP: 696
 Title: Type defaults for TypeVarLikes
 Author: James Hilton-Balfe <gobot1234yt@gmail.com>
 Sponsor: Jelle Zijlstra <jelle.zijlstra@gmail.com>
-Discussions-To: https://mail.python.org/archives/list/typing-sig@python.org/thread/7VWBZWXTCX6RAJO6GG67BAXUPFZ24NTC
+Discussions-To: https://discuss.python.org/t/pep-696-type-defaults-for-typevarlikes/22569https://mail.python.org/archives/list/typing-sig@python.org/thread/7VWBZWXTCX6RAJO6GG67BAXUPFZ24NTC
 Status: Draft
 Type: Standards Track
 Topic: Typing


### PR DESCRIPTION
The latest discussion thread is now on discourse.

Cc @Gobot1234 @JelleZijlstra 

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3493.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->