### PR TITLE
PEP 705: Clean up examples in Inheritance section

### DIFF
--- a/peps/pep-0705.rst
+++ b/peps/pep-0705.rst
@@ -312,19 +312,27 @@ Inheritance
 
 To avoid potential confusion, it is an error to have a read-only type extend a non-read-only type::
 
+    class BandAndAlbum(TypedDict):
+        band: str
+        album: ReadOnly[Album]
+
     class BandAlbumAndLabel(BandAndAlbum, readonly=True):  # Runtime error
         label: str
 
 
 It is also an error to have a type without ``other_keys`` specified extend a type with ``other_keys=Never``::
 
-    class NamedDict(TypedDict, readonly=True):
+    class Building(TypedDict, other_keys=Never):
         name: str
+        address: str
 
-    class Person(NamedDict):  # Runtime error
-        age: float
+    class Museum(Building):  # Runtime error
+        pass
 
 It is valid to have a non-read-only type extend a read-only one. The subclass will not be read-only, but any keys not redeclared in the subclass will remain read-only::
+
+    class NamedDict(TypedDict, readonly=True):
+        name: str
 
     class Album(NamedDict, TypedDict):
         year: int


### PR DESCRIPTION
- Respecify `BandAndAlbum` from previous section to avoid having to bounce around between examples.
- `NamedDict` was incorrectly used as an example of a type with `other_keys=Never` specified when it didn't, but then also used as an example of a type with `readonly=True`. Rewrite the `other_keys=Never` example completely, and move the `NamedDict` declaration down to the first example that correctly uses it.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3495.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->