### PR TITLE
PEP 544: Mark as Final (take 2)

### DIFF
--- a/peps/pep-0544.rst
+++ b/peps/pep-0544.rst
@@ -3,7 +3,7 @@ Title: Protocols: Structural subtyping (static duck typing)
 Author: Ivan Levkivskyi <levkivskyi@gmail.com>, Jukka Lehtosalo <jukka.lehtosalo@iki.fi>, Łukasz Langa <lukasz@python.org>
 BDFL-Delegate: Guido van Rossum <guido@python.org>
 Discussions-To: python-dev@python.org
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
 Created: 05-Mar-2017


### PR DESCRIPTION
Follow on from https://github.com/python/peps/pull/3646, _actually_ change the status to "Final" this time...

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3647.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->