### PR TITLE
PEP 734: Multiple Interpreters in the Stdlib

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -611,6 +611,7 @@ peps/pep-0730.rst  @ned-deily
 peps/pep-0731.rst  @gvanrossum @encukou @vstinner @zooba @iritkatriel
 peps/pep-0732.rst  @Mariatta
 peps/pep-0733.rst  @encukou @vstinner @zooba @iritkatriel
+peps/pep-0734.rst  @ericsnowcurrently
 # ...
 # peps/pep-0754.rst
 # ...

--- a/peps/pep-0554.rst
+++ b/peps/pep-0554.rst
@@ -23,6 +23,7 @@ Superseded-By: 734
    background information and deferred/rejected ideas that have
    been stripped from :pep:`734`.
 
+
 Abstract
 ========
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -516,13 +516,24 @@ Here's the initial list of supported objects:
 * ``None``
 * ``tuple`` (only with shareable items)
 * channels (``SendChannel``/``RecvChannel``)
-* ``memoryview``
+* ``memoryview`` (underlying buffer actually shared)
 
-Again, for some types the actual object is shared, whereas for others
-only the underlying data (or even a copy or proxy) is shared.
+Note that the last two on the list, channels and ``memoryview``, are
+technically mutable data types, whereas the rest are not.  When any
+interpreters share mutable data there is always a risk of data races.
+Cross-interpreter safety, including thread-safety, is a fundamental
+feature of channels.
 
-Regardless, the guarantee of "shareable" objects is that corresponding
-objects in different interpreters will always strictly match each other.
+However, ``memoryview`` does not have any native accommodations.
+The user is responsible for managing thread safety, whether passing
+a token back and forth through a channel to indicate safety,
+or by assigning sub-range exclusivity to individual interpreters.
+
+Finally, a reminder: for some types the actual object is shared,
+whereas for others only the underlying data (or even a copy or proxy)
+is shared.  Regardless, the guarantee of "shareable" objects is that
+corresponding objects in different interpreters will always strictly
+match each other.
 
 InterpreterPoolExecutor
 -----------------------

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -318,11 +318,12 @@ values at once.
 Propagating Exceptions
 ----------------------
 
-An uncaught exception from a subinterpreter, via ``Interpreter.exec()``,
+An uncaught exception from a subinterpreter,
+via ``Interpreter.exec_sync()``,
 could either be (effectively) ignored, like ``threading.Thread()`` does,
-or propagated, like the builtin ``exec()`` does.  Since
-``Interpreter.exec()`` is a synchronous operation, like the builtin
-``exec()``, uncaught exceptions are propagated.
+or propagated, like the builtin ``exec()`` does.  Since ``exec_sync()``
+is a synchronous operation, like the builtin ``exec()``,
+uncaught exceptions are propagated.
 
 However, such exceptions are not raised directly.  That's because
 interpreters are isolated from each other and must not share objects,
@@ -337,7 +338,7 @@ immediately caught, it will bubble up through the call stack until
 caught (or not).  In the case that code somewhere else may catch it,
 it is helpful to identify that the exception came from a subinterpreter
 (i.e. a "remote" source), rather than from the current interpreter.
-That's why ``Interpreter.exec()`` raises ``RunFailedError`` and why
+That's why ``Interpreter.exec_sync()`` raises ``RunFailedError`` and why
 it is a plain ``Exception``, rather than a copy or proxy with a class
 that matches the original exception.  For example, an uncaught
 ``ValueError`` from a subinterpreter would never get caught in a later
@@ -404,7 +405,7 @@ The module defines the following functions:
       for it.  The interpreter doesn't do anything on its own and is
       not inherently tied to any OS thread.  That only happens when
       something is actually run in the interpreter
-      (e.g. ``Interpreter.exec()``), and only while running.
+      (e.g. ``Interpreter.exec_sync()``), and only while running.
       The interpreter may or may not have thread states ready to use,
       but that is strictly an internal implementation detail.
 
@@ -436,8 +437,8 @@ Attributes and methods:
 
       It refers only to if there is an OS thread
       running a script (code) in the interpreter's ``__main__`` module.
-      That basically means whether or not ``Interpreter.exec()`` is
-      running in some OS thread.  Code running in sub-threads
+      That basically means whether or not ``Interpreter.exec_sync()``
+      is running in some OS thread.  Code running in sub-threads
       is ignored.
 
 * ``prepare_main(**kwargs)``
@@ -451,7 +452,7 @@ Attributes and methods:
       ``prepare_main()`` is helpful for initializing the
       globals for an interpreter before running code in it.
 
-* ``exec(code, /)``
+* ``exec_sync(code, /)``
       Execute the given source code in the interpreter
       (in the current OS thread), using its ``__main__`` module.
       It doesn't return anything.
@@ -462,11 +463,11 @@ Attributes and methods:
       the globals and locals.
 
       The code running in the current OS thread (a different
-      interpreter) is effectively paused until ``Interpreter.exec()``
+      interpreter) is effectively paused until ``exec_sync()``
       finishes.  To avoid pausing it, create a new ``threading.Thread``
-      and call ``Interpreter.exec()`` in it.
+      and call ``exec_sync()`` in it.
 
-      ``Interpreter.exec()`` does not reset the interpreter's state nor
+      ``exec_sync()`` does not reset the interpreter's state nor
       the ``__main__`` module, neither before nor after, so each
       successive call picks up where the last one left off.  This can
       be useful for running some code to initialize an interpreter
@@ -482,7 +483,7 @@ Attributes and methods:
 
       If exception propagation is not desired then an explicit
       try-except should be used around the *code* passed to
-      ``Interpreter.exec()``.  Likewise any error handling that depends
+      ``exec_sync()``.  Likewise any error handling that depends
       on specific information from the exception must use an explicit
       try-except around the given *code*, since ``RunFailedError``
       will not preserve that information.
@@ -695,7 +696,7 @@ pass an object around to indicate who can use the resource::
    def worker():
        interp = interpreters.create()
        interp.prepare_main(control=control, data=data)
