### PR TITLE
PEP 735: Dependency Groups in pyproject.toml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -611,6 +611,7 @@ peps/pep-0730.rst  @ned-deily
 peps/pep-0731.rst  @gvanrossum @encukou @vstinner @zooba @iritkatriel
 peps/pep-0732.rst  @Mariatta
 peps/pep-0733.rst  @encukou @vstinner @zooba @iritkatriel
+peps/pep-0735.rst  @brettcannon
 # ...
 # peps/pep-0754.rst
 # ...

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -239,7 +239,7 @@ formats:
   which refers to the current project as a package including some extras, e.g.,
   ``.[mysql]`` to refer to the current package with its ``mysql`` extra
 
-Requirement specifiers can now be defined as one of the following:
+Requirement specifiers are one of the following:
 
 * A string, which is a valid PEP 735 Dependency Specifier. e.g., ``numpy>1``
 * An object, which has exactly one key, ``spec``, which is a valid PEP 735
@@ -275,7 +275,7 @@ Tools which support Dependency Groups MUST support both string and object
 representations of requirements.
 
 When unrecognized keys are encountered in requirement specifiers or the
-``requirements`` table, tools MUST NOT fail. They MAY emit warnings.
+``requirements`` table, tools MUST NOT fail. They SHOULD emit warnings.
 
 When installing the current package (``.``) from a dependency group, tools
 SHOULD prefer editable installs over non-editable installs. They MAY provide

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -137,10 +137,10 @@ The format does not support many forms of non-package data from
 ``requirements.txt`` files, such as ``pip`` options for package servers or
 hashes. Including them in the initial stage complicates this proposal and it is
 not clear that the majority of use-cases require them. Future expansions to
-this specification may enable the use of object declarations, rather than
-strings, in the ``[dependency-groups]`` values. Because this specification
-provides for an object format for the data, it is possible for these to be
-added in future specifications.
+this specification may extend the object format for dependencies in
+``[dependency-groups]`` values. Because this specification provides for an
+object format for the data, it is possible for these to be added in future
+specifications.
 
 The following use cases are considered important targets for this PEP:
 
@@ -246,20 +246,21 @@ are already normalized.
 Requirements specifiers will use a definition based on standardized
 `Dependency Specifiers <https://packaging.python.org/en/latest/specifications/dependency-specifiers/>`__
 introduced in :pep:`508`.
-This PEP also proposes an object format to define a dependency, called a "PEP
-735 Dependency" (defined below). The elements in ``[dependency-groups]``
-lists must either be strings, in which case they must be valid Dependency
-Specifiers or else PEP 735 Dependencies.
 
-PEP 735 Dependencies
---------------------
+This PEP also proposes an object format to define a dependency, called a
+"Dependency Object Specifier" (defined below). The elements in
+``[dependency-groups]`` lists must either be strings, in which case they must
+be valid Dependency Specifiers (PEP 508) or else Dependency Object Specifiers.
 
-PEP 735 Dependencies are objects which define a set of dependencies. They do
-not necessarily refer to a single package, as will become clear from the
-definitions below.
+Dependency Object Specifiers
+----------------------------
 
-There are two forms of PEP 735 Dependencies: "Dependency Group Includes" and
-"Path Dependencies".
+Dependency Object Specifiers are objects (tables in TOML) which define a set of
+dependencies. They do not necessarily refer to a single package, as will become
+clear from the definitions below.
+
+There are two forms of Dependency Object Specifiers: "Dependency Group Includes"
+and "Path Dependencies".
 
 Dependency Group Include
 ''''''''''''''''''''''''
@@ -284,7 +285,7 @@ It contains the following keys, with associated types:
 * ``path``: a string, required
 * ``extras``: a list of strings, optional
 * ``editable``: a boolean, optional
-* ``only_deps``: a boolean, optional
+* ``only-deps``: a boolean, optional
 
 For a simple example, ``{path = ".", editable = true, extras = ["mysql"]}`` is
 a Path Dependency on the current project including its ``mysql`` extra. In
@@ -296,13 +297,16 @@ a Path Dependency on the current project including its ``mysql`` extra. In
 The ``path`` must refer to the path to a built distribution (wheel, sdist, or
 any future file format) or a directory containing python package source code.
 
+If the ``path`` is relative, it is relative to the directory containing
+``pyproject.toml``.
+
 If the path refers to a built distribution, that package should be installed
 when the Dependency Group is installed.
 
 If the path refers to a directory, the directory SHOULD be a valid Python
 package. Implementations MAY refuse to process ``path`` directives which are
-not packages, even when ``only_deps`` is specified (see below for how
-``only_deps`` would potentially make it possible to process non-package paths).
+not packages, even when ``only-deps`` is specified (see below for how
+``only-deps`` would potentially make it possible to process non-package paths).
 
 ``extras``
 ~~~~~~~~~~
@@ -327,18 +331,18 @@ present.
 If ``editable`` is specified on a Path Dependency which refers to a built
 distribution, implementations MUST treat this as an error.
 
-``only_deps``
+``only-deps``
 ~~~~~~~~~~~~~
 
-If ``only_deps`` is ``true``, implementations MUST NOT install the package
+If ``only-deps`` is ``true``, implementations MUST NOT install the package
 at the specified ``path``. Instead, they should only install the dependencies
 of that package. This may still require building a package from a source tree
 in order to discover ``dynamic`` dependency data.
 
-If ``only_deps`` is ``false`` or absent, implementations should install the
+If ``only-deps`` is ``false`` or absent, implementations should install the
 package at the specified ``path``.
 
-It is possible to specify ``only_deps`` on a Path Dependency which does not
+It is possible to specify ``only-deps`` on a Path Dependency which does not
 refer to a valid python package and for tools to, at least in theory, process
 such a dependency successfully. For example, a ``pyproject.toml`` file
 containing only ``[project.dependencies]`` and none of the other required keys
@@ -346,7 +350,7 @@ in the ``[project]`` table could be supported. Implementations SHOULD NOT
 support such structures and SHOULD fail if a Path Dependency refers to a python
 project which is not a package.
 
-If ``only_deps`` is ``true`` and ``extras`` are specified, implementations
+If ``only-deps`` is ``true`` and ``extras`` are specified, implementations
 should install the ``extras`` as well as all of the non-optional dependencies
 of the package.
 
@@ -367,9 +371,9 @@ a singular Path Dependency following the rules below:
 - The ``extras`` keys are concatenated into a single list
 - If ``editable`` is always ``true`` or always ``false``, it is treated as
   such. Otherwise, the ``editable`` key is treated as though it were absent.
-- If the ``only_deps`` key is present, a ``false`` or absent value takes
+- If the ``only-deps`` key is present, a ``false`` or absent value takes
   priority over any ``true`` values. In other words, implementations respect
-  ``only_deps`` if it is ``true`` for all instances of the same ``path``.
+  ``only-deps`` if it is ``true`` for all instances of the same ``path``.
   Otherwise, they treat it as ``false``.
 
 
@@ -385,7 +389,7 @@ define four dependency groups: ``test``, ``docs``, ``typing``, and
     [dependency-groups]
     test = ["pytest", "coverage", {path = ".", editable = true}]
     docs = ["sphinx", "sphinx-rtd-theme"]
-    typing = ["mypy", "types-requests", {path = ".", extras = ["types"], only_deps = true}]
+    typing = ["mypy", "types-requests", {path = ".", extras = ["types"], only-deps = true}]
     typing-test = [{include = "typing"}, {include = "test"}, "useful-types"]
 
     [project.optional-dependencies]
@@ -400,7 +404,7 @@ additional package. ``typing`` includes an extra, ``types``, and this is
 included by extension under ``typing-test``.
 Under ``typing-test`` implementations may choose whether or not to use an
 editable installation of the current package or not, but they MUST treat
-``only_deps`` as ``false``.
+``only-deps`` as ``false``.
 
 Package Building
 ----------------
@@ -476,8 +480,8 @@ without needing to learn about package building.
 A ``pyproject.toml`` file with only ``[dependency-groups]`` and no other tables
 is valid.
 
-For both new and experienced users, the object style used in PEP 735
-Dependencies will need to be explained. Support for
+For both new and experienced users, the object style used in Dependency Object
+Specifiers will need to be explained. Support for
 ``path = ".", editable = true`` and
 ``path = ".", editable = true, extras = ["extra"]`` should be taught
 similarly to teaching ``pip install -e .`` and ``pip install -e '.[extra]'``
@@ -500,8 +504,8 @@ However, it also makes the structure nested more deeply, and therefore harder
 to teach and learn. One of the goals of this PEP is to be an easy replacement
 for many ``requirements.txt`` use-cases.
 
-Why not define a special string syntax for PEP 735 Dependencies?
-----------------------------------------------------------------
+Why not define a special string syntax to extend Dependency Specifiers?
+-----------------------------------------------------------------------
 
 Earlier drafts of this specification defined syntactic forms for Dependency
 Group Includes and Path Dependencies.
@@ -513,7 +517,7 @@ However, there were three major issues with this approach:
 * the resulting strings would always need to be disambiguated from PEP 508
   specifiers, complicating implementations
 
-* support for the matrix of Path Dependency requirements (``editable``, ``only_deps``,
+* support for the matrix of Path Dependency requirements (``editable``, ``only-deps``,
   ``extras``) would require a complex syntax whose design was unclear
 
 Why not restrict dependencies to PEP 508 only?
@@ -526,7 +530,7 @@ There are known use cases for:
 * including the current package with extras (if the project is a package)
 * installing ``project.dependencies`` from the current project but not
   installing the current project (as can be done with
-  ``{path = ".", only_deps = true}``)
+  ``{path = ".", only-deps = true}``)
 * specifying that an installation be done in editable mode
 
 These are not satisfiable without some expansion of syntax beyond what is
@@ -587,6 +591,33 @@ Dependabot will not flag dependencies which are pinned in ``tox.ini`` files.)
 
 Open Issues
 ===========
+
+Documenting Distinctions from Poetry and PDM Object Formats
+-----------------------------------------------------------
+
+The object format here is similar to the ones used by Poetry and PDM, but not
+identical.
+The differences should be captured in Appendix B, as a part of documenting Poetry
+and PDM behaviors and data formats.
+
+Editable Installation May or May Not Be In Scope
+------------------------------------------------
+
+The ``editable`` field formalizes a behavior which is supported by setuptools
+and pip, but which has three major issues:
+
+- it combines information about the existence of a dependency with information
+  about *how* that dependency should be installed
+
+- editable installs, as implemented today, do not provide for seamless updates
+  to package metadata
+
+- there is no specification for the behavior of an editable install -- this is
+  an implementation-specific feature
+
+Therefore, ``editable`` may need to be removed.
+Such a removal must account for how existing tools and workflows which rely on
+editable installs will be impacted.
 
 Footnotes
 =========

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -37,7 +37,9 @@ standardized answer:
 In the absence of any standard, two known workflow tools, PDM and Poetry, have
 defined their own solutions for Dependency Groups to address the first of these
 two needs. Their definitions are very similar to one another, although PDM
-structures them much more similarly to extras than Poetry does.
+structures them much more similarly to
+`extras <https://packaging.python.org/en/latest/specifications/dependency-specifiers/#extras>`__
+than Poetry does.
 Neither of them addresses the needs of non-package projects, and neither can be
 referenced natively from other tools like ``tox``, ``nox``, or ``pip``.
 
@@ -168,8 +170,9 @@ The following use cases are considered important targets for this PEP:
   currently be achieved, for example, with ``deps = -r requirements.txt`` in
   ``tox.ini``. These tools will need to add additional options for processing
   Dependency Groups.
-* Embeddable data for ``pyproject.toml`` within a script (as in :pep:`723`). This
-  PEP does not define exactly how PEP 723 should be modified, but being
+* Embeddable data for ``pyproject.toml`` within a script, as in :pep:`723`,
+  which defines embedded ``pyproject.toml`` data within scripts. This
+  PEP does not define exactly how :pep:`723` should be modified, but being
   consumable by that interface is a stated goal.
 * IDE discovery of requirements data. For example, VS Code could look for a dependency
   group named ``test`` to use when running tests.
@@ -240,11 +243,13 @@ least two characters long. These requirements are chosen so that the
 normalization rules used for PyPI package names are unnecessary as the names
 are already normalized.
 
-Requirements specifiers will use a definition based on :pep:`508`. This PEP
-also proposes an object format to define a dependency, called a
-"PEP 735 Dependency" (defined below). The elements in ``[dependency-groups]``
-lists must either be strings, in which case they must be valid :pep:`508`
-specifiers or else PEP 735 Dependencies.
+Requirements specifiers will use a definition based on standardized
+`Dependency Specifiers <https://packaging.python.org/en/latest/specifications/dependency-specifiers/>`__
+introduced in :pep:`508`.
+This PEP also proposes an object format to define a dependency, called a "PEP
+735 Dependency" (defined below). The elements in ``[dependency-groups]``
+lists must either be strings, in which case they must be valid Dependency
+Specifiers or else PEP 735 Dependencies.
 
 PEP 735 Dependencies
 --------------------
