### PR TITLE
PEP 20: Added 20th Zen

### DIFF
--- a/peps/pep-0020.rst
+++ b/peps/pep-0020.rst
@@ -11,9 +11,7 @@ Post-History: 22-Aug-2004
 Abstract
 ========
 
-Long time Pythoneer Tim Peters succinctly channels the BDFL's guiding
-principles for Python's design into 20 aphorisms, only 19 of which
-have been written down.
+Tim Peters, a seasoned Python developer, eloquently distilled the founding principles of Python's design, as envisioned by the BDFL, into 20 maxims. However, only 19 of these were originally documented. SmartManoj has contributed the final one.
 
 
 The Zen of Python
@@ -40,6 +38,7 @@ The Zen of Python
     If the implementation is hard to explain, it's a bad idea.
     If the implementation is easy to explain, it may be a good idea.
     Namespaces are one honking great idea -- let's do more of those!
+    Avoid shadows on your path; name your creations uniquely to prevent confusion with those who walk the standard library's trail.
 
 
 Easter Egg


### PR DESCRIPTION
Many Python beginners often name their files using the same names as Python's standard modules. This common practice can lead to unintentional conflicts and errors in the program, as Python may import the user's file instead of the intended standard module. This Zen underscores the importance of choosing unique and descriptive names for files to avoid such conflicts and ensure smoother programming experiences.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [ ] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3595.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->