### PR TITLE
PEP 696: some suggestions to make the text clearer

### DIFF
--- a/peps/pep-0696.rst
+++ b/peps/pep-0696.rst
@@ -318,7 +318,10 @@ Subclassing
 '''''''''''
 
 Subclasses of ``Generic``\ s with type parameters that have defaults
-behave similarly to ``Generic`` ``TypeAlias``\ es.
+behave similarly to ``Generic`` ``TypeAlias``\ es. That is, subclasses can be
+further subscripted following normal subscription rules, non-overridden
+defaults should be substituted in, and type parameters with such defaults can be
+further specialised down the line.
 
 ::
 

--- a/peps/pep-0696.rst
+++ b/peps/pep-0696.rst
@@ -247,9 +247,9 @@ Bound Rules
 ::
 
    T1 = TypeVar("T1", bound=int)
-   TypeVar("Ok", default=T1, bound=float)        # Valid
-   TypeVar("AlsoOk", default=T1, bound=int)  # Valid
-   TypeVar("Invalid", default=T1, bound=str)   # Invalid: int is not a subtype of str
+   TypeVar("Ok", default=T1, bound=float)     # Valid
+   TypeVar("AlsoOk", default=T1, bound=int)   # Valid
+   TypeVar("Invalid", default=T1, bound=str)  # Invalid: int is not a subtype of str
 
 Constraint Rules
 ~~~~~~~~~~~~~~~~

--- a/peps/pep-0696.rst
+++ b/peps/pep-0696.rst
@@ -216,19 +216,8 @@ default to the type of ``start`` and step default to ``int | None``.
    Foo[int](1, "")          # Invalid: Foo[int, str] cannot be assigned to self: Foo[int, int] in Foo.__init__
    Foo[int]("", 1)          # Invalid: Foo[str, int] cannot be assigned to self: Foo[int, int] in Foo.__init__
 
-When using a type parameter as the default to another type parameter.
-Where ``T1`` is the default for ``T2`` the following rules apply.
-
-``TypeVarTuple``\s are not supported because:
-
-- `Scoping Rules`_ does not allow usage of type parameters
-  from outer scopes.
-- Multiple ``TypeVarTuple``\s cannot appear in the type
-  parameter list for a single object, as specified in
-  :pep:`646#multiple-type-variable-tuples-not-allowed`.
-
-These reasons leave no current valid location where a
-``TypeVarTuple`` could be used as the default of another ``TypeVarTuple``.
+When using a type parameter as the default to another type parameter, the
+following rules apply, where ``T1`` is the default for ``T2``.
 
 Scoping Rules
 ~~~~~~~~~~~~~
@@ -420,6 +409,20 @@ for the ``ParamSpec`` and one for the ``TypeVarTuple``.
 
    Foo[int, str]  # Ts = (int, str), P = [float, bool]
    Foo[int, str, [bytes]]  # Ts = (int, str), P = [bytes]
+
+``TypeVarTuple``s as Defaults
+'''''''''''''''''''''''''''''
+
+Using a ``TypeVarTuple`` as a default is not supported because:
+
+- `Scoping Rules`_ does not allow usage of type parameters
+  from outer scopes.
+- Multiple ``TypeVarTuple``\s cannot appear in the type
+  parameter list for a single object, as specified in
+  :pep:`646#multiple-type-variable-tuples-not-allowed`.
+
+These reasons leave no current valid location where a
+``TypeVarTuple`` could be used as the default of another ``TypeVarTuple``.
 
 Binding rules
 -------------

--- a/peps/pep-0696.rst
+++ b/peps/pep-0696.rst
@@ -230,7 +230,7 @@ Scoping Rules
 
    class Foo(Generic[T1, T2]): ...   # Valid
    class Foo(Generic[T1]):
-       class Bar(Generic[T2]): ...  # Valid
+       class Bar(Generic[T2]): ...   # Valid
 
    StartT = TypeVar("StartT", default="StopT")  # Swapped defaults around from previous example
    StopT = TypeVar("StopT", default=int)

--- a/peps/pep-0696.rst
+++ b/peps/pep-0696.rst
@@ -413,14 +413,14 @@ for the ``ParamSpec`` and one for the ``TypeVarTuple``.
    Foo[int, str]  # Ts = (int, str), P = [float, bool]
    Foo[int, str, [bytes]]  # Ts = (int, str), P = [bytes]
 
-``TypeVarTuple``s as Defaults
-'''''''''''''''''''''''''''''
+``TypeVarTuple``\ s as Defaults
+'''''''''''''''''''''''''''''''
 
 Using a ``TypeVarTuple`` as a default is not supported because:
 
 - `Scoping Rules`_ does not allow usage of type parameters
   from outer scopes.
-- Multiple ``TypeVarTuple``\s cannot appear in the type
+- Multiple ``TypeVarTuple``\ s cannot appear in the type
   parameter list for a single object, as specified in
   :pep:`646#multiple-type-variable-tuples-not-allowed`.
 

--- a/peps/pep-0696.rst
+++ b/peps/pep-0696.rst
@@ -226,11 +226,11 @@ Scoping Rules
 
 ::
 
-   DefaultT = TypeVar("DefaultT", default=T)
+   T2 = TypeVar("T2", default=T1)
 
-   class Foo(Generic[T, DefaultT]): ...   # Valid
-   class Foo(Generic[T]):
-       class Bar(Generic[DefaultT]): ...  # Valid
+   class Foo(Generic[T1, T2]): ...   # Valid
+   class Foo(Generic[T1]):
+       class Bar(Generic[T2]): ...  # Valid
 
    StartT = TypeVar("StartT", default="StopT")  # Swapped defaults around from previous example
    StopT = TypeVar("StopT", default=int)
@@ -246,10 +246,10 @@ Bound Rules
 
 ::
 
-   T = TypeVar("T", bound=float)
-   TypeVar("Ok", default=T, bound=int)        # Valid
-   TypeVar("AlsoOk", default=T, bound=float)  # Valid
-   TypeVar("Invalid", default=T, bound=str)   # Invalid: str is not a subtype of float
+   T1 = TypeVar("T1", bound=float)
+   TypeVar("Ok", default=T1, bound=int)        # Valid
+   TypeVar("AlsoOk", default=T1, bound=float)  # Valid
+   TypeVar("Invalid", default=T1, bound=str)   # Invalid: str is not a subtype of float
 
 Constraint Rules
 ~~~~~~~~~~~~~~~~

--- a/peps/pep-0696.rst
+++ b/peps/pep-0696.rst
@@ -242,14 +242,14 @@ Using a type parameter from an outer scope as a default is not supported.
 Bound Rules
 ~~~~~~~~~~~
 
-``T2``'s bound must be a subtype of ``T1``'s bound.
+``T1``'s bound must be a subtype of ``T2``'s bound.
 
 ::
 
-   T1 = TypeVar("T1", bound=float)
-   TypeVar("Ok", default=T1, bound=int)        # Valid
-   TypeVar("AlsoOk", default=T1, bound=float)  # Valid
-   TypeVar("Invalid", default=T1, bound=str)   # Invalid: str is not a subtype of float
+   T1 = TypeVar("T1", bound=int)
+   TypeVar("Ok", default=T1, bound=float)        # Valid
+   TypeVar("AlsoOk", default=T1, bound=int)  # Valid
+   TypeVar("Invalid", default=T1, bound=str)   # Invalid: int is not a subtype of str
 
 Constraint Rules
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

I've made some suggested edits to the text for readability and fixed what I think is a typo in a code example. Feel free to reject any edits that don't make sense.

cc @Gobot1234 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3641.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->