### PR TITLE
PEP 723: Rename to `Inline script metadata`

### DIFF
--- a/peps/pep-0723.rst
+++ b/peps/pep-0723.rst
@@ -1,5 +1,5 @@
 PEP: 723
-Title: Embedding pyproject.toml in single-file scripts
+Title: Inline script metadata
 Author: Ofek Lev <ofekmeister@gmail.com>
 Sponsor: Adam Turner <python@quite.org.uk>
 PEP-Delegate: Brett Cannon <brett@python.org>


### PR DESCRIPTION
https://discuss.python.org/t/name-for-pep-723-style-dependency-declarations/37993/4

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3522.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->