### PR TITLE
PEP 617: Mark as Final

### DIFF
--- a/peps/pep-0617.rst
+++ b/peps/pep-0617.rst
@@ -4,12 +4,13 @@ Author: Guido van Rossum <guido@python.org>,
         Pablo Galindo <pablogsal@python.org>,
         Lysandros Nikolaou <lisandrosnik@gmail.com>
 Discussions-To: python-dev@python.org
-Status: Accepted
+Status: Final
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 24-Mar-2020
 Python-Version: 3.9
 Post-History: 02-Apr-2020
+
+.. canonical-doc:: `the full grammar specification <https://docs.python.org/3/reference/grammar.html>`__
 
 .. highlight:: PEG
 
@@ -184,7 +185,7 @@ is, the collection of all valid Python programs).
 Similar workarounds appear in multiple other rules of the current grammar.
 Sometimes this problem is unsolvable. For instance, `bpo-12782: Multiple context
 expressions do not support parentheses for continuation across lines
-<http://bugs.python.org/issue12782>`_ shows how making an LL(1) rule that supports
+<https://github.com/python/cpython/issues/56991>`_ shows how making an LL(1) rule that supports
 writing::
 
   with (
@@ -254,7 +255,7 @@ the code in the CST production is reused in the module). Which is worse: the who
 tree is kept in memory, keeping many branches that consist of chains of nodes with
 a single child. This has been shown to consume a considerable amount of memory (for
 instance in `bpo-26415: Excessive peak memory consumption by the Python
-parser <https://bugs.python.org/issue26415>`_).
+parser <https://github.com/python/cpython/issues/70603>`_).
 
 Having to produce an intermediate result between the grammar and the AST is not only
 undesirable but also makes the AST generation step much more complicated, raising
@@ -715,7 +716,9 @@ taking the median of three runs. No particular care was taken to stop
 other applications running on the same machine.
 
 The first timings are for our canonical test file, which has 100,000
-lines endlessly repeating the following three lines::
+lines endlessly repeating the following three lines:
+
+.. code-block:: python
 
     1 + 2 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + ((((((11 * 12 * 13 * 14 * 15 + 16 * 17 + 18 * 19 * 20))))))
     2*3 + 4*5*6


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive (or ``canonical-pypa-spec``, for packaging PEPs)

Helps https://github.com/python/peps/issues/2872.

Also replace some old BPO links with their more accessible GitHub issue equivalents, and update some code block formatting.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3596.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->