### PR TITLE
PEP 3333: Fix a TypeError in the example CGI Driver code

### DIFF
--- a/peps/pep-3333.rst
+++ b/peps/pep-3333.rst
@@ -348,7 +348,7 @@ server.
                 if data:    # don't send headers until body appears
                     write(data)
             if not headers_sent:
-                write('')   # send headers now if body was empty
+                write(b'')   # send headers now if body was empty
         finally:
             if hasattr(result, 'close'):
                 result.close()


### PR DESCRIPTION
Only bytestrings should be written to output.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3497.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->