### PR TITLE
PEP 735: Minor updates and fixes

### DIFF
--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -154,7 +154,7 @@ Use Cases
 ---------
 
 The following use cases are considered important targets for this PEP. They are
-defined in greater detail in the `Use Cases Appendix <use_cases>`_.
+defined in greater detail in the :ref:`Use Cases Appendix <use_cases>`.
 
 * Web Applications deployed via a non-python-packaging build process
 * Libraries with unpublished dev dependency groups
@@ -1052,7 +1052,7 @@ without relying on packaging metadata, and without trying to express their
 needs in packaging terms.
 
 Libraries
-'''''''''
+---------
 
 Libraries are python packages which build distributions (sdist and wheel) and
 publish them to PyPI.
@@ -1090,7 +1090,7 @@ install the appropriate Dependency Groups along with the library when needed,
 as in the case of ``test``.
 
 Data Science Projects
-'''''''''''''''''''''
+---------------------
 
 Data Science Projects typically take the form of a logical collection of
 scripts and utilities for processing and analyzing data, using a common
@@ -1133,7 +1133,7 @@ scripts. Such combinations of data are left as a problem for tool authors to
 solve, and perhaps eventually standardize.
 
 Lockfile Generation
-'''''''''''''''''''
+-------------------
 
 There are a number of tools which generate lockfiles in the Python ecosystem
 today. PDM and Poetry each use their own lockfile formats, and pip-tools
@@ -1174,7 +1174,7 @@ As two examples of how combinations might be locked:
   solution, rather than a set or matrix of solutions.)
 
 Environment Manager Inputs
-''''''''''''''''''''''''''
+--------------------------
 
 A common usage in tox, Nox, and Hatch is to install a set of dependencies into
 a testing environment.
@@ -1217,7 +1217,7 @@ environment managers, the environment managers will need to support processing
 Dependency Groups similarly to how they support inline dependency declaration.
 
 IDE and Editor Use of Requirements Data
-'''''''''''''''''''''''''''''''''''''''
+---------------------------------------
 
 IDE and Editor integrations may benefit from conventional or configurable name
 definitions for Dependency Groups which are used for integrations.

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -195,6 +195,20 @@ further:
 * installation of a Dependency Group does not imply installation of a package's
   dependencies (or the package itself)
 
+Future Compatibility & Invalid Data
+-----------------------------------
+
+Dependency Groups are intended to be extensible in future PEPs.
+However, Dependency Groups should also be usable by multiple tools in a
+single Python project.
+With multiple tools using the same data, it is possible that one implements
+a future PEP which extends Dependency Groups, while another does not.
+
+To support users in this case, this PEP defines and recommends validation
+behaviors in which tools only examine Dependency Groups which they are using.
+This allows multiple tools, using different versions of Dependency Groups data,
+to share a single table in ``pyproject.toml``.
+
 Specification
 =============
 

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -1048,10 +1048,10 @@ Web Applications
 A web application (e.g. a Django or Flask app) often does not need to build a
 distribution, but bundles and ships its source to a deployment toolchain.
 
-For example, a source code repository may define python packaging metadata as
+For example, a source code repository may define Python packaging metadata as
 well as containerization or other build pipeline metadata (``Dockerfile``,
 etc).
-The python application is built by copying the entire repository into a
+The Python application is built by copying the entire repository into a
 build context, installing dependencies, and bundling the result as a machine
 image or container.
 
@@ -1068,7 +1068,7 @@ needs in packaging terms.
 Libraries
 ---------
 
-Libraries are python packages which build distributions (sdist and wheel) and
+Libraries are Python packages which build distributions (sdist and wheel) and
 publish them to PyPI.
 
 For libraries, Dependency Groups represent an alternative to ``extras`` for
@@ -1109,7 +1109,7 @@ Data Science Projects
 Data Science Projects typically take the form of a logical collection of
 scripts and utilities for processing and analyzing data, using a common
 toolchain. Components may be defined in the Jupyter Notebook format (ipynb),
-but rely on the same common core set of utlities.
+but rely on the same common core set of utilities.
 
 In such a project, there is no package to build or install. Therefore,
 ``pyproject.toml`` currently does not offer any solution for dependency
@@ -1233,7 +1233,7 @@ Dependency Groups similarly to how they support inline dependency declaration.
 IDE and Editor Use of Requirements Data
 ---------------------------------------
 
-IDE and Editor integrations may benefit from conventional or configurable name
+IDE and editor integrations may benefit from conventional or configurable name
 definitions for Dependency Groups which are used for integrations.
 
 There are at least two known scenarios in which it is valuable for an editor or


### PR DESCRIPTION
There are two commits here.

One is to fix some mistakes which were noted in the PEP thread.

The other adds a note to the Rationale section about designing the spec to allow for future extensions to the data.
Such "future compatibility" is an explicit goal of the PEP.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3627.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->