### PR TITLE
PEP 11: Make unsupporting a platform less draconian

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -222,11 +222,11 @@ If a platform drops out of tiered support, a note must be posted
 in this PEP that the platform is no longer actively supported.  This
 note must include:
 
-- the name of the system
-- the first release number that does not support this platform
+- The name of the system,
+- The first release number that does not support this platform
   anymore, and
-- the first release where the historical support code is actively
-  removed
+- The first release where the historical support code is actively
+  removed.
 
 In some cases, it is not possible to identify the specific list of
 systems for which some code is used (e.g. when autoconf tests for
@@ -235,11 +235,15 @@ supported systems).  In this case, the name will give the precise
 condition (usually a preprocessor symbol) that will become
 unsupported.
 
-At the same time, the CPython source code must be changed to
-produce a build-time error if somebody tries to install CPython on
-this platform.  On platforms using autoconf, configure must fail.
-This gives potential users of the platform a chance to step
-forward and offer maintenance.
+At the same time, the CPython build must be changed to produce a
+warning if somebody tries to install CPython on this platform.  On
+platforms using autoconf, configure should also be made emit a warning
+about the unsupported platform.
+
+This gives potential users of the platform a chance to step forward
+and offer maintenance.  Yet we do not treat a no longer tier supported
+platform any worse than we treat existing never officially tier
+supported platforms.
 
 
 No-longer-supported platforms

--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -241,9 +241,8 @@ platforms using autoconf, configure should also be made emit a warning
 about the unsupported platform.
 
 This gives potential users of the platform a chance to step forward
-and offer maintenance.  Yet we do not treat a no longer tier supported
-platform any worse than we treat existing never officially tier
-supported platforms.
+and offer maintenance.  At the same time, we do not treat a platform that
+loses Tier 3 support any worse than a platform that was never supported.
 
 
 No-longer-supported platforms

--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -242,8 +242,8 @@ platforms using autoconf, configure should also be made emit a warning
 about the unsupported platform.
 
 This gives potential users of the platform a chance to step forward
-and offer maintenance.  At the same time, we do not treat a platform that
-loses Tier 3 support any worse than a platform that was never supported.
+and offer maintenance.  We do not treat a platform that loses Tier 3
+support any worse than a platform that was never supported.
 
 
 No-longer-supported platforms


### PR DESCRIPTION
This loosens the statements about builds and configure needing to Break and instead changes this to a mere build/configure time warning. This is in line with how we treat platforms that are not on a support Tier (of which there are many).  Doing anything else would basically be unreasonable punshiment for anything in our support Tiers that then loses its official PEP-11 support for whatever reason.

Discuss this change in https://discuss.python.org/t/proposed-update-to-pep-11-on-unsupporting-a-platform-less-draconian-measures/44065

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3633.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->