### PR TITLE
PEP 719: Update for 3.13.0a3

### DIFF
--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -39,7 +39,7 @@ Actual:
 - 3.13 development begins: Monday, 2023-05-22
 - 3.13.0 alpha 1: Friday, 2023-10-13
 - 3.13.0 alpha 2: Wednesday, 2023-11-22
-- 3.13.0 alpha 4: Wednesday, 2024-01-17
+- 3.13.0 alpha 3: Wednesday, 2024-01-17
 
 Expected:
 

--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -13,13 +13,7 @@ Abstract
 ========
 
 This document describes the development and release schedule for
-Python 3.13.  The schedule primarily concerns itself with PEP-sized
-items.
-
-.. Small features may be added up to the first beta
-   release.  Bugs may be fixed until the final release,
-   which is planned for October 2024.
-
+Python 3.13.
 
 Release Manager and Crew
 ========================
@@ -45,14 +39,13 @@ Actual:
 - 3.13 development begins: Monday, 2023-05-22
 - 3.13.0 alpha 1: Friday, 2023-10-13
 - 3.13.0 alpha 2: Wednesday, 2023-11-22
+- 3.13.0 alpha 4: Wednesday, 2024-01-17
 
 Expected:
 
-- 3.13.0 alpha 3: Tuesday, 2023-12-19
-- 3.13.0 alpha 4: Tuesday, 2024-01-16
-- 3.13.0 alpha 5: Tuesday, 2024-02-13
-- 3.13.0 alpha 6: Tuesday, 2024-03-12
-- 3.13.0 alpha 7: Tuesday, 2024-04-09
+- 3.13.0 alpha 4: Tuesday, 2024-02-13
+- 3.13.0 alpha 5: Tuesday, 2024-03-12
+- 3.13.0 alpha 6: Tuesday, 2024-04-09
 - 3.13.0 beta 1: Tuesday, 2024-05-07
   (No new features beyond this point.)
 - 3.13.0 beta 2: Tuesday, 2024-05-28


### PR DESCRIPTION

Update PEP 719 for 3.13.0a3's release, and adjust the future alpha's for the skipping of the Christmas alpha. Also drop the mention of "PEP-sized items" since we no longer try to keep track of PEPs for the release in the release schedule itself.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3623.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->