### PR TITLE
PEP 7: Add C pre-processor macro style recommendations

### DIFF
--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -135,6 +135,20 @@ Code lay-out
           return 0; /* "Forgive" adding a __dict__ only */
       }
 
+* Vertically align line continuation characters in multi-line macros.
+
+* Macros intended to be used as a statement should use the
+  ``do {... }while(0)``` macro idiom.
+  Example::
+
+      #define ADD_INT_MACRO(MOD, INT) do {                          \
+          if (PyModule_AddIntConstant((MOD), (#INT), (INT)) < 0) {  \
+              goto error;                                           \
+          }                                                         \
+      } while (0)
+
+* ``#undef`` macros after use.
+
 * Put blank lines around functions, structure definitions, and major
   sections inside functions.
 
@@ -169,6 +183,9 @@ Naming conventions
 
 * Macros should have a MixedCase prefix and then use upper case, for
   example: ``PyString_AS_STRING``, ``Py_PRINT_RAW``.
+
+* Macro parameters should use ``ALL_CAPS`` style,
+  so they are easily distinguishable from C variables and struct members.
 
 
 Documentation Strings

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -138,7 +138,8 @@ Code lay-out
 * Vertically align line continuation characters in multi-line macros.
 
 * Macros intended to be used as a statement should use the
-  ``do {... } while(0)`` macro idiom.
+  ``do {... } while(0)`` macro idiom,
+  without a final semicolon.
   Example::
 
       #define ADD_INT_MACRO(MOD, INT) do {                          \

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -138,11 +138,12 @@ Code lay-out
 * Vertically align line continuation characters in multi-line macros.
 
 * Macros intended to be used as a statement should use the
-  ``do {... } while(0)`` macro idiom,
+  ``do { ... } while (0)`` macro idiom,
   without a final semicolon.
   Example::
 
-      #define ADD_INT_MACRO(MOD, INT) do {                          \
+      #define ADD_INT_MACRO(MOD, INT)                               \
+      do {                                                          \
           if (PyModule_AddIntConstant((MOD), (#INT), (INT)) < 0) {  \
               goto error;                                           \
           }                                                         \

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -138,7 +138,7 @@ Code lay-out
 * Vertically align line continuation characters in multi-line macros.
 
 * Macros intended to be used as a statement should use the
-  ``do {... }while(0)``` macro idiom.
+  ``do {... }while(0)`` macro idiom.
   Example::
 
       #define ADD_INT_MACRO(MOD, INT) do {                          \

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -147,7 +147,7 @@ Code lay-out
           }                                                         \
       } while (0)
 
-* ``#undef`` macros after use.
+* ``#undef`` private macros after use.
 
 * Put blank lines around functions, structure definitions, and major
   sections inside functions.

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -138,7 +138,7 @@ Code lay-out
 * Vertically align line continuation characters in multi-line macros.
 
 * Macros intended to be used as a statement should use the
-  ``do {... }while(0)`` macro idiom.
+  ``do {... } while(0)`` macro idiom.
   Example::
 
       #define ADD_INT_MACRO(MOD, INT) do {                          \

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -142,12 +142,12 @@ Code lay-out
   without a final semicolon.
   Example::
 
-      #define ADD_INT_MACRO(MOD, INT)                               \
-      do {                                                          \
-          if (PyModule_AddIntConstant((MOD), (#INT), (INT)) < 0) {  \
-              goto error;                                           \
-          }                                                         \
-      } while (0)
+      #define ADD_INT_MACRO(MOD, INT)                                   \
+          do {                                                          \
+              if (PyModule_AddIntConstant((MOD), (#INT), (INT)) < 0) {  \
+                  goto error;                                           \
+              }                                                         \
+          } while (0)
 
 * ``#undef`` private macros after use.
 

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -149,7 +149,7 @@ Code lay-out
               }                                                         \
           } while (0)
 
-* ``#undef`` private macros after use.
+* ``#undef`` file local macros after use.
 
 * Put blank lines around functions, structure definitions, and major
   sections inside functions.

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -149,6 +149,9 @@ Code lay-out
               }                                                         \
           } while (0)
 
+      // To be used like a statement with a semicolon:
+      ADD_INT_MACRO(m, SOME_CONSTANT);
+
 * ``#undef`` file local macros after use.
 
 * Put blank lines around functions, structure definitions, and major


### PR DESCRIPTION
See [discussion over at Discourse](https://discuss.python.org/t/all-caps-for-macro-parameter-names/37119?u=erlendaasland).

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3516.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->