### PR TITLE
Update Read the Docs name and URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,11 +34,11 @@ generation to fail, or result in major rendering defects relative to what you
 intend.
 
 
-Browse the ReadTheDocs preview
-------------------------------
+Browse the "Read the Docs" preview
+----------------------------------
 
 For every PR, we automatically create a preview of the rendered PEPs using
-`ReadTheDocs <https://readthedocs.org/>`_.
+`Read the Docs <https://about.readthedocs.com>`_.
 You can find it in the merge box at the bottom of the PR page:
 
 1. Click "Show all checks" to expand the checks section

--- a/peps/pep-0426.rst
+++ b/peps/pep-0426.rst
@@ -1111,7 +1111,7 @@ RPM.
 A documentation toolchain dependency like Sphinx would either go in the
 ``build`` extra (for example, if man pages were included in the
 built distribution) or in the ``doc`` extra (for example, if the
-documentation is published solely through ReadTheDocs or the
+documentation is published solely through Read the Docs or the
 project website). This would be enough to allow an automated converter
 to map it to an appropriate dependency in the spec file.
 


### PR DESCRIPTION
Hello,

I realize this is a minor thing, but I believe [Read the Docs](https://github.com/readthedocs) as an organization deserves their name to be written as they write it themselves, so I'd like to suggest changes that:
  * replace `ReadTheDocs` with `Read the Docs`
  * update a link to avoid a redirection

Best regards!

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3588.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->