### PR TITLE
PEP 536: Mark as Withdrawn

### DIFF
--- a/check-peps.py
+++ b/check-peps.py
@@ -421,7 +421,7 @@ def _validate_post_history(line_num: int, body: str) -> MessageIterator:
                 yield from _date(offset, post_date, "Post-History")
                 yield from _thread(offset, post_url, "Post-History")
             else:
-                yield line, f"post line must start with “`” and end with “>`__”"
+                yield offset, f"post line must start with “`” and end with “>`__”"
 
 
 def _validate_resolution(line_num: int, line: str) -> MessageIterator:

--- a/check-peps.py
+++ b/check-peps.py
@@ -416,12 +416,10 @@ def _validate_post_history(line_num: int, body: str) -> MessageIterator:
         for post in line.removesuffix(",").strip().split(", "):
             if not post.startswith("`") and not post.endswith(">`__"):
                 yield from _date(offset, post, "Post-History")
-            elif post.startswith("`") and post.endswith(">`__"):
+            else:
                 post_date, post_url = post[1:-4].split(" <")
                 yield from _date(offset, post_date, "Post-History")
                 yield from _thread(offset, post_url, "Post-History")
-            else:
-                yield offset, f"post line must be a date or both start with “`” and end with “>`__”"
 
 
 def _validate_resolution(line_num: int, line: str) -> MessageIterator:

--- a/check-peps.py
+++ b/check-peps.py
@@ -416,10 +416,12 @@ def _validate_post_history(line_num: int, body: str) -> MessageIterator:
         for post in line.removesuffix(",").strip().split(", "):
             if not post.startswith("`") and not post.endswith(">`__"):
                 yield from _date(offset, post, "Post-History")
-            else:
+            elif post.startswith("`") and post.endswith(">`__"):
                 post_date, post_url = post[1:-4].split(" <")
                 yield from _date(offset, post_date, "Post-History")
                 yield from _thread(offset, post_url, "Post-History")
+            else:
+                yield line, f"post line must start with “`” and end with “>`__”"
 
 
 def _validate_resolution(line_num: int, line: str) -> MessageIterator:

--- a/check-peps.py
+++ b/check-peps.py
@@ -421,7 +421,7 @@ def _validate_post_history(line_num: int, body: str) -> MessageIterator:
                 yield from _date(offset, post_date, "Post-History")
                 yield from _thread(offset, post_url, "Post-History")
             else:
-                yield offset, f"post line must start with “`” and end with “>`__”"
+                yield offset, f"post line must be a date or both start with “`” and end with “>`__”"
 
 
 def _validate_resolution(line_num: int, line: str) -> MessageIterator:

--- a/peps/pep-0536.rst
+++ b/peps/pep-0536.rst
@@ -8,7 +8,10 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 11-Dec-2016
 Python-Version: 3.7
-Post-History: 12-Dec-2016
+Post-History: `18-Aug-2016 <https://mail.python.org/archives/list/python-ideas@python.org/thread/FOYKXOFWEINPVQSK2XGEHKXSTEVO5WWA/
+>`__
+              `23-Dec-2016 <https://mail.python.org/archives/list/python-ideas@python.org/thread/YKKEA5NIMMKHZTMRE5UFHST4WQ4NN3XJ/>`__
+              `15-Mar-2019 <https://mail.python.org/archives/list/python-dev@python.org/thread/N43O4KNLZW4U7YZC4NVPCETZIVRDUVU2/>`__
 Resolution: https://discuss.python.org/t/pep-536-should-be-marked-as-rejected/35226/4
 
 Abstract

--- a/peps/pep-0536.rst
+++ b/peps/pep-0536.rst
@@ -9,7 +9,7 @@ Content-Type: text/x-rst
 Created: 11-Dec-2016
 Python-Version: 3.7
 Post-History: 12-Dec-2016
-Resolution: https://github.com/python/steering-council/issues/209#issuecomment-1777231536
+Resolution: https://discuss.python.org/t/pep-536-should-be-marked-as-rejected/35226/4
 
 Abstract
 ========

