### PR TITLE
Infra: Add `make htmllive` to rebuild and reload HTML files in your browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ html: venv
 htmlview: html
 	$(PYTHON) -c "import os, webbrowser; webbrowser.open('file://' + os.path.realpath('build/index.html'))"
 
+## htmllive       to rebuild and reload HTML files in your browser
+.PHONY: htmllive
+htmllive: SPHINXBUILD = $(VENVDIR)/bin/sphinx-autobuild
+htmllive: SPHINXERRORHANDLING = --re-ignore="/\.idea/|/venv/|/pep-0000.rst|/topic/"
+htmllive: html
+
 ## dirhtml        to render PEPs to "index.html" files within "pep-NNNN" directories
 .PHONY: dirhtml
 dirhtml: BUILDER = dirhtml

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ Pygments >= 2.9.0
 Sphinx >= 5.1.1, != 6.1.0, != 6.1.1
 docutils >= 0.19.0
 
+sphinx-autobuild
+
 # For tests
 pytest
 pytest-cov


### PR DESCRIPTION

Add a `make htmllive` target to use https://github.com/executablebooks/sphinx-autobuild.

When you run it, it builds the docs and serves them at something like http://127.0.0.1:8000/

You can visit any page, for example http://127.0.0.1:8000/pep-0101.html, and when you edit/save your source `.rst` file, it will automatically rebuild and update the page in the browser.

This drastically improves the edit/inspect loop. A very nice touch is it will also keep you at the same position in the page.

Compare before:

1. switch to IDE: edit, save
2. switch to prompt: `make html`
3. switch to browser: reload, inspect
4. repeat

To this PR:

1. switch to IDE: edit, save
2. ~switch to prompt: `make html`~
3. switch to browser: ~reload,~ inspect
4. repeat

(There's still some slowness due to https://github.com/python/peps/issues/3477, but this automation reduces the manual labour.)

We've already added this to the devguide (https://github.com/python/devguide/pull/1208, https://github.com/python/devguide/pull/1212) and can add thing to CPython Docs later.

cc @pradyunsg 






<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3521.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->