### PR TITLE
PEP 726: Fix error message description

### DIFF
--- a/peps/pep-0726.rst
+++ b/peps/pep-0726.rst
@@ -59,7 +59,7 @@ For example
    def validate(n):
        n = int(n)
        if n <= 0:
-           raise ValueError('non-negative integer expected')
+           raise ValueError('Positive integer expected')
        return n
 
    def __setattr__(name, value):
@@ -105,7 +105,7 @@ For example
   >>> mplib.dps = 0
   Traceback (most recent call last):
     ...
-  ValueError: non-negative integer expected
+  ValueError: Positive integer expected
 
 
 Existing Options

--- a/peps/pep-0726.rst
+++ b/peps/pep-0726.rst
@@ -279,7 +279,7 @@ See `related issue
 <https://github.com/python/cpython/issues/106016#issue-1771174774>`__ for
 other details.
 
-Other stdlib modules also come with attributes which can be overriden (as a
+Other stdlib modules also come with attributes which can be overridden (as a
 feature) and some input validation here could be helpful.  Examples:
 :py:obj:`threading.excepthook`, :py:obj:`warnings.showwarning`,
 :py:obj:`io.DEFAULT_BUFFER_SIZE` or :py:obj:`os.SEEK_SET`.


### PR DESCRIPTION
Zero is a non-negative number, but since zero is being excluded here, the check is really ensuring that it is a positive number.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3562.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->