### PR TITLE
Infra: CI: Test Python 3.13

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         python-version:
         - "3.x"
-        - "3.12-dev"
+        - "3.13-dev"
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,8 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
-        - "3.12-dev"
+        - "3.12"
+        - "3.13"
         os:
         - "windows-latest"
         - "macos-latest"
@@ -46,6 +47,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+          allow-prereleases: true
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
3.13 alpha is now available for testing with GitHub Actions.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3517.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->