### PR TITLE
PEPs 729, 731, 732: Add contact for asking for a decision

### DIFF
--- a/peps/pep-0729.rst
+++ b/peps/pep-0729.rst
@@ -438,6 +438,14 @@ a slow process that can often end in inaction. The latter can result in a less
 consistent ecosystem. Finally, easily legible governance structures make the
 community more accessible and equitable.
 
+Contact
+=======
+
+To ask the Typing Council for a decision,
+community members may open an issue in the
+`python/typing-council <https://github.com/python/typing-council/>`__
+repository.
+
 Copyright
 =========
 

--- a/peps/pep-0731.rst
+++ b/peps/pep-0731.rst
@@ -188,6 +188,14 @@ or through a change to this PEP.
 In either case, the change will be decided upon
 by the Steering Council after discussion in the community.
 
+Contact
+=======
+
+To ask the C API Working Group for a decision,
+community members may open an issue in the
+`capi-workgroup/decisions <https://github.com/capi-workgroup/decisions/>`__
+repository.
+
 Copyright
 =========
 

--- a/peps/pep-0732.rst
+++ b/peps/pep-0732.rst
@@ -186,6 +186,15 @@ docstrings in the standard library, once the Board is sufficiently established
 and the higher priorities have been taken care of.
 
 
+Contact
+=======
+
+To ask the Editorial Board for a decision,
+community members may open an issue in the
+`python/editorial-board <https://github.com/python/editorial-board/>`__
+repository.
+
+
 Copyright
 =========
 


### PR DESCRIPTION
Add contact details to the three new governance PEPs, pointing to the repos where community members can open an issue to ask for a decision.

Re: https://devguide.python.org/developer-workflow/development-cycle/#governance
