### PR TITLE
PEP 440: Link to PyPA spec

### DIFF
--- a/peps/pep-0440.rst
+++ b/peps/pep-0440.rst
@@ -15,6 +15,8 @@ Post-History: 30-Mar-2013, 27-May-2013, 20-Jun-2013,
 Replaces: 386
 Resolution: https://mail.python.org/pipermail/distutils-sig/2014-August/024673.html
 
+.. canonical-pypa-spec:: :ref:`version-specifiers`
+
 
 Abstract
 ========


### PR DESCRIPTION
Spec was migrated in https://github.com/pypa/packaging.python.org/pull/1340

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3527.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->