--- a/peps/pep-0536.rst
+++ b/peps/pep-0536.rst
@@ -9,8 +9,8 @@ Content-Type: text/x-rst
 Created: 11-Dec-2016
 Python-Version: 3.7
 Post-History: `18-Aug-2016 <https://mail.python.org/archives/list/python-ideas@python.org/thread/FOYKXOFWEINPVQSK2XGEHKXSTEVO5WWA/
->`__
-              `23-Dec-2016 <https://mail.python.org/archives/list/python-ideas@python.org/thread/YKKEA5NIMMKHZTMRE5UFHST4WQ4NN3XJ/>`__
+>`__,
+              `23-Dec-2016 <https://mail.python.org/archives/list/python-ideas@python.org/thread/YKKEA5NIMMKHZTMRE5UFHST4WQ4NN3XJ/>`__,
               `15-Mar-2019 <https://mail.python.org/archives/list/python-dev@python.org/thread/N43O4KNLZW4U7YZC4NVPCETZIVRDUVU2/>`__
 Resolution: https://discuss.python.org/t/pep-536-should-be-marked-as-rejected/35226/4
 

--- a/peps/pep-0536.rst
+++ b/peps/pep-0536.rst
@@ -3,12 +3,13 @@ Title: Final Grammar for Literal String Interpolation
 Version: $Revision$
 Last-Modified: $Date$
 Author: Philipp Angerer <phil.angerer@gmail.com>
-Status: Deferred
+Status: Withdrawn
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 11-Dec-2016
 Python-Version: 3.7
 Post-History: 12-Dec-2016
+Resolution: https://discuss.python.org/t/pep-701-syntactic-formalization-of-f-strings/22046/119
 
 Abstract
 ========
@@ -21,10 +22,11 @@ those restrictions, promoting “f-strings” to “f expressions” or f-litera
 This PEP expands upon the f-strings introduced by :pep:`498`,
 so this text requires familiarity with :pep:`498`.
 
-PEP Status
-==========
+PEP Withdrawal
+==============
 
-This PEP is deferred until an implementation is available.
+This PEP has been withdrawn in favour of :pep:`701`.
+:pep:`701` addresses all important points of this PEP.
 
 
 Terminology

--- a/peps/pep-0536.rst
+++ b/peps/pep-0536.rst
@@ -9,7 +9,7 @@ Content-Type: text/x-rst
 Created: 11-Dec-2016
 Python-Version: 3.7
 Post-History: 12-Dec-2016
-Resolution: https://discuss.python.org/t/pep-701-syntactic-formalization-of-f-strings/22046/119
+Resolution: https://github.com/python/steering-council/issues/209#issuecomment-1777231536
 
 Abstract
 ========

--- a/peps/pep-0536.rst
+++ b/peps/pep-0536.rst
@@ -8,8 +8,7 @@ Type: Standards Track
 Content-Type: text/x-rst
 Created: 11-Dec-2016
 Python-Version: 3.7
-Post-History: `18-Aug-2016 <https://mail.python.org/archives/list/python-ideas@python.org/thread/FOYKXOFWEINPVQSK2XGEHKXSTEVO5WWA/
->`__,
+Post-History: `18-Aug-2016 <https://mail.python.org/archives/list/python-ideas@python.org/thread/FOYKXOFWEINPVQSK2XGEHKXSTEVO5WWA/>`__,
               `23-Dec-2016 <https://mail.python.org/archives/list/python-ideas@python.org/thread/YKKEA5NIMMKHZTMRE5UFHST4WQ4NN3XJ/>`__,
               `15-Mar-2019 <https://mail.python.org/archives/list/python-dev@python.org/thread/N43O4KNLZW4U7YZC4NVPCETZIVRDUVU2/>`__
 Resolution: https://discuss.python.org/t/pep-536-should-be-marked-as-rejected/35226/4


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

Fixes https://github.com/python/steering-council/issues/209

* [x] Author has withdrawn and linked to “discussion”
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Withdrawn``
* [x] ``Resolution`` link points directly to author’s withdrawal post
* [x] Withdrawal notice added
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date

I’m unclear what the fields of the last point should be


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3510.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->