### PR TITLE
PEP 634: Mark as Final

### DIFF
--- a/peps/pep-0634.rst
+++ b/peps/pep-0634.rst
@@ -1,20 +1,18 @@
 PEP: 634
 Title: Structural Pattern Matching: Specification
-Version: $Revision$
-Last-Modified: $Date$
 Author: Brandt Bucher <brandt@python.org>,
         Guido van Rossum <guido@python.org>
 BDFL-Delegate:
 Discussions-To: python-dev@python.org
-Status: Accepted
+Status: Final
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 12-Sep-2020
 Python-Version: 3.10
 Post-History: 22-Oct-2020, 08-Feb-2021
 Replaces: 622
 Resolution: https://mail.python.org/archives/list/python-committers@python.org/message/SQC2FTLFV5A7DV7RCEAR2I2IKJKGK7W3
 
+.. canonical-doc:: :external+python:ref:`match`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive (or ``canonical-pypa-spec``, for packaging PEPs)

Link to https://docs.python.org/3/reference/compound_stmts.html#the-match-statement as the canonical docs, and remove some redundant headers.

cc @Fidget-Spinner 

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3576.org.readthedocs.build/pep-0634/

<!-- readthedocs-preview pep-previews end -->