### PR TITLE
PEP 737: type.fully_qualified_name() method

### DIFF
--- a/peps/pep-0737.rst
+++ b/peps/pep-0737.rst
@@ -396,7 +396,10 @@ expression from the format specification. For example, ``f"{3.14:g}"``
 uses ``g`` format which comes after the colon (``:``). Usually, a format
 type is a single letter, such as ``g`` in ``f"{3.14:g}"``, not ``M.T``
 or ``M:T``. Reusing dot and colon characters for a different purpose can
-be misleading and make the format parser more complicated.
+be misleading and make the format parser (`Python/formatter_unicode.c
+<https://github.com/python/cpython/blob/86a77f4e1a5ceaff1036b0072521e12752b5df47/Python/formatter_unicode.c>`_)
+more complicated.
+
 
 Add !t formatter to get an object type
 --------------------------------------

--- a/peps/pep-0737.rst
+++ b/peps/pep-0737.rst
@@ -19,6 +19,10 @@ implemented. No longer truncate type names in the standard library.
 Recommend using the type fully qualified name in error messages and in
 ``__repr__()`` methods in new code.
 
+Add an option to format a fully qualified name using the colon separator
+(``:``): format used by ``pkgutil.resolve_name()``, the ``inspect``
+module, and ``setuptools`` entry points.
+
 Make C code safer by avoiding borrowed reference which can lead to
 crashes. The new C API is compatible with the limited C API.
 
@@ -171,10 +175,11 @@ limit of 500 bytes is outdated
 Specification
 =============
 
-* Add ``type.__fully_qualified_name__`` attribute.
+* Add ``type.fully_qualified_name()`` method.
 * Add ``%T``, ``%#T``, ``%N``, ``%#N`` formats to
   ``PyUnicode_FromFormat()``.
 * Add ``PyType_GetFullyQualifiedName()`` function.
+* Add ``PyType_GetModuleName()`` function.
 * Recommend using the type fully qualified name in error messages and
   in ``__repr__()`` methods in new code.
 * Recommend not truncating type names.
@@ -183,11 +188,15 @@ Specification
 Python API
 ----------
 
-Add ``type.__fully_qualified_name__`` read-only attribute, the fully
+Add ``type.fully_qualified_name(sep='.')`` method, the fully
 qualified name of a type: similar to
-``f"{type.__module__}.{type.__qualname__}"``, or ``type.__qualname__`` if
-``type.__module__`` is not a string or is equal to ``"builtins"`` or is
-equal to ``"__main__"``.
+``f"{type.__module__}{sep}{type.__qualname__}"``, or
+``type.__qualname__`` if ``type.__module__`` is not a string or is equal
+to ``"builtins"`` or is equal to ``"__main__"``.
+
+``type.fully_qualified_name(':')`` can be used to use the colon
+separator (``:``): format used by ``pkgutil.resolve_name()``,
+the ``inspect`` module, and ``setuptools`` entry points.
 
 The ``type.__repr__()`` is left unchanged, it only omits the module if
 the module is equal to ``"builtins"``. It includes the module if the
@@ -207,11 +216,11 @@ Add PyUnicode_FromFormat() formats
 Add formats to ``PyUnicode_FromFormat()``:
 
 * ``%T`` formats the type fully qualified name of an **object**:
-  similar to ``type(obj).__fully_qualified_name__``.
+  similar to ``type(obj).fully_qualified_name()``.
 * ``%#T`` formats the type short name of an **object**:
   similar to ``type(obj).__name__``.
 * ``%N`` formats the fully qualified name of a **type**:
-  similar to ``type.__fully_qualified_name__``.
+  similar to ``type.fully_qualified_name()``.
 * ``%#N`` formats the short name of an object of a **type**:
   similar to ``type.__name__``.
 
@@ -246,7 +255,7 @@ Advantages of the updated code:
   code becomes compatible with the limited C API.
 * The ``PyTypeObject.tp_name`` bytes string no longer has to be decoded
   from UTF-8 at each ``PyErr_Format()`` call, since
-  ``type.__fully_qualified_name__`` is already a Unicode string.
+  ``type.fully_qualified_name()`` returns a Unicode string.
 * The type name is no longer truncated.
 
 
