### PR TITLE
PEP 544: Mark as Final

### DIFF
--- a/peps/pep-0544.rst
+++ b/peps/pep-0544.rst
@@ -1,17 +1,16 @@
 PEP: 544
 Title: Protocols: Structural subtyping (static duck typing)
-Version: $Revision$
-Last-Modified: $Date$
 Author: Ivan Levkivskyi <levkivskyi@gmail.com>, Jukka Lehtosalo <jukka.lehtosalo@iki.fi>, Łukasz Langa <lukasz@python.org>
 BDFL-Delegate: Guido van Rossum <guido@python.org>
 Discussions-To: python-dev@python.org
 Status: Accepted
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 05-Mar-2017
 Python-Version: 3.8
 Resolution: https://mail.python.org/archives/list/typing-sig@python.org/message/FDO4KFYWYQEP3U2HVVBEBR3SXPHQSHYR/
+
+.. canonical-typing-spec:: :ref:`typing:protocols`
 
 
 Abstract


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps https://github.com/python/peps/issues/2872.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3646.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->