### PR TITLE
PEP 664: Update 3.11.7 release date

### DIFF
--- a/peps/pep-0664.rst
+++ b/peps/pep-0664.rst
@@ -72,10 +72,10 @@ Actual:
 - 3.11.4: Tuesday, 2023-06-06
 - 3.11.5: Thursday, 2023-08-24
 - 3.11.6: Monday, 2023-10-02
+- 3.11.7: Monday, 2023-12-04
 
 Expected:
 
-- 3.11.7: Monday, 2023-12-04
 - 3.11.8: Monday, 2024-02-05
 
 Final regular bugfix release with binary installers:


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3117/

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3565.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->