### PR TITLE
PEP 590: Mark as Final

### DIFF
--- a/peps/pep-0590.rst
+++ b/peps/pep-0590.rst
@@ -4,10 +4,11 @@ Author: Mark Shannon <mark@hotpy.org>, Jeroen Demeyer <J.Demeyer@UGent.be>
 BDFL-Delegate: Petr Viktorin <encukou@gmail.com>
 Status: Accepted
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 29-Mar-2019
 Python-Version: 3.8
 Post-History:
+
+.. canonical-doc:: :ref:`python:vectorcall`
 
 Abstract
 ========
@@ -323,14 +324,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive (or ``canonical-pypa-spec``, for packaging PEPs)

Helps https://github.com/python/peps/issues/2872.

This is still listed under "[Accepted PEPs (accepted; may not be implemented yet)](https://peps.python.org/#accepted-peps-accepted-may-not-be-implemented-yet)".

If it's fully implemented, let's mark it as Final and add a banner linking to the canonical docs at https://docs.python.org/3/c-api/call.html#vectorcall.

Also remove a redundant header and footer.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3598.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->