-       interp.exec("""if True:
+       interp.exec_sync("""if True:
            from mymodule import edit_data
            while True:
                token = control.get()
@@ -718,11 +719,11 @@ Exceptions
 ----------
 
 * ``RunFailedError``
-      Raised from ``Interpreter.exec()`` when there's an uncaught
-      exception.  The error display for this exception includes
-      the traceback of the uncaught exception, just as if that
-      uncaught exception had been set as ``__cause__`` on the
-      ``RunFailedError``.
+      Raised from ``Interpreter.exec_sync()`` when there's an
+      uncaught exception.  The error display for this exception
+      includes the traceback of the uncaught exception, just as
+      if that uncaught exception had been set as ``__cause__``
+      on the ``RunFailedError``.
 
       Attributes:
 
@@ -804,7 +805,7 @@ via workers in sub-threads.
    def worker():
        interp = interpreters.create()
        interp.prepare_main(tasks=tasks, results=results)
-       interp.exec("""if True:
+       interp.exec_sync("""if True:
            from mymodule import handle_request, capture_exception
 
            while True:
@@ -866,7 +867,7 @@ so the code takes advantage of directly sharing ``memoryview`` buffers.
    def worker(id):
        interp = interpreters.create()
        interp.prepare_main(data=buf, results=results, tasks=tasks)
-       interp.exec("""if True:
+       interp.exec_sync("""if True:
            from mymodule import reduce_chunk
 
            while True:

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -89,9 +89,11 @@ available via the :ref:`C API <python:sub-interpreter-support>`.
 Interpreters and Threads
 ------------------------
 
-There's a one-to-many relationship between thread states and interpreter
-states.  A thread state belongs to a single interpreter and stores
-a pointer to it.  That thread state is never used for a different
+Thread states are related to interpreter states in much the same way
+that OS threads and processes are related (at a hight level).  To
+begin with, the relationship is one-to-many.
+A thread state belongs to a single interpreter (and stores
+a pointer to it).  That thread state is never used for a different
 interpreter.  In the other direction, however, an interpreter may have
 more than thread state associated with it.  The interpreter is only
 considered active in OS threads where one of its thread states

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -228,10 +228,10 @@ using them in `concurrency benchmarks`_.
 .. _concurrency benchmarks:
    https://github.com/ericsnowcurrently/concurrency-benchmarks
 
-Interpreter.prepare___main__() Sets Multiple Variables
-------------------------------------------------------
+Interpreter.prepare_main() Sets Multiple Variables
+--------------------------------------------------
 
-``prepare___main__()`` may be seen as a setter function of sorts.
+``prepare_main()`` may be seen as a setter function of sorts.
 It supports setting multiple names at once, whereas most setters
 set one item at a time.  The main reason is for efficiency.
 
@@ -242,7 +242,7 @@ Furthermore, there is some overhead to the mechanism by which it passes
 objects between interpreters, which can be reduced in aggregate if
 multiple values are set at once.
 
-Therefore, ``prepare___main__()`` supports setting multiple
+Therefore, ``prepare_main()`` supports setting multiple
 values at once.
 
 Propagating Exceptions
@@ -349,7 +349,7 @@ Attributes and methods:
       running in some OS thread.  Code running in sub-threads
       is ignored.
 
-* ``prepare___main__(**kwargs)``
+* ``prepare_main(**kwargs)``
       Bind one or more objects in the interpreter's ``__main__`` module.
 
       The keyword argument names will be used as the attribute names.
@@ -357,7 +357,7 @@ Attributes and methods:
       to the original.  Only objects specifically supported for passing
       between interpreters are allowed.  See `Shareable Objects`_.
 
-      ``prepare___main__()`` is helpful for initializing the
+      ``prepare_main()`` is helpful for initializing the
       globals for an interpreter before running code in it.
 
 * ``exec(code, /)``
@@ -518,7 +518,7 @@ Attributes and methods:
 Shareable Objects
 -----------------
 
-Both ``Interpreter.prepare___main__()`` and ``Queue`` work only with
+Both ``Interpreter.prepare_main()`` and ``Queue`` work only with
 "shareable" objects.
 
 A "shareable" object is one which may be passed from one interpreter
@@ -563,7 +563,7 @@ a token back and forth through a queue to indicate safety
 to individual interpreters.
 
 Regarding queues, the primary situation for sharing is where an
-interpreter is using ``prepare___main__()`` to provide another
+interpreter is using ``prepare_main()`` to provide another
 interpreter with a means of further communication.
 
 Finally, a reminder: for some types the actual object is shared,
@@ -601,7 +601,7 @@ pass an object around to indicate who can use the resource::
 
    def worker():
        interp = interpreters.create()
-       interp.prepare___main__(control=control, data=data)
+       interp.prepare_main(control=control, data=data)
        interp.exec("""if True:
            from mymodule import edit_data
            while True:
@@ -631,7 +631,7 @@ to synchronize in both directions::
 
    def worker():
        interp = interpreters.create()
-       interp.prepare___main__(sync=sync)
+       interp.prepare_main(sync=sync)
        interp.exec("""if True:
            # do step 1
            token = sync.get()
@@ -734,7 +734,7 @@ via workers in sub-threads.
 
    def worker():
        interp = interpreters.create()
-       interp.prepare___main__(tasks=tasks, results=results)
+       interp.prepare_main(tasks=tasks, results=results)
        interp.exec("""if True:
            from mymodule import handle_request, capture_exception
 
@@ -796,7 +796,7 @@ so the code takes advantage of directly sharing ``memoryview`` buffers.
 
    def worker(id):
        interp = interpreters.create()
-       interp.prepare___main__(data=buf, results=results, tasks=tasks)
+       interp.prepare_main(data=buf, results=results, tasks=tasks)
        interp.exec("""if True:
            from mymodule import reduce_chunk
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -226,19 +226,6 @@ Here are some relevant characteristics of the builtin ``exec()``:
   namespace).  At module-level, ``exec()`` defaults to using
   ``__dict__`` of the current module (i.e. ``globals()``).
   ``exec()`` uses that namespace as-is and does not clear it before or after.
-* It discards any object returned from the executed code::
-
-   def func():
-       global spam
-       spam = True
-       return 'a returned value'
-
-   ns = {}
-   res = exec(func.__code__, ns)
-   # Nothing is returned.  The returned string was discarded.
-   assert res is None, res
-   assert ns['spam'] is True, ns
-
 * It propagates any uncaught exception from the code it ran.
   The exception is raised from the ``exec()`` call in the Python
   thread that originally called ``exec()``.

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -38,41 +38,45 @@ look at threads.  Then we'll circle back to interpreters.
 Threads and Thread States
 -------------------------
 
-A Python process will have one or more threads running Python code
+A Python process will have one or more OS threads running Python code
 (or otherwise interacting with the C API).  Each of these threads
-targets a distinct thread state (``PyThreadState``) which holds all
-the runtime state unique to that thread.  Each thread also targets
-some runtime state it shares with other threads.
+interacts with the CPython runtime using its own thread state
+(``PyThreadState``), which holds all the runtime state unique to that
+thread.  There is also some runtime state that is shared between
+multiple OS threads.
 
-A thread's distinct thread state is known as the "current" thread state.
-It is stored by the runtime in a thread-local variable, and may be
-looked up explicitly with ``PyThreadState_Get()``.  It gets set
-automatically for the initial ("main") thread and for
-``threading.Thread`` objects.  From the C API it is set (and cleared)
-by ``PyThreadState_Swap()`` and may be set by ``PyGILState_Ensure()``.
-Most of the C API requires that there be a current thread state,
-either looked up implicitly or passed in as an argument.
+Any OS thread may switch which thread state it is currently using, as
+long as it isn't one that another OS thread is already using (or has
+been using).  This "current" thread state is stored by the runtime
+in a thread-local variable, and may be looked up explicitly with
+``PyThreadState_Get()``.  It gets set automatically for the initial
+("main") OS thread and for ``threading.Thread`` objects.  From the
+C API it is set (and cleared) by ``PyThreadState_Swap()`` and may
+be set by ``PyGILState_Ensure()``.  Most of the C API requires that
+there be a current thread state, either looked up implicitly
+or passed in as an argument.
 
-The relationship between threads and thread states in one-to-many.
-Each thread state is associated with at most a single thread and
-records its thread ID.  It is never used for another thread.
-In the other direction, however, a thread may have more than one thread
-state associated with it, though, again, only one may be current.
+The relationship between OS threads and thread states is one-to-many.
+Each thread state is associated with at most a single OS thread and
+records its thread ID.  A thread state is never used for more than one
+OS thread.  In the other direction, however, an OS thread may have more
+than one thread state associated with it, though, again, only one
+may be current.
 
-When there's more than one thread state for a thread,
-``PyThreadState_Swap()`` is used to switch between them,
-with the requested thread state becoming the current one.
-Whatever was running in the thread using the old thread state
-is effectively paused until that thread state is swapped back in.
+When there's more than one thread state for an OS thread,
+``PyThreadState_Swap()`` is used in that OS thread to switch
+between them, with the requested thread state becoming the current one.
+Whatever was running in the thread using the old thread state is
+effectively paused until that thread state is swapped back in.
 
 Interpreter States
 ------------------
 
-As noted earlier, there is some runtime state that multiple threads
+As noted earlier, there is some runtime state that multiple OS threads
 share.  Some of it is exposed by the ``sys`` module, though much is
 used internally and not exposed explicitly or only through the C API.
 
-This state that thread states share is called the interpreter state
+This shared state is called the interpreter state
 (``PyInterpreterState``).  We'll sometimes refer to it here as just
 "interpreter", though that is also sometimes used to refer to the
 ``python`` executable, to the Python implementation, and to the
@@ -90,7 +94,8 @@ states.  A thread state belongs to a single interpreter and stores
 a pointer to it.  That thread state is never used for a different
 interpreter.  In the other direction, however, an interpreter may have
 more than thread state associated with it.  The interpreter is only
-considered active in threads where one of its thread states is current.
+considered active in OS threads where one of its thread states
+is current.
 
 Interpreters are created via the C API using ``Py_NewInterpreter()``
 or ``Py_NewInterpreterFromConfig()``.  Both functions do the following:
@@ -101,14 +106,14 @@ or ``Py_NewInterpreterFromConfig()``.  Both functions do the following:
 4. initialize the interpreter state using that thread state
 5. return the thread state (still current)
 
-To make an existing interpreter active in the current thread,
-we first make sure it has a thread state for the thread.  Then
-we call ``PyThreadState_Swap()`` like normal using that thread state.
-If the thread state for another interpreter was already current then
-it gets swapped out like normal and execution of that interpreter in
-the thread is thus effectively paused until it is swapped back in.
+To make an existing interpreter active in the current OS thread,
+we first make sure that interpreter has a corresponding thread state.
+Then we call ``PyThreadState_Swap()`` like normal using that thread
+state.  If the thread state for another interpreter was already current
+then it gets swapped out like normal and execution of that interpreter
+in the OS thread is thus effectively paused until it is swapped back in.
 
-Once an interpreter is active in the current thread like that, we can
+Once an interpreter is active in the current OS thread like that, we can
 call any of the C API, such as ``PyEval_EvalCode()`` (i.e. ``exec()``).
 
 The "Main" Interpreter
@@ -116,13 +121,13 @@ The "Main" Interpreter
 
 When a Python process starts, it creates a single interpreter state
 (the "main" interpreter) with a single thread state for the current
-thread.  The Python runtime is then initialized using them.
+OS thread.  The Python runtime is then initialized using them.
 
 After initialization, the script or module or REPL is executed using
 them.  That execution happens in the interpreter's ``__main__`` module.
 
 When execution is done, the Python runtime is finalized in the main
-thread using the main interpreter.
+OS thread using the main interpreter.
 
 Interpreter Isolation
 ---------------------
@@ -268,12 +273,12 @@ The module defines the following functions:
 
 * ``list_all() -> list[Interpreter]``
       Returns an ``Interpreter`` object for each existing interpreter,
-      whether it is currently running in any threads or not.
+      whether it is currently running in any OS threads or not.
 
 * ``create() -> Interpreter``
       Create a new interpreter and return an ``Interpreter`` object
-      for it.  The interpreter will not be associated with any threads
-      until something is actually run in the interpreter.
+      for it.  The interpreter will not be associated with any
+      OS threads until something is actually run in the interpreter.
 
 Interpreter Objects
 -------------------
@@ -302,10 +307,11 @@ Attributes and methods:
       Returns ``True`` if the interpreter is currently executing code
       in its ``__main__`` module.  This excludes sub-threads.
 
-      It refers only to if there is a thread
+      It refers only to if there is an OS thread
       running a script (code) in the interpreter's ``__main__`` module.
       That basically means whether or not ``Interpreter.exec()`` is
-      running in some thread.  Code running in sub-threads is ignored.
+      running in some OS thread.  Code running in sub-threads
+      is ignored.
 
 * ``prepare___main__(**kwargs)``
       Bind one or more objects in the interpreter's ``__main__`` module.
@@ -320,10 +326,10 @@ Attributes and methods:
 
 * ``exec(code, /)``
       Run the given source code in the interpreter
-      (in the current thread).
+      (in the current OS thread).
 
       This is essentially equivalent to switching to this interpreter
-      in the current thread and then calling the builtin ``exec()``
+      in the current OS thread and then calling the builtin ``exec()``
       using this interpreter's ``__main__`` module's ``__dict__`` as
       the globals and locals.
 
@@ -343,10 +349,10 @@ interpreter's distinct runtime state.
 Here are the relevant characteristics of the builtin ``exec()``,
 for comparison:
 
-* It runs in the current OS thread and pauses whatever was running there,
-  which resumes when ``exec()`` finishes.  No other threads are affected.
-  (To avoid pausing the current thread, run ``exec()``
-  in a ``threading.Thread``.)
+* It runs in the current OS thread and pauses whatever was running
+  there, which resumes when ``exec()`` finishes.  No other OS threads
+  are affected.  (To avoid pausing the current Python thread,
+  run ``exec()`` in a ``threading.Thread``.)
 * It executes against a namespace, by default the ``__dict__`` of the
   current module (i.e. ``globals()``).  It uses that namespace as-is
   and does not clear it before or after.
@@ -367,8 +373,8 @@ for comparison:
    assert ns['spam'] is True, ns
 
 * It propagates any uncaught exception from the code it ran.
-  The exception is raised from the ``exec()`` call in the thread
-  that originally called ``exec()``.
+  The exception is raised from the ``exec()`` call in the Python
+  thread that originally called ``exec()``.
 
 The only difference is that, rather than propagate the uncaught
 exception directly, ``Interpreter.exec()`` raises an
@@ -513,7 +519,7 @@ Cross-interpreter safety, including thread-safety, is a fundamental
 feature of queues.
 
 However, ``memoryview`` does not have any native accommodations.
-The user is responsible for managing thread safety, whether passing
+The user is responsible for managing thread-safety, whether passing
 a token back and forth through a queue to indicate safety
 (see `Synchronization`_), or by assigning sub-range exclusivity
 to individual interpreters.

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -421,8 +421,7 @@ cross-interpreter-safe queues exposed by the ``interpreters`` module.
 Aside from cross-interpreter support, the main things that set
 ``Queue`` apart from those other queue classes are:
 the "sync" arg to ``put()``,
-the "default" arg to ``get_nowait()``,
-and the "all" arg to ``close()``.
+and the "default" arg to ``get_nowait()``.
 
 Attributes and methods:
 
@@ -471,9 +470,6 @@ Attributes and methods:
       is removed from the queue (regardless of position).
       (Also see `Synchronization`_).
 
-      Raise ``interpreters.QueueClosed`` if the queue has already been
-      closed in this interpreter.
-
 * ``put_nowait(obj)``
       Like ``put()`` but effectively with an immediate timeout,
       and it never waits for the object to be received.
@@ -484,23 +480,10 @@ Attributes and methods:
       object hasn't been added to the queue in that many seconds
       then raise ``interpreters.QueueEmpty``.
 
-      Raise ``interpreters.QueueEmptyClosed`` if the queue has been
-      closed in all interpreters and is now empty.
-
 * ``get_nowait([default]) -> object``
       Like ``get()``, but do not block.  If the queue is not empty
       then return the next item.  Otherwise, return the default if
       one was provided else raise ``interpreters.QueueEmpty``.
-
-* ``close(*, all=False)``
-      Indicate that no more objects will be put on this queue
-      by the current interpreter.  This is called automatically
-      (with ``all=False``) when the queue object is garbage collected.
-      This is effectively the same as ``multiprocessing.Queue.close()``
-      (though no pipes are involved).
-
-      If "all" is ``True`` then this indicates that no more objects
-      will be put on this queue by *any* interpreters.
 
 Shareable Objects
 -----------------
@@ -660,18 +643,6 @@ Exceptions
       when the object isn't received in time.
 
       This exception is a subclass of ``Exception``.
-
-* ``QueueClosed``
-      Raised from ``Queue.put()`` and ``put_nowait()`` once ``close()``
-      has been closed for the current interpreter (or all interpreters).
-
-      This exception is a subclass of ``ValueError``.
-
-* ``QueueClosedEmpty``
-      Raised from ``Queue.get()`` and ``get_nowait()`` once ``close()``
-      has been closed for *all* interpreters and the queue is empty.
-
-      This exception is a subclass of ``QueueClosed`` and ``QueueEmpty``.
 
 InterpreterPoolExecutor
 -----------------------

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -330,7 +330,7 @@ interpreters are isolated from each other and must not share objects,
 including exceptions.  That could be addressed by raising a surrogate
 of the exception, whether a summary, a copy, or a proxy that wraps it.
 Any of those could preserve the traceback, which is useful for
-debugging.  The ``RunFailedError`` that gets raised
+debugging.  The ``ExecFailure`` that gets raised
 is such a surrogate.
 
 There's another concern to consider.  If a propagated exception isn't
@@ -338,11 +338,11 @@ immediately caught, it will bubble up through the call stack until
 caught (or not).  In the case that code somewhere else may catch it,
 it is helpful to identify that the exception came from a subinterpreter
 (i.e. a "remote" source), rather than from the current interpreter.
-That's why ``Interpreter.exec_sync()`` raises ``RunFailedError`` and why
+That's why ``Interpreter.exec_sync()`` raises ``ExecFailure`` and why
 it is a plain ``Exception``, rather than a copy or proxy with a class
 that matches the original exception.  For example, an uncaught
 ``ValueError`` from a subinterpreter would never get caught in a later
-``try: ... except ValueError: ...``.  Instead, ``RunFailedError``
+``try: ... except ValueError: ...``.  Instead, ``ExecFailure``
 must be handled directly.
 
 Limited Object Sharing
@@ -474,9 +474,9 @@ Attributes and methods:
       (e.g. with imports) before later performing some repeated task.
 
       If there is an uncaught exception, it will be propagated into
-      the calling interpreter as a ``RunFailedError``, which
+      the calling interpreter as a ``ExecFailure``, which
       preserves enough information for a helpful error display.  That
-      means if the ``RunFailedError`` isn't caught then the full
+      means if the ``ExecFailure`` isn't caught then the full
       traceback of the propagated exception, including details about
       syntax errors, etc., will be displayed.  Having the full
       traceback is particularly useful when debugging.
@@ -485,7 +485,7 @@ Attributes and methods:
       try-except should be used around the *code* passed to
       ``exec_sync()``.  Likewise any error handling that depends
       on specific information from the exception must use an explicit
-      try-except around the given *code*, since ``RunFailedError``
+      try-except around the given *code*, since ``ExecFailure``
       will not preserve that information.
 
 * ``run(code, /) -> threading.Thread``
@@ -729,7 +729,7 @@ pass an object around to indicate who can use the resource::
 Exceptions
 ----------
 
-* ``RunFailedError``
+* ``ExecFailure``
       Raised from ``Interpreter.exec_sync()`` when there's an
       uncaught exception.  The error display for this exception
       includes the traceback of the uncaught exception, which gets

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -121,7 +121,8 @@ it is swapped back in.
 
 Once an interpreter is active in the current OS thread like that, the
 thread can call any of the C API, such as ``PyEval_EvalCode()``
-(i.e. ``exec()``).
+(i.e. ``exec()``).  This works by using the current thread state as
+the runtime context.
 
 The "Main" Interpreter
 ----------------------

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -99,8 +99,10 @@ more than thread state associated with it.  The interpreter is only
 considered active in OS threads where one of its thread states
 is current.
 
-Interpreters are created via the C API using ``Py_NewInterpreter()``
-or ``Py_NewInterpreterFromConfig()``.  Both functions do the following:
+Interpreters are created via the C API using
+``Py_NewInterpreterFromConfig()`` (or ``Py_NewInterpreter()``, which
+is a light wrapper around ``Py_NewInterpreterFromConfig()``).
+That function does the following:
 
 1. create a new interpreter state
 2. create a new thread state

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -250,10 +250,31 @@ values at once.
 Propagating Exceptions
 ----------------------
 
-Directly raising (a proxy of) the exception
-is problematic since it's harder to distinguish between an error
-in the ``Interpreter.exec()`` call and an uncaught exception
-from the subinterpreter.
+An uncaught exception from a subinterpreter, via ``Interpreter.exec()``,
+could either be (effectively) ignored, like ``threading.Thread()`` does,
+or propagated, like the builtin ``exec()`` does.  Since
+``Interpreter.exec()`` is a synchronous operation, like the builtin
+``exec()``, uncaught exceptions are propagated.
+
+However, such exceptions are not raised directly.  That's because
+interpreters are isolated from each other and must not share objects,
+including exceptions.  That could be addressed by raising a surrogate
+of the exception, whether a summary, a copy, or a proxy that wraps it.
+Any of those could preserve the traceback, which is useful for
+debugging.  The ``RunFailedError`` that gets raised
+is such a surrogate.
+
+There's another concern to consider.  If a propagated exception isn't
+immediately caught, it will bubble up through the call stack until
+caught (or not).  In the case that code somewhere else may catch it,
+it is helpful to identify that the exception came from a subinterpreter
+(i.e. a "remote" source), rather than from the current interpreter.
+That's why ``Interpreter.exec()`` raises ``RunFailedError`` and why
+it is a plain ``Exception``, rather than a copy or proxy with a class
+that matches the original exception.  For example, an uncaught
+``ValueError`` from a subinterpreter would never get caught in a later
+``try: ... except ValueError: ...``.  Instead, ``RunFailedError``
+must be handled directly.
 
 Directly Shareable Objects
 --------------------------
@@ -376,6 +397,16 @@ Attributes and methods:
       successive call picks up where the last one left off.  This can
       be useful for running some code to initialize an interpreter
       (e.g. with imports) before later performing some repeated task.
+
+      If there is an uncaught exception, it will be propagated into
+      the calling interpreter as a ``RunFailedError``, which
+      preserves enough information for a helpful error display.
+      If exception propagation is not desired then an explicit
+      try-except should be used around the *code* passed to ``exec()``.
+      Likewise any error handling that depends on specific information
+      from the exception must use an explicit try-except around
+      the given *code*, since ``RunFailedError`` will not preserve
+      that information.
 
 Comparison with builtins.exec()
 -------------------------------
@@ -663,7 +694,18 @@ Exceptions
 
 * ``RunFailedError``
       Raised from ``Interpreter.exec()`` when there's an uncaught
-      exception.
+      exception.  The error display for this exception includes
+      the traceback of the uncaught exception, just as if that
+      uncaught exception had been set as ``__cause__`` on the
+      ``RunFailedError``.
+
+      Attributes:
+
+      * ``type`` - a representation of the original exception's class,
+        with ``__name__``, ``__module__``, and ``__qualname__`` attrs.
+      * ``msg`` - ``str(exc)`` of the original exception
+      * ``snapshot`` - a ``traceback.TracebackException`` object
+        for the original exception
 
       This exception is a subclass of ``RuntimeError``.
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -424,7 +424,7 @@ The module defines the following functions:
 Interpreter Objects
 -------------------
 
-An ``interpreters.Interpreter`` object represents the interpreter
+An ``interpreters.Interpreter`` object that represents the interpreter
 (``PyInterpreterState``) with the corresponding unique ID.
 
 If the interpreter was created with ``interpreters.create()`` then

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -403,7 +403,11 @@ The only difference is that, rather than propagate the uncaught
 exception directly, ``Interpreter.exec()`` raises an
 ``interpreters.RunFailedError`` with a snapshot
 (``traceback.TracebackException``) of the uncaught exception
-(including its traceback) as the ``__cause__``.
+(including its traceback) as the ``__cause__``.  That means if the
+``RunFailedError`` isn't caught then the full traceback of the
+propagated exception, including details about syntax errors, etc.,
+will be displayed.  Having the full traceback is particularly useful
+when debugging.
 
 Communicating Between Interpreters
 ----------------------------------

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -564,6 +564,7 @@ pass an object around to indicate who can use the resource::
                token = control.get()
                edit_data(data)
                control.put_nowait(token)
+           """)
    threads = [threading.Thread(target=worker) for _ in range(numworkers)]
    for t in threads:
        t.start()
@@ -597,6 +598,7 @@ to synchronize in both directions::
            # do step 3
            sync.put(None)
            sync.get()
+           """)
    t = threading.Thread(target=worker)
    t.start()
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -662,15 +662,7 @@ equivalent to the corresponding object in the other interpreter.
 In other words, the two objects will be indistinguishable from each
 other.  The shared object should be treated as though the original
 had been shared directly, whether or not it actually was.
-Even if the actual object isn't directly shared, the
-two objects will still match each other exactly in both raw value/state
-and behavior, as though they *were* the same object.
-
-For many objects, especially simple immutable ones, this at least
-means equality.  However, it would be as though equality were
-implemented were implemented as deeply and thoroughly as possible.
-For special equality-defying objects like ``NaN``, the appropriate
-check would pass, e.g. ``math.isnan()``.
+That's a slightly different and stronger promise than just equality.
 
 The guarantee is especially important for mutable objects, like
 ``Queue`` and ``memoryview``.  Mutating the object in one interpreter

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -662,41 +662,6 @@ pass an object around to indicate who can use the resource::
            break
        control.put(token)
 
-If an interpreter needs to wait for another to reach a certain point
-then they can synchronize through a queue.  They just need to make sure
-to synchronize in both directions::
-
-   import interpreters
-
-   sync = interpreters.create_queue()
-
-   def worker():
-       interp = interpreters.create()
-       interp.prepare_main(sync=sync)
-       interp.exec("""if True:
-           # do step 1
-           token = sync.get()
-           sync.put(token)
-           # do step 2
-           sync.put(None)
-           sync.get()
-           # do step 3
-           sync.put(None)
-           sync.get()
-           """)
-   t = threading.Thread(target=worker)
-   t.start()
-
-   # do step A
-   sync.put(None)
-   sync.get()
-   # do step B
-   token = sync.get()
-   sync.put(token)
-   # do step C
-   token = sync.get()
-   sync.put(token)
-
 Exceptions
 ----------
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -554,14 +554,23 @@ Attributes and methods:
 * ``empty()``
       Return ``True`` if the queue is empty, ``False`` otherwise.
 
+      This is only a snapshot of the state at the time of the call.
+      Other threads or interpreters may cause this to change.
+
 * ``full()``
       Return ``True`` if there are ``maxsize`` items in the queue.
 
       If the queue was initialized with ``maxsize=0`` (the default),
       then ``full()`` never returns ``True``.
 
+      This is only a snapshot of the state at the time of the call.
+      Other threads or interpreters may cause this to change.
+
 * ``qsize()``
       Return the number of items in the queue.
+
+      This is only a snapshot of the state at the time of the call.
+      Other threads or interpreters may cause this to change.
 
 * ``put(obj, timeout=None)``
       Add the object to the queue.

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -729,34 +729,6 @@ so we take advantage of directly sharing ``memoryview`` buffers.
    use_results(results)
 
 
-Documentation
-=============
-
-The new stdlib docs page for the ``interpreters`` module will include
-the following:
-
-* (at the top) a clear note that support for multiple interpreters
-  is not required from extension modules
-* some explanation about what subinterpreters are
-* brief examples of how to use multiple interpreters
-  (and communicating between them)
-* a summary of the limitations of using multiple interpreters
-* (for extension maintainers) a link to the resources for ensuring
-  multiple interpreters compatibility
-* much of the API information in this PEP
-
-Docs about resources for extension maintainers already exist on the
-:ref:`python:isolating-extensions-howto` howto page.  Any
-extra help will be added there.  For example, it may prove helpful
-to discuss strategies for dealing with linked libraries that keep
-their own subinterpreter-incompatible global state.
-
-Also, the ``ImportError`` for incompatible extension modules will be
-updated to clearly say it is due to missing multiple interpreters
-compatibility and that extensions are not required to provide it.  This
-will help set user expectations properly.
-
-
 Rejected Ideas
 ==============
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -191,6 +191,82 @@ Immutable:
 * underlying static module data (e.g. functions) for
   builtin/extension/frozen modules
 
+Existing Execution Components
+-----------------------------
+
+There are a number of existing parts of Python that may help
+with understanding how code may be run in a subinterpreter.
+
+In CPython, each component is built around one of the following
+C API functions (or variants):
+
+* ``PyEval_EvalCode()``: run the bytecode interpreter with the given
+  code object
+* ``PyRun_String()``: compile + ``PyEval_EvalCode()``
+* ``PyRun_File()``: read + compile + ``PyEval_EvalCode()``
+* ``PyRun_InteractiveOneObject()``: compile + ``PyEval_EvalCode()``
+* ``PyObject_Call()``: calls ``PyEval_EvalCode()``
+
+builtins.exec()
+^^^^^^^^^^^^^^^
+
+The builtin ``exec()`` may be used to execute Python code.  It is
+essentially a wrapper around the C API functions ``PyRun_String()``
+and ``PyEval_EvalCode()``.
+
+Here are some relevant characteristics of the builtin ``exec()``:
+
+* It runs in the current OS thread and pauses whatever
+  was running there, which resumes when ``exec()`` finishes.
+  No other OS threads are affected.
+  (To avoid pausing the current Python thread, run ``exec()``
+  in a ``threading.Thread``.)
+* It may start additional threads, which don't interrupt it.
+* It executes against a "globals" namespace (and a "locals"
+  namespace).  At module-level, ``exec()`` defaults to using
+  ``__dict__`` of the current module (i.e. ``globals()``).
+  ``exec()`` uses that namespace as-is and does not clear it before or after.
+* It discards any object returned from the executed code::
+
+   def func():
+       global spam
+       spam = True
+       return 'a returned value'
+
+   ns = {}
+   res = exec(func.__code__, ns)
+   # Nothing is returned.  The returned string was discarded.
+   assert res is None, res
+   assert ns['spam'] is True, ns
+
+* It propagates any uncaught exception from the code it ran.
+  The exception is raised from the ``exec()`` call in the Python
+  thread that originally called ``exec()``.
+
+Command-line
+^^^^^^^^^^^^
+
+The ``python`` CLI provides several ways to run Python code.  In each
+case it maps to a corresponding C API call:
+
+* ``<no args>``, ``-i`` - run the REPL
+  (``PyRun_InteractiveOneObject()``)
+* ``<filename>`` - run a script (``PyRun_File()``)
+* ``-c <code>`` - run the given Python code (``PyRun_String()``)
+* ``-m module`` - run the module as a script
+  (``PyEval_EvalCode()`` via ``runpy._run_module_as_main()``)
+
+In each case it is essentially a variant of running ``exec()``
+at the top-level of the ``__main__`` module of the main interpreter.
+
+threading.Thread
+^^^^^^^^^^^^^^^^
+
+When a Python thread is started, it runs the "target" function
+with ``PyObject_Call()`` using a new thread state.  The globals
+namespace come from ``func.__globals__`` and any uncaught
+exception is discarded.
+
 
 Motivation
 ==========
@@ -420,43 +496,6 @@ Attributes and methods:
       from the exception must use an explicit try-except around
       the given *code*, since ``RunFailedError`` will not preserve
       that information.
-
-Comparison with builtins.exec()
--------------------------------
-
-``Interpreter.exec()`` is essentially the same as the builtin
-``exec()``, except it uses a different interpreter by switching the
-current OS thread to that interpreter's thread state.
-
-Here are the relevant characteristics of the builtin ``exec()``,
-for comparison:
-
-* It runs in the current OS thread and pauses whatever was running
-  there, which resumes when ``exec()`` finishes.  No other OS threads
-  are affected.  (To avoid pausing the current Python thread,
-  run ``exec()`` in a ``threading.Thread``.)
-* It executes against a namespace, by default the ``__dict__`` of the
-  current module (i.e. ``globals()``).  It uses that namespace as-is
-  and does not clear it before or after.
-* When code is run from the command-line (e.g. ``-m``) or the REPL,
-  the "current" module is always the ``__main__`` module
-  of the main interpreter.
-* It discards any object returned from the executed code::
-
-   def func():
-       global spam
-       spam = True
-       return 'a returned value'
-
-   ns = {}
-   res = exec(func.__code__, ns)
-   # Nothing is returned.  The returned string was discarded.
-   assert res is None, res
-   assert ns['spam'] is True, ns
-
-* It propagates any uncaught exception from the code it ran.
-  The exception is raised from the ``exec()`` call in the Python
-  thread that originally called ``exec()``.
 
 Communicating Between Interpreters
 ----------------------------------

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -443,9 +443,6 @@ Attributes and methods:
       Returns the hash of the interpreter's ``id``.  This is the same
       as the hash of the ID's integer value.
 
-* ``__eq__(other)``
-      Returns ``other is self``.
-
 * ``is_running() -> bool``
       Returns ``True`` if the interpreter is currently executing code
       in its ``__main__`` module.  This excludes sub-threads.
@@ -553,9 +550,6 @@ Attributes and methods:
 * ``__hash__()``
       Return the hash of the queue's ``id``.  This is the same
       as the hash of the ID's integer value.
-
-* ``__eq__(other)``
-      Return ``other is self``.
 
 * ``empty()``
       Return ``True`` if the queue is empty, ``False`` otherwise.

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -587,10 +587,10 @@ Attributes and methods:
       object hasn't been added to the queue in that many seconds
       then raise ``interpreters.QueueEmpty``.
 
-* ``get_nowait([default]) -> object``
+* ``get_nowait() -> object``
       Like ``get()``, but do not block.  If the queue is not empty
-      then return the next item.  Otherwise, return *default* if
-      one was provided else raise ``interpreters.QueueEmpty``.
+      then return the next item.  Otherwise, raise
+      ``interpreters.QueueEmpty``.
 
 Shareable Objects
 -----------------

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -721,9 +721,9 @@ Exceptions
 * ``RunFailedError``
       Raised from ``Interpreter.exec_sync()`` when there's an
       uncaught exception.  The error display for this exception
-      includes the traceback of the uncaught exception, just as
-      if that uncaught exception had been set as ``__cause__``
-      on the ``RunFailedError``.
+      includes the traceback of the uncaught exception, which gets
+      shown after the normal error display, much like happens for
+      ``ExceptionGroup``.
 
       Attributes:
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -134,8 +134,22 @@ OS thread.  The Python runtime is then initialized using them.
 After initialization, the script or module or REPL is executed using
 them.  That execution happens in the interpreter's ``__main__`` module.
 
-When execution is done, the Python runtime is finalized in the main
-OS thread using the main interpreter.
+When the process finishes running the requested Python code or REPL,
+in the main OS thread, the Python runtime is finalized in that thread
+using the main interpreter.
+
+Runtime finalization has only a slight, indirect effect on still-running
+Python threads, whether in the main interpreter or in subinterpreters.
+That's because right away it waits indefinitely for all non-daemon
+Python threads to finish.
+
+While the C API may be queried, there is no mechanism by which any
+Python thread is directly alerted that finalization has begun,
+other than perhaps with "atexit" functions that may be been
+registered using ``threading._register_atexit()``.
+
+Any remaining subinterpreters are themselves finalized later,
+but at that point they aren't current in any OS threads.
 
 Interpreter Isolation
 ---------------------

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -39,7 +39,7 @@ Threads and Thread States
 -------------------------
 
 A Python process will have one or more threads running Python code
-(or otherwise interacting with the C-API).  Each of these threads
+(or otherwise interacting with the C API).  Each of these threads
 targets a distinct thread state (``PyThreadState``) which holds all
 the runtime state unique to that thread.  Each thread also targets
 some runtime state it shares with other threads.
@@ -48,9 +48,9 @@ A thread's distinct thread state is known as the "current" thread state.
 It is stored by the runtime in a thread-local variable, and may be
 looked up explicitly with ``PyThreadState_Get()``.  It gets set
 automatically for the initial ("main") thread and for
-``threading.Thread`` objects.  From the C-API it is set (and cleared)
+``threading.Thread`` objects.  From the C API it is set (and cleared)
 by ``PyThreadState_Swap()`` and may be set by ``PyGILState_Ensure()``.
-Most of the C-API requires that there be a current thread state,
+Most of the C API requires that there be a current thread state,
 either looked up implicitly or passed in as an argument.
 
 The relationship between threads and thread states in one-to-many.
@@ -70,7 +70,7 @@ Interpreter States
 
 As noted earlier, there is some runtime state that multiple threads
 share.  Some of it is exposed by the ``sys`` module, though much is
-used internally and not exposed explicitly or only through the C-API.
+used internally and not exposed explicitly or only through the C API.
 
 This state that thread states share is called the interpreter state
 (``PyInterpreterState``).  We'll sometimes refer to it here as just
@@ -92,7 +92,7 @@ interpreter.  In the other direction, however, an interpreter may have
 more than thread state associated with it.  The interpreter is only
 considered active in threads where one of its thread states is current.
 
-Interpreters are created via the C-API using ``Py_NewInterpreter()``
+Interpreters are created via the C API using ``Py_NewInterpreter()``
 or ``Py_NewInterpreterFromConfig()``.  Both functions do the following:
 
 1. create a new interpreter state
@@ -109,7 +109,7 @@ it gets swapped out like normal and execution of that interpreter in
 the thread is thus effectively paused until it is swapped back in.
 
 Once an interpreter is active in the current thread like that, we can
-call any of the C-API, such as ``PyEval_EvalCode()`` (i.e. ``exec()``).
+call any of the C API, such as ``PyEval_EvalCode()`` (i.e. ``exec()``).
 
 The "Main" Interpreter
 ----------------------
@@ -133,7 +133,7 @@ specific cases internally). Each interpreter has its own modules
 (``sys.modules``), classes, functions, and variables.  Even where
 two interpreters define the same class, each will have a distinct copy.
 The same applies to state in C, including in extension modules.
-The CPython C-API docs `explain more`_.
+The CPython C API docs `explain more`_.
 
 .. _explain more:
    https://docs.python.org/3/c-api/init.html#bugs-and-caveats

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -529,6 +529,10 @@ The user is responsible for managing thread safety, whether passing
 a token back and forth through a channel to indicate safety,
 or by assigning sub-range exclusivity to individual interpreters.
 
+Regarding channels, the primary situation for sharing is where an
+interpreter is using ``prepare___main__()`` to provide the target
+interpreter with their means of further communication.
+
 Finally, a reminder: for some types the actual object is shared,
 whereas for others only the underlying data (or even a copy or proxy)
 is shared.  Regardless, the guarantee of "shareable" objects is that

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -262,67 +262,45 @@ Using Interpreters
 
 The module defines the following functions:
 
-``interpreters.get_current() -> Interpreter``::
+* ``interpreters.get_current() -> Interpreter``
+      Returns an ``Interpreter`` object for the currently executing
+      interpreter.
 
-   Returns an ``Interpreter`` object for the currently executing
-   interpreter.
+* ``interpreters.list_all() -> list[Interpreter]``
+      Returns an ``Interpreter`` object for each existing interpreter,
+      whether it is currently running in any threads or not.
 
-``interpreters.list_all() -> list[Interpreter]``::
-
-   Returns an ``Interpreter`` object for each existing interpreter,
-   whether it is currently running in any threads or not.
-
-``interpreters.create() -> Interpreter``::
-
-   Create a new interpreter and return an ``Interpreter`` object for it.
-   The interpreter will not be associated with any threads until
-   something is actually run in the interpreter.
+* ``interpreters.create() -> Interpreter``
+      Create a new interpreter and return an ``Interpreter`` object
+      for it.  The interpreter will not be associated with any threads
+      until something is actually run in the interpreter.
 
 Interpreter Objects
 -------------------
 
-An ``Interpreter`` object represents the interpreter
+An ``interpreters.Interpreter`` object represents the interpreter
 (``PyInterpreterState``) with the corresponding ID.
 
 If the interpreter was created with ``interpreters.create()`` then
 it will be destroyed as soon as all ``Interpreter`` objects have been
 deleted.
 
-``class interpreters.Interpreter(id)``::
+``interpreters.Interpreter`` attributes:
 
-   An ``Interpreter`` object is not normally created directly.
-   Instead, it should come from one of the module functions
-   (e.g. ``create()``, ``list_all()``).
-
-   Arguments:
-
-   ``id`` is the ID of an existing ``PyInterpreterState`` and is used
-   to target that interprter..  It must be an
-   ``_interpreters.InterpreterID`` object or a non-negative ``int``.
-   An ``int`` will be converted to an ``InterpreterID``.
-   If an interpreter state with that ID does not exist then this raises
-   ``ValueError`.
-
-   Attibutes:
-
-   ``id``::
-
+* ``id``
       (read-only) The target interpreter's ``InterpreterID`` object.
       It is an int-like object with some internal bookkeeping.
 
-   Methods:
+``interpreters.Interpreter`` methods:
 
-   ``__hash__()``::
-
+* ``__hash__()``
       Returns the hash of the interpreter's ``id``.  This is the same
       as the hash of the ID's integer value.
 
-   ``__eq__(other)``::
-
+* ``__eq__(other)``
       Returns ``other is self``.
 
-   ``is_running() -> bool``::
-
+* ``is_running() -> bool``
       Returns ``True`` if the interpreter is currently executing code
       in its ``__main__`` module.  This excludes sub-threads.
 
@@ -331,8 +309,7 @@ deleted.
       That basically means whether or not ``Interpreter.exec()`` is
       running in some thread.  Code running in sub-threads is ignored.
 
-   ``prepare___main__(**kwargs)``::
-
+* ``prepare___main__(**kwargs)``
       Bind one or more objects in the interpreter's ``__main__`` module.
 
       The keyword argument names will be used as the attribute names.
@@ -343,8 +320,7 @@ deleted.
       ``prepare___main__()`` is helpful for initializing the
       globals for an interpreter before running code in it.
 
-   ``exec(code, /)``::
-
+* ``exec(code, /)``
       Run the given source code in the interpreter
       (in the current thread).
 
@@ -430,49 +406,31 @@ See `Shareable Objects`_.
 
 The module defines the following functions:
 
-``create_queue() -> Queue``::
-
+* ``create_queue() -> Queue``
    Create a new queue.
 
 Queue Objects
 -------------
 
-``Queue`` objects act as proxies for the underlying
+``interpreters.Queue`` objects act as proxies for the underlying
 cross-interpreter-safe queues exposed by the ``interpreters`` module.
 
-``class Queue(id)``::
+``interpreter.Queue`` attributes:
 
-   A ``Queue`` object is not normally created directly.
-   Instead, it should come from ``interpreters.create_queue()``.
-
-   Arguments:
-
-   ``id`` is a non-negative int or ``_interpreters.QueueID``
-   corresponding to the ID of an existing cross-interpreter queue
-   and is used to target that queue.  An ``int`` will be converted
-   to a ``QueueID``.  If a queue with that ID does not exist
-   then this raises ``ValueError`.
-
-   Attributes:
-
-   ``id``::
-
+* ``id``
       (read-only) The target queue's ``QueueID`` object.
       It is an int-like object with some internal bookkeeping.
 
-   Methods:
+``interpreter.Queue`` methods:
 
-   ``__hash__()``::
-
+* ``__hash__()``
       Returns the hash of the queue's ``id``.  This is the same
       as the hash of the ID's integer value.
 
-   ``__eq__(other)``::
-
+* ``__eq__(other)``
       Returns ``other is self``.
 
-   ``put(obj, timeout=None)``::
-
+* ``put(obj, timeout=None)``
       Add the `shareable object <Shareable Objects_>`_ (i.e. its data)
       to the queue and wait for it to be received.  If a timeout is
       provided and the object is not received in that time then raise
@@ -484,18 +442,15 @@ cross-interpreter-safe queues exposed by the ``interpreters`` module.
       waiting for the object to be popped off.  In that regard think
       of each ``Queue`` as having a max size of zero.
 
-   ``put_nowait(obj) -> bool``::
-
+* ``put_nowait(obj) -> bool``
       Like ``put()``, but return False if not received.
 
-   ``get(timeout=None) -> object``::
-
+* ``get(timeout=None) -> object``
       Get the next object from the queue.  Wait while the queue is
       empty.  If a timeout is provided and an object hasn't been added
       to the queue in that time then raise ``interpreters.QueueEmpty``.
 
-   ``get_nowait([default]) -> object``::
-
+* ``get_nowait([default]) -> object``
       Like ``get()``, but return the default instead of waiting.
       If no default is provided then raise ``interpreters.QueueEmpty``.
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -756,9 +756,9 @@ Exceptions
 InterpreterPoolExecutor
 -----------------------
 
-The new ``concurrent.futures.InterpreterPoolExecutor`` will be
-a subclass of ``concurrent.futures.ThreadPoolExecutor``, where each
-worker executes tasks in its own subinterpreter.  Communication may
+Along with the new ``interpreters`` module, there will be a new
+``concurrent.futures.InterpreterPoolExecutor``.  Each worker executes
+in its own thread with its own subinterpreter.  Communication may
 still be done through ``Queue`` objects, set with the initializer.
 
 Examples

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -95,7 +95,7 @@ begin with, the relationship is one-to-many.
 A thread state belongs to a single interpreter (and stores
 a pointer to it).  That thread state is never used for a different
 interpreter.  In the other direction, however, an interpreter may have
-more than thread state associated with it.  The interpreter is only
+zero or more thread states associated with it.  The interpreter is only
 considered active in OS threads where one of its thread states
 is current.
 
@@ -110,6 +110,11 @@ That function does the following:
    (a current tstate is needed for interpreter init)
 4. initialize the interpreter state using that thread state
 5. return the thread state (still current)
+
+Note that the returned thread state may be immediately discarded.
+There is no requirement that an interpreter have any thread states,
+except as soon as the interpreter is meant to actually be used.
+At that point it must be made active in the current OS thread.
 
 To make an existing interpreter active in the current OS thread,
 the C API user first makes sure that interpreter has a corresponding
@@ -333,8 +338,12 @@ The module defines the following functions:
 
 * ``create() -> Interpreter``
       Create a new interpreter and return the ``Interpreter`` object
-      for it.  The interpreter will not be associated with any
-      OS threads until something is actually run in the interpreter.
+      for it.  The interpreter doesn't do anything on its own and is
+      not inherently tied to any OS thread.  That only happens when
+      something is actually run in the interpreter
+      (e.g. ``Interpreter.exec()``), and only while running.
+      The interpreter may or may not have thread states ready to use,
+      but that is strictly an internal implementation detail.
 
 Interpreter Objects
 -------------------

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -465,15 +465,21 @@ Attributes and methods:
       globals for an interpreter before running code in it.
 
 * ``exec(code, /)``
-      Run the given source code in the interpreter
-      (in the current OS thread).
+      Execute the given source code in the interpreter
+      (in the current OS thread), using its ``__main__`` module.
+      It doesn't return anything.
 
       This is essentially equivalent to switching to this interpreter
       in the current OS thread and then calling the builtin ``exec()``
       using this interpreter's ``__main__`` module's ``__dict__`` as
       the globals and locals.
 
-      ``exec()`` does not reset the interpreter's state nor
+      The code running in the current OS thread (a different
+      interpreter) is effectively paused until ``Interpreter.exec()``
+      finishes.  To avoid pausing it, create a new ``threading.Thread``
+      and call ``Interpreter.exec()`` in it.
+
+      ``Interpreter.exec()`` does not reset the interpreter's state nor
       the ``__main__`` module, neither before nor after, so each
       successive call picks up where the last one left off.  This can
       be useful for running some code to initialize an interpreter
@@ -488,11 +494,11 @@ Attributes and methods:
       traceback is particularly useful when debugging.
 
       If exception propagation is not desired then an explicit
-      try-except should be used around the *code* passed to ``exec()``.
-      Likewise any error handling that depends on specific information
-      from the exception must use an explicit try-except around
-      the given *code*, since ``RunFailedError`` will not preserve
-      that information.
+      try-except should be used around the *code* passed to
+      ``Interpreter.exec()``.  Likewise any error handling that depends
+      on specific information from the exception must use an explicit
+      try-except around the given *code*, since ``RunFailedError``
+      will not preserve that information.
 
 Communicating Between Interpreters
 ----------------------------------

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -587,55 +587,104 @@ still be done through channels, set with the initializer.
 Examples
 --------
 
-Using interpreters as workers, with channels to communicate:
+The following examples demonstrate practical cases where multiple
+interpreters may be useful.
+
+Example 1:
+
+We have a stream of requests coming in that we will handle
+via workers in sub-threads.
+
+* each worker thread has its own interpreter
+* we use one channel to send tasks to workers and
+  another channel to return results
+* the results are handled in a dedicated thread
+* each worker keeps going until it receives a "stop" sentinel (``None``)
+* the results handler keeps going until all workers have stopped
 
 ::
 
+   import time
    import interpreters
-   import textwrap as tw
-   from mymodule import iter_requests
+   from mymodule import iter_requests, handle_result
 
    tasks_recv, tasks = interpreters.create_channel()
    results, results_send = interpreters.create_channel()
 
+   numworkers = 20
+   threads = []
+
+   def results_handler():
+       empty = object()
+       running = numworkers
+       while running:
+           res = results.recv_nowait(empty)
+           if res is empty:
+               # No workers have finished a request since last time.
+               time.sleep(0.1)
+           elif res is None:
+               # A worker has stopped.
+               running -= 1
+           else:
+               handle_result(res)
+       assert results.recv_nowait(empty) is empty
+   threads.append(threading.Thread(target=results_handler))
+
    def worker():
        interp = interpreters.create()
        interp.prepare___main__(tasks=tasks_recv, results=results_send)
-       interp.exec(tw.dedent("""
+       interp.exec("""if True:
            from mymodule import handle_request, capture_exception
 
            while True:
-               try:
-                   req = tasks.recv()
-               except Exception:
-                   # channel closed
+               req = tasks.recv()
+               if req is None:
+                   # Stop!
                    break
                try:
                    res = handle_request(req)
                except Exception as exc:
                    res = capture_exception(exc)
                results.send_nowait(res)
+           # Notify the results handler.
+           results.send_nowait(None)
            """))
-   threads = [threading.Thread(target=worker) for _ in range(20)]
+   threads.extend(threading.Thread(target=worker) for _ in range(numworkers))
+
    for t in threads:
        t.start()
 
    for req in iter_requests():
        tasks.send(req)
-   tasks.close()
+   # Send the "stop" signal.
+   for _ in range(numworkers):
+       tasks.send(None)
 
    for t in threads:
        t.join()
 
-Sharing a ``memoryview`` (imagine map-reduce):
+Example 2:
+
+This case is similar to the last as we have a bunch of workers
+in sub-threads.  However, this time we are chunking up a big array
+of data, where each worker processes one chunk at a time.  Copying
+that data to each interpreter would be exceptionally inefficient,
+so we take advantage of directly sharing ``memoryview`` buffers.
+
+* all the interpreters share the buffer of the source array
+* each one writes its results to a second shared buffer
+* we use a channel to send tasks to workers
+* only one worker will ever read any given index in the source array
+* only one worker will ever write to any given index in the results
+  (this is how we ensure thread-safety)
 
 ::
 
    import interpreters
    import queue
-   import textwrap as tw
    from mymodule import read_large_data_set, use_results
 
+   numworkers = 3
    data, chunksize = read_large_data_set()
    buf = memoryview(data)
    numchunks = (len(buf) + 1) / chunksize
@@ -646,21 +695,19 @@ Sharing a ``memoryview`` (imagine map-reduce):
    def worker(id):
        interp = interpreters.create()
        interp.prepare___main__(data=buf, results=results, tasks=tasks_recv)
-       interp.exec(tw.dedent("""
+       interp.exec("""if True:
            from mymodule import reduce_chunk
 
            while True:
-               try:
-                   req = tasks.recv()
-               except Exception:
-                   # channel closed
+               req = tasks.recv()
+               if res is None:
+                   # Stop!
                    break
                resindex, start, end = req
                chunk = data[start: end]
                res = reduce_chunk(chunk)
                results[resindex] = res
            """))
-   numworkers = 3
    threads = [threading.Thread(target=worker) for _ in range(numworkers)]
    for t in threads:
        t.start()
@@ -672,7 +719,10 @@ Sharing a ``memoryview`` (imagine map-reduce):
        if end > len(buf):
            end = len(buf)
        tasks.send((start, end, i))
-   tasks.close()
+   # Send the "stop" signal.
+   for _ in range(numworkers):
+       tasks.send(None)
+
    for t in threads:
        t.join()
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -648,19 +648,19 @@ pass an object around to indicate who can use the resource::
            while True:
                token = control.get()
                edit_data(data)
-               control.put_nowait(token)
+               control.put(token)
            """)
    threads = [threading.Thread(target=worker) for _ in range(numworkers)]
    for t in threads:
        t.start()
 
    token = 'football'
-   control.put_nowait(token)
+   control.put(token)
    while True:
        control.get()
        if not check_data(data):
            break
-       control.put_nowait(token)
+       control.put(token)
 
 If an interpreter needs to wait for another to reach a certain point
 then they can synchronize through a queue.  They just need to make sure

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -15,6 +15,7 @@ Replaces: 554
    that extra information is still valid and useful, just not in the
    immediate context of the specific proposal here.
 
+
 Abstract
 ========
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -23,11 +23,9 @@ This PEP proposes to add a new module, ``interpreters``, to support
 inspecting, creating, and running code in multiple interpreters in the
 current process.  This includes ``Interpreter`` objects that represent
 the underlying interpreters.  The module will also provide a basic
-mechanism called "channels" for communication between interpreters.
-This includes ``SendChannel`` and ``RecvChannel`` objects to represent
-the pair of ends of each channel.  Finally, we will add a new
-``concurrent.futures.InterpreterPoolExecutor`` based on the
-``interpreters`` module.
+``Queue`` class for communication between interpreters.  Finally, we
+will add a new ``concurrent.futures.InterpreterPoolExecutor`` based
+on the ``interpreters`` module.
 
 
 Introduction
@@ -202,7 +200,7 @@ set one item at a time.  The main reason is for efficiency.
 To set a value in ``__main__.__dict__`` we must first switch to the
 target interpreter, which involves some non-negligible overhead.
 After setting the value we must switch back.  Furthermore, there
-is some overhead to the mechanism by which we send objects between
+is some overhead to the mechanism by which we pass objects between
 interpreters, which can be reduced in aggregate if multiple values
 are set at once.
 
@@ -217,30 +215,16 @@ is problematic since it's harder to distinguish between an error
 in the ``Interpreter.exec()`` call and an uncaught exception
 from the subinterpreter.
 
-Channels
---------
+Directly Shareable Objects
+--------------------------
 
-Channels are based on `CSP`_, as is Go's concurrency model (loosely).
-However, at it's core a channel is a simple FIFO queue, with the
-recv and send ends exposed distinctly, so reading about CSP should
-not be necessary.
-
-.. _CSP:
-   https://en.wikipedia.org/wiki/Communicating_sequential_processes
-
-Exposing the channel ends as distinct objects, rather than combined
-in one object, is a deliberate choice based on experience with Go's
-channels.  Go has both directional and bidirectional channels.  The
-directional channels make intentions clear and are easier to reason
-about.
-
-We cannot support directly sharing any and all objects through channels
+We cannot support directly sharing any and all objects through queues
 because all objects have at least some mutable state (e.g. refcount)
 which the GIL protects normally.  Furthermore, objects must only be
 deleted by the interpreter that created them, which makes direct
 sharing even more complex.
 
-Supporting indirect sharing of all objects in channels would be
+Supporting indirect sharing of all objects in queues would be
 possible by automatically pickling them if we can't use the more
 efficient mechanism.  However, it's helpful to know that only the
 efficient way is being used.  Furthermore, for mutable objects
@@ -251,7 +235,7 @@ include automatic pickling.
 Objects vs. ID Proxies
 ----------------------
 
-For both interpreters and channels, we provide objects that expose them
+For both interpreters and queues, we provide objects that expose them
 indirectly with ID-wrapping surrogates for the underlying state.
 In both cases the state is process-global and will be used by multiple
 interpreters.  Thus they aren't suitable to be implemented as
@@ -268,8 +252,8 @@ The module will:
 * expose the existing multiple interpreter support
 * introduce a basic mechanism for communicating between interpreters
 
-The module will wrap a new low-level ``_interpreters`` module and
-``_channels`` module (in the same way as the ``threading`` module).
+The module will wrap a new low-level ``_interpreters`` module
+(in the same way as the ``threading`` module).
 However, that low-level API is not intended for public use
 and thus not part of this proposal.
 
@@ -425,121 +409,100 @@ when debugging.
 Communicating Between Interpreters
 ----------------------------------
 
-The module introduces a basic communication mechanism called "channels".
+The module introduces a basic communication mechanism through special
+queues.
 
-A channel is a FIFO queue that exists outside any one interpreter.
-Channels have special accommodations for safely passing object data
-between interpreters, without violating interpreter isolation.
-This includes thread-safety.
+There are ``interpreters.Queue`` objects, but they only proxy
+the actual data structure: an unbounded FIFO queue that exists
+outside any one interpreter.  These queues have special accommodations
+for safely passing object data between interpreters, without violating
+interpreter isolation.  This includes thread-safety.
 
-As with other queues in Python, each sent object is added to the back
-of the channel's internal queue and each recv() pops the next one off
-the front of that queue.  Every sent object will be received.
+As with other queues in Python, for each "put" the object is added to
+the back and each "get" pops the next one off the front.  Every added
+object will be popped off in the order it was pushed on.
 
 Only objects that are specifically supported for passing
-between interpreters may be sent through a channel.  Note that the
-actual objects aren't send, but rather their underlying data.
-However, the received object will still be identical to the original.
+between interpreters may be sent through a ``Queue``.  Note that the
+actual objects aren't sent, but rather their underlying data.
+However, the popped object will still be identical to the original.
 See `Shareable Objects`_.
 
 The module defines the following functions:
 
-``create_channel() -> tuple[RecvChannel, SendChannel]``::
+``create_queue() -> Queue``::
 
-   Create a new channel, returning objects for the two ends.
+   Create a new queue.
 
-Channel Objects
----------------
+Queue Objects
+-------------
 
-The ``interpreters`` module exposes channels with objects for the two
-distinct ends, "send" and "recv", rather than a single object that
-combines both ends (like other queues).
+``Queue`` objects act as proxies for the underlying
+cross-interpreter-safe queues exposed by the ``interpreters`` module.
 
-The receiving end of a channel:
+``class Queue(id)``::
 
-``class RecvChannel(id)``::
-
-   A ``RecvChannel`` object is not normally created directly.
-   Instead, it should come from ``interpreters.create_channel()``.
+   A ``Queue`` object is not normally created directly.
+   Instead, it should come from ``interpreters.create_queue()``.
 
    Arguments:
 
-   ``id`` is a non-negative int or ``_channels.ChannelID`` corresponding
-   to the ID of an existing channel and is used to target the recv end
-   of that channel.  An ``int`` will be converted to a ``ChannelID``.
-   If a channel that ID does not exist then this raises ``ValueError`.
+   ``id`` is a non-negative int or ``_interpreters.QueueID``
+   corresponding to the ID of an existing cross-interpreter queue
+   and is used to target that queue.  An ``int`` will be converted
+   to a ``QueueID``.  If a queue with that ID does not exist
+   then this raises ``ValueError`.
 
    Attributes:
 
    ``id``::
 
-      (read-only) The target channel's ``ChannelID`` object.
+      (read-only) The target queue's ``QueueID`` object.
       It is an int-like object with some internal bookkeeping.
 
    Methods:
 
    ``__hash__()``::
 
-      Returns the hash of the channel's ``id``.  This is the same
+      Returns the hash of the queue's ``id``.  This is the same
       as the hash of the ID's integer value.
 
    ``__eq__(other)``::
 
       Returns ``other is self``.
 
-   ``recv() -> object``::
+   ``put(obj, timeout=None)``::
 
-      Get the next object from the channel.  Wait if none have been sent.
+      Add the `shareable object <Shareable Objects_>`_ (i.e. its data)
+      to the queue and wait for it to be received.  If a timeout is
+      provided and the object is not received in that time then raise
+      ``TimeoutError``.  The object will be removed from the queue at
+      that time.
 
-   ``recv_nowait(default=None) -> object``::
+      Note that other Python queue types will block only if there is
+      a max size set and the queue is full.  They do not block while
+      waiting for the object to be popped off.  In that regard think
+      of each ``Queue`` as having a max size of zero.
 
-      Like ``recv()``, but return the default instead of waiting.
+   ``put_nowait(obj) -> bool``::
 
-The sending end of a channel:
+      Like ``put()``, but return False if not received.
 
-``class SendChannel(id)``::
+   ``get(timeout=None) -> object``::
 
-   A ``SendChannel`` object is not normally created directly.
-   Instead, it should come from ``interpreters.create_channel()``.
+      Get the next object from the queue.  Wait while the queue is
+      empty.  If a timeout is provided and an object hasn't been added
+      to the queue in that time then raise ``interpreters.QueueEmpty``.
 
-   Arguments:
+   ``get_nowait([default]) -> object``::
 
-   ``id`` is a non-negative int or ``_channels.ChannelID`` corresponding
-   to the ID of an existing channel and is used to target the send end
-   of that channel.  An ``int`` will be converted to a ``ChannelID``.
-   If a channel that ID does not exist then this raises ``ValueError`.
-
-   Attributes:
-
-   ``id``::
-
-      (read-only) The target channel's ``ChannelID`` object.
-
-   Methods:
-
-   ``__hash__()``::
-
-      Returns the hash of the channel's ``id``.  This is the same
-      as the hash of the ID's integer value.
-
-   ``__eq__(other)``::
-
-      Returns ``other is self``.
-
-   ``send(obj)``::
-
-      Send the `shareable object <Shareable Objects_>`_ (i.e. its data)
-      to the receiving end of the channel and wait for it
-      to be received.
-
-   ``send_nowait(obj) -> bool``::
-
-      Like ``send()``, but return False if not received.
+      Like ``get()``, but return the default instead of waiting.
+      If no default is provided then raise ``interpreters.QueueEmpty``.
 
 Shareable Objects
 -----------------
 
-Both ``Interpreter.prepare___main__()`` and channels work only with
+Both ``Interpreter.prepare___main__()`` and ``Queue`` work only with
 "shareable" objects.
 
 A "shareable" object is one which may be passed from one interpreter
@@ -568,21 +531,21 @@ Here's the initial list of supported objects:
 * ``bool`` (``True``/``False``)
 * ``None``
 * ``tuple`` (only with shareable items)
-* channels (``SendChannel``/``RecvChannel``)
+* ``Queue``
 * ``memoryview`` (underlying buffer actually shared)
 
-Note that the last two on the list, channels and ``memoryview``, are
+Note that the last two on the list, queues and ``memoryview``, are
 technically mutable data types, whereas the rest are not.  When any
 interpreters share mutable data there is always a risk of data races.
 Cross-interpreter safety, including thread-safety, is a fundamental
-feature of channels.
+feature of queues.
 
 However, ``memoryview`` does not have any native accommodations.
 The user is responsible for managing thread safety, whether passing
-a token back and forth through a channel to indicate safety,
+a token back and forth through a queue to indicate safety,
 or by assigning sub-range exclusivity to individual interpreters.
 
-Regarding channels, the primary situation for sharing is where an
+Regarding queues, the primary situation for sharing is where an
 interpreter is using ``prepare___main__()`` to provide the target
 interpreter with their means of further communication.
 
@@ -598,7 +561,7 @@ InterpreterPoolExecutor
 The new ``concurrent.futures.InterpreterPoolExecutor`` will be
 a subclass of ``concurrent.futures.ThreadPoolExecutor``, where each
 worker executes tasks in its own subinterpreter.  Communication may
-still be done through channels, set with the initializer.
+still be done through ``Queue`` objects, set with the initializer.
 
 
 Examples
@@ -613,8 +576,8 @@ We have a stream of requests coming in that we will handle
 via workers in sub-threads.
 
 * each worker thread has its own interpreter
-* we use one channel to send tasks to workers and
-  another channel to return results
+* we use one queue to send tasks to workers and
+  another queue to return results
 * the results are handled in a dedicated thread
 * each worker keeps going until it receives a "stop" sentinel (``None``)
 * the results handler keeps going until all workers have stopped
@@ -625,36 +588,38 @@ via workers in sub-threads.
    import interpreters
    from mymodule import iter_requests, handle_result
 
-   tasks_recv, tasks = interpreters.create_channel()
-   results, results_send = interpreters.create_channel()
+   tasks = interpreters.create_queue()
+   results = interpreters.create_queue()
 
    numworkers = 20
    threads = []
 
    def results_handler():
-       empty = object()
        running = numworkers
        while running:
-           res = results.recv_nowait(empty)
-           if res is empty:
+           try:
+               res = results.get(timeout=0.1)
+           except interpreters.QueueEmpty:
                # No workers have finished a request since last time.
-               time.sleep(0.1)
-           elif res is None:
-               # A worker has stopped.
-               running -= 1
+               pass
            else:
-               handle_result(res)
-       assert results.recv_nowait(empty) is empty
+               if res is None:
+                   # A worker has stopped.
+                   running -= 1
+               else:
+                   handle_result(res)
+       empty = object()
+       assert results.get_nowait(empty) is empty
    threads.append(threading.Thread(target=results_handler))
 
    def worker():
        interp = interpreters.create()
-       interp.prepare___main__(tasks=tasks_recv, results=results_send)
+       interp.prepare___main__(tasks=tasks, results=results)
        interp.exec("""if True:
            from mymodule import handle_request, capture_exception
 
            while True:
-               req = tasks.recv()
+               req = tasks.get()
                if req is None:
                    # Stop!
                    break
@@ -662,9 +627,9 @@ via workers in sub-threads.
                    res = handle_request(req)
                except Exception as exc:
                    res = capture_exception(exc)
-               results.send_nowait(res)
+               results.put_nowait(res)
            # Notify the results handler.
-           results.send_nowait(None)
+           results.put_nowait(None)
            """))
    threads.extend(threading.Thread(target=worker) for _ in range(numworkers))
 
@@ -672,10 +637,10 @@ via workers in sub-threads.
        t.start()
 
    for req in iter_requests():
-       tasks.send(req)
+       tasks.put_nowait(req)
    # Send the "stop" signal.
    for _ in range(numworkers):
-       tasks.send(None)
+       tasks.put_nowait(None)
 
    for t in threads:
        t.join()
@@ -690,7 +655,7 @@ so we take advantage of directly sharing ``memoryview`` buffers.
 
 * all the interpreters share the buffer of the source array
 * each one writes its results to a second shared buffer
-* we use a channel to send tasks to workers
+* we use a queue to send tasks to workers
 * only one worker will ever read any given index in the source array
 * only one worker will ever write to any given index in the results
   (this is how we ensure thread-safety)
@@ -707,16 +672,16 @@ so we take advantage of directly sharing ``memoryview`` buffers.
    numchunks = (len(buf) + 1) / chunksize
    results = memoryview(b'\0' * numchunks)
 
-   tasks_recv, tasks = interpreters.create_channel()
+   tasks = interpreters.create_queue()
 
    def worker(id):
        interp = interpreters.create()
-       interp.prepare___main__(data=buf, results=results, tasks=tasks_recv)
+       interp.prepare___main__(data=buf, results=results, tasks=tasks)
        interp.exec("""if True:
            from mymodule import reduce_chunk
 
            while True:
-               req = tasks.recv()
+               req = tasks.get()
                if res is None:
                    # Stop!
                    break
@@ -735,10 +700,10 @@ so we take advantage of directly sharing ``memoryview`` buffers.
        end = start + chunksize
        if end > len(buf):
            end = len(buf)
-       tasks.send((start, end, i))
+       tasks.put_nowait((start, end, i))
    # Send the "stop" signal.
    for _ in range(numworkers):
-       tasks.send(None)
+       tasks.put_nowait(None)
 
    for t in threads:
        t.join()

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -488,6 +488,17 @@ Attributes and methods:
       try-except around the given *code*, since ``RunFailedError``
       will not preserve that information.
 
+* ``run(code, /) -> threading.Thread``
+      Create a new thread and call ``exec_sync()`` in it.
+      Exceptions are not propagated.
+
+      This is roughly equivalent to::
+
+         def task():
+             interp.exec_sync(code)
+         t = threading.Thread(target=task)
+         t.start()
+
 Communicating Between Interpreters
 ----------------------------------
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -585,6 +585,8 @@ Attributes and methods:
 
 * ``put_nowait(obj)``
       Like ``put()`` but effectively with an immediate timeout.
+      Thus if the queue is full, it immediately raises
+      ``interpreters.QueueFull``.
 
 * ``get(timeout=None) -> object``
       Pop the next object from the queue and return it.  Block while

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -232,15 +232,17 @@ Interpreter.prepare_main() Sets Multiple Variables
 --------------------------------------------------
 
 ``prepare_main()`` may be seen as a setter function of sorts.
-It supports setting multiple names at once, whereas most setters
+It supports setting multiple names at once,
+e.g. ``interp.prepare_main(spam=1, eggs=2)``, whereas most setters
 set one item at a time.  The main reason is for efficiency.
 
-To set a value in ``__main__.__dict__`` the implementation must first
-switch the OS thread to the desired interpreter, which involves some
-non-negligible overhead.  After setting the value it must switch back.
-Furthermore, there is some overhead to the mechanism by which it passes
-objects between interpreters, which can be reduced in aggregate if
-multiple values are set at once.
+To set a value in the interpreter's ``__main__.__dict__``, the
+implementation must first switch the OS thread to the identified
+interpreter, which involves some non-negligible overhead.  After
+setting the value it must switch back.
+Furthermore, there is some additional overhead to the mechanism
+by which it passes objects between interpreters, which can be
+reduced in aggregate if multiple values are set at once.
 
 Therefore, ``prepare_main()`` supports setting multiple
 values at once.

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -404,8 +404,9 @@ See `Shareable Objects`_.
 
 The module defines the following functions:
 
-* ``create_queue() -> Queue``
-   Create a new queue.
+* ``create_queue(maxsize=0) -> Queue``
+      Create a new queue.  If the maxsize is zero or negative then the
+      queue is unbounded.
 
 Queue Objects
 -------------
@@ -413,11 +414,24 @@ Queue Objects
 ``interpreters.Queue`` objects act as proxies for the underlying
 cross-interpreter-safe queues exposed by the ``interpreters`` module.
 
+``Queue`` implements all the methods of ``queue.Queue`` except for
+``task_done()`` and ``join()``, hence it is similar to
+``asyncio.Queue`` and ``multiprocessing.Queue``.
+
+Aside from cross-interpreter support, the main things that set
+``Queue`` apart from those other queue classes are:
+the "sync" arg to ``put()``,
+the "default" arg to ``get_nowait()``,
+and the "all" arg to ``close()``.
+
 Attributes and methods:
 
 * ``id``
       (read-only) The target queue's ``QueueID`` object.
       It is an int-like object with some internal bookkeeping.
+
+* ``maxsize``
+      Number of items allowed in the queue.
 
 * ``__hash__()``
       Returns the hash of the queue's ``id``.  This is the same
@@ -426,29 +440,67 @@ Attributes and methods:
 * ``__eq__(other)``
       Returns ``other is self``.
 
-* ``put(obj, timeout=None)``
-      Add the `shareable object <Shareable Objects_>`_ (i.e. its data)
-      to the queue and wait for it to be received.  If a timeout is
-      provided and the object is not received in that time then raise
-      ``TimeoutError``.  The object will be removed from the queue at
-      that time.
+* ``empty()``
+      Return True if the queue is empty, False otherwise.
 
-      Note that other Python queue types will block only if there is
-      a max size set and the queue is full.  They do not block while
-      waiting for the object to be popped off.  In that regard think
-      of each ``Queue`` as having a max size of zero.
+* ``full()``
+      Return True if there are maxsize items in the queue.
 
-* ``put_nowait(obj) -> bool``
-      Like ``put()``, but return False if not received.
+      If the queue was initialized with maxsize=0 (the default),
+      then full() never returns True.
+
+* ``qsize()``
+      Return the number of items in the queue.
+
+* ``put(obj, timeout=None, *, sync=False)``
+      Add the object to the queue.
+
+      The object must be `shareable <Shareable Objects_>`_, which means
+      the object's data is passed through rather than the object itself.
+
+      If maxsize > 0 and the queue is full then this blocks until a free
+      slot is available.  If "timeout" is a positive number then it only
+      blocks at least that many seconds and then raises
+      ``interpreters.QueueFull``.  Otherwise is blocks forever.
+
+      If "sync" is ``True`` then this also blocks until
+      the object is received (popped off).  The timeout, if provided,
+      applies here as well.  If the timeout is reached while waiting
+      to be received then this raises
+      ``interpreters.QueueItemNotReceived``.  At that point the object
+      is removed from the queue (regardless of position).
+      (Also see `Synchronization`_).
+
+      Raise ``interpreters.QueueClosed`` if the queue has already been
+      closed in this interpreter.
+
+* ``put_nowait(obj)``
+      Like ``put()`` but effectively with an immediate timeout,
+      and it never waits for the object to be received.
 
 * ``get(timeout=None) -> object``
-      Get the next object from the queue.  Wait while the queue is
-      empty.  If a timeout is provided and an object hasn't been added
-      to the queue in that time then raise ``interpreters.QueueEmpty``.
+      Pop the next object from the queue and return it.  Block while
+      the queue is empty.  If a positive timeout is provided and an
+      object hasn't been added to the queue in that many seconds
+      then raise ``interpreters.QueueEmpty``.
+
+      Raise ``interpreters.QueueEmptyClosed`` if the queue has been
+      closed in all interpreters and is now empty.
 
 * ``get_nowait([default]) -> object``
-      Like ``get()``, but return the default instead of waiting.
-      If no default is provided then raise ``interpreters.QueueEmpty``.
+      Like ``get()``, but do not block.  If the queue is not empty
+      then return the next item.  Otherwise, return the default if
+      one was provided else raise ``interpreters.QueueEmpty``.
+
+* ``close(*, all=False)``
+      Indicate that no more objects will be put on this queue
+      by the current interpreter.  This is called automatically
+      (with ``all=False``) when the queue object is garbage collected.
+      This is effectively the same as ``multiprocessing.Queue.close()``
+      (though no pipes are involved).
+
+      If "all" is ``True`` then this indicates that no more objects
+      will be put on this queue by *any* interpreters.
 
 Shareable Objects
 -----------------

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -298,6 +298,7 @@ Attributes and methods:
       (read-only) An ``InterpreterID`` object that identifies the
       interpreter that this ``Interpreter`` instance represents.
       The ID is an int-like object with some internal bookkeeping.
+      Conceptually, this is similar to a process ID.
 
 * ``__hash__()``
       Returns the hash of the interpreter's ``id``.  This is the same
@@ -433,6 +434,7 @@ Attributes and methods:
       (read-only) A ``QueueID`` object that identifies the corresponding
       cross-interpreter queue.
       It is an int-like object with some internal bookkeeping.
+      This is similar to a file descriptor used for a pipe.
 
 * ``maxsize``
       Number of items allowed in the queue.

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -156,11 +156,11 @@ Interpreter Isolation
 
 CPython's interpreters are intended to be strictly isolated from each
 other.  That means interpreters never share objects (except in very
-specific cases internally). Each interpreter has its own modules
-(``sys.modules``), classes, functions, and variables.  Even where
-two interpreters define the same class, each will have its own copy.
-The same applies to state in C, including in extension modules.
-The CPython C API docs `explain more`_.
+specific cases with immortal, immutable builtin objects).  Each
+interpreter has its own modules (``sys.modules``), classes, functions,
+and variables.  Even where two interpreters define the same class,
+each will have its own copy.  The same applies to state in C, including
+in extension modules.  The CPython C API docs `explain more`_.
 
 .. _explain more:
    https://docs.python.org/3/c-api/init.html#bugs-and-caveats
@@ -276,22 +276,22 @@ that matches the original exception.  For example, an uncaught
 ``try: ... except ValueError: ...``.  Instead, ``RunFailedError``
 must be handled directly.
 
-Directly Shareable Objects
---------------------------
+Limited Object Sharing
+----------------------
 
-Support for directly sharing any and all objects through queues
-isn't an option because all objects have at least some mutable state
-(e.g. refcount) which the GIL protects normally.  Furthermore, objects
-must only be deleted by the interpreter that created them, which makes
-direct sharing even more complex.
+As noted in `Interpreter Isolation`_, only a small number of builtin
+objects may be truly shared between interpreters.  In all other cases
+objects can only be shared indirectly, through copies or proxies.
 
-Supporting indirect sharing of all objects in queues would be
-possible by automatically pickling them if the more efficient mechanism
-couldn't be used.  However, it's helpful to know that only the
-efficient way is being used.  Furthermore, for mutable objects
-pickling would violate the guarantee that "shared" objects be
-equivalent (and stay that way).  Thus the proposal does not
-include automatic pickling.
+The set of objects that are shareable as copies through queues
+(and ``Interpreter.prepare_main()``) is limited for the sake of
+efficiency.
+
+Supporting sharing of *all* objects is possible (via pickle)
+but not part of this proposal.  For one thing, it's helpful to know
+that only an efficient implementation is being used.  Furthermore,
+for mutable objects pickling would violate the guarantee that "shared"
+objects be equivalent (and stay that way).
 
 Objects vs. ID Proxies
 ----------------------

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -395,7 +395,19 @@ for comparison:
 * When code is run from the command-line (e.g. ``-m``) or the REPL,
   the "current" module is always the ``__main__`` module
   of the target (main) interpreter.
-* It discards any object returned from the executed code.
+* It discards any object returned from the executed code::
+
+   def func():
+       global spam
+       spam = True
+       return 'a returned value'
+
+   ns = {}
+   res = exec(func.__code__, ns)
+   # Nothing is returned.  The returned string was discarded.
+   assert res is None, res
+   assert ns['spam'] is True, ns
+
 * It propagates any uncaught exception from the code it ran.
   The exception is raised from the ``exec()`` call in the thread
   that originally called ``exec()``.

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -823,9 +823,9 @@ via workers in sub-threads.
                    res = handle_request(req)
                except Exception as exc:
                    res = capture_exception(exc)
-               results.put_nowait(res)
+               results.put(res)
            # Notify the results handler.
-           results.put_nowait(None)
+           results.put(None)
            """)
    threads.extend(threading.Thread(target=worker) for _ in range(numworkers))
 
@@ -833,10 +833,10 @@ via workers in sub-threads.
        t.start()
 
    for req in iter_requests():
-       tasks.put_nowait(req)
+       tasks.put(req)
    # Send the "stop" signal.
    for _ in range(numworkers):
-       tasks.put_nowait(None)
+       tasks.put(None)
 
    for t in threads:
        t.join()
@@ -896,10 +896,10 @@ so the code takes advantage of directly sharing ``memoryview`` buffers.
        end = start + chunksize
        if end > len(buf):
            end = len(buf)
-       tasks.put_nowait((start, end, i))
+       tasks.put((start, end, i))
    # Send the "stop" signal.
    for _ in range(numworkers):
-       tasks.put_nowait(None)
+       tasks.put(None)
 
    for t in threads:
        t.join()

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -166,11 +166,21 @@ The CPython C API docs `explain more`_.
    https://docs.python.org/3/c-api/init.html#bugs-and-caveats
 
 Notably, there is some process-global state that interpreters will
-always share:
+always share, some mutable and some immutable.  Sharing immutable
+state presents few problems, while providing some benefits (mainly
+performance).  However, all shared mutable state requires special
+management, particularly for thread-safety, some of which the OS
+takes care of for us.
+
+Mutable:
 
 * file descriptors
 * low-level env vars
 * process memory (though allocators *are* isolated)
+* the list of interpreters
+
+Immutable:
+
 * builtin types (e.g. ``dict``, ``bytes``)
 * singletons (e.g. ``None``)
 * underlying static module data (e.g. functions) for

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -606,9 +606,11 @@ Both ``Interpreter.prepare_main()`` and ``Queue`` work only with
 "shareable" objects.
 
 A "shareable" object is one which may be passed from one interpreter
-to another.  The object is not necessarily actually shared by the
-interpreters.  However, the object in the one interpreter is guaranteed
-to exactly match the corresponding object in the other interpreter.
+to another.  The object is not necessarily actually directly shared
+by the interpreters.  However, even if it isn't, the shared object
+should be treated as though it *were* shared directly.  That's a
+strong equivalence guarantee for all shareable objects.
+(See below.)
 
 For some types (builtin singletons), the actual object is shared.
 For some, the object's underlying data is actually shared but each
@@ -650,11 +652,30 @@ Regarding queues, the primary situation for sharing is where an
 interpreter is using ``prepare_main()`` to provide another
 interpreter with a means of further communication.
 
-Finally, a reminder: for some types the actual object is shared,
-whereas for others only the underlying data (or even a copy or proxy)
-is shared.  Regardless, the guarantee of "shareable" objects is that
-corresponding objects in different interpreters will always strictly
-match each other.
+Finally, a reminder: for a few types the actual object is shared,
+whereas for the rest only the underlying data is shared, whether
+as a copy or through a proxy.  Regardless, it always preserves
+the strong equivalence guarantee of "shareable" objects.
+
+The guarantee is that a shared object in one interpreter is strictly
+equivalent to the corresponding object in the other interpreter.
+In other words, the two objects will be indistinguishable from each
+other.  The shared object should be treated as though the original
+had been shared directly, whether or not it actually was.
+Even if the actual object isn't directly shared, the
+two objects will still match each other exactly in both raw value/state
+and behavior, as though they *were* the same object.
+
+For many objects, especially simple immutable ones, this at least
+means equality.  However, it would be as though equality were
+implemented were implemented as deeply and thoroughly as possible.
+For special equality-defying objects like ``NaN``, the appropriate
+check would pass, e.g. ``math.isnan()``.
+
+The guarantee is especially important for mutable objects, like
+``Queue`` and ``memoryview``.  Mutating the object in one interpreter
+will always be reflected immediately in every other interpreter
+sharing the object.
 
 Synchronization
 ---------------

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -545,7 +545,7 @@ Attributes and methods:
       used for a pipe.
 
 * ``maxsize``
-      Number of items allowed in the queue.
+      Number of items allowed in the queue.  Zero means "unbounded".
 
 * ``__hash__()``
       Return the hash of the queue's ``id``.  This is the same

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -408,7 +408,12 @@ Attributes and methods:
 
       If there is an uncaught exception, it will be propagated into
       the calling interpreter as a ``RunFailedError``, which
-      preserves enough information for a helpful error display.
+      preserves enough information for a helpful error display.  That
+      means if the ``RunFailedError`` isn't caught then the full
+      traceback of the propagated exception, including details about
+      syntax errors, etc., will be displayed.  Having the full
+      traceback is particularly useful when debugging.
+
       If exception propagation is not desired then an explicit
       try-except should be used around the *code* passed to ``exec()``.
       Likewise any error handling that depends on specific information
@@ -452,16 +457,6 @@ for comparison:
 * It propagates any uncaught exception from the code it ran.
   The exception is raised from the ``exec()`` call in the Python
   thread that originally called ``exec()``.
-
-The only difference is that, rather than propagate the uncaught
-exception directly, ``Interpreter.exec()`` raises an
-``interpreters.RunFailedError`` with a snapshot
-(``traceback.TracebackException``) of the uncaught exception
-(including its traceback) as the ``__cause__``.  That means if the
-``RunFailedError`` isn't caught then the full traceback of the
-propagated exception, including details about syntax errors, etc.,
-will be displayed.  Having the full traceback is particularly useful
-when debugging.
 
 Communicating Between Interpreters
 ----------------------------------

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -542,8 +542,9 @@ feature of queues.
 
 However, ``memoryview`` does not have any native accommodations.
 The user is responsible for managing thread safety, whether passing
-a token back and forth through a queue to indicate safety,
-or by assigning sub-range exclusivity to individual interpreters.
+a token back and forth through a queue to indicate safety
+(see `Synchronization`_), or by assigning sub-range exclusivity
+to individual interpreters.
 
 Regarding queues, the primary situation for sharing is where an
 interpreter is using ``prepare___main__()`` to provide the target
@@ -555,6 +556,28 @@ is shared.  Regardless, the guarantee of "shareable" objects is that
 corresponding objects in different interpreters will always strictly
 match each other.
 
+Synchronization
+---------------
+
+There are situations where two interpreters should be synchronized.
+For example, when working with a memory view it may make sense for
+only one interpreter to use it at a time, to avoid data races.
+
+In threaded programming the typical synchronization primitives are
+things like mutexes.  However, interpreters cannot share objects
+which means they cannot share ``threading.Lock`` objects.
+
+The ``interpreters`` module does not provide any such dedicated
+synchronization primitives.  Instead, ``Queue`` objects provide
+everything we need.
+
+For example, if there's a shared resource that needs managed
+access then a queue may be used to manage it.  A sentinel object
+(e.g. ``None``) can be put into the queue.  Each interpreter that
+wants access will make a blocking ``get()`` call.  The next interpreter
+to successfully pop off the sentinel the assumes access.  When it is
+done it pushes the sentinel back onto the queue.
+
 InterpreterPoolExecutor
 -----------------------
 
@@ -562,7 +585,6 @@ The new ``concurrent.futures.InterpreterPoolExecutor`` will be
 a subclass of ``concurrent.futures.ThreadPoolExecutor``, where each
 worker executes tasks in its own subinterpreter.  Communication may
 still be done through ``Queue`` objects, set with the initializer.
-
 
 Examples
 --------

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -112,14 +112,16 @@ That function does the following:
 5. return the thread state (still current)
 
 To make an existing interpreter active in the current OS thread,
-we first make sure that interpreter has a corresponding thread state.
-Then we call ``PyThreadState_Swap()`` like normal using that thread
-state.  If the thread state for another interpreter was already current
-then it gets swapped out like normal and execution of that interpreter
-in the OS thread is thus effectively paused until it is swapped back in.
+the C API user first makes sure that interpreter has a corresponding
+thread state.  Then ``PyThreadState_Swap()`` is called like normal
+using that thread state.  If the thread state for another interpreter
+was already current then it gets swapped out like normal and execution
+of that interpreter in the OS thread is thus effectively paused until
+it is swapped back in.
 
-Once an interpreter is active in the current OS thread like that, we can
-call any of the C API, such as ``PyEval_EvalCode()`` (i.e. ``exec()``).
+Once an interpreter is active in the current OS thread like that, the
+thread can call any of the C API, such as ``PyEval_EvalCode()``
+(i.e. ``exec()``).
 
 The "Main" Interpreter
 ----------------------
@@ -166,7 +168,7 @@ Motivation
 The ``interpreters`` module will provide a high-level interface to the
 multiple interpreter functionality.  The goal is to make the existing
 multiple-interpreters feature of CPython more easily accessible to
-Python code.  This is particularly relevant now that we have a
+Python code.  This is particularly relevant now that CPython has a
 per-interpreter GIL (:pep:`684`) and people are more interested
 in using multiple interpreters.
 
@@ -185,11 +187,12 @@ Rationale
 A Minimal API
 -------------
 
-Since we have no experience with
-how users will make use of multiple interpreters in Python code, we are
-purposefully keeping the initial API as lean and minimal as possible.
-The objective is to provide a well-considered foundation on which we may
-add further (more advanced) functionality later.
+Since the core dev team has no real experience with
+how users will make use of multiple interpreters in Python code, this
+proposal purposefully keeps the initial API as lean and minimal as
+possible.  The objective is to provide a well-considered foundation
+on which further (more advanced) functionality may be added later,
+as appropriate.
 
 That said, the proposed design incorporates lessons learned from
 existing use of subinterpreters by the community, from existing stdlib
@@ -207,12 +210,12 @@ Interpreter.prepare___main__() Sets Multiple Variables
 It supports setting multiple names at once, whereas most setters
 set one item at a time.  The main reason is for efficiency.
 
-To set a value in ``__main__.__dict__`` we must first switch the
-OS thread to the desired interpreter, which involves some non-negligible
-overhead.  After setting the value we must switch back.  Furthermore,
-there is some overhead to the mechanism by which we pass objects between
-interpreters, which can be reduced in aggregate if multiple values
-are set at once.
+To set a value in ``__main__.__dict__`` the implementation must first
+switch the OS thread to the desired interpreter, which involves some
+non-negligible overhead.  After setting the value it must switch back.
+Furthermore, there is some overhead to the mechanism by which it passes
+objects between interpreters, which can be reduced in aggregate if
+multiple values are set at once.
 
 Therefore, ``prepare___main__()`` supports setting multiple
 values at once.
@@ -228,15 +231,15 @@ from the subinterpreter.
 Directly Shareable Objects
 --------------------------
 
-We cannot support directly sharing any and all objects through queues
-because all objects have at least some mutable state (e.g. refcount)
-which the GIL protects normally.  Furthermore, objects must only be
-deleted by the interpreter that created them, which makes direct
-sharing even more complex.
+Support for directly sharing any and all objects through queues
+isn't an option because all objects have at least some mutable state
+(e.g. refcount) which the GIL protects normally.  Furthermore, objects
+must only be deleted by the interpreter that created them, which makes
+direct sharing even more complex.
 
 Supporting indirect sharing of all objects in queues would be
-possible by automatically pickling them if we can't use the more
-efficient mechanism.  However, it's helpful to know that only the
+possible by automatically pickling them if the more efficient mechanism
+couldn't be used.  However, it's helpful to know that only the
 efficient way is being used.  Furthermore, for mutable objects
 pickling would violate the guarantee that "shared" objects be
 equivalent (and stay that way).  Thus the proposal does not
@@ -245,8 +248,9 @@ include automatic pickling.
 Objects vs. ID Proxies
 ----------------------
 
-For both interpreters and queues, we provide objects that expose them
-indirectly with ID-wrapping surrogates for the underlying state.
+For both interpreters and queues, the low-level module provides objects
+that expose them indirectly with ID-wrapping surrogates for the
+underlying state.
 In both cases the state is process-global and will be used by multiple
 interpreters.  Thus they aren't suitable to be implemented as
 ``PyObject``, which is only really an option for interpreter-specific
@@ -557,7 +561,7 @@ share ``threading.Lock`` objects.
 
 The ``interpreters`` module does not provide any such dedicated
 synchronization primitives.  Instead, ``Queue`` objects provide
-everything we need.
+everything one might need.
 
 For example, if there's a shared resource that needs managed
 access then a queue may be used to manage it, where the interpreters
@@ -593,7 +597,7 @@ pass an object around to indicate who can use the resource::
        control.put_nowait(token)
 
 If an interpreter needs to wait for another to reach a certain point
-then they can synchronize through a queue.  We just need to make sure
+then they can synchronize through a queue.  They just need to make sure
 to synchronize in both directions::
 
    import interpreters
@@ -664,11 +668,11 @@ interpreters may be useful.
 
 Example 1:
 
-We have a stream of requests coming in that we will handle
+There's a stream of requests coming in that will be handled
 via workers in sub-threads.
 
 * each worker thread has its own interpreter
-* we use one queue to send tasks to workers and
+* there's one queue to send tasks to workers and
   another queue to return results
 * the results are handled in a dedicated thread
 * each worker keeps going until it receives a "stop" sentinel (``None``)
@@ -738,18 +742,18 @@ via workers in sub-threads.
 
 Example 2:
 
-This case is similar to the last as we have a bunch of workers
-in sub-threads.  However, this time we are chunking up a big array
+This case is similar to the last as there are a bunch of workers
+in sub-threads.  However, this time the code is chunking up a big array
 of data, where each worker processes one chunk at a time.  Copying
 that data to each interpreter would be exceptionally inefficient,
-so we take advantage of directly sharing ``memoryview`` buffers.
+so the code takes advantage of directly sharing ``memoryview`` buffers.
 
 * all the interpreters share the buffer of the source array
 * each one writes its results to a second shared buffer
-* we use a queue to send tasks to workers
+* there's use a queue to send tasks to workers
 * only one worker will ever read any given index in the source array
 * only one worker will ever write to any given index in the results
-  (this is how we ensure thread-safety)
+  (this is how it ensures thread-safety)
 
 ::
 
@@ -786,7 +790,7 @@ so we take advantage of directly sharing ``memoryview`` buffers.
        t.start()
 
    for i in range(numchunks):
-       # We assume we have at least one worker running still.
+       # Assume there's at least one worker running still.
        start = i * chunksize
        end = start + chunksize
        if end > len(buf):

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -314,6 +314,7 @@ deleted.
    ``id``::
 
       (read-only) The target interpreter's ``InterpreterID`` object.
+      It is an int-like object with some internal bookkeeping.
 
    Methods:
 
@@ -438,6 +439,7 @@ The receiving end of a channel:
    ``id``::
 
       (read-only) The target channel's ``ChannelID`` object.
+      It is an int-like object with some internal bookkeeping.
 
    Methods:
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -324,15 +324,15 @@ Using Interpreters
 The module defines the following functions:
 
 * ``get_current() -> Interpreter``
-      Returns an ``Interpreter`` object for the currently executing
+      Returns the ``Interpreter`` object for the currently executing
       interpreter.
 
 * ``list_all() -> list[Interpreter]``
-      Returns an ``Interpreter`` object for each existing interpreter,
+      Returns the ``Interpreter`` object for each existing interpreter,
       whether it is currently running in any OS threads or not.
 
 * ``create() -> Interpreter``
-      Create a new interpreter and return an ``Interpreter`` object
+      Create a new interpreter and return the ``Interpreter`` object
       for it.  The interpreter will not be associated with any
       OS threads until something is actually run in the interpreter.
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -425,7 +425,7 @@ Interpreter Objects
 -------------------
 
 An ``interpreters.Interpreter`` object represents the interpreter
-(``PyInterpreterState``) with the corresponding ID.
+(``PyInterpreterState``) with the corresponding unique ID.
 
 If the interpreter was created with ``interpreters.create()`` then
 it will be destroyed as soon as all ``Interpreter`` objects have been
@@ -434,9 +434,8 @@ deleted.
 Attributes and methods:
 
 * ``id``
-      (read-only) An ``InterpreterID`` object that identifies the
+      (read-only) A non-negative ``int`` that identifies the
       interpreter that this ``Interpreter`` instance represents.
-      The ID is an int-like object with some internal bookkeeping.
       Conceptually, this is similar to a process ID.
 
 * ``__hash__()``
@@ -531,6 +530,8 @@ Queue Objects
 
 ``interpreters.Queue`` objects act as proxies for the underlying
 cross-interpreter-safe queues exposed by the ``interpreters`` module.
+Each ``Queue`` object represents the queue with the corresponding
+unique ID.
 
 ``Queue`` implements all the methods of ``queue.Queue`` except for
 ``task_done()`` and ``join()``, hence it is similar to
@@ -539,10 +540,10 @@ cross-interpreter-safe queues exposed by the ``interpreters`` module.
 Attributes and methods:
 
 * ``id``
-      (read-only) A ``QueueID`` object that identifies the corresponding
-      cross-interpreter queue.
-      It is an int-like object with some internal bookkeeping.
-      This is similar to a file descriptor used for a pipe.
+      (read-only) A non-negative ``int`` that identifies
+      the corresponding cross-interpreter queue.
+      Conceptually, this is similar to the file descriptor
+      used for a pipe.
 
 * ``maxsize``
       Number of items allowed in the queue.

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -144,8 +144,8 @@ always share:
 * file descriptors
 * low-level env vars
 * process memory (though allocators *are* isolated)
-* builtin types (e.g. dict, bytes)
-* singletons (e.g. None)
+* builtin types (e.g. ``dict``, ``bytes``)
+* singletons (e.g. ``None``)
 * underlying static module data (e.g. functions) for
   builtin/extension/frozen modules
 
@@ -428,20 +428,20 @@ Attributes and methods:
       Number of items allowed in the queue.
 
 * ``__hash__()``
-      Returns the hash of the queue's ``id``.  This is the same
+      Return the hash of the queue's ``id``.  This is the same
       as the hash of the ID's integer value.
 
 * ``__eq__(other)``
-      Returns ``other is self``.
+      Return ``other is self``.
 
 * ``empty()``
-      Return True if the queue is empty, False otherwise.
+      Return ``True`` if the queue is empty, ``False`` otherwise.
 
 * ``full()``
-      Return True if there are maxsize items in the queue.
+      Return ``True`` if there are ``maxsize`` items in the queue.
 
-      If the queue was initialized with maxsize=0 (the default),
-      then full() never returns True.
+      If the queue was initialized with ``maxsize=0`` (the default),
+      then ``full()`` never returns ``True``.
 
 * ``qsize()``
       Return the number of items in the queue.
@@ -452,9 +452,9 @@ Attributes and methods:
       The object must be `shareable <Shareable Objects_>`_, which means
       the object's data is passed through rather than the object itself.
 
-      If maxsize > 0 and the queue is full then this blocks until a free
-      slot is available.  If "timeout" is a positive number then it only
-      blocks at least that many seconds and then raises
+      If ``maxsize > 0`` and the queue is full then this blocks until
+      a free slot is available.  If *timeout* is a positive number
+      then it only blocks at least that many seconds and then raises
       ``interpreters.QueueFull``.  Otherwise is blocks forever.
 
 * ``put_nowait(obj)``
@@ -462,13 +462,13 @@ Attributes and methods:
 
 * ``get(timeout=None) -> object``
       Pop the next object from the queue and return it.  Block while
-      the queue is empty.  If a positive timeout is provided and an
+      the queue is empty.  If a positive *timeout* is provided and an
       object hasn't been added to the queue in that many seconds
       then raise ``interpreters.QueueEmpty``.
 
 * ``get_nowait([default]) -> object``
       Like ``get()``, but do not block.  If the queue is not empty
-      then return the next item.  Otherwise, return the default if
+      then return the next item.  Otherwise, return *default* if
       one was provided else raise ``interpreters.QueueEmpty``.
 
 Shareable Objects

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -327,6 +327,15 @@ deleted.
 
    Methods:
 
+   ``__hash__()``::
+
+      Returns the hash of the interpreter's ``id``.  This is the same
+      as the hash of the ID's integer value.
+
+   ``__eq__(other)``::
+
+      Returns ``other is self``.
+
    ``is_running() -> bool``::
 
       Returns ``True`` if the interpreter is currently executing code
@@ -452,6 +461,15 @@ The receiving end of a channel:
 
    Methods:
 
+   ``__hash__()``::
+
+      Returns the hash of the channel's ``id``.  This is the same
+      as the hash of the ID's integer value.
+
+   ``__eq__(other)``::
+
+      Returns ``other is self``.
+
    ``recv() -> object``::
 
       Get the next object from the channel.  Wait if none have been sent.
@@ -481,6 +499,15 @@ The sending end of a channel:
       (read-only) The target channel's ``ChannelID`` object.
 
    Methods:
+
+   ``__hash__()``::
+
+      Returns the hash of the channel's ``id``.  This is the same
+      as the hash of the ID's integer value.
+
+   ``__eq__(other)``::
+
+      Returns ``other is self``.
 
    ``send(obj)``::
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -648,9 +648,12 @@ a token back and forth through a queue to indicate safety
 (see `Synchronization`_), or by assigning sub-range exclusivity
 to individual interpreters.
 
-Regarding queues, the primary situation for sharing is where an
-interpreter is using ``prepare_main()`` to provide another
-interpreter with a means of further communication.
+Most objects will be shared through queues (``Queue``), as interpreters
+communicate information between each other.  Less frequently, objects
+will be shared through ``prepare_main()`` to set up an interpreter
+prior to running code in it.  However, ``prepare_main()`` is the
+primary way that queues are shared, to provide another interpreter
+with a means of further communication.
 
 Finally, a reminder: for a few types the actual object is shared,
 whereas for the rest only the underlying data is shared, whether

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -514,9 +514,10 @@ the back and each "get" pops the next one off the front.  Every added
 object will be popped off in the order it was pushed on.
 
 Only objects that are specifically supported for passing
-between interpreters may be sent through a ``Queue``.  Note that the
-actual objects aren't sent, but rather their underlying data.
-However, the popped object will still be identical to the original.
+between interpreters may be sent through a ``Queue``.
+Note that the actual objects aren't sent, but rather their
+underlying data.  However, the popped object will still be
+strictly equivalent to the original.
 See `Shareable Objects`_.
 
 The module defines the following functions:

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -563,23 +563,76 @@ Synchronization
 ---------------
 
 There are situations where two interpreters should be synchronized.
-For example, when working with a memory view it may make sense for
-only one interpreter to use it at a time, to avoid data races.
+That may involve sharing a resource, worker management, or preserving
+sequential consistency.
 
 In threaded programming the typical synchronization primitives are
-things like mutexes.  However, interpreters cannot share objects
-which means they cannot share ``threading.Lock`` objects.
+types like mutexes.  The ``threading`` module exposes several.
+However, interpreters cannot share objects which means they cannot
+share ``threading.Lock`` objects.
 
 The ``interpreters`` module does not provide any such dedicated
 synchronization primitives.  Instead, ``Queue`` objects provide
 everything we need.
 
 For example, if there's a shared resource that needs managed
-access then a queue may be used to manage it.  A sentinel object
-(e.g. ``None``) can be put into the queue.  Each interpreter that
-wants access will make a blocking ``get()`` call.  The next interpreter
-to successfully pop off the sentinel the assumes access.  When it is
-done it pushes the sentinel back onto the queue.
+access then a queue may be used to manage it, where the interpreters
+pass an object around to indicate who can use the resource::
+
+   import interpreters
+   from mymodule import load_big_data, check_data
+
+   numworkers = 10
+   control = interpreters.create_queue()
+   data = memoryview(load_big_data())
+
+   def worker():
+       interp = interpreters.create()
+       interp.prepare___main__(control=control, data=data)
+       interp.exec("""if True:
+           from mymodule import edit_data
+           while True:
+               token = control.get()
+               edit_data(data)
+               control.put_nowait(token)
+   threads = [threading.Thread(target=worker) for _ in range(numworkers)]
+   for t in threads:
+       t.start()
+
+   token = 'football'
+   control.put_nowait(token)
+   while True:
+       control.get()
+       if not check_data(data):
+           break
+       control.put_nowait(token)
+
+If an interpreter needs to wait for another to reach a certain point
+then they can synchronize through a queue::
+
+   import interpreters
+
+   sync = interpreters.create_queue()
+
+   def worker():
+       interp = interpreters.create()
+       interp.prepare___main__(sync=sync)
+       interp.exec("""if True:
+           # do step 1
+           sync.get()  # synchronize!
+           # do step 2
+           sync.put(None, sync=True)  # synchronize!
+           # do step 3
+           sync.put(None, sync=True)  # synchronize!
+   t = threading.Thread(target=worker)
+   t.start()
+
+   # do step A
+   sync.put(None, sync=True)  # synchronize!
+   # do step B
+   sync.get()  # synchronize!
+   # do step C
+   sync.get()  # synchronize!
 
 InterpreterPoolExecutor
 -----------------------
@@ -609,7 +662,6 @@ via workers in sub-threads.
 
 ::
 
-   import time
    import interpreters
    from mymodule import iter_requests, handle_result
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -426,6 +426,7 @@ Interpreter Objects
 
 An ``interpreters.Interpreter`` object that represents the interpreter
 (``PyInterpreterState``) with the corresponding unique ID.
+There will only be one object for any given interpreter.
 
 If the interpreter was created with ``interpreters.create()`` then
 it will be destroyed as soon as all ``Interpreter`` objects have been
@@ -532,6 +533,7 @@ Queue Objects
 cross-interpreter-safe queues exposed by the ``interpreters`` module.
 Each ``Queue`` object represents the queue with the corresponding
 unique ID.
+There will only be one object for any given queue.
 
 ``Queue`` implements all the methods of ``queue.Queue`` except for
 ``task_done()`` and ``join()``, hence it is similar to

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -136,7 +136,7 @@ CPython's interpreters are intended to be strictly isolated from each
 other.  That means interpreters never share objects (except in very
 specific cases internally). Each interpreter has its own modules
 (``sys.modules``), classes, functions, and variables.  Even where
-two interpreters define the same class, each will have a distinct copy.
+two interpreters define the same class, each will have its own copy.
 The same applies to state in C, including in extension modules.
 The CPython C API docs `explain more`_.
 
@@ -202,10 +202,10 @@ Interpreter.prepare___main__() Sets Multiple Variables
 It supports setting multiple names at once, whereas most setters
 set one item at a time.  The main reason is for efficiency.
 
-To set a value in ``__main__.__dict__`` we must first switch to the
-target interpreter, which involves some non-negligible overhead.
-After setting the value we must switch back.  Furthermore, there
-is some overhead to the mechanism by which we pass objects between
+To set a value in ``__main__.__dict__`` we must first switch the
+OS thread to the desired interpreter, which involves some non-negligible
+overhead.  After setting the value we must switch back.  Furthermore,
+there is some overhead to the mechanism by which we pass objects between
 interpreters, which can be reduced in aggregate if multiple values
 are set at once.
 
@@ -293,8 +293,9 @@ deleted.
 Attributes and methods:
 
 * ``id``
-      (read-only) The target interpreter's ``InterpreterID`` object.
-      It is an int-like object with some internal bookkeeping.
+      (read-only) An ``InterpreterID`` object that identifies the
+      interpreter that this ``Interpreter`` instance represents.
+      The ID is an int-like object with some internal bookkeeping.
 
 * ``__hash__()``
       Returns the hash of the interpreter's ``id``.  This is the same
@@ -343,8 +344,8 @@ Comparison with builtins.exec()
 -------------------------------
 
 ``Interpreter.exec()`` is essentially the same as the builtin
-``exec()``, except it targets a different interpreter, using that
-interpreter's distinct runtime state.
+``exec()``, except it uses a different interpreter by switching the
+current OS thread to that interpreter's thread state.
 
 Here are the relevant characteristics of the builtin ``exec()``,
 for comparison:
@@ -358,7 +359,7 @@ for comparison:
   and does not clear it before or after.
 * When code is run from the command-line (e.g. ``-m``) or the REPL,
   the "current" module is always the ``__main__`` module
-  of the target (main) interpreter.
+  of the main interpreter.
 * It discards any object returned from the executed code::
 
    def func():
@@ -427,7 +428,8 @@ cross-interpreter-safe queues exposed by the ``interpreters`` module.
 Attributes and methods:
 
 * ``id``
-      (read-only) The target queue's ``QueueID`` object.
+      (read-only) A ``QueueID`` object that identifies the corresponding
+      cross-interpreter queue.
       It is an int-like object with some internal bookkeeping.
 
 * ``maxsize``
@@ -525,8 +527,8 @@ a token back and forth through a queue to indicate safety
 to individual interpreters.
 
 Regarding queues, the primary situation for sharing is where an
-interpreter is using ``prepare___main__()`` to provide the target
-interpreter with their means of further communication.
+interpreter is using ``prepare___main__()`` to provide another
+interpreter with a means of further communication.
 
 Finally, a reminder: for some types the actual object is shared,
 whereas for others only the underlying data (or even a copy or proxy)

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -634,6 +634,45 @@ then they can synchronize through a queue::
    # do step C
    sync.get()  # synchronize!
 
+Exceptions
+----------
+
+* ``RunFailedError``
+      Raised from ``Interpreter.exec()`` when there's an uncaught
+      exception.
+
+      This exception is a subclass of ``RuntimeError``.
+
+* ``QueueEmpty``
+      Raised from ``Queue.get()`` (or ``get_nowait()`` with no default)
+      when the queue is empty.
+
+      This exception is a subclass of ``queue.Empty``.
+
+* ``QueueFull``
+      Raised from ``Queue.put()`` (with a timeout) or ``put_nowait()``
+      when the queue is already at its max size.
+
+      This exception is a subclass of ``queue.Full``.
+
+* ``QueueItemNotReceived``
+      Raised from ``Queue.put()`` (with ``sync=True`` and a timeout)
+      when the object isn't received in time.
+
+      This exception is a subclass of ``Exception``.
+
+* ``QueueClosed``
+      Raised from ``Queue.put()`` and ``put_nowait()`` once ``close()``
+      has been closed for the current interpreter (or all interpreters).
+
+      This exception is a subclass of ``ValueError``.
+
+* ``QueueClosedEmpty``
+      Raised from ``Queue.get()`` and ``get_nowait()`` once ``close()``
+      has been closed for *all* interpreters and the queue is empty.
+
+      This exception is a subclass of ``QueueClosed`` and ``QueueEmpty``.
+
 InterpreterPoolExecutor
 -----------------------
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -262,15 +262,15 @@ Using Interpreters
 
 The module defines the following functions:
 
-* ``interpreters.get_current() -> Interpreter``
+* ``get_current() -> Interpreter``
       Returns an ``Interpreter`` object for the currently executing
       interpreter.
 
-* ``interpreters.list_all() -> list[Interpreter]``
+* ``list_all() -> list[Interpreter]``
       Returns an ``Interpreter`` object for each existing interpreter,
       whether it is currently running in any threads or not.
 
-* ``interpreters.create() -> Interpreter``
+* ``create() -> Interpreter``
       Create a new interpreter and return an ``Interpreter`` object
       for it.  The interpreter will not be associated with any threads
       until something is actually run in the interpreter.
@@ -285,13 +285,11 @@ If the interpreter was created with ``interpreters.create()`` then
 it will be destroyed as soon as all ``Interpreter`` objects have been
 deleted.
 
-``interpreters.Interpreter`` attributes:
+Attributes and methods:
 
 * ``id``
       (read-only) The target interpreter's ``InterpreterID`` object.
       It is an int-like object with some internal bookkeeping.
-
-``interpreters.Interpreter`` methods:
 
 * ``__hash__()``
       Returns the hash of the interpreter's ``id``.  This is the same
@@ -415,13 +413,11 @@ Queue Objects
 ``interpreters.Queue`` objects act as proxies for the underlying
 cross-interpreter-safe queues exposed by the ``interpreters`` module.
 
-``interpreter.Queue`` attributes:
+Attributes and methods:
 
 * ``id``
       (read-only) The target queue's ``QueueID`` object.
       It is an int-like object with some internal bookkeeping.
-
-``interpreter.Queue`` methods:
 
 * ``__hash__()``
       Returns the hash of the queue's ``id``.  This is the same

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -107,6 +107,7 @@ That function does the following:
 1. create a new interpreter state
 2. create a new thread state
 3. set the thread state as current
+   (a current tstate is needed for interpreter init)
 4. initialize the interpreter state using that thread state
 5. return the thread state (still current)
 

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -826,7 +826,7 @@ via workers in sub-threads.
                results.put_nowait(res)
            # Notify the results handler.
            results.put_nowait(None)
-           """))
+           """)
    threads.extend(threading.Thread(target=worker) for _ in range(numworkers))
 
    for t in threads:
@@ -885,7 +885,7 @@ so the code takes advantage of directly sharing ``memoryview`` buffers.
                chunk = data[start: end]
                res = reduce_chunk(chunk)
                results[resindex] = res
-           """))
+           """)
    threads = [threading.Thread(target=worker) for _ in range(numworkers)]
    for t in threads:
        t.start()

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -233,10 +233,19 @@ channels.  Go has both directional and bidirectional channels.  The
 directional channels make intentions clear and are easier to reason
 about.
 
-Supporting all objects in channels would be possible by automatically
-pickling them if we can't use the more efficient mechanism.  However,
-it's helpful to know that only the efficient way is being used.  Thus
-the proposal does not include automatic pickling.
+We cannot support directly sharing any and all objects through channels
+because all objects have at least some mutable state (e.g. refcount)
+which the GIL protects normally.  Furthermore, objects must only be
+deleted by the interpreter that created them, which makes direct
+sharing even more complex.
+
+Supporting indirect sharing of all objects in channels would be
+possible by automatically pickling them if we can't use the more
+efficient mechanism.  However, it's helpful to know that only the
+efficient way is being used.  Furthermore, for mutable objects
+pickling would violate the guarantee that "shared" objects be
+equivalent (and stay that way).  Thus the proposal does not
+include automatic pickling.
 
 Objects vs. ID Proxies
 ----------------------

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -296,14 +296,13 @@ objects be equivalent (and stay that way).
 Objects vs. ID Proxies
 ----------------------
 
-For both interpreters and queues, the low-level module provides objects
-that expose them indirectly with ID-wrapping surrogates for the
-underlying state.
-In both cases the state is process-global and will be used by multiple
-interpreters.  Thus they aren't suitable to be implemented as
-``PyObject``, which is only really an option for interpreter-specific
-data.  That's why the ``interpreters`` module instead provides objects
-that are weakly associated through the ID.
+For both interpreters and queues, the low-level module makes use of
+proxy objects that expose the underlying state by their corresponding
+process-global IDs.  In both cases the state is likewise process-global
+and will be used by multiple interpreters.  Thus they aren't suitable
+to be implemented as ``PyObject``, which is only really an option for
+interpreter-specific data.  That's why the ``interpreters`` module
+instead provides objects that are weakly associated through the ID.
 
 
 Specification

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -418,11 +418,6 @@ cross-interpreter-safe queues exposed by the ``interpreters`` module.
 ``task_done()`` and ``join()``, hence it is similar to
 ``asyncio.Queue`` and ``multiprocessing.Queue``.
 
-Aside from cross-interpreter support, the main things that set
-``Queue`` apart from those other queue classes are:
-the "sync" arg to ``put()``,
-and the "default" arg to ``get_nowait()``.
-
 Attributes and methods:
 
 * ``id``
@@ -451,7 +446,7 @@ Attributes and methods:
 * ``qsize()``
       Return the number of items in the queue.
 
-* ``put(obj, timeout=None, *, sync=False)``
+* ``put(obj, timeout=None)``
       Add the object to the queue.
 
       The object must be `shareable <Shareable Objects_>`_, which means
@@ -462,17 +457,8 @@ Attributes and methods:
       blocks at least that many seconds and then raises
       ``interpreters.QueueFull``.  Otherwise is blocks forever.
 
-      If "sync" is ``True`` then this also blocks until
-      the object is received (popped off).  The timeout, if provided,
-      applies here as well.  If the timeout is reached while waiting
-      to be received then this raises
-      ``interpreters.QueueItemNotReceived``.  At that point the object
-      is removed from the queue (regardless of position).
-      (Also see `Synchronization`_).
-
 * ``put_nowait(obj)``
-      Like ``put()`` but effectively with an immediate timeout,
-      and it never waits for the object to be received.
+      Like ``put()`` but effectively with an immediate timeout.
 
 * ``get(timeout=None) -> object``
       Pop the next object from the queue and return it.  Block while
@@ -591,7 +577,8 @@ pass an object around to indicate who can use the resource::
        control.put_nowait(token)
 
 If an interpreter needs to wait for another to reach a certain point
-then they can synchronize through a queue::
+then they can synchronize through a queue.  We just need to make sure
+to synchronize in both directions::
 
    import interpreters
 
@@ -602,20 +589,26 @@ then they can synchronize through a queue::
        interp.prepare___main__(sync=sync)
        interp.exec("""if True:
            # do step 1
