### PR TITLE
PEP 734: Multiple Interpreters in the Stdlib

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -611,6 +611,7 @@ peps/pep-0730.rst  @ned-deily
 peps/pep-0731.rst  @gvanrossum @encukou @vstinner @zooba @iritkatriel
 peps/pep-0732.rst  @Mariatta
 peps/pep-0733.rst  @encukou @vstinner @zooba @iritkatriel
+peps/pep-0734.rst  @ericsnowcurrently
 # ...
 # peps/pep-0754.rst
 # ...

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -1,0 +1,83 @@
+PEP: 734
+Title: Multiple Interpreters in the Stdlib
+Author: Eric Snow <ericsnowcurrently@gmail.com>
+Status: Draft
+Type: Standards Track
+Created: 06-Nov-2023
+Python-Version: 3.13
+
+
+The initial PEP text is under review: https://github.com/python/peps/pull/3523.
+
+
+Abstract
+========
+
+TBD
+
+
+Introduction
+============
+
+TBD
+
+
+Motivation
+==========
+
+TBD
+
+
+Rationale
+=========
+
+TBD
+
+
+Specification
+=============
+
+TBD
+
+
+Backward Compatibility
+======================
+
+TBD
+
+
+Security Implications
+=====================
+
+TBD
+
+
+How to Teach This
+=================
+
+TBD
+
+
+Reference Implementation
+========================
+
+TBD
+
+
+Rejected Ideas
+==============
+
+TBD
+
+
+Open Issues
+===========
+
+TBD
+
+
+Copyright
+=========
+
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.


### PR DESCRIPTION
This a placeholder, to keep folks from getting confused about PEP 734 already being reserved (or about why there's a gap at PEP 734).  I'm still working on the actual text in #3523 and am not sure how soon it might be merged.  (In retrospect, I should have made a placeholder in the first place. 😄)

<!--
You can use the following checklist when double-checking your PEP,
and you can help complete some of it yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about anything, just leave it blank and we'll take a look.

If your PEP is not Standards Track, remove the corresponding section.
-->

## Basic requirements (all PEP Types)

* [ ] Read and followed [PEP 1](https://peps.python.org/1) & [PEP 12](https://peps.python.org/12)
* [ ] File created from the [latest PEP template](https://github.com/python/peps/blob/main/peps/pep-0012/pep-NNNN.rst?plain=1)
* [x] PEP has next available number, & set in filename (``pep-NNNN.rst``), PR title (``PEP 123: <Title of PEP>``) and ``PEP`` header
* [x] Title clearly, accurately and concisely describes the content in 79 characters or less
* [x] Core dev/PEP editor listed as ``Author`` or ``Sponsor``, and formally confirmed their approval
* [x] ``Author``, ``Status`` (``Draft``), ``Type`` and ``Created`` headers filled out correctly
* [ ] ``PEP-Delegate``, ``Topic``, ``Requires`` and ``Replaces`` headers completed if appropriate
* [x] Required sections included
    * [x] Abstract (first section)
    * [x] Copyright (last section; exact wording from template required)
* [x] Code is well-formatted (PEP 7/PEP 8) and is in [code blocks, with the right lexer names](https://peps.python.org/pep-0012/#literal-blocks) if non-Python
* [x] PEP builds with no warnings, pre-commit checks pass and content displays as intended in the rendered HTML
* [x] Authors/sponsor added to ``.github/CODEOWNERS`` for the PEP


## Standards Track requirements

* [x] PEP topic [discussed in a suitable venue](https://peps.python.org/pep-0001/#start-with-an-idea-for-python) with general agreement that a PEP is appropriate
* [ ] [Suggested sections](https://peps.python.org/pep-0012/#suggested-sections) included (unless not applicable)
    * [x] Motivation
    * [x] Rationale
    * [x] Specification
    * [x] Backwards Compatibility
    * [x] Security Implications
    * [x] How to Teach This
    * [x] Reference Implementation
    * [x] Rejected Ideas
    * [x] Open Issues
* [x] ``Python-Version`` set to valid (pre-beta) future Python version, if relevant
* [ ] Any project stated in the PEP as supporting/endorsing/benefiting from the PEP formally confirmed such
* [ ] Right before or after initial merging, [PEP discussion thread](https://peps.python.org/pep-0001/#discussing-a-pep) created and linked to in ``Discussions-To`` and ``Post-History``


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3549.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->