### PR TITLE
PEP 668: Link to PyPA spec

### DIFF
--- a/peps/pep-0668.rst
+++ b/peps/pep-0668.rst
@@ -18,6 +18,8 @@ Created: 18-May-2021
 Post-History: 28-May-2021
 Resolution: https://discuss.python.org/t/10302/44
 
+.. canonical-pypa-spec:: :ref:`externally-managed-environments`
+
 Abstract
 ========
 


### PR DESCRIPTION
Spec was imported in https://github.com/pypa/packaging.python.org/pull/1372/files

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3532.org.readthedocs.build/pep-0668/

<!-- readthedocs-preview pep-previews end -->