### PR TITLE
PEP 700: Mark as Final

### DIFF
--- a/peps/pep-0700.rst
+++ b/peps/pep-0700.rst
@@ -3,14 +3,14 @@ Title: Additional Fields for the Simple API for Package Indexes
 Author: Paul Moore <p.f.moore@gmail.com>
 PEP-Delegate: Donald Stufft <donald@stufft.io>
 Discussions-To: https://discuss.python.org/t/pep-700-additional-fields-for-the-simple-api-for-package-indexes/20177
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Packaging
-Content-Type: text/x-rst
 Created: 21-Oct-2022
 Post-History: `21-Oct-2022 <https://discuss.python.org/t/pep-700-additional-fields-for-the-simple-api-for-package-indexes/20177>`__
 Resolution: https://discuss.python.org/t/pep-700-additional-fields-for-the-simple-api-for-package-indexes/20177/42
 
+.. canonical-pypa-spec:: :ref:`packaging:simple-repository-api`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps https://github.com/python/peps/issues/2872.

The new `size` and `upload-time` fields have been documented in the spec: 

* https://packaging.python.org/en/latest/specifications/simple-repository-api/#additional-file-information

And have been implemented at least in:

* PyPI: https://github.com/pypi/warehouse/pull/12727
* Bandersnatch: https://github.com/pypa/bandersnatch/pull/1557
* pypi-simple: https://github.com/jwodder/pypi-simple/issues/5
* Mousebender: https://github.com/brettcannon/mousebender/pull/93



<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3643.org.readthedocs.build/pep-0700/

<!-- readthedocs-preview pep-previews end -->