### PR TITLE
PEP 730: More revisions and clarifications

### DIFF
--- a/peps/pep-0730.rst
+++ b/peps/pep-0730.rst
@@ -68,6 +68,9 @@ development perspective, there is no discernable difference between iPadOS and
 iOS. A binary that has been compiled for the ``iphoneos`` or ``iphonesimulator``
 ABIs can be deployed on iPad.
 
+Other Apple platforms, such as tvOS, watchOS, and visionOS, use different ABIs,
+and are not covered by this PEP.
+
 POSIX compliance
 ----------------
 
@@ -118,13 +121,14 @@ the Python module no longer holds.
 
 As with macOS, compiling a binary module that is accessible from a
 statically-linked build of Python requires the use of the ``--undefined
-dynamic_lookup`` option to avoid linking ``libPython`` into every binary module.
-However, on iOS, this compiler flag raises a deprecation warning when it is
-used. A warning from this flag has been observed on macOS as well - however, responses from
-Apple staff suggest that they `do not intend to break the CPython ecosystem by
-removing this option <https://github.com/python/cpython/issues/97524#issuecomment-1458855301>`__. As
-Python does not have a notable presence on iOS, it is difficult to judge whether
-iOS usage of this flag would fall under the same umbrella.
+dynamic_lookup`` option to avoid linking ``libpython3.x`` into every binary
+module. However, on iOS, this compiler flag raises a deprecation warning when it
+is used. A warning from this flag has been observed on macOS as well - however,
+responses from Apple staff suggest that they `do not intend to break the CPython
+ecosystem by removing this option
+<https://github.com/python/cpython/issues/97524#issuecomment-1458855301>`__. As
+Python does not currently have a notable presence on iOS, it is difficult to
+judge whether iOS usage of this flag would fall under the same umbrella.
 
 Console and interactive usage
 -----------------------------
@@ -135,8 +139,7 @@ not be considered a goal of this work.
 Mobile devices (including iOS) do not provide a TTY-style console. They do not
 provide ``stdin``, ``stdout`` or ``stderr``. iOS provides a system log, and it
 is possible to install a redirection so that all ``stdout`` and ``stderr``
