### PR TITLE
Make check-peps’ _validate_post_history crash less

### DIFF
--- a/check-peps.py
+++ b/check-peps.py
@@ -414,12 +414,15 @@ def _validate_post_history(line_num: int, body: str) -> MessageIterator:
 
     for offset, line in enumerate(body.removesuffix(",").split("\n"), start=line_num):
         for post in line.removesuffix(",").strip().split(", "):
-            if not post.startswith("`") and not post.endswith(">`__"):
-                yield from _date(offset, post, "Post-History")
-            else:
-                post_date, post_url = post[1:-4].split(" <")
-                yield from _date(offset, post_date, "Post-History")
-                yield from _thread(offset, post_url, "Post-History")
+            match (post.startswith("`"), post.endswith(">`__")):
+                case (True, True):
+                    yield from _date(offset, post, "Post-History")
+                case (False, False):
+                    post_date, post_url = post[1:-4].split(" <")
+                    yield from _date(offset, post_date, "Post-History")
+                    yield from _thread(offset, post_url, "Post-History")
+                case _:
+                    yield offset, f"post line must be a date or both start with “`” and end with “>`__”"
 
 
 def _validate_resolution(line_num: int, line: str) -> MessageIterator:

--- a/check-peps.py
+++ b/check-peps.py
@@ -414,15 +414,15 @@ def _validate_post_history(line_num: int, body: str) -> MessageIterator:
 
     for offset, line in enumerate(body.removesuffix(",").split("\n"), start=line_num):
         for post in line.removesuffix(",").strip().split(", "):
-            match (post.startswith("`"), post.endswith(">`__")):
-                case (False, False):
-                    yield from _date(offset, post, "Post-History")
-                case (True, True):
-                    post_date, post_url = post[1:-4].split(" <")
-                    yield from _date(offset, post_date, "Post-History")
-                    yield from _thread(offset, post_url, "Post-History")
-                case _:
-                    yield offset, f"post line must be a date or both start with “`” and end with “>`__”"
+            prefix, postfix = (post.startswith("`"), post.endswith(">`__"))
+            if not prefix and not postfix:
+                yield from _date(offset, post, "Post-History")
+            elif prefix and postfix:
+                post_date, post_url = post[1:-4].split(" <")
+                yield from _date(offset, post_date, "Post-History")
+                yield from _thread(offset, post_url, "Post-History")
+            else:
+                yield offset, f"post line must be a date or both start with “`” and end with “>`__”"
 
 
 def _validate_resolution(line_num: int, line: str) -> MessageIterator:

--- a/check-peps.py
+++ b/check-peps.py
@@ -415,9 +415,9 @@ def _validate_post_history(line_num: int, body: str) -> MessageIterator:
     for offset, line in enumerate(body.removesuffix(",").split("\n"), start=line_num):
         for post in line.removesuffix(",").strip().split(", "):
             match (post.startswith("`"), post.endswith(">`__")):
-                case (True, True):
-                    yield from _date(offset, post, "Post-History")
                 case (False, False):
+                    yield from _date(offset, post, "Post-History")
+                case (True, True):
                     post_date, post_url = post[1:-4].split(" <")
                     yield from _date(offset, post_date, "Post-History")
                     yield from _thread(offset, post_url, "Post-History")


### PR DESCRIPTION
In #3510, I accidentally typed

```rst
Post-History: `18-Aug-2016 <https://mail.python.org/...
>`__
```

instead of

```rst
Post-History: `18-Aug-2016 <https://mail.python.org/...>`__
```

This PR makes the check-peps script detect that case like this (I tweaked the message a bit since):

![image](https://github.com/python/peps/assets/291575/9ff5a5d0-565a-4148-9b6a-5b5d034d50a9)

… instead of crashing like this:

![image](https://github.com/python/peps/assets/291575/0222d208-7660-4c30-a695-2cb0ff02dc92)

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3511.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->