### PR TITLE
PEP 5, 6: Mark as Superseded

### DIFF
--- a/peps/pep-0005.rst
+++ b/peps/pep-0005.rst
@@ -1,7 +1,7 @@
 PEP: 5
 Title: Guidelines for Language Evolution
 Author: Paul Prescod <paul@prescod.net>
-Status: Active
+Status: Superseded
 Type: Process
 Content-Type: text/x-rst
 Created: 26-Oct-2000

--- a/peps/pep-0005.rst
+++ b/peps/pep-0005.rst
@@ -6,6 +6,7 @@ Type: Process
 Content-Type: text/x-rst
 Created: 26-Oct-2000
 Post-History:
+Superseded-By: 387
 
 
 Abstract

--- a/peps/pep-0006.rst
+++ b/peps/pep-0006.rst
@@ -7,6 +7,10 @@ Content-Type: text/x-rst
 Created: 15-Mar-2001
 Post-History: 15-Mar-2001, 18-Apr-2001, 19-Aug-2004
 
+.. note:: This PEP is obsolete.
+   The current release policy is documented in `the devguide
+   <https://devguide.python.org/developer-workflow/development-cycle/>`__.
+   See also :pep:`101` for mechanics of the release process.
 
 
 Abstract

--- a/peps/pep-0006.rst
+++ b/peps/pep-0006.rst
@@ -1,7 +1,7 @@
 PEP: 6
 Title: Bug Fix Releases
 Author: Aahz <aahz@pythoncraft.com>, Anthony Baxter <anthony@interlink.com.au>
-Status: Active
+Status: Superseded
 Type: Process
 Content-Type: text/x-rst
 Created: 15-Mar-2001


### PR DESCRIPTION
These are both marked as Active, but neither represents current
practice.

PEP 5 has been replaced by PEP 387, the backwards compatibility policy.
PEP 6 concerns bugfix releases. The procedure for those is now
documented at https://devguide.python.org/developer-workflow/development-cycle/


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3547.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->