### PR TITLE
PEP 709: Mark as Final

### DIFF
--- a/peps/pep-0709.rst
+++ b/peps/pep-0709.rst
@@ -3,9 +3,8 @@ Title: Inlined comprehensions
 Author: Carl Meyer <carl@oddbird.net>
 Sponsor: Guido van Rossum <guido@python.org>
 Discussions-To: https://discuss.python.org/t/pep-709-inlined-comprehensions/24240
-Status: Accepted
+Status: Final
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 24-Feb-2023
 Python-Version: 3.12
 Post-History: `25-Feb-2023 <https://discuss.python.org/t/pep-709-inlined-comprehensions/24240>`__


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [x] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [ ] Canonical docs/spec linked with a ``canonical-doc`` directive (or ``canonical-pypa-spec``, for packaging PEPs)

PEP 709 was implemented in Python 3.12, we should mark it as Final so it's no longer listed under [Accepted PEPs (accepted; may not be implemented yet)](https://peps.python.org/#accepted-peps-accepted-may-not-be-implemented-yet).

Should this have a `.. canonical-doc::` banner at the top to link to canonical docs?

For example, compare https://peps.python.org/pep-0634/

All I could find in the CPython docs is the [What's New entry](https://docs.python.org/3/whatsnew/3.12.html#pep-709-comprehension-inlining), but perhaps as an internal change, "canonical docs" doesn't apply in this instance?


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3591.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->