### PR TITLE
PEP 617: Update canonical link

### DIFF
--- a/peps/pep-0617.rst
+++ b/peps/pep-0617.rst
@@ -10,7 +10,7 @@ Created: 24-Mar-2020
 Python-Version: 3.9
 Post-History: 02-Apr-2020
 
-.. canonical-doc:: `the full grammar specification <https://docs.python.org/3/reference/grammar.html>`__
+.. canonical-doc:: :ref:`python:full-grammar-specification`
 
 .. highlight:: PEG
 


### PR DESCRIPTION
Follow on from https://github.com/python/peps/pull/3596.

Sorry for the second PR, I forgot to actually commit this for the first PR...

Using a Sphinx label is more reliable in case of later re-orgs.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3597.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->