-           sync.get()  # synchronize!
+           token = sync.get()
+           sync.put(token)
            # do step 2
-           sync.put(None, sync=True)  # synchronize!
+           sync.put(None)
+           sync.get()
            # do step 3
-           sync.put(None, sync=True)  # synchronize!
+           sync.put(None)
+           sync.get()
    t = threading.Thread(target=worker)
    t.start()
 
    # do step A
-   sync.put(None, sync=True)  # synchronize!
+   sync.put(None)
+   sync.get()
    # do step B
-   sync.get()  # synchronize!
+   token = sync.get()
+   sync.put(token)
    # do step C
-   sync.get()  # synchronize!
+   token = sync.get()
+   sync.put(token)
 
 Exceptions
 ----------
@@ -637,12 +630,6 @@ Exceptions
       when the queue is already at its max size.
 
       This exception is a subclass of ``queue.Full``.
-
-* ``QueueItemNotReceived``
-      Raised from ``Queue.put()`` (with ``sync=True`` and a timeout)
-      when the object isn't received in time.
-
-      This exception is a subclass of ``Exception``.
 
 InterpreterPoolExecutor
 -----------------------


### PR DESCRIPTION
<!--
You can use the following checklist when double-checking your PEP,
and you can help complete some of it yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about anything, just leave it blank and we'll take a look.