@@ -458,10 +463,10 @@ How to Teach This
 This feature should be referred to by its canonical name, "Dependency Groups".
 
 The basic form of usage should be taught as a variant on typical
-``requirements.txt`` data. :pep:`508` package specifiers can be added to a named
-list. Rather than asking pip to install from a ``requirements.txt`` file,
-either pip or a relevant workflow tool will install from a named Dependency
-Group.
+``requirements.txt`` data. Standard dependency specifiers (:pep:`508`) can be
+added to a named list. Rather than asking pip to install from a
+``requirements.txt`` file, either pip or a relevant workflow tool will install
+from a named Dependency Group.
 
 For new Python users, they may be taught directly to create a section in
 ``pyproject.toml`` containing their dependency groups, similarly to how they
@@ -525,7 +530,7 @@ There are known use cases for:
 * specifying that an installation be done in editable mode
 
 These are not satisfiable without some expansion of syntax beyond what is
-possible with :pep:`508`.
+possible with exsting Dependency Specifiers (:pep:`508`).
 
 Why is the table not named ``[run]``, ``[project.dependency-groups]``, ...?
 ---------------------------------------------------------------------------
@@ -533,8 +538,8 @@ Why is the table not named ``[run]``, ``[project.dependency-groups]``, ...?
 There are many possible names for this concept.
 It will have to live alongside the already existing ``[project.dependencies]``
 and ``[project.optional-dependencies]`` tables, and possibly a new
-``[external]`` dependency table as well (at time of writing, :pep:`725` is in
-progress).
+``[external]`` dependency table as well (at time of writing, :pep:`725`, which
+defines the ``[external]`` table, is in progress).
 
 ``[run]`` was a leading proposal in earlier discussions, but its proposed usage
 centered around a single set of runtime dependencies. This PEP explicitly

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -32,7 +32,7 @@ examples include webapps (which often run from source), and data science
 projects (which may start as collections of scripts and only later evolve
 package structures). This PEP seeks to offer these projects a way to specify
 their package dependencies in a way which is not constrained by the
-requirements of distribution building -- for example, a data sicence project
+requirements of distribution building -- for example, a data science project
 does not need to declare a version or authors in order for these data to be
 valid.
 
@@ -60,7 +60,7 @@ the use of ``extras`` for development requirements -- because these are publishe
 data, package developers often restrain themselves to a single extra or a small
 number of extras, and are concerned about ensuring that their development
 extras are not confused with user-facing extras. The second is the use of
-``requirements.txt`` files for libaries and applications, which takes a similar
+``requirements.txt`` files for libraries and applications, which takes a similar
 form to their use in non-distribution-building projects.
 
 Rationale
@@ -73,7 +73,7 @@ later. Discussions about project needs have included mention of python version
 requirements and other potential metadata. These could be added to the
 ``[requirements]`` table as siblings of the ``[requirements.packages]`` table.
 Second, the desire for this format to be as simple and learnable as possible,
-having a format very similar to existing ``reuqirements.txt`` files. Each list
+having a format very similar to existing ``requirements.txt`` files. Each list
 in ``[requirements.packages]`` is defined as a list of package specifiers.
 
 The format does not support non-package data from ``requirements.txt`` files,

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -7,13 +7,13 @@ Status: Draft
 Type: Standards Track
 Topic: Packaging
 Created: 20-Nov-2023
-Post-History: `20-Nov-2023 <https://discuss.python.org/t/39233>`__, `14-Nov-2023 <https://discuss.python.org/t/29684>`__
+Post-History: `14-Nov-2023 <https://discuss.python.org/t/29684>`__, `20-Nov-2023 <https://discuss.python.org/t/39233>`__
 
 Abstract
 ========
 
 This PEP specifies a mechanism for storing package requirements in
-pyproject.toml files such that it is not included in any built distribution of
+``pyproject.toml`` files such that it is not included in any built distribution of
 the project.
 
 This is suitable for creating named groups of dependencies, similar to
@@ -47,10 +47,15 @@ Regarding ``requirements.txt``, many projects may define one or more of these fi
 and may arrange them either at the project root (e.g. ``requirements.txt`` and
 ``test-requirements.txt``) or else in a directory (e.g.
 ``requirements/base.txt`` and ``requirements/test.txt``). However, there are
-two major issues with the use of requirements files in this way: (1) there is no
-standardized naming convention such that tools can discover or use these files
-by name and (2) ``requirementst.txt`` files are *not standardized*, but instead
-provide options to ``pip``. Therefore, their use is not portable to any new
+two major issues with the use of requirements files in this way:
+
+* There is no standardized naming convention such that tools can discover or
+  use these files by name.
+
+* ``requirementst.txt`` files are *not standardized*, but instead provide
+  options to ``pip``.
+
+Therefore, their use is not portable to any new
 installer or tool which wishes to process them without relying upon ``pip``.
 Additionally, ``requirements.txt`` files may be viewed as a heavyweight
 solution for very small dependency sets of only one or two items, and a terser
@@ -58,13 +63,17 @@ declaration will be beneficial to projects with a number of small groups of
 dependencies.
 
 Regarding extras, the use of extras to define development dependencies is a
-widespread practice, but it has two major downsides. First, an extra is defined
-as an additive group of dependencies for a package. This means that it cannot
-be installed without installing all of the package dependencies, and the
-project must be defined as a package. Second, many developers view their extras
-as part of the public interface for their package. Because these are published
-data, package developers often are concerned about ensuring that their
-development extras are not confused with user-facing extras. Therefore, their
+widespread practice, but it has two major downsides.
+
+* An extra is defined as an additive group of dependencies for a package.
+  This means that it cannot be installed without installing all of the package
+  dependencies, and the project must be defined as a package.
+
+* Many developers view their extras as part of the public interface for their
+  package. Because these are published data, package developers often are
+  concerned about ensuring that their development extras are not confused with
+  user-facing extras. Therefore, their development needs are not appropriate to
+  publish in the manner of extras.
 development needs are not appropriate to publish in the manner of extras.
 
 Providing a standardized place to store dependency data which matches the
@@ -78,10 +87,12 @@ should be used to declare development dependencies.
 Supported Project Types
 -----------------------
 
-This PEP aims to serve the needs of two distinct project types: libraries and
-other packages which want to define development dependencies, and projects
-which do not build distributions which want a standardized way to declare their
-dependency data.
+This PEP aims to serve the needs of two distinct project types:
+
+* libraries and other packages which want to define development dependencies
+
+* projects which do not build distributions which want a standardized way to
+  declare their dependency data
 
 The Python packaging toolchain is oriented towards the production of wheel and
 sdist files, containing project source for installation. However, not all
@@ -97,23 +108,29 @@ valid, nor does it need to define an installable package source tree.
 Simultaneously, this PEP should benefit projects which *are* intended to build
 distributions. Because these requirements data are explicitly defined to not be
 included in any built distribution, two common use-cases are addressed by this
-addition. The first is the use of ``extras``, as discussed above. The second is
-the use of ``requirements.txt`` files for distributed libraries and
-applications, which takes a similar form to their use in
-non-distribution-building projects.
+addition:
+
+* the use of ``extras``, as discussed above
+
+* the use of ``requirements.txt`` files for distributed libraries and
+  applications, which takes a similar form to their use in
+  non-distribution-building projects
 
 Rationale
 =========
 
 This PEP defines the storage of requirements data in lists within a
 ``[requirements.packages]`` table. The naming is motivated by two major
-factors. First, the desire to lay claim to a namespace which can be extended
-later. Discussions about project needs have included mention of python version
-requirements and other potential metadata. These could be added to the
-``[requirements]`` table as siblings of the ``[requirements.packages]`` table.
-Second, the desire for this format to be as simple and learnable as possible,
-having a format very similar to existing ``requirements.txt`` files. Each list
-in ``[requirements.packages]`` is defined as a list of package specifiers.
+factors:
+
+* The desire to lay claim to a namespace which can be extended
+  later. Discussions about project needs have included mention of python version
+  requirements and other potential metadata. These could be added to the
+  ``[requirements]`` table as siblings of the ``[requirements.packages]`` table.
+
+* The desire for this format to be as simple and learnable as possible,
+  having a format very similar to existing ``requirements.txt`` files. Each list
+  in ``[requirements.packages]`` is defined as a list of package specifiers.
 
 The format does not support non-package data from ``requirements.txt`` files,
 such as ``pip`` options for package servers or hashes. Including them in the
@@ -125,7 +142,7 @@ this by specifying a valid object format with only one well-defined key.
 
 The following use cases are considered important targets for this PEP:
 
-* A web application (e.g. a django or flask app) which does not build a
+* A web application (e.g. a Django or Flask app) which does not build a
   distribution, but bundles and ships its source to a deployment toolchain. The
   app has runtime dependencies, testing dependencies, and development
   environment dependencies. All of these dependency sets should be declared
@@ -147,20 +164,20 @@ The following use cases are considered important targets for this PEP:
   Furthermore, tools may define their own structures and conventions such that
   the generated lockfiles can be referenced by the names of their originating
   dependency groups in ``pyproject.toml``.
-* *Input data* to a ``tox``, ``nox``, or ``hatch`` environment, as can
+* *Input data* to a tox, Nox, or Hatch environment, as can
   currently be achieved, for example, with ``deps = -r requirements.txt`` in
   ``tox.ini``. These tools will need to add additional options for processing
   Dependency Groups.
-* Embeddable data for ``pyproject.toml`` within a script (as in PEP 723). This
+* Embeddable data for ``pyproject.toml`` within a script (as in :pep:`723`). This
   PEP does not define exactly how PEP 723 should be modified, but being
   consumable by that interface is a stated goal.
-* IDE discovery of requirements data. e.g. VSCode could look for a dependency
+* IDE discovery of requirements data. e.g. VS Code could look for a dependency
   group named ``test`` to use when running tests.
 
 Regarding Poetry and PDM Dependency Groups
 ------------------------------------------
 
-Poetry and PDM already offers a feature which each calls "Dependency Groups",
+Poetry and PDM already offer a feature which each calls "Dependency Groups",
 but using non-standard data belonging to the ``poetry`` and ``pdm`` tools.
 (PDM also uses extras for some Dependency Groups, and overlaps the notion
 heavily with extras.)
@@ -204,17 +221,17 @@ These keys must match the following regular expression:
 ``[a-z0-9][a-z0-9-]*[a-z0-9]``. Meaning that they must be all lower-case
 alphanumerics, with ``-`` allowed only in the middle, and at least
 two characters long. These requirements are chosen so that the normalization
-rules used for pypi package names do not apply, as the names are already
+rules used for PyPI package names are unnecessary as the names are already
 normalized.
 
-Requirements specifiers will use a definition which extends PEP 508. Therefore,
+Requirements specifiers will use a definition which extends :pep:`508`. Therefore,
 it is first necessary to define a string format, a "PEP 735 Dependency". These
 are defined as strings in one of the three following formats:
 
 * a PEP 508 specification, e.g., ``numpy>1``
 * a comma-delimited list of Dependency Group names, enclosed in square
   brackets, e.g., ``[test,docs]`` to refer to other Dependency Groups named
-  ``test`` and ``docs``
+  ``test`` and ``docs`` as specified in ``[requirements.packages]``
 * a single dot, ``.``, which refers to the current project as a package
   (similar to ``pip install .``)
 * a single dot, followed by square brackets enclosing a list of extra names,
@@ -280,7 +297,7 @@ reasons:
 * there is not guaranteed to be a current package for dependency groups -- part
   of their purpose is to support non-package projects
 
-For example, a possible ``pip`` interface for installing dependency groups
+For example, a possible pip interface for installing dependency groups
 would be:
 
 .. code:: shell
@@ -293,19 +310,15 @@ for how tools support the installation of Dependency Groups.
 Reference Implementation
 ========================
 
-TODO! STUB!
-
-Planned reference implementation:
-A very simple "environment manager" which can be used to build virtualenvs from
-specified Dependency Groups. It will therefore need to fully support parsing of
-Dependency Groups.
+There is currently no reference implementation/consumer of this specification.
 
 Backwards Compatibility
 =======================
 
-At time of writing, the ``requirements`` table is reserved for use by PEPs,
-meaning that this lays claim to a previously unused namespace.
-There should therefore be no direct backwards compatibility concerns.
+At time of writing, the ``requirements`` namespace within a
+``pyproject.toml`` file is unused. Since the top-level namespace is
+reserved for use only by standards specified at packaging.python.org,
+there should be no direct backwards compatibility concerns.
 
 Future Compatiiblity
 --------------------
