### PR TITLE
PEP 675: Mark malicious code example with red sidebar

### DIFF
--- a/peps/pep-0675.rst
+++ b/peps/pep-0675.rst
@@ -1,14 +1,11 @@
 PEP: 675
 Title: Arbitrary Literal String Type
-Version: $Revision$
-Last-Modified: $Date$
 Author: Pradeep Kumar Srinivasan <gohanpra@gmail.com>, Graham Bleaney <gbleaney@gmail.com>
 Sponsor: Jelle Zijlstra <jelle.zijlstra@gmail.com>
 Discussions-To: https://mail.python.org/archives/list/typing-sig@python.org/thread/VB74EHNM4RODDFM64NEEEBJQVAUAWIAW/
 Status: Accepted
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 30-Nov-2021
 Python-Version: 3.11
 Post-History: 07-Feb-2022
@@ -50,7 +47,8 @@ However, the user-controlled data ``user_id`` is being mixed with the
 SQL command string, which means a malicious user could run arbitrary
 SQL commands:
 
-::
+.. code-block::
+   :class: bad
 
     # Delete the table.
     query_user(conn, "user123; DROP TABLE data;")


### PR DESCRIPTION
Fixes https://github.com/python/docs-community/issues/22.

As suggested by @encukou in https://github.com/python/docs-community/issues/22, the dangerous "naive" SQL code could do with a red marker.

<table>
<tr>
 <td>
<img width="823" alt="image" src="https://github.com/python/peps/assets/1324225/15ecc276-ef87-4875-911c-9e2063b61e0e">

 <td>
<img width="806" alt="image" src="https://github.com/python/peps/assets/1324225/b14cb591-0e99-419b-9303-37a729023336">

</table>


Regarding accessibility, similar to https://github.com/python/peps/pull/3567, we're not relying on colour to convey meaning, it's also there in the text. ✅ 

Are there any examples in this PEP that could benefit from a red or green (or even yellow) sidebar? Perhaps the "written safely" one immediately after could be green?

Also remove the redundant headers.

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3574.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->