### PR TITLE
PEP 703: Mark as Accepted

### DIFF
--- a/peps/pep-0703.rst
+++ b/peps/pep-0703.rst
@@ -13,7 +13,7 @@ Post-History: `09-Jan-2023 <https://discuss.python.org/t/22606>`__,
 Resolution: https://discuss.python.org/t/pep-703-making-the-global-interpreter-lock-optional-in-cpython-acceptance/37075
 
 .. note::
-   The steering council accepts PEP 703, but with clear provisio: that
+   The Steering Council accepts PEP 703, but with clear provisio: that
    the rollout be gradual and break as little as possible, and that we can roll
    back any changes that turn out to be too disruptive – which includes
    potentially rolling back all of PEP 703 entirely if necessary

--- a/peps/pep-0703.rst
+++ b/peps/pep-0703.rst
@@ -3,13 +3,21 @@ Title: Making the Global Interpreter Lock Optional in CPython
 Author: Sam Gross <colesbury at gmail.com>
 Sponsor: Łukasz Langa <lukasz at python.org>
 Discussions-To: https://discuss.python.org/t/22606
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 09-Jan-2023
 Python-Version: 3.13
 Post-History: `09-Jan-2023 <https://discuss.python.org/t/22606>`__,
               `04-May-2023 <https://discuss.python.org/t/26503>`__
+Resolution: https://discuss.python.org/t/pep-703-making-the-global-interpreter-lock-optional-in-cpython-acceptance/37075
+
+.. note::
+   The steering council accepts PEP 703, but with clear provisio: that
+   the rollout be gradual and break as little as possible, and that we can roll
+   back any changes that turn out to be too disruptive – which includes
+   potentially rolling back all of PEP 703 entirely if necessary
+   (however unlikely or undesirable we expect that to be).
 
 
 Abstract


### PR DESCRIPTION
* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
(https://discuss.python.org/t/pep-703-making-the-global-interpreter-lock-optional-in-cpython-acceptance/37075)
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` link points directly to SC/PEP Delegate official acceptance/rejected post
* [x] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3512.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->