### PR TITLE
Meta: Remove theller from `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -153,7 +153,7 @@ peps/pep-0293.rst  @doerwalter
 # peps/pep-0295.rst
 # peps/pep-0296.rst
 peps/pep-0297.rst  @malemburg
-peps/pep-0298.rst  @theller
+peps/pep-0298.rst
 # peps/pep-0299.rst
 # peps/pep-0301.rst
 peps/pep-0302.rst  @pfmoore

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -153,7 +153,7 @@ peps/pep-0293.rst  @doerwalter
 # peps/pep-0295.rst
 # peps/pep-0296.rst
 peps/pep-0297.rst  @malemburg
-peps/pep-0298.rst
+# peps/pep-0298.rst
 # peps/pep-0299.rst
 # peps/pep-0301.rst
 peps/pep-0302.rst  @pfmoore


### PR DESCRIPTION
The https://github.com/python/peps/blob/main/.github/CODEOWNERS file is showing errors:

> This CODEOWNERS file contains errors
>
> Unknown owner on line 156: make sure @theller exists and has write access to the repository
> `peps/pep-0298.rst  @theller`


https://github.com/theller aka Thomas Heller hasn't been active on GitHub for a long time, and I presume  was removed from the https://github.com/python org as a result of requiring 2FA:

* https://github.com/python/steering-council/issues/91#issuecomment-1932716492

Thomas resigned as a committer in 2011: https://pythoninsider.blogspot.com/2011/04/thomas-heller-steps-down-as-ctypes.html. [PEP 298](https://peps.python.org/pep-0298/) was withdrawn in 2002, so it's unlikely to need updates and we don't need an explicit CODEOWNER for it.

@theller If need to be re-added to the org, please turn on 2FA and comment on the issue above.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3650.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->