-content is redirected to the system log; but there is no analog for
-``stdin``.
+content is redirected to the system log; but there is no analog for ``stdin``.
 
 In addition, iOS places restrictions on downloading additional code at runtime
 (as this behavior would be functionally indistinguishable from trying to work
@@ -187,9 +190,10 @@ In addition, a ``platform.ios_ver()`` method will be added. This mirrors
 ``ios_ver()`` will return a namedtuple that contains the following:
 
 * ``release`` - the iOS version, as a string (e.g., ``"16.6.1"``).
-* ``min_release`` - the minimum supported iOS version, as a string (e.g., ``"12.0"``)
-* ``model`` - the model identifier of the device, as a string (e.g., ``"iPhone13,2"``).
-  On simulators, this will return ``"iPhoneSimulator"``.
+* ``min_release`` - the minimum supported iOS version, as a string (e.g.,
+  ``"12.0"``)
+* ``model`` - the model identifier of the device, as a string (e.g.,
+  ``"iPhone13,2"``). On simulators, this will return ``"iPhoneSimulator"``.
 * ``is_simulator`` - a boolean indicating if the device is a simulator.
 
 ``os``
@@ -209,8 +213,8 @@ This approach treats the ``os`` module as a "raw" interface to system APIs, and
 '''''''''''''
 
 The ``sysconfig`` module will use the minimum iOS version as part of
-``sysconfig.get_platform()`` (e.g., ``"ios-12.0-iphoneos-arm64"``).
-The ``sysconfigdata_name`` and Config makefile will follow the same patterns as
+``sysconfig.get_platform()`` (e.g., ``"ios-12.0-iphoneos-arm64"``). The
+``sysconfigdata_name`` and Config makefile will follow the same patterns as
 existing platforms (using ``sys.platform``, ``sys.implementation._multiarch``
 etc.) to construct identifiers.
 
@@ -239,12 +243,12 @@ Compilation
 -----------
 
 The only binary format that will be supported is a dynamically-linkable
-``libpython3.x.dylib``, packaged in an iOS-compatible framework format. While the
-``--undefined dynamic_lookup`` compiler option currently works, the long-term
-viability of the option cannot be guaranteed. Rather than rely on a compiler
-flag with an uncertain future, binary modules on iOS will be linked with
-``libPython``. This, in turn, makes statically-linkable builds of
-``libPython.a`` impractical.
+``libpython3.x.dylib``, packaged in an iOS-compatible framework format. While
+the ``--undefined dynamic_lookup`` compiler option currently works, the
+long-term viability of the option cannot be guaranteed. Rather than rely on a
+compiler flag with an uncertain future, binary modules on iOS will be linked
+with ``libpython3.x``. This, in turn, makes statically-linkable builds of
+``libpython3.x.a`` impractical.
 
 Building CPython for iOS requires the use of the cross-platform tooling in
 CPython's ``configure`` build system. A single ``configure``/``make``/``make
@@ -270,7 +274,7 @@ require production of officially distributed iOS artefacts for use by end-users.
 If/when iOS is updated to Tier 2 or 1 support, the tooling used to generate an
 ``XCframework`` package could be used to produce an iOS distribution artefact.
 This could then be distributed as an "embedded distribution" analogous to the
-Windows embedded distribution, or as a Cocoapod or Swift Package that could be
+Windows embedded distribution, or as a CocoaPod or Swift package that could be
 added to an Xcode project.
 
 CI resources
@@ -300,8 +304,8 @@ iOS wheels will use tags:
 * ``ios_12_0_iphonesimulator_x86_64``
 
 In these tags, "12.0" is the minimum supported iOS version. As with macOS, the
-tag will incorporate the minimum iOS version that is selected when the wheel
-is compiled; a wheel compiled with a minimum iOS version of 15.0 would use the
+tag will incorporate the minimum iOS version that is selected when the wheel is
+compiled; a wheel compiled with a minimum iOS version of 15.0 would use the
 ``ios_15_0_iphone*`` tags. At time of writing, iOS 12.0 exposes most significant
 iOS features, while reaching near 100% of devices; this will be used as a floor
 for iOS version matching.
@@ -421,8 +425,9 @@ The decision was made to use ``arm64-apple-ios`` and
 1. The ``autoconf`` toolchain already contains support for ``ios`` as a platform
    in ``config.sub``; it's only the simulator that doesn't have a representation.
 2. The third part of the host triple is used as ``sys.platform``.
-3. When Apple's own tools reference CPU architecture, they use ``arm64``, and the
-   GNU tooling usage of the architecture isn't visible outside the build process.
+3. When Apple's own tools reference CPU architecture, they use ``arm64``, and
+   the GNU tooling usage of the architecture isn't visible outside the build
+   process.
 4. When Apple's own tools reference simulator status independent of the OS
    (e.g., in the naming of Swift submodules), they use a ``-simulator`` suffix.
 5. While *some* iOS packages will use Rust, *all* iOS packages will use Apple's
@@ -439,10 +444,10 @@ It would be conceptually possible to offer an analogous "universal" iOS wheel
 format. However, this PEP does not use this approach, for 2 reasons.
 
 Firstly, the experience on macOS, especially in the numerical Python ecosystem,
-has been that universal wheels can be exceedingly difficult to accommodate. While
-native macOS libraries maintain strong multi-platform support, and Python itself
-has been updated, the vast majority of upstream non-Python libraries do not
-provide multi-architecture build support. As a result, compiling universal
+has been that universal wheels can be exceedingly difficult to accommodate.
+While native macOS libraries maintain strong multi-platform support, and Python
+itself has been updated, the vast majority of upstream non-Python libraries do
+not provide multi-architecture build support. As a result, compiling universal
 wheels inevitably requires multiple compilation passes, and complex decisions
 over how to distribute header files for different architectures. As a result of
 this complexity, many popular projects (including NumPy and Pillow) do not
@@ -452,10 +457,10 @@ wheels.
 Secondly, historical experience is that iOS would require a much more fluid
 "universal" definition. In the last 10 years, there have been *at least* 5
 different possible interpretations of "universal" that would apply to iOS,
-including various combinations of armv6, armv7, armv7s, arm64, x86 and
-x86_64 architectures, on device and simulator. If defined right now,
-"universal-iOS" would likely include x86_64 and arm64 on simulator, and arm64 on
-device; however, the pending deprecation of x86_64 hardware would add another
+including various combinations of armv6, armv7, armv7s, arm64, x86 and x86_64
+architectures, on device and simulator. If defined right now, "universal-iOS"
+would likely include x86_64 and arm64 on simulator, and arm64 on device;
+however, the pending deprecation of x86_64 hardware would add another
 interpretation; and there may be a need to add arm64e as a new device
 architecture in the future. Specifying iOS wheels as single-platform-only means
 the Python core team can avoid an ongoing standardization discussion about the
@@ -485,8 +490,8 @@ Given that Apple's decision-making process is entirely opaque, this would be, at
 best, a risky option. When combined with the fact that the broader iOS
 development ecosystem encourages the use of frameworks, there are no legacy uses
 of a static library to consider, and the only benefit to a statically-linked iOS
-``libPython`` is a very slightly reduced app startup time, omitting support for
-static builds of ``libPython`` seems a reasonable compromise.
+``libpython3.x`` is a very slightly reduced app startup time, omitting support
+for static builds of ``libpython3.x`` seems a reasonable compromise.
 
 It is worth nothing that there has been some discussion on `an alternate
 approach to linking on macOS
@@ -495,15 +500,15 @@ for the ``--undefined dynamic_lookup`` option, although discussion on this
 approach appears to have stalled due to complications in implementation. If
 those complications were to be overcome, it is highly likely that the same
 approach *could* be used on iOS, which *would* make a statically linked
-``libPython`` plausible.
+``libpython3.x`` plausible.
 
-The decision to link binary modules against ``libPython`` would complicate the
-introduction of static ``libPython`` builds in the future, as the process of
-moving to a different binary module linking approach would require a clear way
-to differentate "dynamically-linked" iOS binary modules from "static-compatible"
-iOS binary modules. However, given the lack of tangible benefits of a static
-``libPython``, it seems unlikely that there will be any requirement to make this
-change.
+The decision to link binary modules against ``libpython3.x`` would complicate
+the introduction of static ``libpython3.x`` builds in the future, as the process
+of moving to a different binary module linking approach would require a clear
+way to differentate "dynamically-linked" iOS binary modules from
+"static-compatible" iOS binary modules. However, given the lack of tangible
+benefits of a static ``libpython3.x``, it seems unlikely that there will be any
+requirement to make this change.
 
 Interactive/REPL mode
 ---------------------
@@ -535,9 +540,9 @@ pose a significant impediment to adoption or long term maintenance.
 On-device testing
 -----------------
 
-CI testing on simulators can be accommodated reasonably easily.
-On-device testing is much harder, as availability of device farms that could be
-configured to provide Buildbots or Github Actions runners is limited.
+CI testing on simulators can be accommodated reasonably easily. On-device
+testing is much harder, as availability of device farms that could be configured
+to provide Buildbots or Github Actions runners is limited.
 
 However, on device testing may not be necessary. As a data point - Apple's Xcode
 Cloud solution doesn't provide on-device testing. They rely on the fact that the

--- a/peps/pep-0730.rst
+++ b/peps/pep-0730.rst
@@ -120,9 +120,9 @@ As with macOS, compiling a binary module that is accessible from a
 statically-linked build of Python requires the use of the ``--undefined
 dynamic_lookup`` option to avoid linking ``libPython`` into every binary module.
 However, on iOS, this compiler flag raises a deprecation warning when it is
-used. This warning has been observed on macOS as well - however, responses from
-Apple staff suggests that they `do not intend to break the CPython ecosystem by
-removing this option <https://developer.apple.com/forums/thread/719961>`__. As
+used. A warning from this flag has been observed on macOS as well - however, responses from
+Apple staff suggest that they `do not intend to break the CPython ecosystem by
+removing this option <https://github.com/python/cpython/issues/97524#issuecomment-1458855301>`__. As
 Python does not have a notable presence on iOS, it is difficult to judge whether
 iOS usage of this flag would fall under the same umbrella.
 
@@ -239,7 +239,7 @@ Compilation
 -----------
 
 The only binary format that will be supported is a dynamically-linkable
-``libPython.dylib``, packaged in an iOS-compatible framework format. While the
+``libpython3.x.dylib``, packaged in an iOS-compatible framework format. While the
 ``--undefined dynamic_lookup`` compiler option currently works, the long-term
 viability of the option cannot be guaranteed. Rather than rely on a compiler
 flag with an uncertain future, binary modules on iOS will be linked with

--- a/peps/pep-0730.rst
+++ b/peps/pep-0730.rst
@@ -63,6 +63,11 @@ significant platform differences between iOS and macOS.
 
 iOS code is compiled for compatibility against a minimum iOS version.
 
+Apple frequently refers to "iPadOS" in their marketing material. However, from a
+development perspective, there is no discernable difference between iPadOS and
+iOS. A binary that has been compiled for the ``iphoneos`` or ``iphonesimulator``
+ABIs can be deployed on iPad.
+
 POSIX compliance
 ----------------
 
@@ -111,26 +116,15 @@ a Framework. This also means that the common assumption that a Python module can
 construct the location of a binary module by using the ``__file__`` attribute of
 the Python module no longer holds.
 
-As with macOS, compiling a dynamic library requires the use of the ``--undefined
-dynamic_lookup`` option to avoid linking libPython into every binary module.
-This option currently raises a deprecation warning when it is used. This warning
-*was* previously raised on macOS builds as well; however, responses from Apple
-staff suggests this was unintentional, and they `did not intend to break the
-CPython ecosystem by removing this option
-<https://developer.apple.com/forums/thread/719961>`__. It is difficult to judge
-whether iOS support would fall under the same umbrella.
-
-Distribution
-------------
-
-Adding iOS as a Tier 3 platform only requires adding support for compiling an
-iOS-compatible build from an unpatched CPython code checkout. It does not
-require production of officially distributed iOS artefacts for use by end-users.
-
-If/when iOS is updated to Tier 2 or 1 support, there should be a process for
-producing iOS distribution artefacts. This could be in the form of an "embedded
-distribution" analogous to the Windows embedded distribution, or as a Cocoapod
-or Swift Package that could be added to an Xcode project.
+As with macOS, compiling a binary module that is accessible from a
+statically-linked build of Python requires the use of the ``--undefined
+dynamic_lookup`` option to avoid linking ``libPython`` into every binary module.
+However, on iOS, this compiler flag raises a deprecation warning when it is
+used. This warning has been observed on macOS as well - however, responses from
+Apple staff suggests that they `do not intend to break the CPython ecosystem by
+removing this option <https://developer.apple.com/forums/thread/719961>`__. As
+Python does not have a notable presence on iOS, it is difficult to judge whether
+iOS usage of this flag would fall under the same umbrella.
 
 Console and interactive usage
 -----------------------------
@@ -179,7 +173,7 @@ devices.
 ``platform``
 ''''''''''''
 
-``platform`` will be modified to support returning iOS-specific details. Most of 
+``platform`` will be modified to support returning iOS-specific details. Most of
 the values returned by the ``platform`` module will match those returned by
 ``os.uname()``, with the exception of:
 
@@ -240,6 +234,44 @@ This finder will convert a Python module name (e.g., ``foo.bar._whiz``) into a
 unique Framework name by using the full module name as the framework name (i.e.,
 ``foo.bar._whiz.framework``). A framework is a directory; the finder will look
 for ``_whiz.dylib`` in that directory.
+
+Compilation
+-----------
+
+The only binary format that will be supported is a dynamically-linkable
+``libPython.dylib``, packaged in an iOS-compatible framework format. While the
+``--undefined dynamic_lookup`` compiler option currently works, the long-term
+viability of the option cannot be guaranteed. Rather than rely on a compiler
+flag with an uncertain future, binary modules on iOS will be linked with
+``libPython``. This, in turn, makes statically-linkable builds of
+``libPython.a`` impractical.
+
+Building CPython for iOS requires the use of the cross-platform tooling in
+CPython's ``configure`` build system. A single ``configure``/``make``/``make
+install`` pass will produce a ``Python.framework`` artefact that can be used on
+a single ABI and architecture.
+
+Additional tooling will be required to merge the ``Python.framework`` builds for
+multiple architectures into a single "fat" library. Tooling will also be
+required to merge multiple ABIs into the ``XCframework`` format that Apple uses
+to distribute multiple frameworks for different ABIs in a single bundle.
+
+An Xcode project will be provided for the purpose of running the CPython test
+suite. Tooling will be provided to automate the process of compiling the test
+suite binary, start the simulator, install the test suite, and execute it.
+
+Distribution
+------------
+
+Adding iOS as a Tier 3 platform only requires adding support for compiling an
+iOS-compatible build from an unpatched CPython code checkout. It does not
+require production of officially distributed iOS artefacts for use by end-users.
+
+If/when iOS is updated to Tier 2 or 1 support, the tooling used to generate an
+``XCframework`` package could be used to produce an iOS distribution artefact.
+This could then be distributed as an "embedded distribution" analogous to the
+Windows embedded distribution, or as a Cocoapod or Swift Package that could be
+added to an Xcode project.
 
 CI resources
 ------------
@@ -440,6 +472,38 @@ deployment on iOS is already a complicated process that is best aided by tools.
 At present, no binary merging is required, as there is only one on-device
 architecture, and simulator binaries are not considered to be distributable
 artefacts, so only one architecture is needed to build an app for a simulator.
+
+Supporting static builds
+------------------------
+
+While the long-term viability of the ``--undefined dynamic_lookup`` option
+cannot be guaranteed, the option does exist, and it works. One option would be
+to ignore the deprecation warning, and hope that Apple either reverses the
+deprecation decision, or never finalizes the deprecation.
+
+Given that Apple's decision-making process is entirely opaque, this would be, at
+best, a risky option. When combined with the fact that the broader iOS
+development ecosystem encourages the use of frameworks, there are no legacy uses
+of a static library to consider, and the only benefit to a statically-linked iOS
+``libPython`` is a very slightly reduced app startup time, omitting support for
+static builds of ``libPython`` seems a reasonable compromise.
+
+It is worth nothing that there has been some discussion on `an alternate
+approach to linking on macOS
+<https://github.com/python/cpython/issues/103306>`__ that would remove the need
+for the ``--undefined dynamic_lookup`` option, although discussion on this
+approach appears to have stalled due to complications in implementation. If
+those complications were to be overcome, it is highly likely that the same
+approach *could* be used on iOS, which *would* make a statically linked
+``libPython`` plausible.
+
+The decision to link binary modules against ``libPython`` would complicate the
+introduction of static ``libPython`` builds in the future, as the process of
+moving to a different binary module linking approach would require a clear way
+to differentate "dynamically-linked" iOS binary modules from "static-compatible"
+iOS binary modules. However, given the lack of tangible benefits of a static
+``libPython``, it seems unlikely that there will be any requirement to make this
+change.
 
 Interactive/REPL mode
 ---------------------

--- a/peps/pep-0730.rst
+++ b/peps/pep-0730.rst
@@ -247,8 +247,10 @@ The only binary format that will be supported is a dynamically-linkable
 the ``--undefined dynamic_lookup`` compiler option currently works, the
 long-term viability of the option cannot be guaranteed. Rather than rely on a
 compiler flag with an uncertain future, binary modules on iOS will be linked
-with ``libpython3.x``. This, in turn, makes statically-linkable builds of
-``libpython3.x.a`` impractical.
+with ``libpython3.x.dylib``. This means iOS binary modules will not be loadable
+by an executable that has been statically linked against ``libpython3.x.a``.
+Therefore, a static ``libpython3.x.a`` iOS library will not be supported. This
+is the same pattern used by CPython on Windows.
 
 Building CPython for iOS requires the use of the cross-platform tooling in
 CPython's ``configure`` build system. A single ``configure``/``make``/``make
@@ -490,25 +492,24 @@ Given that Apple's decision-making process is entirely opaque, this would be, at
 best, a risky option. When combined with the fact that the broader iOS
 development ecosystem encourages the use of frameworks, there are no legacy uses
 of a static library to consider, and the only benefit to a statically-linked iOS
-``libpython3.x`` is a very slightly reduced app startup time, omitting support
+``libpython3.x.a`` is a very slightly reduced app startup time, omitting support
 for static builds of ``libpython3.x`` seems a reasonable compromise.
 
-It is worth nothing that there has been some discussion on `an alternate
-approach to linking on macOS
-<https://github.com/python/cpython/issues/103306>`__ that would remove the need
-for the ``--undefined dynamic_lookup`` option, although discussion on this
-approach appears to have stalled due to complications in implementation. If
-those complications were to be overcome, it is highly likely that the same
-approach *could* be used on iOS, which *would* make a statically linked
-``libpython3.x`` plausible.
+It is worth noting that there has been some discussion on `an alternate approach
+to linking on macOS <https://github.com/python/cpython/issues/103306>`__ that
+would remove the need for the ``--undefined dynamic_lookup`` option, although
+discussion on this approach appears to have stalled due to complications in
+implementation. If those complications were to be overcome, it is highly likely
+that the same approach *could* be used on iOS, which *would* make a statically
+linked ``libpython3.x.a`` plausible.
 
-The decision to link binary modules against ``libpython3.x`` would complicate
-the introduction of static ``libpython3.x`` builds in the future, as the process
-of moving to a different binary module linking approach would require a clear
-way to differentate "dynamically-linked" iOS binary modules from
+The decision to link binary modules against ``libpython3.x.dylib`` would
+complicate the introduction of static ``libpython3.x.a`` builds in the future,
+as the process of moving to a different binary module linking approach would
+require a clear way to differentate "dynamically-linked" iOS binary modules from
 "static-compatible" iOS binary modules. However, given the lack of tangible
-benefits of a static ``libpython3.x``, it seems unlikely that there will be any
-requirement to make this change.
+benefits of a static ``libpython3.x.a``, it seems unlikely that there will be
+any requirement to make this change.
 
 Interactive/REPL mode
 ---------------------


### PR DESCRIPTION
A second pass of revisions and clarifications on PEP 730, adding Tier 3 iOS support.

* Adds an explicit mention of iPadOS
* Proposes linking binary modules with libPython to avoid a deprecated compiler option
* Proposes dropping static libPython.a builds as a supported output format
* Clarifies the compilation process and the relationship between the configure/make/make install build and the useable artefacts.
 
* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3529.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->