### PR TITLE
PEP 612: Mark as Final

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/Mark a PEP Final.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Mark a PEP Final.md
@@ -9,4 +9,6 @@ If you're unsure about something, just leave it blank and we'll take a look.
 * [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
 * [ ] Pull request title in appropriate format (``PEP 123: Mark Final``)
 * [ ] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
-* [ ] Canonical docs/spec linked with a ``canonical-doc`` directive (or ``canonical-pypa-spec``, for packaging PEPs)
+* [ ] Canonical docs/spec linked with a ``canonical-doc`` directive 
+      (or ``canonical-pypa-spec`` for packaging PEPs,
+       or ``canonical-typing-spec`` for typing PEPs)

--- a/pep_sphinx_extensions/__init__.py
+++ b/pep_sphinx_extensions/__init__.py
@@ -73,6 +73,8 @@ def setup(app: Sphinx) -> dict[str, bool]:
         "canonical-doc", pep_banner_directive.CanonicalDocBanner)
     app.add_directive(
         "canonical-pypa-spec", pep_banner_directive.CanonicalPyPASpecBanner)
+    app.add_directive(
+        "canonical-typing-spec", pep_banner_directive.CanonicalTypingSpecBanner)
 
     # Register event callbacks
     app.connect("builder-inited", _update_config_for_builder)  # Update configuration values for builder used

--- a/pep_sphinx_extensions/pep_processor/parsing/pep_banner_directive.py
+++ b/pep_sphinx_extensions/pep_processor/parsing/pep_banner_directive.py
@@ -6,6 +6,7 @@ from docutils import nodes
 from docutils.parsers import rst
 
 PYPA_SPEC_BASE_URL = "https://packaging.python.org/en/latest/specifications/"
+TYPING_SPEC_BASE_URL = "https://typing.readthedocs.io/en/latest/spec/"
 
 
 class PEPBanner(rst.Directive):
@@ -23,7 +24,6 @@ class PEPBanner(rst.Directive):
 
     admonition_class = nodes.important
     css_classes = []
-
 
     def run(self) -> list[nodes.admonition]:
 
@@ -81,7 +81,6 @@ class CanonicalDocBanner(PEPBanner):
     css_classes = ["canonical-doc", "sticky-banner"]
 
 
-
 class CanonicalPyPASpecBanner(PEPBanner):
     """Insert a specialized admonition for PyPA packaging specifications."""
 
@@ -103,3 +102,26 @@ class CanonicalPyPASpecBanner(PEPBanner):
     admonition_class = nodes.attention
 
     css_classes = ["canonical-pypa-spec", "sticky-banner"]
+
+
+class CanonicalTypingSpecBanner(PEPBanner):
+    """Insert a specialized admonition for the typing specification."""
+
+    admonition_pre_template = (
+        "This PEP is a historical document. "
+        "The up-to-date, canonical spec, {link_content}, is maintained on "
+        f"the `typing specs site <{TYPING_SPEC_BASE_URL}>`__."
+    )
+    admonition_pre_text = (
+        "This PEP is a historical document. "
+        "The up-to-date, canonical specifications are maintained on "
+        f"the `typing specs site <{TYPING_SPEC_BASE_URL}>`__."
+    )
+    admonition_post_text = (
+        "See the `typing specification update process "
+        "<https://typing.readthedocs.io/en/latest/spec/TODO.html>`__ "
+        "for how to propose changes."
+    )
+    admonition_class = nodes.attention
+
+    css_classes = ["canonical-typing-spec", "sticky-banner"]

--- a/pep_sphinx_extensions/pep_processor/parsing/pep_banner_directive.py
+++ b/pep_sphinx_extensions/pep_processor/parsing/pep_banner_directive.py
@@ -119,7 +119,7 @@ class CanonicalTypingSpecBanner(PEPBanner):
     )
     admonition_post_text = (
         "See the `typing specification update process "
-        "<https://typing.readthedocs.io/en/latest/spec/TODO.html>`__ "
+        "<https://typing.readthedocs.io/en/latest/spec/meta.html>`__ "
         "for how to propose changes."
     )
     admonition_class = nodes.attention

