### PR TITLE
PEP 11: Move powerpc64le to tier 3

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -104,7 +104,6 @@ aarch64-apple-darwin          clang                      Ned Deily, Ronald Ousso
 aarch64-unknown-linux-gnu     glibc, gcc                 Petr Viktorin, Victor Stinner
 
                               glibc, clang               Victor Stinner, Gregory P. Smith
-powerpc64le-unknown-linux-gnu glibc, gcc                 Petr Viktorin, Victor Stinner
 x86_64-unknown-linux-gnu      glibc, clang               Victor Stinner, Gregory P. Smith
 ============================= ========================== ========
 
@@ -124,6 +123,8 @@ Target Triple                    Notes                       Contacts
 aarch64-pc-windows-msvc                                      Steve Dower
 armv7l-unknown-linux-gnueabihf   Raspberry Pi OS, glibc, gcc Gregory P. Smith
 powerpc64le-unknown-linux-gnu    glibc, clang                Victor Stinner
+
+                                 glibc, gcc                  Victor Stinner
 s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
 wasm32-unknown-wasi                                          Brett Cannon, Eric Snow
 x86_64-unknown-freebsd           BSD libc, clang             Victor Stinner


### PR DESCRIPTION
As announced in https://discuss.python.org/t/43534, I'm stepping down as the contact for powerpc64le.
This demotes the platform to Tier 3 (which is the right place for it, IMO).

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3632.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->