### PR TITLE
PEP 448: Fix misleading passage in the abstract

### DIFF
--- a/peps/pep-0448.rst
+++ b/peps/pep-0448.rst
@@ -16,9 +16,7 @@ Abstract
 This PEP proposes extended usages of the ``*`` iterable unpacking
 operator and ``**`` dictionary unpacking operators
 to allow unpacking in more positions, an arbitrary number of
-times, and in additional circumstances.  Specifically,
-in function calls, in comprehensions and generator expressions, and
-in displays.
+times, and in function calls and displays.
 
 Function calls are proposed to support an arbitrary number of
 unpackings rather than just one::


### PR DESCRIPTION
The passage in the PEP misleads its readers into believing, that unpacking in comprehensions is supported. This is not the case, as presented by the abstract itself:

> This PEP does not include unpacking operators inside list, set and  dictionary comprehensions although this has not been ruled out for future proposals.

See discussion in https://discuss.python.org/t/pep-448-contradictory-abstract/40657/6

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3573.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->