@@ -333,12 +346,12 @@ How to Teach This
 This feature should be referred to by its canonical name, "Dependency Groups".
 
 The basic form of usage should be taught as a variant on typical
-``requirements.txt`` data. PEP 508 package specifiers can be added to a named
-list. Rather than asking ``pip`` to install from a ``requirements.txt`` file,
-either ``pip`` or a relevant workflow tool will install from a named Dependency
+``requirements.txt`` data. :pep:`508` package specifiers can be added to a named
+list. Rather than asking pip to install from a ``requirements.txt`` file,
+either pip or a relevant workflow tool will install from a named Dependency
 Group.
 
-For new python users, they may be taught directly to create a section in
+For new Python users, they may be taught directly to create a section in
 ``pyproject.toml`` containing their dependency groups, similarly to how they
 are currently taught to use ``pyproject.toml``.
 
@@ -348,7 +361,7 @@ Rejected Ideas
 Why not define python-requires as part of the requirements table?
 -----------------------------------------------------------------
 
-Discussion around PEP 722 and PEP 723, as well as discussions of projects which
+Discussion around :pep:`722` and :pep:`723,` as well as discussions of projects which
 do not produce wheels, have often raised the need to define the python version
 which will be used.
 
@@ -374,14 +387,14 @@ for many ``requirements.txt`` use-cases.
 Why not restrict dependencies to PEP 508 only?
 ----------------------------------------------
 
-There are valid use-cases for
+There are valid use-cases for:
 
 * including one dependency group in another
 * including the current package (if the project is a package)
 * including the current package with extras (if the project is a package)
 
 These are not satisfiable without some expansion of syntax beyond what is
-possible with PEP 508.
+possible with :pep:`508`.
 
 Why not define keys in dependency specifications for common options seen in ``requirements.txt`` (e.g. ``--hash``)?
 -------------------------------------------------------------------------------------------------------------------
@@ -409,7 +422,7 @@ Why is the table not named ``[run]``, ``[dependency_groups]``, ...?
 There are many possible names for this concept.
 It will have to live alongside the already existing ``[project.dependencies]``
 and ``[project.optional-dependencies]`` tables, and possibly a new
