### PR TITLE
PEP 11: wasm32-unknown-emscripten is no longer supported

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -125,7 +125,6 @@ aarch64-pc-windows-msvc                                      Steve Dower
 armv7l-unknown-linux-gnueabihf   Raspberry Pi OS, glibc, gcc Gregory P. Smith
 powerpc64le-unknown-linux-gnu    glibc, clang                Victor Stinner
 s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
-wasm32-unknown-emscripten                                    Brett Cannon
 wasm32-unknown-wasi                                          Brett Cannon, Eric Snow
 x86_64-unknown-freebsd           BSD libc, clang             Victor Stinner
 ================================ =========================== ========
@@ -354,6 +353,10 @@ No-longer-supported platforms
 * | Name:             Systems without multithreading support
   | Unsupported in:   Python 3.7
   | Code removed in:  Python 3.7
+
+* | Name:             wasm32-unknown-emscripten
+  | Unsupported in:   Python 3.13
+  | Code removed in:  Unknown
 
 
 Discussions


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3612.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->