### PR TITLE
PEP 702: Fix typo

### DIFF
--- a/peps/pep-0702.rst
+++ b/peps/pep-0702.rst
@@ -239,7 +239,7 @@ To accommodate runtime introspection, the decorator sets an attribute
 ``__deprecated__`` on the object it is passed, as well as on the wrapper
 callables it generates for deprecated classes and functions.
 The value of the attribute is the message passed to the decorator.
-Decorating objecs that do not allow setting this attribute is not supported.
+Decorating objects that do not allow setting this attribute is not supported.
 
 If a ``Protocol`` with the ``@runtime_checkable`` decorator is marked as deprecated,
 the ``__deprecated__`` attribute should not be considered a member of the protocol,


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [x] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

Spotted this typo because I was facing this issue:

```python
@deprecated("test", category=None)
@property
def prop(self) -> int:
    ...

#  AttributeError: 'property' object has no attribute '__deprecated__'
```

This can be fixed by applying the `deprecated` decorator first, I don't know if it worth mentioning in the PEP or docs :shrug: 

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3548.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->