### PR TITLE
PEP 673: Mark as Final

### DIFF
--- a/peps/pep-0673.rst
+++ b/peps/pep-0673.rst
@@ -1,19 +1,18 @@
 PEP: 673
 Title: Self Type
-Version: $Revision$
-Last-Modified: $Date$
 Author: Pradeep Kumar Srinivasan <gohanpra@gmail.com>,
         James Hilton-Balfe <gobot1234yt@gmail.com>
 Sponsor: Jelle Zijlstra <jelle.zijlstra@gmail.com>
 Discussions-To: typing-sig@python.org
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 10-Nov-2021
 Python-Version: 3.11
 Post-History: 17-Nov-2021
 Resolution: https://mail.python.org/archives/list/python-dev@python.org/thread/J7BWL5KWOPQQK5KFWKENVLXW6UGSPTGI/
+
+.. canonical-typing-spec:: :ref:`typing:self`
 
 Abstract
 ========
@@ -805,14 +804,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps https://github.com/python/peps/issues/2872.

Documented in the typing spec at https://typing.readthedocs.io/en/latest/spec/generics.html#self


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3644.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->