### PR TITLE
PEP 719: 3.13.0a2 has been released

### DIFF
--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -44,7 +44,7 @@ Actual:
 
 - 3.13 development begins: Monday, 2023-05-22
 - 3.13.0 alpha 1: Friday, 2023-10-13
-- 3.13.0 alpha 2: Tuesday, 2023-11-21
+- 3.13.0 alpha 2: Wednesday, 2023-11-22
 
 Expected:
 

--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -44,10 +44,10 @@ Actual:
 
 - 3.13 development begins: Monday, 2023-05-22
 - 3.13.0 alpha 1: Friday, 2023-10-13
+- 3.13.0 alpha 2: Tuesday, 2023-11-21
 
 Expected:
 
-- 3.13.0 alpha 2: Tuesday, 2023-11-21
 - 3.13.0 alpha 3: Tuesday, 2023-12-19
 - 3.13.0 alpha 4: Tuesday, 2024-01-16
 - 3.13.0 alpha 5: Tuesday, 2024-02-13


### PR DESCRIPTION
* https://www.python.org/downloads/release/python-3130a2/
* https://discuss.python.org/t/python-3-13-0-alpha-2/39379


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3544.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->