### PR TITLE
PEP 696: consolidate discussion of constraint solving in "Function Defaults" section, add new "Subtyping" section

### DIFF
--- a/peps/pep-0696.rst
+++ b/peps/pep-0696.rst
@@ -17,8 +17,7 @@ Abstract
 
 This PEP introduces the concept of type defaults for type parameters,
 including ``TypeVar``, ``ParamSpec``, and ``TypeVarTuple``,
-which act as defaults for a type parameter when one is not specified or
-the constraint solver isn't able to solve a type parameter to anything.
+which act as defaults for type parameters for which no type is specified.
 
 Default type argument support is available in some popular languages
 such as C++, TypeScript, and Rust. A survey of type parameter syntax in
@@ -182,8 +181,7 @@ or another in-scope ``TypeVarTuple`` (see `Scoping Rules`_).
 Using Another Type Parameter as ``default``
 ''''''''''''''''''''''''''''''''''''''''''''
 
-This allows for a value to be used again when the constraints solver
-fails to solve a constraint for a type, or the type parameter to a
+This allows for a value to be used again when the type parameter to a
 generic is missing but another type parameter is specified.
 
 To use another type parameter as a default the ``default`` and the
@@ -381,11 +379,18 @@ subtype of one of the constraints.
 Function Defaults
 '''''''''''''''''
 
-We leave the semantics of type parameter defaults in generic functions
-unspecified, as ensuring the ``default`` is returned in every code path
-where the type parameter can go unsolved may be too hard to implement.
-Type checkers are free to either disallow this case or experiment with
-implementing support.
+In generic functions, type checkers may use a type parameter's default when the
+type parameter cannot be solved to anything. We leave the semantics of this
+usage unspecified, as ensuring the ``default`` is returned in every code path
+where the type parameter can go unsolved may be too hard to implement. Type
+checkers are free to either disallow this case or experiment with implementing
+support.
+
+::
+
+   T = TypeVar('T', default=int)
+   def func(x: int | set[T]) -> T: ...
+   reveal_type(func(0))  # a type checker may reveal T's default of int here
 
 Defaults following ``TypeVarTuple``
 '''''''''''''''''''''''''''''''''''

--- a/peps/pep-0696.rst
+++ b/peps/pep-0696.rst
@@ -426,6 +426,13 @@ for the ``ParamSpec`` and one for the ``TypeVarTuple``.
    Foo[int, str]  # Ts = (int, str), P = [float, bool]
    Foo[int, str, [bytes]]  # Ts = (int, str), P = [bytes]
 
+Subtyping
+'''''''''
+
+Type parameter defaults do not affect the subtyping rules for generic classes.
+In particular, defaults can be ignored when considering whether a class is
+compatible with a generic protocol.
+
 Binding rules
 -------------
 


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

A couple more proposed changes (likely the last ones from me):
* Consolidates discussion of usage of defaults in constraint solving in the "Function Defaults" section, to make it more obvious that this is experimental. Otherwise, I find it confusing for the abstract to mention a usage that is then not precisely specified.
* Adds a section that explicitly calls out that type parameter defaults don't affect subtyping.

cc @Gobot1234 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3648.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->