### PR TITLE
PEP 1: Remove outdated info about omitting delegate's email address

### DIFF
--- a/peps/pep-0001.rst
+++ b/peps/pep-0001.rst
@@ -651,8 +651,7 @@ out.
 
 The PEP-Delegate field is used to record the individual appointed by the
 Steering Council to make the final decision on whether or not to approve or
-reject a PEP. (The delegate's email address is currently omitted due to a
-limitation in the email address masking for reStructuredText PEPs.)
+reject a PEP.
 
 *Note: The Resolution header is required for Standards Track PEPs
 only.  It contains a URL that should point to an email message or


### PR DESCRIPTION
Remove:

> (The delegate's email address is currently omitted due to a
limitation in the email address masking for reStructuredText PEPs.)

I don't know when this changed, but some 81 of 117 PEP-Delegate fields have email addresses.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3622.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->