### PR TITLE
Floating-point/double is used, i.e. "optional" IEEE in C[11]

### DIFF
--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -31,7 +31,7 @@ particular rule:
 C dialect
 =========
 
-* Python 3.11 and newer versions use C11 without `optional features
+* Python 3.11 and newer versions use C11 without some `optional features
   <https://en.wikipedia.org/wiki/C11_%28C_standard_revision%29#Optional_features>`_.
   The public C API should be compatible with C++.
 


### PR DESCRIPTION
It may be unclear to many but C does not specify floating point. I.e. what float and double mean exactly. But Python's floats use double/Float64.

So that means at least one optional C feature is used, Annex F (`__STDC_IEC_559__`)?

This is sort of a nitpick/question.

But another issue with this PEP is "XP" unexplained. I believe it means "extreme programming", and maybe it's best to link it. Not all may be familiar so maybe it's NOT better to (simply) spell it out.

https://stackoverflow.com/questions/31181897/status-of-stdc-iec-559-with-modern-c-compilers 

https://softwarerecs.stackexchange.com/questions/78793/is-there-any-c-compiler-which-defines-both-stdc-and-stdc-iec-559-to-1  

https://gcc.gnu.org/onlinedocs/gcc/Floating-point-implementation.html
>The accuracy of the floating-point operations and of the library functions in <math.h> and <complex.h> that return floating-point results (C90, C99 and C11 5.2.4.2.2).
>The accuracy is unknown.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3593.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->