### PR TITLE
PEP 669: Mark final

### DIFF
--- a/peps/pep-0669.rst
+++ b/peps/pep-0669.rst
@@ -10,6 +10,8 @@ Post-History: `07-Dec-2021 <https://mail.python.org/archives/list/python-dev@pyt
               `10-Jan-2022 <https://discuss.python.org/t/pep-669-low-impact-monitoring-for-cpython/13018>`__,
 Resolution: https://discuss.python.org/t/pep-669-low-impact-monitoring-for-cpython/13018/42
 
+.. canonical-doc:: :mod:`python:sys.monitoring`
+
 Abstract
 ========
 

--- a/peps/pep-0669.rst
+++ b/peps/pep-0669.rst
@@ -1,8 +1,7 @@
 PEP: 669
 Title: Low Impact Monitoring for CPython
 Author: Mark Shannon <mark@hotpy.org>
-Discussions-To: https://discuss.python.org/t/pep-669-low-impact-monitoring-for-cpython/13018/
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 18-Aug-2021

--- a/peps/pep-0669.rst
+++ b/peps/pep-0669.rst
@@ -1,9 +1,9 @@
 PEP: 669
 Title: Low Impact Monitoring for CPython
 Author: Mark Shannon <mark@hotpy.org>
+Discussions-To: https://discuss.python.org/t/pep-669-low-impact-monitoring-for-cpython/13018/
 Status: Final
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 18-Aug-2021
 Python-Version: 3.12
 Post-History: `07-Dec-2021 <https://mail.python.org/archives/list/python-dev@python.org/thread/VNSD4TSAM2BM64FJNIQPAOPNEGNX4MDX/>`__,


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [x] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive (or ``canonical-pypa-spec``, for packaging PEPs)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3615.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->