@@ -254,11 +263,28 @@ Add PyType_GetFullyQualifiedName() function
 -------------------------------------------
 
 Add the ``PyType_GetFullyQualifiedName()`` function to get the fully
-qualified name of a type (``type.__fully_qualified_name__``). API:
+qualified name of a type (``type.fully_qualified_name()``). API:
 
 .. code-block:: c
 
-    PyObject* PyType_GetFullyQualifiedName(PyTypeObject *type)
+    PyObject* PyType_GetFullyQualifiedName(PyTypeObject *type, Py_UCS4 sep)
+
+Call ``PyType_GetFullyQualifiedName(type, '.')`` to format with the
+default dot (``.``) separator.
+
+On success, return a new reference to the string. On error, raise an
+exception and return ``NULL``.
+
+
+Add PyType_GetModuleName() function
+-----------------------------------
+
+Add the ``PyType_GetModuleName()`` function to get the module name of a
+type (``type.__module__``). API:
+
+.. code-block:: c
+
+    PyObject* PyType_GetModuleName(PyTypeObject *type)
 
 On success, return a new reference to the string. On error, raise an
 exception and return ``NULL``.
@@ -290,7 +316,7 @@ names.
 Implementation
 ==============
 
-* Pull request: `Add type.__fully_qualified_name__ attribute <https://github.com/python/cpython/pull/112133>`_.
+* Pull request: `Add type.fully_qualified_name() method <https://github.com/python/cpython/pull/112133>`_.
 * Pull request: `Add %T format to PyUnicode_FromFormat() <https://github.com/python/cpython/pull/111703>`_.
 
 
@@ -314,6 +340,25 @@ than 100 characters are rare.
 Rejected Ideas
 ==============
 
+Add type.__fully_qualified_name__ attribute
+-------------------------------------------
+
+Add ``type.__fully_qualified_name__`` attribute, the fully qualified name
+of a type: similar to ``f"{type.__module__}.{type.__qualname__}"``, or
+``type.__qualname__`` if ``type.__module__`` is not a string or is equal
+to ``"builtins"`` or is equal to ``"__main__"``. Similar to
+the ``type.fully_qualified_name(sep='.')`` method, except that the
+separator is always the dot (``.``).
+
+The problem of only providing an API for the dot separator is that it
+discourages the usage of the colon separator: format used by
+``pkgutil.resolve_name()``, the ``inspect`` module, and ``setuptools``
+entry points.
+
+The method has an option *sep* parameter which can be used to use a
+different separator such as colon (``:``).
+
+
 Change str(type)
 ----------------
 
@@ -336,11 +381,10 @@ Add formats to type.__format__()
 Examples of proposed formats for ``type.__format__()``:
 
 * ``f"{type(obj):z}"`` formats ``type(obj).__name__``.
-* ``f"{type(obj):M.T}"`` formats ``type(obj).__fully_qualified_name__``.
-* ``f"{type(obj):M:T}"`` formats ``type(obj).__fully_qualified_name__``
-  using colon (``:``) separator.
+* ``f"{type(obj):M.T}"`` formats ``type(obj).fully_qualified_name()``.
+* ``f"{type(obj):M:T}"`` formats ``type(obj).fully_qualified_name(':')``.
 * ``f"{type(obj):T}"`` formats ``type(obj).__name__``.
-* ``f"{type(obj):#T}"`` formats ``type(obj).__fully_qualified_name__``.
+* ``f"{type(obj):#T}"`` formats ``type(obj).fully_qualified_name()``.
 
 Using short format (such as ``z``, a single letter) requires to refer to
 format documentation to understand how a type name is formatted, whereas
@@ -375,18 +419,6 @@ For example, ``%T`` and ``%#T`` formats.
 Nowadays, f-strings are preferred for new code.
 
 
-Use colon separator in fully qualified name
--------------------------------------------
-
-The colon (``:``) separator eliminates guesswork when you want to import
-the name, see ``pkgutil.resolve_name()``. A type fully qualified name
-can be formatted as ``f"{type.__module__}:{type.__qualname__}"``, or
-``type.__qualname__`` if the type module is ``"builtins"``.
-
-In the standard library, no code formats a type fully qualified name
-this way.
-
-
 Other ways to format type names in C
 ------------------------------------
 
