### PR TITLE
PEP 101: Docs: Less steps to update versions.

### DIFF
--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -293,14 +293,6 @@ to perform some manual editing steps.
   release tag in the repo is signed with your gpg key.  When prompted
   choose the private key you use for signing release tarballs etc.
 
-- For a **new branch** release, add it to the ``VERSIONS`` list of
-  `docsbuild scripts`_, so that the new maintenance branch is now
-  ``pre-release`` and add the new ``in development`` version.
-
-- For a **final** major release, update the ``VERSIONS`` list of
-  `docsbuild scripts`_: the release branch must be changed from
-  ``pre-release`` to ``stable``.
-
 - For **begin security-only mode** and **end-of-life** releases, review the
   two files and update the versions accordingly in all active branches.
 
@@ -425,14 +417,9 @@ to perform some manual editing steps.
   - If this is a **final** or rc release (even a maintenance release), also
     unpack the HTML docs to ``/srv/docs.python.org/release/3.X.Y[rcA]`` on
     docs.nyc1.psf.io. Make sure the files are in group ``docs`` and are
-    group-writeable.  If it is a release of a security-fix-only version,
-    tell the DE to start a build (``security-fixes`` and ``EOL`` version
-    are not built daily).
+    group-writeable.
 
   - Let the DE check if the docs are built and work all right.
-
-  - If this is a **final** major release: Tell the DE to adapt redirects for
-    docs.python.org/3.X in the nginx config for docs.python.org.
 
   - Note both the documentation and downloads are behind a caching CDN. If
     you change archives after downloading them through the website, you'll
@@ -798,9 +785,6 @@ with RevSys.)
   - Ensure buildbots are defined for the new branch (contact Łukasz
     or Zach Ware).
 
-  - Ensure the daily docs build scripts are updated to include
-    the new branch (contact DE).
-
   - Ensure the various GitHub bots are updated, as needed, for the
     new branch, in particular, make sure backporting to the new
     branch works (contact core-workflow team)
@@ -847,16 +831,6 @@ else does them.  Some of those tasks include:
 
 - Optionally making a final release to publish any remaining unreleased
   changes.
-
-- Update the ``VERSIONS`` list of `docsbuild scripts`_: change the
-  version state to ``EOL``.
-
-- On the docs download server (docs.nyc1.psf.io), ensure the top-level
-  symlink points to the upload of unpacked html docs from final release::
-
-        cd /srv/docs.python.org
-        ls -l 3.3
-        lrwxrwxrwx 1 nad docs 13 Sep  6 21:38 3.3 -> release/3.3.7
 
 - Freeze the state of the release branch by creating a tag of its current HEAD
   and then deleting the branch from the cpython repo.  The current HEAD should
@@ -947,9 +921,6 @@ Copyright
 
 This document has been placed in the public domain.
 
-
-.. _docsbuild scripts:
-   https://github.com/python/docsbuild-scripts/blob/main/build_docs.py
 
 ..
   Local Variables:


### PR DESCRIPTION
CPython versions to be built on the docs server are now fetched from the devguide to avoid duplication of information.

CC @ambv @pablogsal @Yhg1s beware, for the next release, you do no longer need to update the docsbuild script, just the devguide's [release-cycle.json](https://github.com/python/devguide/blob/main/include/release-cycle.json).

The PEP tells about updating the devguide's release cycle but not about this specific file, should I update it to reflect this?