-``[external]`` dependency table as well (at time of writing, PEP 725 is in
+``[external]`` dependency table as well (at time of writing, :pep:`725` is in
 progress).
 
 ``[run]`` was a leading proposal in earlier discussions, but its proposed usage
@@ -427,23 +440,23 @@ requirements.
 
     No name has been declared final yet.
 
-Why is ``pip``'s planned implementation of ``--only-deps`` not sufficient?
---------------------------------------------------------------------------
+Why is pip's planned implementation of ``--only-deps`` not sufficient?
+----------------------------------------------------------------------
 
-``pip`` currently has a feature on the roadmap to add an
+pip currently has a feature on the roadmap to add an
 `--only-deps flag <pip only-deps_>`_. This flag is intended to allow users to
 install package dependencies and extras without installing the current package.
 
 It does not address the needs of non-package projects, nor does it allow for
 the installation of an extra without the package dependencies.
 
-Therefore, while it may be a useful feature for ``pip`` to pursue, it does not
+Therefore, while it may be a useful feature for pip to pursue, it does not
 address the same use-cases addressed here.
 
 Why isn't <environment manager> a solution?
 -------------------------------------------
 
-Existing environment managers like ``tox``, ``nox``, and ``hatch`` already have
+Existing environment managers like tox, Nox, and Hatch already have
 the ability to list inlined dependencies as part of their configuration data.
 This meets many development dependency needs, and clearly associates dependency
 groups with relevant tasks which can be run.

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -536,7 +536,7 @@ There are known use cases for:
 * specifying that an installation be done in editable mode
 
 These are not satisfiable without some expansion of syntax beyond what is
-possible with exsting Dependency Specifiers (:pep:`508`).
+possible with existing Dependency Specifiers (:pep:`508`).
 
 Why is the table not named ``[run]``, ``[project.dependency-groups]``, ...?
 ---------------------------------------------------------------------------

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -1,14 +1,13 @@
 PEP: 735
 Title: Dependency Groups in pyproject.toml
 Author: Stephen Rosen <sirosen0@gmail.com>
-Discussions-To: https://discuss.python.org/t/29684
 Sponsor: Brett Cannon <brett@python.org>
+Discussions-To: https://discuss.python.org/t/29684
 Status: Draft
 Type: Standards Track
 Topic: Packaging
-Content-Type: text/x-rst
 Created: 20-Nov-2023
-Post-History: https://discuss.python.org/t/29684
+Post-History: `14-Nov-2023 <https://discuss.python.org/t/29684>`__
 
 Abstract
 ========
@@ -18,7 +17,7 @@ pyproject.toml files such that it is not included in any built distribution of
 the project.
 
 This is suitable for creating named groups of dependencies, similar to
-`requirements.txt` files, which launchers, IDEs, and other tools can find and
+``requirements.txt`` files, which launchers, IDEs, and other tools can find and
 identify by name.
 
 The feature defined here is referred to as "Dependency Groups".
@@ -152,19 +151,21 @@ normalized.
 Requirements specifiers will use a definition which extends PEP 508. Therefore,
 it is first necessary to define a string format, a "PEP 735 Dependency". These
 are defined as strings in one of the three following formats:
-- a PEP 508 specification, e.g., ``numpy>1``
-- a comma-delimited list of Dependency Group names, enclosed in square
+
+* a PEP 508 specification, e.g., ``numpy>1``
+* a comma-delimited list of Dependency Group names, enclosed in square
   brackets, e.g., ``[test,docs]`` to refer to other Dependency Groups named
   ``test`` and ``docs``
-- a single dot, ``.``, which refers to the current project as a package
+* a single dot, ``.``, which refers to the current project as a package
   (similar to ``pip install .``)
-- a single dot, followed by square brackets enclosing a list of extra names,
+* a single dot, followed by square brackets enclosing a list of extra names,
   which refers to the current project as a package including some extras, e.g.,
   ``.[mysql]`` to refer to the current package with its ``mysql`` extra
 
 Requirement specifiers can now be defined as one of the following:
-- A string, which is a valid PEP 735 Dependency Specifier. e.g., ``numpy>1``
-- An object, which has exactly one key, ``spec``, which is a valid PEP 735
+
+* A string, which is a valid PEP 735 Dependency Specifier. e.g., ``numpy>1``
+* An object, which has exactly one key, ``spec``, which is a valid PEP 735
   Dependency Spec. e.g., ``{spec = "numpy>1"}``
 
 Any additional keys in a requirement specifier object are reserved for future

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -120,25 +120,25 @@ Rationale
 =========
 
 This PEP defines the storage of requirements data in lists within a
-``[requirements.packages]`` table. The naming is motivated by two major
-factors:
+``[dependency-groups]`` table.
+This name was chosen to matche the canonical name of the feature
+("Dependency Groups").
 
-* The desire to lay claim to a namespace which can be extended
-  later. Discussions about project needs have included mention of python version
-  requirements and other potential metadata. These could be added to the
-  ``[requirements]`` table as siblings of the ``[requirements.packages]`` table.
+This format should be as simple and learnable as possible, having a format
+very similar to existing ``requirements.txt`` files for many cases. Each list
+in ``[dependency-groups]`` is defined as a list of package specifiers. However,
+there are a number of use cases which require data which cannot be expressed in
+PEP 508 package specifiers. Therefore, this PEP also defines an object-format
+for package specification, capable of defining these additional data.
 
-* The desire for this format to be as simple and learnable as possible,
-  having a format very similar to existing ``requirements.txt`` files. Each list
-  in ``[requirements.packages]`` is defined as a list of package specifiers.
-
-The format does not support non-package data from ``requirements.txt`` files,
-such as ``pip`` options for package servers or hashes. Including them in the
-initial stage complicates this proposal and it is not clear that the majority
-of use-cases require them. Future expansions to this specification may enable
-the use of object declarations, rather than strings, in the
-``[requirements.packages]`` values. This specification is written to allow for
-this by specifying a valid object format with only one well-defined key.
+The format does not support many forms of non-package data from
+``requirements.txt`` files, such as ``pip`` options for package servers or
+hashes. Including them in the initial stage complicates this proposal and it is
+not clear that the majority of use-cases require them. Future expansions to
+this specification may enable the use of object declarations, rather than
+strings, in the ``[dependency-groups]`` values. Because this specification
+provides for an object format for the data, it is possible for these to be
+added in future specifications.
 
 The following use cases are considered important targets for this PEP:
 
@@ -174,6 +174,10 @@ The following use cases are considered important targets for this PEP:
 * IDE discovery of requirements data. For example, VS Code could look for a dependency
   group named ``test`` to use when running tests.
 
+Note that this PEP does not reserve any names for specific use cases. It is
+considered a problem for downstream standards and conventions to define
+well-known names for certain needs, such as ``test`` or ``docs``.
+
 Regarding Poetry and PDM Dependency Groups
 ------------------------------------------
 
@@ -207,42 +211,165 @@ extras:
 * installation of a dependency group does not imply installation of a package's
   dependencies (or the package itself)
 
+Object Specification Does Not Allow for "PEP 508 Decomposition"
+---------------------------------------------------------------
+
+Poetry and PDM both allow for their object formats for dependency data to be
+used to decompose a PEP 508 specification into parts. For example, a dependency
+on ``requests==2.21.0`` could be written under these tools in a form like
+``{name = "requests", version = "==2.21.0"}``.
+
+This spec does not allow for such a structure. There is only one way to write
+down a PEP 508 dependency, as a string. This has two positive effects:
+
+* There are fewer ways of writing identical data
+
+* It is not possible, by design, to combine a PEP 508 specifier with other
+  key-value pairs in a dependency specifier
+
 Specification
 =============
 
 This PEP defines a new section (table) in ``pyproject.toml`` files named
-``requirements``. The ``requirements`` table contains exactly one key,
-``packages``, which is a table. All other keys in ``requirements`` are reserved
-for future use.
-
-The ``packages`` table contains an arbitrary number of user-defined keys, each of
-which has, as its value, a list of requirements specifiers (defined below).
-These keys must match the following regular expression:
-``[a-z0-9][a-z0-9-]*[a-z0-9]``. Meaning that they must be all lower-case
-alphanumerics, with ``-`` allowed only in the middle, and at least
-two characters long. These requirements are chosen so that the normalization
-rules used for PyPI package names are unnecessary as the names are already
-normalized.
+``dependency-groups``. The ``dependency-groups`` table contains an arbitrary
+number of user-defined keys, each of which has, as its value, a list of
+requirements specifiers (defined below).  These keys must match the following
+regular expression: ``[a-z0-9][a-z0-9-]*[a-z0-9]``. Meaning that they must be
+all lower-case alphanumerics, with ``-`` allowed only in the middle, and at
+least two characters long. These requirements are chosen so that the
+normalization rules used for PyPI package names are unnecessary as the names
+are already normalized.
 
 Requirements specifiers will use a definition based on :pep:`508`. This PEP
-also proposes extending the syntax to define a string format, a
-"PEP 735 Dependency". These are defined as strings in one of the following
-formats:
+also proposes an object format to define a dependency, called a
+"PEP 735 Dependency" (defined below). The elements in ``[dependency-groups]``
+lists must either be strings, in which case they must be valid :pep:`508`
+specifiers or else PEP 735 Dependencies.
 
-* a PEP 508 specification, e.g., ``numpy>1``
-* a comma-delimited list of Dependency Group names, enclosed in square
-  brackets, e.g., ``[test,docs]`` to refer to other Dependency Groups named
-  ``test`` and ``docs`` as specified in ``[requirements.packages]``
-* a single dot, ``.``, which refers to the current project as a package
-  (similar to ``pip install .``)
-* a single dot, followed by square brackets enclosing a list of extra names,
-  which refers to the current project as a package including some extras, e.g.,
-  ``.[mysql]`` to refer to the current package with its ``mysql`` extra
+PEP 735 Dependencies
+--------------------
 
-Each dependency group maps a name to a list of PEP 735 Dependencies.
+PEP 735 Dependencies are objects which define a set of dependencies. They do
+not necessarily refer to a single package, as will become clear from the
+definitions below.
 
-Any additional keys in a requirement specifier object are reserved for future
-use.
+There are two forms of PEP 735 Dependencies: "Dependency Group Includes" and
+"Path Dependencies".
+
+Dependency Group Include
+''''''''''''''''''''''''
+
+A Dependency Group Include includes the dependencies of another Dependency
+Group in the current Dependency Group.
+
+An include is defined as an object with exactly one key, ``"include"``, whose
+value is a string, the name of another Dependency Group.
+
+For example, ``{include = "test"}`` is an include which expands to the
+contents of the ``test`` Dependency Group.
+
+Path Dependency
+'''''''''''''''
+
+A Path Dependency is a dependency on a package found via a local filesystem
+path OR on dependencies of a package found via a local filesystem path.
+
+It contains the following keys, with associated types:
+
+* ``path``: a string, required
+* ``extras``: a list of strings, optional
+* ``editable``: a boolean, optional
+* ``only_deps``: a boolean, optional
+
+For a simple example, ``{path = ".", editable = true, extras = ["mysql"]}`` is
+a Path Dependency on the current project including its ``mysql`` extra. In
+``requirements.txt`` files, a similar idea can be expressed as ``-e .[mysql]``.
+
+``path``
+~~~~~~~~
+
+The ``path`` must refer to the path to a built distribution (wheel, sdist, or
+any future file format) or a directory containing python package source code.
+
+If the path refers to a built distribution, that package should be installed
+when the Dependency Group is installed.
+
+If the path refers to a directory, the directory SHOULD be a valid Python
+package. Implementations MAY refuse to process ``path`` directives which are
+not packages, even when ``only_deps`` is specified (see below for how
+``only_deps`` would potentially make it possible to process non-package paths).
+
+``extras``
+~~~~~~~~~~
+
+The ``extras`` key is a list of strings, each of which is the name of an extra
+which should be included in the package installation.
+
+``editable``
+~~~~~~~~~~~~
+
+If ``editable`` is ``true``, implementations installing the dependency group
+SHOULD install the dependency in editable mode. If it is ``false``, they SHOULD
+install it in non-editable mode. If ``editable`` is absent, no default behavior
+is specified and implementations may choose their preferred default.
+
+Implementations MAY provide options to users to configure or override this behavior.
+For example, a tool may have an option ``--never-editable`` which always treats
+``editable`` as ``false``.
+However, implementations SHOULD prefer to use the ``editable`` value if it is
+present.
+
+If ``editable`` is specified on a Path Dependency which refers to a built
+distribution, implementations MUST treat this as an error.
+
+``only_deps``
+~~~~~~~~~~~~~
+
+If ``only_deps`` is ``true``, implementations MUST NOT install the package
+at the specified ``path``. Instead, they should only install the dependencies
+of that package. This may still require building a package from a source tree
+in order to discover ``dynamic`` dependency data.
+
+If ``only_deps`` is ``false`` or absent, implementations should install the
+package at the specified ``path``.
+
+It is possible to specify ``only_deps`` on a Path Dependency which does not
+refer to a valid python package and for tools to, at least in theory, process
+such a dependency successfully. For example, a ``pyproject.toml`` file
+containing only ``[project.dependencies]`` and none of the other required keys
+in the ``[project]`` table could be supported. Implementations SHOULD NOT
+support such structures and SHOULD fail if a Path Dependency refers to a python
+project which is not a package.
+
+If ``only_deps`` is ``true`` and ``extras`` are specified, implementations
+should install the ``extras`` as well as all of the non-optional dependencies
+of the package.
+
+Handling of Multiple Path Dependencies Referring to the Same Path
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+It is possible for resolution of a Dependency Group to refer to the same
+path multiple times (for example, via two combined includes) using distinct
+Path Dependencies.
+
+If the ``path`` values are distinct, but refer to the same concrete file or
+directory on the filesystem, handling behavior is unspecified. Implementations
+MAY normalize these paths to a single value.
+
+If the ``path`` values are identical, implementations MUST treat the result as
+a singular Path Dependency following the rules below:
+
+- The ``extras`` keys are concatenated into a single list
+- If ``editable`` is always ``true`` or always ``false``, it is treated as
+  such. Otherwise, the ``editable`` key is treated as though it were absent.
+- If the ``only_deps`` key is present, a ``false`` or absent value takes
+  priority over any ``true`` values. In other words, implementations respect
+  ``only_deps`` if it is ``true`` for all instances of the same ``path``.
+  Otherwise, they treat it as ``false``.
+
+
+Example Dependency Groups Table
+-------------------------------
 
 The following is an example of a partial ``pyproject.toml`` which uses this to
 define four dependency groups: ``test``, ``docs``, ``typing``, and
@@ -251,36 +378,35 @@ define four dependency groups: ``test``, ``docs``, ``typing``, and
 .. code:: toml
 
     [requirements.packages]
-    test = ["pytest", "coverage", "."]
+    test = ["pytest", "coverage", {path = ".", editable = true}]
     docs = ["sphinx", "sphinx-rtd-theme"]
-    typing = ["mypy", "types-requests", ".[types]"]
-    typing-test = ["[typing,test]", "useful-types"]
+    typing = ["mypy", "types-requests", {path = ".", extras = ["types"], only_deps = true}]
+    typing-test = [{include = "typing"}, {include = "test"}, "useful-types"]
 
     [project.optional-dependencies]
     types = ["typing-extensions"]
 
-Note how ``test`` and ``typing`` refer to the current package
-while ``docs`` does not. This reflects the ability of Dependency Groups to be used
-in the same manner as extras, adding to dependencies, or completely
-independently. ``typing-test`` is defined as a union of two existing groups,
-plus an additional package. ``typing`` includes an extra, ``types``.
+Note how ``test`` and ``typing`` refer to the current package while ``docs``
+does not. This reflects the ability of Dependency Groups to be used in the same
+manner as extras, adding to dependencies, or completely independently.
 
-Implementation Requirements
----------------------------
+``typing-test`` is defined as a union of two existing groups, plus an
+additional package. ``typing`` includes an extra, ``types``, and this is
+included by extension under ``typing-test``.
+Under ``typing-test`` implementations may choose whether or not to use an
+editable installation of the current package or not, but they MUST treat
+``only_deps`` as ``false``.
+
+Package Building
+----------------
 
 Build backends MUST NOT include dependency group data in built distributions.
-
-When installing the current package (``.``) from a dependency group, tools
-SHOULD prefer editable installs over non-editable installs. They MAY provide
-users with options to configure this behavior.
 
 Use of Dependency Groups
 ------------------------
 
 Tools which support Dependency Groups are expected to provide new options and
-interfaces to allow users to install from Dependency Groups. Implementations
-may wish to treat them similarly to their current treatments of
-``requirements.txt`` files, or more similarly to extras.
+interfaces to allow users to install from Dependency Groups.
 
 No syntax is defined for expressing the dependency group of a package, for two
 reasons:
@@ -309,7 +435,7 @@ There is currently no reference implementation/consumer of this specification.
 Backwards Compatibility
 =======================
 
-At time of writing, the ``requirements`` namespace within a
+At time of writing, the ``dependency-groups`` namespace within a
 ``pyproject.toml`` file is unused. Since the top-level namespace is
 reserved for use only by standards specified at packaging.python.org,
 there should be no direct backwards compatibility concerns.
@@ -342,36 +468,26 @@ For new Python users, they may be taught directly to create a section in
 are currently taught to use ``requirements.txt`` files.
 This also allows new python users to learn about ``pyproject.toml`` files
 without needing to learn about package building.
+A ``pyproject.toml`` file with only ``[dependency-groups]`` and no other tables
+is valid.
 
-For both new and experienced users, the special syntax used in PEP 735
-Dependencies will need to be explained. Support for ``.`` and ``.[extra]``
-should be taught similarly to teaching ``pip install -e .`` and
-``pip install -e '.[extra]'`` -- it intentionally mirrors the effects of those
-commands. Support for inclusion of one dependency group in another can be
+For both new and experienced users, the object style used in PEP 735
+Dependencies will need to be explained. Support for
+``path = ".", editable = true`` and
+``path = ".", editable = true, extras = ["extra"]`` should be taught
+similarly to teaching ``pip install -e .`` and ``pip install -e '.[extra]'``
+-- it intentionally mirrors the effects of those commands.
+
+Support for inclusion of one dependency group in another can be
 taught as a homologue for one requirements file including another using ``-r``.
 
 Rejected Ideas
 ==============
 
-Why not define python-requires as part of the requirements table?
------------------------------------------------------------------
-
-Discussion around :pep:`722` and :pep:`723`, as well as discussions of projects which
-do not produce wheels, have often raised the need to define the Python version
-which will be used.
-
-This PEP explicitly does not define such a key -- doing so must define
-interoperability semantics with respect to the existing packaging-oriented
-``python-requires`` key.
-It is treated as out-of-scope for the sake of simplicity.
-
-The Dependency Groups data can be defined here and intentionally leaves space
-for the addition of new keys in ``[requirements]`` for future PEPs.
-
 Why not define each Dependency Group as a table?
 ------------------------------------------------
 
-If the goal is to allow for future expansion, then defining each Dependency
+If our goal is to allow for future expansion, then defining each Dependency
 Group as a subtable, thus enabling us to attach future keys to each group,
 allows for the greatest future flexibility.
 
@@ -379,34 +495,40 @@ However, it also makes the structure nested more deeply, and therefore harder
 to teach and learn. One of the goals of this PEP is to be an easy replacement
 for many ``requirements.txt`` use-cases.
 
-Why not allow for requirement specifiers to be objects with multiple fields?
-----------------------------------------------------------------------------
+Why not define a special string syntax for PEP 735 Dependencies?
+----------------------------------------------------------------
 
-It is currently not clear what additional fields will or would be necessary for
-a package specification. Because an object format would only have one field
-(containing the string specifier), it introduces complexity to the spec to
-include it now.
+Earlier drafts of this specification defined syntactic forms for Dependency
+Group Includes and Path Dependencies.
 
-The first draft of this PEP included an object format, but it was removed. The
-goal in including it was to specify strictly compatible behavior for tools,
-such that new fields would be allowed. During discussion of the feature,
-several commenters expressed a preference for having tools fail if they do not
-support a new data shape.
+However, there were three major issues with this approach:
+
+* it complicates the string syntax which must be taught, beyond PEP 508
+
+* the resulting strings would always need to be disambiguated from PEP 508
+  specifiers, complicating implementations
+
+* support for the matrix of Path Dependency requirements (``editable``, ``only_deps``,
+  ``extras``) would require a complex syntax whose design was unclear
 
 Why not restrict dependencies to PEP 508 only?
 ----------------------------------------------
 
-There are valid use-cases for:
+There are known use cases for:
 
 * including one dependency group in another
 * including the current package (if the project is a package)
 * including the current package with extras (if the project is a package)
+* installing ``project.dependencies`` from the current project but not
+  installing the current project (as can be done with
+  ``{path = ".", only_deps = true}``)
+* specifying that an installation be done in editable mode
 
 These are not satisfiable without some expansion of syntax beyond what is
 possible with :pep:`508`.
 
-Why is the table not named ``[run]``, ``[dependency_groups]``, ...?
--------------------------------------------------------------------
+Why is the table not named ``[run]``, ``[project.dependency-groups]``, ...?
+---------------------------------------------------------------------------
 
 There are many possible names for this concept.
 It will have to live alongside the already existing ``[project.dependencies]``
@@ -420,17 +542,21 @@ outlines multiple groups of dependencies, which makes ``[run]`` a less
 appropriate fit -- this is not just dependency data for a specific runtime
 context, but for multiple contexts.
 
-``[dependency_groups]`` is a reasonable name, but it fails to namespace the
-dependency group data under a related umbrella term. As a result, it would be
-harder to extend in the future to include other data, such as python version
-requirements.
+``[project.dependency-groups]`` would be ideal, but has major downsides for
+non-package projects. ``[project]`` requires several keys to be defined, such
+as ``name`` and ``version``. Using this name would either require redefining
+the ``[project]`` table to allow for these keys to be absent, or else would
+impose a requirement on non-package projects to define and use these keys. By
+extension, it would effectively require any non-package project allow itself to
+be treated as a package.
 
 Why is pip's planned implementation of ``--only-deps`` not sufficient?
 ----------------------------------------------------------------------
 
 pip currently has a feature on the roadmap to add an
-`--only-deps flag <pip only-deps_>`_. This flag is intended to allow users to
-install package dependencies and extras without installing the current package.
+`--only-deps flag <https://github.com/pypa/pip/issues/11440>`_.
+This flag is intended to allow users to install package dependencies and extras
+without installing the current package.
 
 It does not address the needs of non-package projects, nor does it allow for
 the installation of an extra without the package dependencies.
@@ -457,31 +583,23 @@ Dependabot will not flag dependencies which are pinned in ``tox.ini`` files.)
 Open Issues
 ===========
 
-Section Naming
---------------
-
-The name of the section is not yet finalized. The current proposal is
-``[requirements.packages]``.
-
-Some commenters have suggested that ``requirements`` should be avoided, and
-others have suggested that ``requirements`` is fine but ``packages`` is too
-vague/generic.
-
-Syntax For Groups Including Groups
-----------------------------------
-
-One of the current outstanding concerns is that ``.[test]`` (an extra) and
-``[test]`` (a dependency group) are too similar.
-
-The syntax for Dependency Groups to refer to one another is not yet finalized.
-
-References
-==========
-
-.. _pip only-deps: https://github.com/pypa/pip/issues/11440
-
 Footnotes
 =========
+
+Appendix A: Prior Art in Non-Python Languages
+=============================================
+
+TODO
+
+Appendix B: Prior Art in Python
+===============================
+
+TODO
+
+Appendix C: Use Cases
+=====================
+
+TODO
 
 Copyright
 =========

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -619,6 +619,12 @@ Therefore, ``editable`` may need to be removed.
 Such a removal must account for how existing tools and workflows which rely on
 editable installs will be impacted.
 
+Should ``include`` accept a list?
+---------------------------------
+
+This would enable more compact includes of multiple other dependency groups, at
+the cost of a minor complication to the specification.
+
 Footnotes
 =========
 

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -66,7 +66,7 @@ declaration will be beneficial to projects with a number of small groups of
 dependencies.
 
 Regarding extras, the use of extras to define development dependencies is a
-widespread practice, but it has two major downsides.
+widespread practice, but it has two major downsides:
 
 * An extra is defined as an additive group of dependencies for a package.
   This means that it cannot be installed without installing all of the package
@@ -108,7 +108,7 @@ does not need to declare a version or authors in order for these data to be
 valid, nor does it need to define an installable package source tree.
 
 Simultaneously, this PEP should benefit projects which *are* intended to build
-distributions. Because these requirements data are explicitly defined to not be
+distributions. Because dependency groups, as specified in this PEP, are explicitly defined to not be
 included in any built distribution, two common use cases are addressed by this
 addition:
 
@@ -123,7 +123,7 @@ Rationale
 
 This PEP defines the storage of requirements data in lists within a
 ``[dependency-groups]`` table.
-This name was chosen to matche the canonical name of the feature
+This name was chosen to match the canonical name of the feature
 ("Dependency Groups").
 
 This format should be as simple and learnable as possible, having a format
@@ -471,7 +471,7 @@ from a named Dependency Group.
 For new Python users, they may be taught directly to create a section in
 ``pyproject.toml`` containing their dependency groups, similarly to how they
 are currently taught to use ``requirements.txt`` files.
-This also allows new python users to learn about ``pyproject.toml`` files
+This also allows new Python users to learn about ``pyproject.toml`` files
 without needing to learn about package building.
 A ``pyproject.toml`` file with only ``[dependency-groups]`` and no other tables
 is valid.

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -74,7 +74,6 @@ widespread practice, but it has two major downsides.
   concerned about ensuring that their development extras are not confused with
   user-facing extras. Therefore, their development needs are not appropriate to
   publish in the manner of extras.
-development needs are not appropriate to publish in the manner of extras.
 
 Providing a standardized place to store dependency data which matches the
 typical use-cases of ``requirements.txt`` files will allow for better

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -224,9 +224,10 @@ two characters long. These requirements are chosen so that the normalization
 rules used for PyPI package names are unnecessary as the names are already
 normalized.
 
-Requirements specifiers will use a definition which extends :pep:`508`. Therefore,
-it is first necessary to define a string format, a "PEP 735 Dependency". These
-are defined as strings in one of the three following formats:
+Requirements specifiers will use a definition based on :pep:`508`. This PEP
+also proposes extending the syntax to define a string format, a
+"PEP 735 Dependency". These are defined as strings in one of the following
+formats:
 
 * a PEP 508 specification, e.g., ``numpy>1``
 * a comma-delimited list of Dependency Group names, enclosed in square

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -436,10 +436,6 @@ dependency group data under a related umbrella term. As a result, it would be
 harder to extend in the future to include other data, such as python version
 requirements.
 
-.. note::
-
-    No name has been declared final yet.
-
 Why is pip's planned implementation of ``--only-deps`` not sufficient?
 ----------------------------------------------------------------------
 
@@ -472,7 +468,23 @@ Dependabot will not flag dependencies which are pinned in ``tox.ini`` files.)
 Open Issues
 ===========
 
-None at this point.
+Section Naming
+--------------
+
+The name of the section is not yet finalized. The current proposal is
+``[requirements.packages]``.
+
+Some commenters have suggested that ``requirements`` should be avoided, and
+others have suggested that ``requirements`` is fine but ``packages`` is too
+vague/generic.
+
+Syntax For Groups Including Groups
+----------------------------------
+
+One of the current outstanding concerns is that ``.[test]`` (an extra) and
+``[test]`` (a dependency group) are too similar.
+
+The syntax for Dependency Groups to refer to one another is not yet finalized.
 
 References
 ==========

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -238,16 +238,12 @@ formats:
   which refers to the current project as a package including some extras, e.g.,
   ``.[mysql]`` to refer to the current package with its ``mysql`` extra
 
-Requirement specifiers are one of the following:
-
-* A string, which is a valid PEP 735 Dependency Specifier. e.g., ``numpy>1``
-* An object, which has exactly one key, ``spec``, which is a valid PEP 735
-  Dependency Spec. e.g., ``{spec = "numpy>1"}``
+Each dependency group maps a name to a list of PEP 735 Dependencies.
 
 Any additional keys in a requirement specifier object are reserved for future
 use.
 
-The following is an example of a ``pyproject.toml`` section which uses this to
+The following is an example of a partial ``pyproject.toml`` which uses this to
 define four dependency groups: ``test``, ``docs``, ``typing``, and
 ``typing-test``:
 
@@ -259,6 +255,9 @@ define four dependency groups: ``test``, ``docs``, ``typing``, and
     typing = ["mypy", "types-requests", ".[types]"]
     typing-test = ["[typing,test]", "useful-types"]
 
+    [project.optional-dependencies]
+    types = ["typing-extensions"]
+
 Note how ``test`` and ``typing`` are able to refer to the current package
 while ``docs`` does not. This reflects the ability of Dependency Groups to be used
 in the same manner as extras, adding to dependencies, or completely
@@ -269,12 +268,6 @@ Implementation Requirements
 ---------------------------
 
 Build backends MUST NOT include dependency group data in built distributions.
-
-Tools which support Dependency Groups MUST support both string and object
-representations of requirements.
-
-When unrecognized keys are encountered in requirement specifiers or the
-``requirements`` table, tools MUST NOT fail. They SHOULD emit warnings.
 
 When installing the current package (``.``) from a dependency group, tools
 SHOULD prefer editable installs over non-editable installs. They MAY provide
@@ -320,14 +313,6 @@ At time of writing, the ``requirements`` namespace within a
 reserved for use only by standards specified at packaging.python.org,
 there should be no direct backwards compatibility concerns.
 
-Future Compatiiblity
---------------------
-
-This PEP defines explicit behaviors for tools when encountering unknown keys
-which must be followed in order to remain spec-compliant. These behaviors are
-meant to ensure that future PEPs can extend the data with very clear
-expectations about how existing tools will behave.
-
 Security Implications
 =====================
 
@@ -353,7 +338,16 @@ Group.
 
 For new Python users, they may be taught directly to create a section in
 ``pyproject.toml`` containing their dependency groups, similarly to how they
-are currently taught to use ``pyproject.toml``.
+are currently taught to use ``requirements.txt`` files.
+This also allows new python users to learn about ``pyproject.toml`` files
+without needing to learn about package building.
+
+For both new and experienced users, the special syntax used in PEP 735
+Dependencies will need to be explained. Support for ``.`` and ``.[extra]``
+should be taught similarly to teaching ``pip install -e .`` and
+``pip install -e '.[extra]'`` -- it intentionally mirrors the effects of those
+commands. Support for inclusion of one dependency group in another can be
+taught as a homologue for one requirements file including another using ``-r``.
 
 Rejected Ideas
 ==============
@@ -384,6 +378,20 @@ However, it also makes the structure nested more deeply, and therefore harder
 to teach and learn. One of the goals of this PEP is to be an easy replacement
 for many ``requirements.txt`` use-cases.
 
+Why not allow for requirement specifiers to be objects with multiple fields?
+----------------------------------------------------------------------------
+
+It is currently not clear what additional fields will or would be necessary for
+a package specification. Because an object format would only have one field
+(containing the string specifier), it introduces complexity to the spec to
+include it now.
+
+The first draft of this PEP included an object format, but it was removed. The
+goal in including it was to specify strictly compatible behavior for tools,
+such that new fields would be allowed. During discussion of the feature,
+several commenters expressed a preference for having tools fail if they do not
+support a new data shape.
+
 Why not restrict dependencies to PEP 508 only?
 ----------------------------------------------
 
@@ -395,26 +403,6 @@ There are valid use-cases for:
 
 These are not satisfiable without some expansion of syntax beyond what is
 possible with :pep:`508`.
-
-Why not define keys in dependency specifications for common options seen in ``requirements.txt`` (e.g. ``--hash``)?
--------------------------------------------------------------------------------------------------------------------
-
-It is currently unclear which options will be the most necessary and beneficial.
-
-Certain problems, e.g. package hashing, are the domain of lockfiles.
-The data in this PEP is meant to be lockfile *input*, not necessarily lockfile *output*.
-Therefore, hashing should not be privileged, nor should other options.
-
-The PEP defines space for future expansion of the data format and mandates that
-tools support and parse it such that expansion will be a non-breaking change.
-
-Why not restrict dependency specifications to strings only?
------------------------------------------------------------
-
-Failing to establish the object format at this stage would lead to a breaking
-change if it were ever introduced.
-Rather than having a smooth degradation path, users would experience breakage
-if the object format were introduced and only some tools supported it.
 
 Why is the table not named ``[run]``, ``[dependency_groups]``, ...?
 -------------------------------------------------------------------

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -1,0 +1,321 @@
+PEP: 735
+Title: Dependency Groups in pyproject.toml
+Author: Stephen Rosen <sirosen0@gmail.com>
+Discussions-To: https://discuss.python.org/t/29684
+Sponsor: Brett Cannon <brett@python.org>
+Status: Draft
+Type: Standards Track
+Topic: Packaging
+Content-Type: text/x-rst
+Created: 20-Nov-2023
+Post-History: https://discuss.python.org/t/29684
+
+Abstract
+========
+
+This PEP specifies a mechanism for storing package requirements in
+pyproject.toml files such that it is not included in any built distribution of
+the project.
+
+This is suitable for creating named groups of dependencies, similar to
+`requirements.txt` files, which launchers, IDEs, and other tools can find and
+identify by name.
+
+The feature defined here is referred to as "Dependency Groups".
+
+Motivation
+==========
+
+The Python packaging toolchain is oriented towards the production of wheel and
+sdist files, containing project source for installation. However, not all
+projects are designed or intended for this mode of distribution. Primary
+examples include webapps (which often run from source), and data science
+projects (which may start as collections of scripts and only later evolve
+package structures). This PEP seeks to offer these projects a way to specify
+their package dependencies in a way which is not constrained by the
+requirements of distribution building -- for example, a data sicence project
+does not need to declare a version or authors in order for these data to be
+valid.
+
+The pre-existing solution which is most similar to this proposal is the use of
+``requirements.txt`` files. Many projects may define one or more of these files,
+and may arrange them either at the project root (e.g. ``requirements.txt`` and
+``test-requirements.txt``) or else in a directory (e.g.
+``requirements/base.txt`` and ``requirements/test.txt``). However, there are
+two major issues with the use of requirements files in this way: (1) there is no
+standardized naming convention such that tools can discover or use these files
+by name and (2) ``requirementst.txt`` files are *not standardized*, but instead
+provide options to ``pip``. Therefore, their use is not portable to any new
+installer or tool which wishes to process them without relying upon ``pip``.
+Additionally, ``requirements.txt`` files may be viewed as a heavyweight
+solution for very small dependency sets of only one or two items, and a terser
+declaration will be beneficial to projects with a number of small groups of
+dependencies.
+
+Although one primary goal of this PEP is to support some of the needs of
+projects which do not build distributions, there are benefits in this proposal
+for projects which *are* intended to build distributions. Because these
+requirements data are explicitly defined to not be included in any built
+distribution, two common use-cases are addressed by this addition. The first is
+the use of ``extras`` for development requirements -- because these are published
+data, package developers often restrain themselves to a single extra or a small
+number of extras, and are concerned about ensuring that their development
+extras are not confused with user-facing extras. The second is the use of
+``requirements.txt`` files for libaries and applications, which takes a similar
+form to their use in non-distribution-building projects.
+
+Rationale
+=========
+
+This PEP defines the storage of requirements data in lists within a
+``[requirements.packages]`` table. The naming is motivated by two major
+factors. First, the desire to lay claim to a namespace which can be extended
+later. Discussions about project needs have included mention of python version
+requirements and other potential metadata. These could be added to the
+``[requirements]`` table as siblings of the ``[requirements.packages]`` table.
+Second, the desire for this format to be as simple and learnable as possible,
+having a format very similar to existing ``reuqirements.txt`` files. Each list
+in ``[requirements.packages]`` is defined as a list of package specifiers.
+
+The format does not support non-package data from ``requirements.txt`` files,
+such as ``pip`` options for package servers or hashes. Including them in the
+initial stage complicates this proposal and it is not clear that the majority
+of use-cases require them. Future expansions to this specification may enable
+the use of object declarations, rather than strings, in the
+``[requirements.packages]`` values. This specification is written to allow for
+this by specifying a valid object format with only one well-defined key.
+
+The following use cases are considered important targets for this PEP:
+
+* A web application (e.g. a django or flask app) which does not build a
+  distribution, but bundles and ships its source to a deployment toolchain. The
+  app has runtime dependencies, testing dependencies, and development
+  environment dependencies. All of these dependency sets should be declared
+  independently, and none of these runtime contexts should require that the
+  project be built into a wheel.
+* A library which builds a distribution, but has a variety of testing and
+  development environments it wishes to declare. Some of these rely on the
+  library's own dependencies (``test`` and ``typing`` environments) while
+  others do not (``docs`` and ``lint`` environments).
+* A data science project which consists of multiple scripts on the same suite
+  of core libraries (e.g. ``numpy``, ``pandas``, ``matplotlib``), and which
+  also has additional libraries, sometimes conflicting, for specific scripts
+  (e.g. ``scikit-learn==1.3.2`` for one script and ``scikit-learn==0.24.2`` for
+  another).
+* *Input data* to a lockfile generator. Because there is no standardized
+  lockfile format, it is still the prerogative of tools like ``poetry`` and
+  ``pip-compile`` to describe their own formats. However, it should be possible
+  for the data from this PEP to be used as an input to these tools.
+  Furthermore, tools may define their own structures and conventions such that
+  the generated lockfiles can be referenced by the names of their originating
+  dependency groups in ``pyproject.toml``.
+* *Input data* to a ``tox``, ``nox``, or ``hatch`` environment, as can
+  currently be achieved, for example, with ``deps = -r requirements.txt`` in
+  ``tox.ini``. These tools will need to add additional options for processing
+  Dependency Groups.
+* Embeddable data for ``pyproject.toml`` within a script (as in PEP 723). This
+  PEP does not define exactly how PEP 723 should be modified, but being
+  consumable by that interface is a stated goal.
+
+Regarding Poetry Dependency Groups
+----------------------------------
+
+Poetry already offers a feature which it calls "Dependency Groups", but using
+non-standard data belonging to the ``poetry`` tool.
+
+This PEP is not guaranteed to be a perfectly substitutable solution for the
+same problem space. However, the ideas are extremely similar, and it should be
+possible for Poetry to support at least some PEP-735-standardized Dependency
+Group configurations using its own Dependency Group nomenclature.
+
+A level of interoperability with Poetry is a goal of this PEP, but certain
+features and behaviors defined here may not be supported by Poetry. Matching
+the existing Poetry *semantics* for Dependency Groups is a non-goal.
+
+Specification
+=============
+
+This PEP defines a new section (table) in ``pyproject.toml`` files named
+``requirements``. The ``requirements`` table contains exactly one key,
+``packages``, which is a table. All other keys in ``requirements`` are reserved
+for future use.
+
+The ``packages`` table contains an arbitrary number of user-defined keys, each of
+which has, as its value, a list of requirements specifiers (defined below).
+These keys must match the following regular expression:
+``[a-z0-9][a-z0-9-]*[a-z0-9]``. Meaning that they must be all lower-case
+alphanumerics, with ``-`` allowed only in the middle, and at least
+two characters long. These requirements are chosen so that the normalization
+rules used for pypi package names do not apply, as the names are already
+normalized.
+
+Requirements specifiers will use a definition which extends PEP 508. Therefore,
+it is first necessary to define a string format, a "PEP 735 Dependency". These
+are defined as strings in one of the three following formats:
+- a PEP 508 specification, e.g., ``numpy>1``
+- a comma-delimited list of Dependency Group names, enclosed in square
+  brackets, e.g., ``[test,docs]`` to refer to other Dependency Groups named
+  ``test`` and ``docs``
+- a single dot, ``.``, which refers to the current project as a package
+  (similar to ``pip install .``)
+- a single dot, followed by square brackets enclosing a list of extra names,
+  which refers to the current project as a package including some extras, e.g.,
+  ``.[mysql]`` to refer to the current package with its ``mysql`` extra
+
+Requirement specifiers can now be defined as one of the following:
+- A string, which is a valid PEP 735 Dependency Specifier. e.g., ``numpy>1``
+- An object, which has exactly one key, ``spec``, which is a valid PEP 735
+  Dependency Spec. e.g., ``{spec = "numpy>1"}``
+
+Any additional keys in a requirement specifier object are reserved for future
+use.
+
+The following is an example of a ``pyproject.toml`` section which uses this to
+define four dependency groups: ``test``, ``docs``, ``typing``, and
+``typing-test``:
+
+.. code:: toml
+
+    [requirements.packages]
+    test = ["pytest", "coverage", "."]
+    docs = ["sphinx", "sphinx-rtd-theme"]
+    typing = ["mypy", "types-requests", ".[types]"]
+    typing-test = ["[typing,test]", "useful-types"]
+
+Note how ``test`` and ``typing`` are able to refer to the current package
+while ``docs`` does not. This reflects the ability of Dependency Groups to be used
+in the same manner as extras, adding to dependencies, or completely
+independently. ``typing-test`` is defined as a union of two existing groups,
+plus an additional package. ``typing`` includes an extra, ``types``.
+
+Implementation Requirements
+---------------------------
+
+Tools which support Dependency Groups MUST support both string and object
+representations of requirements.
+
+They MAY emit warnings when unrecognized keys are encountered in requirement
+specifiers or in the ``requirements`` table.
+
+When installing the current package (``.``) from a dependency group, tools
+SHOULD prefer editable installs over non-editable installs. They MAY provide
+users with options to configure this behavior.
+
+Reference Implementation
+========================
+
+TODO! STUB!
+
+Planned reference implementation:
+A very simple "environment manager" which can be used to build virtualenvs from
+specified Dependency Groups. It will therefore need to fully support parsing of
+Dependency Groups.
+
+Backwards Compatibility
+=======================
+
+At time of writing, the ``requirements`` table is reserved for use by PEPs,
+meaning that this lays claim to a previously unused namespace.
+There should therefore be no direct backwards compatibility concerns.
+
+Security Implications
+=====================
+
+This PEP introduces new syntaxes and data formats for specifying dependency
+information in projects. However, it does not introduce newly specified
+mechanisms for handling or resolving dependencies.
+
+It therefore does not carry security concerns other than those inherent in any
+tools which may already be used to install dependencies -- i.e. malicious
+dependencies may be specified here, just as they may be specified in
+``requirements.txt`` files.
+
+How to Teach This
+=================
+
+This feature should be referred to by its canonical name, "Dependency Groups".
+
+The basic form of usage should be taught as a variant on typical
+``requirements.txt`` data. PEP 508 package specifiers can be added to a named
+list. Rather than asking ``pip`` to install from a ``requirements.txt`` file,
+either ``pip`` or a relevant workflow tool will install from a named Dependency
+Group.
+
+For new python users, they may be taught directly to create a section in
+``pyproject.toml`` containing their dependency groups, similarly to how they
+are currently taught to use ``pyproject.toml``.
+
+Rejected Ideas
+==============
+
+Why not define python-requires as part of the requirements table?
+-----------------------------------------------------------------
+
+Discussion around PEP 722 and PEP 723, as well as discussions of projects which
+do not produce wheels, have often raised the need to define the python version
+which will be used.
+
+This PEP explicitly does not define such a key -- doing so must define
+interoperability semantics with respect to the existing packaging-oriented
+python-requires key.
+It is treated as out-of-scope for the sake of simplicity.
+
+The Dependency Groups data can be defined here and intentionally leaves space
+for the addition of new keys in ``[requirements]`` for future PEPs.
+
+Why not define each Dependency Group as a table?
+------------------------------------------------
+
+If the goal is to allow for future expansion, then defining each Dependency
+Group as a subtable, thus enabling us to attach future keys to each group,
+allows for the greatest future flexibility.
+
+However, it also makes the structure nested more deeply, and therefore harder
+to teach and learn. One of the goals of this PEP is to be an easy replacement
+for many ``requirements.txt`` use-cases.
+
+Why not restrict dependencies to PEP 508 only?
+----------------------------------------------
+
+There are valid use-cases for
+
+* including one dependency group in another
+* including the current package (if the project is a package)
+* including the current package with extras (if the project is a package)
+
+These are not satisfiable without some expansion of syntax beyond what is
+possible with PEP 508.
+
+Why not define keys in dependency specifications for common options seen in ``requirements.txt`` (e.g. ``--hash``)?
+-------------------------------------------------------------------------------------------------------------------
+
+It is currently unclear which options will be the most necessary and beneficial.
+
+Certain problems, e.g. package hashing, are the domain of lockfiles.
+The data in this PEP is meant to be lockfile *input*, not necessarily lockfile *output*.
+Therefore, hashing should not be privileged, nor should other options.
+
+The PEP defines space for future expansion of the data format and mandates that
+tools support and parse it such that expansion will be a non-breaking change.
+
+Why not restrict dependency specifications to strings only?
+-----------------------------------------------------------
+
+Failing to establish the object format at this stage would lead to a breaking
+change if it were ever introduced.
+Rather than having a smooth degradation path, users would experience breakage
+if the object format were introduced and only some tools supported it.
+
+Open Issues
+===========
+
+None at this point.
+
+Footnotes
+=========
+
+Copyright
+=========
+
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -417,7 +417,7 @@ No syntax is defined for expressing the dependency group of a package, for two
 reasons:
 
 * it would not be valid to refer to the dependency groups of a third-party
-  package from pypi (because the data is defined to be unpublished)
+  package from PyPI (because the data is defined to be unpublished)
 
 * there is not guaranteed to be a current package for dependency groups -- part
   of their purpose is to support non-package projects

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -68,7 +68,8 @@ dependencies.
 Regarding extras, the use of extras to define development dependencies is a
 widespread practice, but it has two major downsides:
 
-* An extra is defined as an additive group of dependencies for a package.
+* An extra is defined as an optional part of a package which may specify
+  additional dependencies.
   This means that it cannot be installed without installing all of the package
   dependencies, and the project must be defined as a package.
 
@@ -82,7 +83,7 @@ Providing a standardized place to store dependency data which matches the
 typical use cases of ``requirements.txt`` files will allow for better
 cross-compatibility between tools and will onboard beginning users into
 ``pyproject.toml`` data more quickly (before they learn about the
-``build-system`` table, for example). It will also resolve the long-standing
+``[build-system]`` table, for example). It will also resolve the long-standing
 ambiguity and tension within the Python community about whether or not extras
 should be used to declare development dependencies.
 
@@ -289,7 +290,7 @@ It contains the following keys, with associated types:
 
 For a simple example, ``{path = ".", editable = true, extras = ["mysql"]}`` is
 a Path Dependency on the current project including its ``mysql`` extra. In
-``requirements.txt`` files, a similar idea can be expressed as ``-e .[mysql]``.
+``requirements.txt`` files, a similar idea can be expressed as ``-e '.[mysql]'``.
 
 ``path``
 ~~~~~~~~
@@ -482,8 +483,8 @@ is valid.
 
 For both new and experienced users, the object style used in Dependency Object
 Specifiers will need to be explained. Support for
-``path = ".", editable = true`` and
-``path = ".", editable = true, extras = ["extra"]`` should be taught
+``{path = ".", editable = true}`` and
+``{path = ".", editable = true, extras = ["extra"]}`` should be taught
 similarly to teaching ``pip install -e .`` and ``pip install -e '.[extra]'``
 -- it intentionally mirrors the effects of those commands.
 

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -25,19 +25,25 @@ The feature defined here is referred to as "Dependency Groups".
 Motivation
 ==========
 
-The Python packaging toolchain is oriented towards the production of wheel and
-sdist files, containing project source for installation. However, not all
-projects are designed or intended for this mode of distribution. Primary
-examples include webapps (which often run from source), and data science
-projects (which may start as collections of scripts and only later evolve
-package structures). This PEP seeks to offer these projects a way to specify
-their package dependencies in a way which is not constrained by the
-requirements of distribution building -- for example, a data science project
-does not need to declare a version or authors in order for these data to be
-valid.
+There are two major use-cases for which the Python community has no
+standardized answer:
 
-The pre-existing solution which is most similar to this proposal is the use of
-``requirements.txt`` files. Many projects may define one or more of these files,
+* How should development dependencies be defined for packages?
+
+* How should dependencies be defined for projects which do not build
+  distributions (non-package projects)?
+
+In the absence of any standard, two known workflow tools, PDM and Poetry, have
+defined their own solutions for Dependency Groups to address the first of these
+two needs. Their definitions are very similar to one another, although PDM
+structures them much more similarly to extras than Poetry does.
+Neither of them addresses the needs of non-package projects, and neither can be
+referenced natively from other tools like ``tox``, ``nox``, or ``pip``.
+
+There are two pre-existing solutions which are similar to this proposal: the
+use of ``requirements.txt`` files and package extras.
+
+Regarding ``requirements.txt``, many projects may define one or more of these files,
 and may arrange them either at the project root (e.g. ``requirements.txt`` and
 ``test-requirements.txt``) or else in a directory (e.g.
 ``requirements/base.txt`` and ``requirements/test.txt``). However, there are
@@ -51,17 +57,50 @@ solution for very small dependency sets of only one or two items, and a terser
 declaration will be beneficial to projects with a number of small groups of
 dependencies.
 
-Although one primary goal of this PEP is to support some of the needs of
-projects which do not build distributions, there are benefits in this proposal
-for projects which *are* intended to build distributions. Because these
-requirements data are explicitly defined to not be included in any built
-distribution, two common use-cases are addressed by this addition. The first is
-the use of ``extras`` for development requirements -- because these are published
-data, package developers often restrain themselves to a single extra or a small
-number of extras, and are concerned about ensuring that their development
-extras are not confused with user-facing extras. The second is the use of
-``requirements.txt`` files for libraries and applications, which takes a similar
-form to their use in non-distribution-building projects.
+Regarding extras, the use of extras to define development dependencies is a
+widespread practice, but it has two major downsides. First, an extra is defined
+as an additive group of dependencies for a package. This means that it cannot
+be installed without installing all of the package dependencies, and the
+project must be defined as a package. Second, many developers view their extras
+as part of the public interface for their package. Because these are published
+data, package developers often are concerned about ensuring that their
+development extras are not confused with user-facing extras. Therefore, their
+development needs are not appropriate to publish in the manner of extras.
+
+Providing a standardized place to store dependency data which matches the
+typical use-cases of ``requirements.txt`` files will allow for better
+cross-compatibility between tools and will onboard beginning users into
+``pyproject.toml`` data more quickly (before they learn about the
+``build-system`` table, for example). It will also resolve the long-standing
+ambiguity and tension within the Python community about whether or not extras
+should be used to declare development dependencies.
+
+Supported Project Types
+-----------------------
+
+This PEP aims to serve the needs of two distinct project types: libraries and
+other packages which want to define development dependencies, and projects
+which do not build distributions which want a standardized way to declare their
+dependency data.
+
+The Python packaging toolchain is oriented towards the production of wheel and
+sdist files, containing project source for installation. However, not all
+projects are designed or intended for this mode of distribution. Primary
+examples include webapps (which often run from source), and data science
+projects (which may start as collections of scripts and only later evolve
+package structures). This PEP seeks to offer these projects a way to specify
+their package dependencies in a way which is not constrained by the
+requirements of distribution building -- for example, a data science project
+does not need to declare a version or authors in order for these data to be
+valid, nor does it need to define an installable package source tree.
+
+Simultaneously, this PEP should benefit projects which *are* intended to build
+distributions. Because these requirements data are explicitly defined to not be
+included in any built distribution, two common use-cases are addressed by this
+addition. The first is the use of ``extras``, as discussed above. The second is
+the use of ``requirements.txt`` files for distributed libraries and
+applications, which takes a similar form to their use in
+non-distribution-building projects.
 
 Rationale
 =========
@@ -115,21 +154,41 @@ The following use cases are considered important targets for this PEP:
 * Embeddable data for ``pyproject.toml`` within a script (as in PEP 723). This
   PEP does not define exactly how PEP 723 should be modified, but being
   consumable by that interface is a stated goal.
+* IDE discovery of requirements data. e.g. VSCode could look for a dependency
+  group named ``test`` to use when running tests.
 
-Regarding Poetry Dependency Groups
-----------------------------------
+Regarding Poetry and PDM Dependency Groups
+------------------------------------------
 
-Poetry already offers a feature which it calls "Dependency Groups", but using
-non-standard data belonging to the ``poetry`` tool.
+Poetry and PDM already offers a feature which each calls "Dependency Groups",
+but using non-standard data belonging to the ``poetry`` and ``pdm`` tools.
+(PDM also uses extras for some Dependency Groups, and overlaps the notion
+heavily with extras.)
 
 This PEP is not guaranteed to be a perfectly substitutable solution for the
-same problem space. However, the ideas are extremely similar, and it should be
-possible for Poetry to support at least some PEP-735-standardized Dependency
-Group configurations using its own Dependency Group nomenclature.
+same problem space for each tool. However, the ideas are extremely similar, and
+it should be possible for Poetry and PDM to support at least some
+PEP-735-standardized Dependency Group configurations using their own Dependency
+Group nomenclature.
 
-A level of interoperability with Poetry is a goal of this PEP, but certain
-features and behaviors defined here may not be supported by Poetry. Matching
-the existing Poetry *semantics* for Dependency Groups is a non-goal.
+A level of interoperability with Poetry and PDM is a goal of this PEP, but
+certain features and behaviors defined here may not be supported by Poetry and
+PDM. Matching the existing Poetry and PDM *semantics* for Dependency Groups is
+a non-goal.
+
+Dependency Groups are not Hidden Extras
+---------------------------------------
+
+One could be forgiven for thinking that Dependency Groups are just extras which
+go unpublished.
+
+However, there are two major features they have which distinguish them from
+extras:
+
+* they support non-package projects
+
+* installation of a dependency group does not imply installation of a package's
+  dependencies (or the package itself)
 
 Specification
 =============
@@ -192,15 +251,44 @@ plus an additional package. ``typing`` includes an extra, ``types``.
 Implementation Requirements
 ---------------------------
 
+Build backends MUST NOT include dependency group data in built distributions.
+
 Tools which support Dependency Groups MUST support both string and object
 representations of requirements.
 
-They MAY emit warnings when unrecognized keys are encountered in requirement
-specifiers or in the ``requirements`` table.
+When unrecognized keys are encountered in requirement specifiers or the
+``requirements`` table, tools MUST NOT fail. They MAY emit warnings.
 
 When installing the current package (``.``) from a dependency group, tools
 SHOULD prefer editable installs over non-editable installs. They MAY provide
 users with options to configure this behavior.
+
+Use of Dependency Groups
+------------------------
+
+Tools which support Dependency Groups are expected to provide new options and
+interfaces to allow users to install from Dependency Groups. Implementations
+may wish to treat them similarly to their current treatments of
+``requirements.txt`` files, or more similarly to extras.
+
+No syntax is defined for expressing the dependency group of a package, for two
+reasons:
+
+* it would not be valid to refer to the dependency groups of a third-party
+  package from pypi (because the data is defined to be unpublished)
+
+* there is not guaranteed to be a current package for dependency groups -- part
+  of their purpose is to support non-package projects
+
+For example, a possible ``pip`` interface for installing dependency groups
+would be:
+
+.. code:: shell
+
+    pip install --dependency-groups=test,typing
+
+Note that this is only an example. This PEP does not declare any requirements
+for how tools support the installation of Dependency Groups.
 
 Reference Implementation
 ========================
@@ -218,6 +306,14 @@ Backwards Compatibility
 At time of writing, the ``requirements`` table is reserved for use by PEPs,
 meaning that this lays claim to a previously unused namespace.
 There should therefore be no direct backwards compatibility concerns.
+
+Future Compatiiblity
+--------------------
+
+This PEP defines explicit behaviors for tools when encountering unknown keys
+which must be followed in order to remain spec-compliant. These behaviors are
+meant to ensure that future PEPs can extend the data with very clear
+expectations about how existing tools will behave.
 
 Security Implications
 =====================
@@ -307,10 +403,68 @@ change if it were ever introduced.
 Rather than having a smooth degradation path, users would experience breakage
 if the object format were introduced and only some tools supported it.
 
+Why is the table not named ``[run]``, ``[dependency_groups]``, ...?
+-------------------------------------------------------------------
+
+There are many possible names for this concept.
+It will have to live alongside the already existing ``[project.dependencies]``
+and ``[project.optional-dependencies]`` tables, and possibly a new
+``[external]`` dependency table as well (at time of writing, PEP 725 is in
+progress).
+
+``[run]`` was a leading proposal in earlier discussions, but its proposed usage
+centered around a single set of runtime dependencies. This PEP explicitly
+outlines multiple groups of dependencies, which makes ``[run]`` a less
+appropriate fit -- this is not just dependency data for a specific runtime
+context, but for multiple contexts.
+
+``[dependency_groups]`` is a reasonable name, but it fails to namespace the
+dependency group data under a related umbrella term. As a result, it would be
+harder to extend in the future to include other data, such as python version
+requirements.
+
+.. note::
+
+    No name has been declared final yet.
+
+Why is ``pip``'s planned implementation of ``--only-deps`` not sufficient?
+--------------------------------------------------------------------------
+
+``pip`` currently has a feature on the roadmap to add an
+`--only-deps flag <pip only-deps_>`_. This flag is intended to allow users to
+install package dependencies and extras without installing the current package.
+
+It does not address the needs of non-package projects, nor does it allow for
+the installation of an extra without the package dependencies.
+
+Therefore, while it may be a useful feature for ``pip`` to pursue, it does not
+address the same use-cases addressed here.
+
+Why isn't <environment manager> a solution?
+-------------------------------------------
+
+Existing environment managers like ``tox``, ``nox``, and ``hatch`` already have
+the ability to list inlined dependencies as part of their configuration data.
+This meets many development dependency needs, and clearly associates dependency
+groups with relevant tasks which can be run.
+These mechanisms are *good* but they are not *sufficient*.
+
+First, they do not address the needs of non-package projects.
+
+Second, there is no standard for other tools to use to access these data. This
+has impacts on high-level tools like IDEs and Dependabot, which cannot support
+deep integration with these dependency groups. (For example, at time of writing
+Dependabot will not flag dependencies which are pinned in ``tox.ini`` files.)
+
 Open Issues
 ===========
 
 None at this point.
+
+References
+==========
+
+.. _pip only-deps: https://github.com/pypa/pip/issues/11440
 
 Footnotes
 =========

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -14,7 +14,7 @@ Abstract
 ========
 
 This PEP specifies a mechanism for storing package requirements in
-``pyproject.toml`` files such that it is not included in any built distribution of
+``pyproject.toml`` files such that they are not included in any built distribution of
 the project.
 
 This is suitable for creating named groups of dependencies, similar to
@@ -26,7 +26,7 @@ The feature defined here is referred to as "Dependency Groups".
 Motivation
 ==========
 
-There are two major use-cases for which the Python community has no
+There are two major use cases for which the Python community has no
 standardized answer:
 
 * How should development dependencies be defined for packages?
@@ -53,7 +53,7 @@ two major issues with the use of requirements files in this way:
 * There is no standardized naming convention such that tools can discover or
   use these files by name.
 
-* ``requirementst.txt`` files are *not standardized*, but instead provide
+* ``requirements.txt`` files are *not standardized*, but instead provide
   options to ``pip``.
 
 Therefore, their use is not portable to any new
@@ -77,7 +77,7 @@ widespread practice, but it has two major downsides.
   publish in the manner of extras.
 
 Providing a standardized place to store dependency data which matches the
-typical use-cases of ``requirements.txt`` files will allow for better
+typical use cases of ``requirements.txt`` files will allow for better
 cross-compatibility between tools and will onboard beginning users into
 ``pyproject.toml`` data more quickly (before they learn about the
 ``build-system`` table, for example). It will also resolve the long-standing
@@ -95,7 +95,7 @@ This PEP aims to serve the needs of two distinct project types:
   declare their dependency data
 
 The Python packaging toolchain is oriented towards the production of wheel and
-sdist files, containing project source for installation. However, not all
+sdist files, containing project source code for installation. However, not all
 projects are designed or intended for this mode of distribution. Primary
 examples include webapps (which often run from source), and data science
 projects (which may start as collections of scripts and only later evolve
@@ -107,7 +107,7 @@ valid, nor does it need to define an installable package source tree.
 
 Simultaneously, this PEP should benefit projects which *are* intended to build
 distributions. Because these requirements data are explicitly defined to not be
-included in any built distribution, two common use-cases are addressed by this
+included in any built distribution, two common use cases are addressed by this
 addition:
 
 * the use of ``extras``, as discussed above
@@ -152,7 +152,7 @@ The following use cases are considered important targets for this PEP:
   development environments it wishes to declare. Some of these rely on the
   library's own dependencies (``test`` and ``typing`` environments) while
   others do not (``docs`` and ``lint`` environments).
-* A data science project which consists of multiple scripts on the same suite
+* A data science project which consists of multiple scripts that depend on the same suite
   of core libraries (e.g. ``numpy``, ``pandas``, ``matplotlib``), and which
   also has additional libraries, sometimes conflicting, for specific scripts
   (e.g. ``scikit-learn==1.3.2`` for one script and ``scikit-learn==0.24.2`` for
@@ -171,7 +171,7 @@ The following use cases are considered important targets for this PEP:
 * Embeddable data for ``pyproject.toml`` within a script (as in :pep:`723`). This
   PEP does not define exactly how PEP 723 should be modified, but being
   consumable by that interface is a stated goal.
-* IDE discovery of requirements data. e.g. VS Code could look for a dependency
+* IDE discovery of requirements data. For example, VS Code could look for a dependency
   group named ``test`` to use when running tests.
 
 Regarding Poetry and PDM Dependency Groups
@@ -199,7 +199,7 @@ Dependency Groups are not Hidden Extras
 One could be forgiven for thinking that Dependency Groups are just extras which
 go unpublished.
 
-However, there are two major features they have which distinguish them from
+However, there are two major features which distinguish them from
 extras:
 
 * they support non-package projects
@@ -259,7 +259,7 @@ define four dependency groups: ``test``, ``docs``, ``typing``, and
     [project.optional-dependencies]
     types = ["typing-extensions"]
 
-Note how ``test`` and ``typing`` are able to refer to the current package
+Note how ``test`` and ``typing`` refer to the current package
 while ``docs`` does not. This reflects the ability of Dependency Groups to be used
 in the same manner as extras, adding to dependencies, or completely
 independently. ``typing-test`` is defined as a union of two existing groups,
@@ -357,12 +357,12 @@ Why not define python-requires as part of the requirements table?
 -----------------------------------------------------------------
 
 Discussion around :pep:`722` and :pep:`723`, as well as discussions of projects which
-do not produce wheels, have often raised the need to define the python version
+do not produce wheels, have often raised the need to define the Python version
 which will be used.
 
 This PEP explicitly does not define such a key -- doing so must define
 interoperability semantics with respect to the existing packaging-oriented
-python-requires key.
+``python-requires`` key.
 It is treated as out-of-scope for the sake of simplicity.
 
 The Dependency Groups data can be defined here and intentionally leaves space

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -361,7 +361,7 @@ Rejected Ideas
 Why not define python-requires as part of the requirements table?
 -----------------------------------------------------------------
 
-Discussion around :pep:`722` and :pep:`723,` as well as discussions of projects which
+Discussion around :pep:`722` and :pep:`723`, as well as discussions of projects which
 do not produce wheels, have often raised the need to define the python version
 which will be used.
 

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -382,7 +382,7 @@ define four dependency groups: ``test``, ``docs``, ``typing``, and
 
 .. code:: toml
 
-    [requirements.packages]
+    [dependency-groups]
     test = ["pytest", "coverage", {path = ".", editable = true}]
     docs = ["sphinx", "sphinx-rtd-theme"]
     typing = ["mypy", "types-requests", {path = ".", extras = ["types"], only_deps = true}]

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -109,9 +109,10 @@ does not need to declare a version or authors in order for these data to be
 valid, nor does it need to define an installable package source tree.
 
 Simultaneously, this PEP should benefit projects which *are* intended to build
-distributions. Because dependency groups, as specified in this PEP, are explicitly defined to not be
-included in any built distribution, two common use cases are addressed by this
-addition:
+distributions.
+Because Dependency Groups, as specified in this PEP, are explicitly defined to
+not be included in any built distribution, two common use cases are addressed
+by this addition:
 
 * the use of ``extras``, as discussed above
 
@@ -166,7 +167,7 @@ The following use cases are considered important targets for this PEP:
   for the data from this PEP to be used as an input to these tools.
   Furthermore, tools may define their own structures and conventions such that
   the generated lockfiles can be referenced by the names of their originating
-  dependency groups in ``pyproject.toml``.
+  Dependency Groups in ``pyproject.toml``.
 * *Input data* to a tox, Nox, or Hatch environment, as can
   currently be achieved, for example, with ``deps = -r requirements.txt`` in
   ``tox.ini``. These tools will need to add additional options for processing
@@ -212,7 +213,7 @@ extras:
 
 * they support non-package projects
 
-* installation of a dependency group does not imply installation of a package's
+* installation of a Dependency Group does not imply installation of a package's
   dependencies (or the package itself)
 
 Object Specification Does Not Allow for "PEP 508 Decomposition"
@@ -318,7 +319,7 @@ which should be included in the package installation.
 ``editable``
 ~~~~~~~~~~~~
 
-If ``editable`` is ``true``, implementations installing the dependency group
+If ``editable`` is ``true``, implementations installing the Dependency Group
 SHOULD install the dependency in editable mode. If it is ``false``, they SHOULD
 install it in non-editable mode. If ``editable`` is absent, no default behavior
 is specified and implementations may choose their preferred default.
@@ -382,7 +383,7 @@ Example Dependency Groups Table
 -------------------------------
 
 The following is an example of a partial ``pyproject.toml`` which uses this to
-define four dependency groups: ``test``, ``docs``, ``typing``, and
+define four Dependency Groups: ``test``, ``docs``, ``typing``, and
 ``typing-test``:
 
 .. code:: toml
@@ -410,7 +411,7 @@ editable installation of the current package or not, but they MUST treat
 Package Building
 ----------------
 
-Build backends MUST NOT include dependency group data in built distributions.
+Build backends MUST NOT include Dependency Group data in built distributions.
 
 Use of Dependency Groups
 ------------------------
@@ -418,16 +419,16 @@ Use of Dependency Groups
 Tools which support Dependency Groups are expected to provide new options and
 interfaces to allow users to install from Dependency Groups.
 
-No syntax is defined for expressing the dependency group of a package, for two
+No syntax is defined for expressing the Dependency Group of a package, for two
 reasons:
 
-* it would not be valid to refer to the dependency groups of a third-party
+* it would not be valid to refer to the Dependency Groups of a third-party
   package from PyPI (because the data is defined to be unpublished)
 
-* there is not guaranteed to be a current package for dependency groups -- part
+* there is not guaranteed to be a current package for Dependency Groups -- part
   of their purpose is to support non-package projects
 
-For example, a possible pip interface for installing dependency groups
+For example, a possible pip interface for installing Dependency Groups
 would be:
 
 .. code:: shell
@@ -474,7 +475,7 @@ added to a named list. Rather than asking pip to install from a
 from a named Dependency Group.
 
 For new Python users, they may be taught directly to create a section in
-``pyproject.toml`` containing their dependency groups, similarly to how they
+``pyproject.toml`` containing their Dependency Groups, similarly to how they
 are currently taught to use ``requirements.txt`` files.
 This also allows new Python users to learn about ``pyproject.toml`` files
 without needing to learn about package building.
@@ -488,7 +489,7 @@ Specifiers will need to be explained. Support for
 similarly to teaching ``pip install -e .`` and ``pip install -e '.[extra]'``
 -- it intentionally mirrors the effects of those commands.
 
-Support for inclusion of one dependency group in another can be
+Support for inclusion of one Dependency Group in another can be
 taught as a homologue for one requirements file including another using ``-r``.
 
 Rejected Ideas
@@ -526,7 +527,7 @@ Why not restrict dependencies to PEP 508 only?
 
 There are known use cases for:
 
-* including one dependency group in another
+* including one Dependency Group in another
 * including the current package (if the project is a package)
 * including the current package with extras (if the project is a package)
 * installing ``project.dependencies`` from the current project but not
@@ -587,7 +588,7 @@ First, they do not address the needs of non-package projects.
 
 Second, there is no standard for other tools to use to access these data. This
 has impacts on high-level tools like IDEs and Dependabot, which cannot support
-deep integration with these dependency groups. (For example, at time of writing
+deep integration with these Dependency Groups. (For example, at time of writing
 Dependabot will not flag dependencies which are pinned in ``tox.ini`` files.)
 
 Open Issues
@@ -623,7 +624,7 @@ editable installs will be impacted.
 Should ``include`` accept a list?
 ---------------------------------
 
-This would enable more compact includes of multiple other dependency groups, at
+This would enable more compact includes of multiple other Dependency Groups, at
 the cost of a minor complication to the specification.
 
 Footnotes

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -2,12 +2,12 @@ PEP: 735
 Title: Dependency Groups in pyproject.toml
 Author: Stephen Rosen <sirosen0@gmail.com>
 Sponsor: Brett Cannon <brett@python.org>
-Discussions-To: https://discuss.python.org/t/29684
+Discussions-To: https://discuss.python.org/t/39233
 Status: Draft
 Type: Standards Track
 Topic: Packaging
 Created: 20-Nov-2023
-Post-History: `14-Nov-2023 <https://discuss.python.org/t/29684>`__
+Post-History: `20-Nov-2023 <https://discuss.python.org/t/39233>`__, `14-Nov-2023 <https://discuss.python.org/t/29684>`__
 
 Abstract
 ========

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -2,6 +2,7 @@ PEP: 735
 Title: Dependency Groups in pyproject.toml
 Author: Stephen Rosen <sirosen0@gmail.com>
 Sponsor: Brett Cannon <brett@python.org>
+PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/39233
 Status: Draft
 Type: Standards Track


### PR DESCRIPTION
I have attempted to put this together correctly, as a PEP to address three desires which have been expressed in the community:
- projects which do not build wheels
- some standardized non-`extra` solution for dev dependency grouping
- a standardized replacement for (or variant of) `requirements.txt` files

However, it's my first time writing a PEP, so I'm learning the process a bit here.
I'll post a thread on discourse as soon as this is up in draft, which will require an update to the discussion link, I believe.

## Basic requirements (all PEP Types)

* [x] Read and followed [PEP 1](https://peps.python.org/1) & [PEP 12](https://peps.python.org/12)
* [x] File created from the [latest PEP template](https://github.com/python/peps/blob/main/peps/pep-0012/pep-NNNN.rst?plain=1)
* [x] PEP has next available number, & set in filename (``pep-NNNN.rst``), PR title (``PEP 123: <Title of PEP>``) and ``PEP`` header
* [x] Title clearly, accurately and concisely describes the content in 79 characters or less
* [x] Core dev/PEP editor listed as ``Author`` or ``Sponsor``, and formally confirmed their approval
    * @brettcannon has volunteered to be Sponsor on this; which I believe counts for this item? "formally confirmed their approval" might mean this isn't satisfied yet?
* [x] ``Author``, ``Status`` (``Draft``), ``Type`` and ``Created`` headers filled out correctly
* [ ] ``PEP-Delegate``, ``Topic``, ``Requires`` and ``Replaces`` headers completed if appropriate
* [x] Required sections included
    * [x] Abstract (first section)
    * [x] Copyright (last section; exact wording from template required)
* [ ] Code is well-formatted (PEP 7/PEP 8) and is in [code blocks, with the right lexer names](https://peps.python.org/pep-0012/#literal-blocks) if non-Python
* [ ] PEP builds with no warnings, pre-commit checks pass and content displays as intended in the rendered HTML
* [x] Authors/sponsor added to ``.github/CODEOWNERS`` for the PEP
    * ~I did not add myself; should I?~

## Standards Track requirements

* [x] PEP topic [discussed in a suitable venue](https://peps.python.org/pep-0001/#start-with-an-idea-for-python) with general agreement that a PEP is appropriate
* [ ] [Suggested sections](https://peps.python.org/pep-0012/#suggested-sections) included (unless not applicable)
    * [x] Motivation
    * [x] Rationale
    * [x] Specification
    * [x] Backwards Compatibility
    * [x] Security Implications
    * [x] How to Teach This
    * [ ] Reference Implementation
        * I have every intention of writing a (very simple) reference implementation, but I do not want to block the PEP discussion on it. That section is therefore stubbed as a "TODO" with a description of what I plan to write.
    * [x] Rejected Ideas
    * [x] Open Issues
* [ ] ``Python-Version`` set to valid (pre-beta) future Python version, if relevant
* [ ] Any project stated in the PEP as supporting/endorsing/benefiting from the PEP formally confirmed such
* [ ] Right before or after initial merging, [PEP discussion thread](https://peps.python.org/pep-0001/#discussing-a-pep) created and linked to in ``Discussions-To`` and ``Post-History``

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3541.org.readthedocs.build/pep-0735/

<!-- readthedocs-preview pep-previews end -->