### PR TITLE
PEP 1: Mention the Typing Council

### DIFF
--- a/peps/pep-0001.rst
+++ b/peps/pep-0001.rst
@@ -168,7 +168,8 @@ then the PEP author(s) will need to find a sponsor for the PEP.
 
 Ideally, a core developer sponsor is identified, but non-core sponsors may also
 be selected with the approval of the Steering Council.  Members of the GitHub
-"PEP editors" team are pre-approved to be sponsors.  The sponsor's job is to
+"PEP editors" team and members of the Typing Council (:pep:`729`) are
+pre-approved to be sponsors.  The sponsor's job is to
 provide guidance to the PEP author to help them through the logistics of the
 PEP process (somewhat acting like a mentor).  Being a sponsor does **not**
 disqualify that person from becoming a co-author or PEP-Delegate later on (but
@@ -341,6 +342,10 @@ experienced to make the final decision on that PEP may offer to serve as its
 PEP-Delegate by `notifying the Steering Council <Steering Council issue_>`_
 of their intent. If the Steering Council approves their offer,
 the PEP-Delegate will then have the authority to approve or reject that PEP.
+For PEPs related to the Python type system, the Typing Council (:pep:`729`)
+provides a recommendation to the Steering Council. To request such a
+recommendation, open an issue on the `Typing Council issue tracker
+<https://github.com/python/typing-council/issues>`_.
 
 The term "PEP-Delegate" is used under the Steering Council governance model
 for the PEP's designated decision maker,


### PR DESCRIPTION
Implements aspects of PEP-729.

See also python/steering-council#222.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3550.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->