### PR TITLE
PEP 621: Remove invalid reference

### DIFF
--- a/peps/pep-0621.rst
+++ b/peps/pep-0621.rst
@@ -20,9 +20,6 @@ Post-History: 22-Jun-2020,
 Resolution: https://discuss.python.org/t/pep-621-round-3/5472/109
 
 
-.. canonical-pypa-spec:: :ref:`packaging:declaring-project-metadata`
-
-
 Abstract
 ========
 


### PR DESCRIPTION
The reference is not rendered, not used, and it doesn't exist.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3564.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->