### PR TITLE
PEP 693: Add 3.12.1 release date

### DIFF
--- a/peps/pep-0693.rst
+++ b/peps/pep-0693.rst
@@ -60,6 +60,13 @@ Actual:
 - 3.12.0 candidate 3: Tuesday, 2023-09-19
 - 3.12.0 final:  Monday, 2023-10-02
 
+Bugfix releases
+---------------
+
+Actual:
+
+- 3.12.1: Thursday, 2023-12-07
+
 Subsequent bugfix releases every two months.
 
 


### PR DESCRIPTION
As is done for the other release schedule PEPs

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--3578.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->