### PR TITLE
PEP 11: promote `wasm32-wasi` to tier 2

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -104,6 +104,8 @@ aarch64-apple-darwin          clang                      Ned Deily, Ronald Ousso
 aarch64-unknown-linux-gnu     glibc, gcc                 Petr Viktorin, Victor Stinner
 
                               glibc, clang               Victor Stinner, Gregory P. Smith
+s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
+wasm32-unknown-wasi           WASI SDK, Wasmtime         Brett Cannon, Eric Snow
 x86_64-unknown-linux-gnu      glibc, clang               Victor Stinner, Gregory P. Smith
 ============================= ========================== ========
 
@@ -125,8 +127,6 @@ armv7l-unknown-linux-gnueabihf   Raspberry Pi OS, glibc, gcc Gregory P. Smith
 powerpc64le-unknown-linux-gnu    glibc, clang                Victor Stinner
 
                                  glibc, gcc                  Victor Stinner
-s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
-wasm32-unknown-wasi                                          Brett Cannon, Eric Snow
 x86_64-unknown-freebsd           BSD libc, clang             Victor Stinner
 ================================ =========================== ========
 

--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -104,7 +104,6 @@ aarch64-apple-darwin          clang                      Ned Deily, Ronald Ousso
 aarch64-unknown-linux-gnu     glibc, gcc                 Petr Viktorin, Victor Stinner
 
                               glibc, clang               Victor Stinner, Gregory P. Smith
-s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
 wasm32-unknown-wasi           WASI SDK, Wasmtime         Brett Cannon, Eric Snow
 x86_64-unknown-linux-gnu      glibc, clang               Victor Stinner, Gregory P. Smith
 ============================= ========================== ========
@@ -127,6 +126,7 @@ armv7l-unknown-linux-gnueabihf   Raspberry Pi OS, glibc, gcc Gregory P. Smith
 powerpc64le-unknown-linux-gnu    glibc, clang                Victor Stinner
 
                                  glibc, gcc                  Victor Stinner
+s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
 x86_64-unknown-freebsd           BSD libc, clang             Victor Stinner
 ================================ =========================== ========
 


### PR DESCRIPTION
Approved by the SC at https://github.com/python/steering-council/issues/223#issuecomment-1910376006 .

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3655.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->