### PR TITLE
PEP 495 and 732: Add alt text to images

### DIFF
--- a/peps/pep-0495.rst
+++ b/peps/pep-0495.rst
@@ -37,7 +37,7 @@ will enumerate the two ambiguous times.
 
 .. image:: pep-0495-daylightsavings.png
    :align: center
-   :alt: A cartoon of a strong man struggling to the hands of a large clock.
+   :alt: A cartoon of a strong man struggling to stop the hands of a large clock.
          The caption reads: You can't stop time... but you can turn it back one
          hour at 2 a.m. Oct. 28 when daylight-saving time ends and standard time
          begins."

--- a/peps/pep-0495.rst
+++ b/peps/pep-0495.rst
@@ -37,6 +37,10 @@ will enumerate the two ambiguous times.
 
 .. image:: pep-0495-daylightsavings.png
    :align: center
+   :alt: A cartoon of a strong man struggling to the hands of a large clock.
+         The caption reads: You can't stop time... but you can turn it back one
+         hour at 2 a.m. Oct. 28 when daylight-saving time ends and standard time
+         begins."
    :width: 30%
 
 
@@ -386,6 +390,8 @@ the ``fold`` attribute depending on the kind of the transition.
 
 .. image:: pep-0495-fold.svg
   :align: center
+  :alt: Diagram of relationship between UTC and local time around a
+        fall-back transition – see full description on page.
   :width: 60%
   :class: invert-in-dark-mode
 
@@ -412,6 +418,8 @@ effect after the transition should be used.
 
 .. image:: pep-0495-gap.svg
   :align: center
+  :alt: Diagram of relationship between UTC and local time around a
+        spring-forward transition – see full description on page.
   :width: 60%
   :class: invert-in-dark-mode
 

--- a/peps/pep-0732.rst
+++ b/peps/pep-0732.rst
@@ -34,7 +34,13 @@ development community and the greater Python documentation
 contributors work together to achieve this:
 
 .. image:: pep-0732-concentric.drawio.svg
+   :align: center
+   :alt: Three concentric circles. At the centre: Documentation Editorial
+         Board, trusted group. Around this: Documentation Working Group,
+         volunteers who contribute to the docs. Finally, the outer circle
+         is the world, includes readers of the documentation.
    :class: invert-in-dark-mode
+   :width: 75%
 
 
 Specification


### PR DESCRIPTION
Improves accessibility, as recommended by PEP 12:
 
https://peps.python.org/pep-0012/#images

(Let's try and make sure images in new PEPs have alt text.)

Also centre the image in PEP 732; PEP 495's already are centred.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3606.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->