### PR TITLE
PEP 11: Add note about interpreting current Windows release

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -183,6 +183,13 @@ as the original feature release, even if no longer supported by Microsoft.
 New versions of Windows released while CPython is in maintenance mode
 may be supported at the discretion of the core team and release manager.
 
+As of 2024, our current interpretation of Microsoft's lifecycles is that
+Windows for IoT and embedded systems is out of scope for new CPython releases,
+as the intent of those is to avoid feature updates. Windows Server will usually
+be the oldest version still receiving free security fixes, and that will
+determine the earliest supported client release with equivalent API version
+(which will usually be past its end-of-life).
+
 Each feature release is built by a specific version of Microsoft
 Visual Studio. That version should have mainstream support when the
 release is made. Developers of extension modules will generally need


### PR DESCRIPTION
Just proposed text right now for discussion, but as the text of the policy requires a bit of interpretation (since Microsoft changes their lifecycle and set of releases frequently), I think it's worth writing our current intention in here.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3617.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->