--- a/peps/conf.py
+++ b/peps/conf.py
@@ -52,6 +52,7 @@ nitpicky = True
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'packaging': ('https://packaging.python.org/en/latest/', None),
+    'typing': ('https://typing.readthedocs.io/en/latest/', None),
     'devguide': ('https://devguide.python.org/', None),
     'py3.11': ('https://docs.python.org/3.11/', None),
     'py3.12': ('https://docs.python.org/3.12/', None),

--- a/peps/pep-0012.rst
+++ b/peps/pep-0012.rst
@@ -654,8 +654,10 @@ As :pep:`PEP 1 describes <1#pep-maintenance>`,
 PEPs are considered historical documents once marked Final,
 and their canonical documentation/specification should be moved elsewhere.
 To indicate this, use the ``canonical-doc`` directive
-or an appropriate subclass
-(currently ``canonical-pypa-spec`` for packaging standards).
+or an appropriate subclass:
+
+* ``canonical-pypa-spec`` for packaging standards
+* ``canonical-typing-spec`` for typing standards
 
 Furthermore, you can use
 `Intersphinx references

--- a/peps/pep-0012.rst
+++ b/peps/pep-0012.rst
@@ -653,7 +653,7 @@ Canonical Documentation and Intersphinx
 As :pep:`PEP 1 describes <1#pep-maintenance>`,
 PEPs are considered historical documents once marked Final,
 and their canonical documentation/specification should be moved elsewhere.
-To indicate this, use the ``canonical-docs`` directive
+To indicate this, use the ``canonical-doc`` directive
 or an appropriate subclass
 (currently ``canonical-pypa-spec`` for packaging standards).
 

--- a/peps/pep-0612.rst
+++ b/peps/pep-0612.rst
@@ -11,8 +11,9 @@ Created: 18-Dec-2019
 Python-Version: 3.10
 Post-History: 18-Dec-2019, 13-Jul-2020
 
-.. canonical-doc:: :external+python:class:`typing.ParamSpec` and
-                   :external+python:data:`typing.Concatenate`
+.. canonical-typing-spec:: :ref:`typing:paramspec`
+
+:)
 
 Abstract
 --------

--- a/peps/pep-0612.rst
+++ b/peps/pep-0612.rst
@@ -4,14 +4,14 @@ Author: Mark Mendoza <mendoza.mark.a@gmail.com>
 Sponsor: Guido van Rossum <guido@python.org>
 BDFL-Delegate: Guido van Rossum <guido@python.org>
 Discussions-To: typing-sig@python.org
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 18-Dec-2019
 Python-Version: 3.10
 Post-History: 18-Dec-2019, 13-Jul-2020
 
+.. canonical-doc:: :external+python:class:`typing.ParamSpec`
 
 Abstract
 --------

--- a/peps/pep-0612.rst
+++ b/peps/pep-0612.rst
@@ -13,8 +13,6 @@ Post-History: 18-Dec-2019, 13-Jul-2020
 
 .. canonical-typing-spec:: :ref:`typing:paramspec`
 
-:)
-
 Abstract
 --------
 

--- a/peps/pep-0612.rst
+++ b/peps/pep-0612.rst
@@ -11,7 +11,8 @@ Created: 18-Dec-2019
 Python-Version: 3.10
 Post-History: 18-Dec-2019, 13-Jul-2020
 
-.. canonical-doc:: :external+python:class:`typing.ParamSpec`
+.. canonical-doc:: :external+python:class:`typing.ParamSpec` and
+                   :external+python:data:`typing.Concatenate`
 
 Abstract
 --------


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive (or ``canonical-pypa-spec``, for packaging PEPs)

Helps https://github.com/python/peps/issues/2872.

Link to https://docs.python.org/3/library/typing.html#typing.ParamSpec as the canonical docs, and remove a redundant header.

cc @Fidget-Spinner

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3575.org.readthedocs.build/pep-0612/

<!-- readthedocs-preview pep-previews end -->