### PR TITLE
PEP 739: don't use raw text in specification titles

### DIFF
--- a/peps/pep-0739.rst
+++ b/peps/pep-0739.rst
@@ -43,41 +43,41 @@ Specification
 The standard Python installation description format consists of the JSON
 representation of a dictionary with the with the following keys.
 
-``schema_version``
-------------------
+schema_version
+--------------
 
 :Type: ``number``
 :Description: Version of the schema to parse the file contents. It should be
               ``1`` for the format described in this document. Future versions
               may add, remove, or change fields.
 
-``language``
-------------
+language
+--------
 
 Subsection with details related to the language specification.
 
-``version``
-~~~~~~~~~~~
+version
+~~~~~~~
 
 :Type: ``string``
 :Description: String representation the Python language version. Same as the
               ``PY_VERSION`` macro on CPython.
 
-``version_parts``
-~~~~~~~~~~~~~~~~~
+version_parts
+~~~~~~~~~~~~~
 
 :Type: ``object``
 :Description: Equivalent to :py:data:`sys.version_info`.
 
-``implementation``
-------------------
+implementation
+--------------
 
 Subsection with details related to Python implementation. While only the
 ``name`` key is required in this section, this section SHOULD be equivalent to
 :py:data:`sys.implementation` on most implementations.
 
-``name``
-~~~~~~~~
+name
+~~~~
 
 :Type: ``string``
 :Description: Lower-case name of the Python implementation.
@@ -88,16 +88,16 @@ Implementation-specific keys
 Additionally to the keys defined above, implementations may choose to include
 extra keys with extra implementation-specific details.
 
-``c_api``
----------
+c_api
+-----
 
 Subsection with details related to the Python C API, if available. If the Python
 implementation does not provide a C API, this section will be missing.
 
 TODO
 
-``libpython``
--------------
+libpython
+---------
 
 Subsection with details related to the ``libpython``, if available. If the
 Python implementation does not provide a ``libpython`` library, this section


### PR DESCRIPTION
Just a minor visual improvement, as with raw text it becomes quite difficult to distinguish the smaller subsections.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3634.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->