### PR TITLE
PEP 705: fix typo in "Motivation" section.

### DIFF
--- a/peps/pep-0705.rst
+++ b/peps/pep-0705.rst
@@ -118,7 +118,7 @@ However, this no longer works once you start nesting dictionaries::
         d["name"] = name
         update_metadata_timestamp(d)  # Type check error: "metadata" is not of type HasTimestamp
 
-This looks like an error, but is simply due to the (unwanted) ability to overwrite the ``metadata`` item held by the ``HasTimestampedMetadata`` instance with a different ``HasTimestamp`` instance, that may no longer be a ``UserAudit`` instance.
+This looks like an error, but is simply due to the (unwanted) ability to overwrite the ``metadata`` item held by the ``HasTimestampedMetadata`` instance with a different ``HasTimestamp`` instance, that may no longer be a ``Logs`` instance.
 
 It is possible to work around this issue with generics (as of Python 3.11), but it is very complicated, requiring a type parameter for every nested dict.
 


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

I think it's meant to say `Logs` instead of `UserAudit` here, as it's `Logs` that has a `timestamp` key in the example.

cc @alicederyn 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3640.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->