### PR TITLE
Infra: `make htmllive`: open browser when ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ htmlview: html
 ## htmllive       to rebuild and reload HTML files in your browser
 .PHONY: htmllive
 htmllive: SPHINXBUILD = $(VENVDIR)/bin/sphinx-autobuild
-htmllive: SPHINXERRORHANDLING = --re-ignore="/\.idea/|/venv/|/pep-0000.rst|/topic/"
+htmllive: SPHINXERRORHANDLING = --re-ignore="/\.idea/|/venv/|/pep-0000.rst|/topic/" --open-browser --delay 0
 htmllive: html
 
 ## dirhtml        to render PEPs to "index.html" files within "pep-NNNN" directories


### PR DESCRIPTION
Like https://github.com/python/devguide/pull/1233.

When running `make htmllive`, this will open the browser when the docs have been built the first time. 

It means you don't need to hunt around for the link in:

```console
❯ make htmllive
venv already exists.
To recreate it, remove it first with `make clean-venv'.
.venv/bin/sphinx-autobuild -b html -j 8  --re-ignore="/\.idea/|/venv/|/pep-0000.rst|/topic/" --open-browser --delay 0 peps build
[sphinx-autobuild] > sphinx-build -b html -j 8 /Users/hugo/github/peps/peps /Users/hugo/github/peps/build
Running Sphinx v7.2.6
loading pickled environment... done
building [html]: targets for 1 source files that are out of date
updating environment: 0 added, 2 changed, 5 removed
reading sources... [100%] topic/typing
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [100%] topic/typing
generating indices... done
writing additional pages... done
dumping object inventory... done
build succeeded.

The HTML pages are in build.
[I 231130 18:08:54 server:335] Serving on http://127.0.0.1:8000
[I 231130 18:08:54 handlers:62] Start watching changes
[I 231130 18:08:54 handlers:64] Start detecting changes
[I 231130 18:08:54 handlers:135] Browser Connected: http://127.0.0.1:8000/
[I 231130 18:08:55 handlers:82] Ignore: /Users/hugo/github/peps/peps/pep-0418/clockutils.py
[I 231130 18:08:56 handlers:92] Reload 1 waiters: None
[I 231130 18:08:57 handlers:135] Browser Connected: http://127.0.0.1:8000/
```

I'll make the same changes for the CPython repo afterwards.


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3558.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->