### PR TITLE
PEP 733: Adjust binding generator for Qt

### DIFF
--- a/peps/pep-0733.rst
+++ b/peps/pep-0733.rst
@@ -208,7 +208,8 @@ Examples are
 `pybind11 <https://pybind11.readthedocs.io/en/stable/>`__ and
 `nanobind <https://github.com/wjakob/nanobind>`__ for C++,
 `PyO3 <https://github.com/PyO3/pyo3>`__ for Rust,
-`Shiboken <https://doc.qt.io/qtforpython-6/shiboken6/index.html>`__ for Qt,
+`Shiboken <https://doc.qt.io/qtforpython-6/shiboken6/index.html>`__ used by
+PySide for Qt,
 `PyGObject <https://pygobject.readthedocs.io/en/latest/>`__ for GTK,
 `Pygolo <https://gitlab.com/pygolo/py>`__ for Go,
 `JPype <https://github.com/jpype-project/jpype/>`__ for Java,

--- a/peps/pep-0733.rst
+++ b/peps/pep-0733.rst
@@ -208,7 +208,7 @@ Examples are
 `pybind11 <https://pybind11.readthedocs.io/en/stable/>`__ and
 `nanobind <https://github.com/wjakob/nanobind>`__ for C++,
 `PyO3 <https://github.com/PyO3/pyo3>`__ for Rust,
-`PySide <https://pypi.org/project/PySide/>`__ for Qt,
+`Shiboken <https://doc.qt.io/qtforpython-6/shiboken6/index.html>`__ for Qt,
 `PyGObject <https://pygobject.readthedocs.io/en/latest/>`__ for GTK,
 `Pygolo <https://gitlab.com/pygolo/py>`__ for Go,
 `JPype <https://github.com/jpype-project/jpype/>`__ for Java,


### PR DESCRIPTION
PySide was listed as a binding generator for Qt, but PySide is the final project.
The name of the used binding generator that PySide uses, is Shiboken.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3533.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->