If your PEP is not Standards Track, remove the corresponding section.
-->

## Basic requirements (all PEP Types)

* [ ] Read and followed [PEP 1](https://peps.python.org/1) & [PEP 12](https://peps.python.org/12)
* [ ] File created from the [latest PEP template](https://github.com/python/peps/blob/main/peps/pep-0012/pep-NNNN.rst?plain=1)
* [x] PEP has next available number, & set in filename (``pep-NNNN.rst``), PR title (``PEP 123: <Title of PEP>``) and ``PEP`` header
* [x] Title clearly, accurately and concisely describes the content in 79 characters or less
* [x] Core dev/PEP editor listed as ``Author`` or ``Sponsor``, and formally confirmed their approval
* [x] ``Author``, ``Status`` (``Draft``), ``Type`` and ``Created`` headers filled out correctly
* [x] ``PEP-Delegate``, ``Topic``, ``Requires`` and ``Replaces`` headers completed if appropriate
* [x] Required sections included
    * [x] Abstract (first section)
    * [x] Copyright (last section; exact wording from template required)
* [x] Code is well-formatted (PEP 7/PEP 8) and is in [code blocks, with the right lexer names](https://peps.python.org/pep-0012/#literal-blocks) if non-Python
* [x] PEP builds with no warnings, pre-commit checks pass and content displays as intended in the rendered HTML
* [x] Authors/sponsor added to ``.github/CODEOWNERS`` for the PEP


## Standards Track requirements

* [x] PEP topic [discussed in a suitable venue](https://peps.python.org/pep-0001/#start-with-an-idea-for-python) with general agreement that a PEP is appropriate
* [x] [Suggested sections](https://peps.python.org/pep-0012/#suggested-sections) included (unless not applicable)
    * [x] Motivation
    * [x] Rationale
    * [x] Specification
    * [ ] Backwards Compatibility
    * [ ] Security Implications
    * [ ] How to Teach This
    * [ ] Reference Implementation
    * [x] Rejected Ideas
    * [ ] Open Issues
* [x] ``Python-Version`` set to valid (pre-beta) future Python version, if relevant
* [ ] Any project stated in the PEP as supporting/endorsing/benefiting from the PEP formally confirmed such
* [ ] Right before or after initial merging, [PEP discussion thread](https://peps.python.org/pep-0001/#discussing-a-pep) created and linked to in ``Discussions-To`` and ``Post-History``


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3523.org.readthedocs.build/pep-0734/

<!-- readthedocs-preview pep-previews end -->