### PR TITLE
PEP 621: Fix reference to canonical spec

### DIFF
--- a/peps/pep-0621.rst
+++ b/peps/pep-0621.rst
@@ -20,7 +20,7 @@ Post-History: 22-Jun-2020,
 Resolution: https://discuss.python.org/t/pep-621-round-3/5472/109
 
 
-.. canonical-pypa-spec:: :ref:`packaging:declaring-project-metadata`
+.. canonical-pypa-spec:: :ref:`packaging:pyproject-toml-spec`
 
 
 Abstract


### PR DESCRIPTION
The build has broken because PEP 621 uses intersphinx to refer to the canonical docs at https://packaging.python.org but they've re-organised things (https://github.com/pypa/packaging.python.org/pull/1396) and deleted the old reference:

```
/home/runner/work/peps/peps/peps/pep-0621.rst:23: WARNING: undefined label: 'packaging:declaring-project-metadata'
```

https://github.com/python/peps/actions/runs/7092751804/job/19304712978

I've opened https://github.com/pypa/packaging.python.org/pull/1434 to add back the old reference, but let's also change it here, we can unblock our build quicker.



<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3563.org.readthedocs.build/pep-0621/

<!-- readthedocs-preview pep-previews end -->