### PR TITLE
PEP 740: update discussions-to

### DIFF
--- a/peps/pep-0740.rst
+++ b/peps/pep-0740.rst
@@ -9,7 +9,8 @@ Status: Draft
 Type: Informational
 Topic: Packaging
 Created: 08-Jan-2024
-Post-History: `29-Jan-2024 <https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498>`__
+Post-History: `2-Jan-2024 <https://discuss.python.org/t/pre-pep-exposing-trusted-publisher-provenance-on-pypi/42337>`__,
+              `29-Jan-2024 <https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498>`__
 
 Abstract
 ========

--- a/peps/pep-0740.rst
+++ b/peps/pep-0740.rst
@@ -9,7 +9,7 @@ Status: Draft
 Type: Informational
 Topic: Packaging
 Created: 08-Jan-2024
-Post-History: `2-Jan-2024 <https://discuss.python.org/t/pre-pep-exposing-trusted-publisher-provenance-on-pypi/42337>`__,
+Post-History: `02-Jan-2024 <https://discuss.python.org/t/pre-pep-exposing-trusted-publisher-provenance-on-pypi/42337>`__,
               `29-Jan-2024 <https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498>`__
 
 Abstract

--- a/peps/pep-0740.rst
+++ b/peps/pep-0740.rst
@@ -9,6 +9,7 @@ Status: Draft
 Type: Informational
 Topic: Packaging
 Created: 08-Jan-2024
+Post-History: `29-Jan-2024 <https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498>`__
 
 Abstract
 ========

--- a/peps/pep-0740.rst
+++ b/peps/pep-0740.rst
@@ -4,7 +4,7 @@ Author: William Woodruff <william@yossarian.net>,
         Facundo Tuesca <facundo.tuesca@trailofbits.com>
 Sponsor: Donald Stufft <donald@stufft.io>
 PEP-Delegate: Donald Stufft <donald@stufft.io>
-Discussions-To: https://discuss.python.org/t/pre-pep-exposing-trusted-publisher-provenance-on-pypi/42337
+Discussions-To: https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498
 Status: Draft
 Type: Informational
 Topic: Packaging


### PR DESCRIPTION
Per PEP 1, I've opened a discussion thread here: https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3635.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->