@@ -399,7 +431,7 @@ Proposed formats using ``h`` and ``hh`` length modifiers:
 
 * ``%hhT`` formats ``type.__name__``.
 * ``%hT`` formats ``type.__qualname__``.
-* ``%T`` formats ``type.__fully_qualified_name__``.
+* ``%T`` formats ``type.fully_qualified_name()``.
 
 Length modifiers are used to specify the C type of the argument, not to
 change how an argument is formatted. The alternate form (``#``) changes
@@ -410,10 +442,10 @@ Other proposed formats:
 
 * ``%Q``
 * ``%t``.
-* ``%lT`` formats ``type.__fully_qualified_name__``.
+* ``%lT`` formats ``type.fully_qualified_name()``.
 * ``%Tn`` formats ``type.__name__``.
 * ``%Tq`` formats ``type.__qualname__``.
-* ``%Tf`` formats ``type.__fully_qualified_name__``.
+* ``%Tf`` formats ``type.fully_qualified_name()``.
 
 Having more options to format type names can lead to inconsistencies
 between different modules and make the API more error prone.
@@ -471,11 +503,11 @@ Python does crash.
 Other proposed APIs to get a type fully qualified name
 ------------------------------------------------------
 
-* ``type.__fullyqualname__`` attribute name: attribute without an underscore
-  between words. Several dunders, including some of the most recently
-  added ones, include an underscore in the word: ``__class_getitem__``,
-  ``__release_buffer__``, ``__type_params__``, ``__init_subclass__`` and
-  ``__text_signature__``.
+* ``type.__fullyqualname__`` attribute name: attribute without an
+  underscore between words. Several dunders, including some of the most
+  recently added ones, include an underscore in the word:
+  ``__class_getitem__``, ``__release_buffer__``, ``__type_params__``,
+  ``__init_subclass__`` and ``__text_signature__``.
 * ``type.__fqn__`` attribute name, where FQN stands for Fully Qualified
   Name.
 * Add a function to the ``inspect`` module. Need to import the
@@ -485,10 +517,11 @@ Other proposed APIs to get a type fully qualified name
 Include the __main__ module in the type fully qualified name
 ------------------------------------------------------------
 
-Format ``type.__fully_qualified_name__`` as
-``f"{type.__module__}.{type.__qualname__}"``, or ``type.__qualname__`` if
-``type.__module__`` is not a string or is equal to ``"builtins"``.  Do
-not treat the ``__main__`` module differently: include it in the name.
+Format ``type.fully_qualified_name(sep='.')`` as
+``f"{type.__module__}{sep}{type.__qualname__}"``, or
+``type.__qualname__`` if ``type.__module__`` is not a string or is equal
+to ``"builtins"``.  Do not treat the ``__main__`` module differently:
+include it in the name.
 
 Existing code such as ``type.__repr__()``, ``collections.abc`` and
 ``unittest`` modules format a type name with
@@ -497,7 +530,7 @@ if the module is equal to ``builtins``. Only the ``traceback`` and
 ``pdb`` modules also the module if it's equal to ``"builtins"`` or
 ``"__main__"``.
 
-The ``type.__fully_qualified_name__`` attribute omits the ``__main__``
+The ``type.fully_qualified_name()`` method omits the ``__main__``
 module to produce shorter names for a common case: types defined in a
 script run with ``python script.py``. For debugging, the ``repr()``
 function can be used on a type, it includes the ``__main__`` module in
@@ -510,7 +543,7 @@ Example of script::
     class MyType:
         pass
 
-    print(f"name: {MyType.__fully_qualified_name__}")
+    print(f"name: {MyType.fully_qualified_name()}")
     print(f"repr: {repr(MyType)}")
 
 Output::


### PR DESCRIPTION
* Replace `type.__fully_qualified_name__` attribute with `type.fully_qualified_name(sep='.')` method.
* Add `PyType_GetModuleName()` function.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3572.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->