### PR TITLE
PEP 733: Add Post-History

### DIFF
--- a/peps/pep-0733.rst
+++ b/peps/pep-0733.rst
@@ -30,8 +30,8 @@ Author: Erlend Egeberg Aasland <erlend@python.org>,
         Jelle Zijlstra <jelle.zijlstra@gmail.com>,
 Status: Draft
 Type: Informational
-Content-Type: text/x-rst
 Created: 16-Oct-2023
+Post-History: `01-Nov-2023 <https://discuss.python.org/t/pep-733-an-evaluation-of-python-s-public-c-api/37618>`__
 
 
 Abstract
@@ -65,7 +65,7 @@ conventions changed, and new usage patterns have emerged, such as bindings
 to languages other than C/C++. In the next few years, new developments
 are expected to further test the C API, such as the removal of the GIL
 and the development of a JIT compiler. However, this growth was not
-supported by clearly documented guidelines, resulting in inconsitent
+supported by clearly documented guidelines, resulting in inconsistent
 approaches to API design in different subsystems of CPython. In addition,
 CPython is no longer the only implementation of Python, and some of the
 design decisions made when it was, are difficult for alternative


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [ ] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


Also remove redundant `Content-Type` (https://github.com/python/peps/pull/3454) and fix a typo.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3518.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->