### PR TITLE
PEP 544: Fix error in "Type[] and class objects vs protocols" section

### DIFF
--- a/peps/pep-0544.rst
+++ b/peps/pep-0544.rst
@@ -782,8 +782,8 @@ For example::
   class C:
       def meth(self, x: int) -> int: ...
 
-  a: ProtoA = C  # Type check error, signatures don't match!
-  b: ProtoB = C  # OK
+  a: Type[ProtoA] = C  # Type check error, signatures don't match!
+  b: Type[ProtoB] = C  # OK
 
 
 ``NewType()`` and type aliases


### PR DESCRIPTION
```
a: ProtoA = C  # Type check error, signatures don't match!
b: ProtoB = C  # OK

```
should be

```
a: Type[ProtoA] = C  # Type check error, signatures don't match!
b: Type[ProtoB] = C  # OK
```

because `C` is a candidate subtype of `ProtoA` and a subtype of `ProtoB`

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [X] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3561.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->