### PR TITLE
PEP 615: Mark as Final

### DIFF
--- a/peps/pep-0615.rst
+++ b/peps/pep-0615.rst
@@ -2,14 +2,14 @@ PEP: 615
 Title: Support for the IANA Time Zone Database in the Standard Library
 Author: Paul Ganssle <paul at ganssle.io>
 Discussions-To: https://discuss.python.org/t/3468
-Status: Accepted
+Status: Final
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 22-Feb-2020
 Python-Version: 3.9
 Post-History: 25-Feb-2020, 29-Mar-2020
 Replaces: 431
 
+.. canonical-doc:: :external+python:mod:`zoneinfo`
 
 Abstract
 ========
@@ -463,7 +463,9 @@ arguments), the ``zoneinfo`` module will use the environment variable
 
 ``PYTHONTZPATH`` is an ``os.pathsep``-delimited string which *replaces* (rather
 than augments) the default time zone path. Some examples of the proposed
-semantics::
+semantics:
+
+.. code-block:: console
 
     $ python print_tzpath.py
     ("/usr/share/zoneinfo",
@@ -481,7 +483,9 @@ semantics::
 This provides no built-in mechanism for prepending or appending to the default
 search path, as these use cases are likely to be somewhat more niche. It should
 be possible to populate an environment variable with the default search path
-fairly easily::
+fairly easily:
+
+.. code-block:: console
 
     $ export DEFAULT_TZPATH=$(python -c \
         "import os, zoneinfo; print(os.pathsep.join(zoneinfo.TZPATH))")
@@ -946,14 +950,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive (or ``canonical-pypa-spec``, for packaging PEPs)

PEP 615 was implemented back in Python 3.9.

Let's mark it as Final, add a banner link to the canonical docs at https://docs.python.org/3/library/zoneinfo.html, and remove a redundant header and footer.
