### PR TITLE
Fix HTML "Last Modified" link in the footer

### DIFF
--- a/pep_sphinx_extensions/pep_processor/transforms/pep_footer.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_footer.py
@@ -66,7 +66,7 @@ def _add_commit_history_info(pep_source_path: Path) -> nodes.paragraph:
     except KeyError:
         return nodes.paragraph()
 
-    commit_link = f"https://github.com/python/peps/commits/main/{pep_source_path.name}"
+    commit_link = f"https://github.com/python/peps/commits/main/peps/{pep_source_path.name}"
     link_node = nodes.reference("", f"{iso_time} GMT", refuri=commit_link)
     return nodes.paragraph("", "Last modified: ", link_node)
 

--- a/pep_sphinx_extensions/tests/pep_processor/transform/test_pep_footer.py
+++ b/pep_sphinx_extensions/tests/pep_processor/transform/test_pep_footer.py
@@ -16,7 +16,7 @@ def test_add_commit_history_info():
 
     assert str(out).startswith(
         "<paragraph>Last modified: "
-        '<reference refuri="https://github.com/python/peps/commits/main/pep-0008.rst">'
+        '<reference refuri="https://github.com/python/peps/commits/main/peps/pep-0008.rst">'
     )
     # A variable timestamp comes next, don't test that
     assert str(out).endswith("</reference></paragraph>")


### PR DESCRIPTION
Add "peps/" to the URL.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3653.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->