### PR TITLE
Withdrawing PEP 724.

### DIFF
--- a/peps/pep-0724.rst
+++ b/peps/pep-0724.rst
@@ -13,7 +13,7 @@ Created: 28-Jul-2023
 Python-Version: 3.13
 Post-History: `30-Dec-2021 <https://mail.python.org/archives/list/typing-sig@python.org/thread/EMUD2D424OI53DCWQ4H5L6SJD2IXBHUL/>`__,
               `19-Sep-2023 <https://discuss.python.org/t/pep-724-stricter-type-guards/34124>`__,
-              `07-Feb-2024 Withdrawn`
+              `08-Feb-2024 <https://github.com/python/typing-council/issues/10>` __,
 
 Status
 ======

--- a/peps/pep-0724.rst
+++ b/peps/pep-0724.rst
@@ -5,7 +5,7 @@ Author: Rich Chiodo <rchiodo at microsoft.com>,
         Erik De Bonte <erikd at microsoft.com>,
 Sponsor: Jelle Zijlstra <jelle.zijlstra@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-724-stricter-type-guards/34124
-Status: Draft
+Status: Withdrawn
 Type: Standards Track
 Topic: Typing
 Content-Type: text/x-rst
@@ -13,6 +13,14 @@ Created: 28-Jul-2023
 Python-Version: 3.13
 Post-History: `30-Dec-2021 <https://mail.python.org/archives/list/typing-sig@python.org/thread/EMUD2D424OI53DCWQ4H5L6SJD2IXBHUL/>`__,
               `19-Sep-2023 <https://discuss.python.org/t/pep-724-stricter-type-guards/34124>`__,
+              `07-Feb-2024 Withdrawn`
+
+Status
+======
+
+This PEP is withdrawn. The Typing Council was unable to reach consensus on
+this proposal, and the authors decided to withdraw it.
+
 
 Abstract
 ========

--- a/peps/pep-0724.rst
+++ b/peps/pep-0724.rst
@@ -13,7 +13,7 @@ Created: 28-Jul-2023
 Python-Version: 3.13
 Post-History: `30-Dec-2021 <https://mail.python.org/archives/list/typing-sig@python.org/thread/EMUD2D424OI53DCWQ4H5L6SJD2IXBHUL/>`__,
               `19-Sep-2023 <https://discuss.python.org/t/pep-724-stricter-type-guards/34124>`__,
-              `08-Feb-2024 <https://github.com/python/typing-council/issues/10>` __,
+              `08-Feb-2024 <https://github.com/python/typing-council/issues/10>`__,
 
 Status
 ======

--- a/peps/pep-0724.rst
+++ b/peps/pep-0724.rst
@@ -13,7 +13,6 @@ Created: 28-Jul-2023
 Python-Version: 3.13
 Post-History: `30-Dec-2021 <https://mail.python.org/archives/list/typing-sig@python.org/thread/EMUD2D424OI53DCWQ4H5L6SJD2IXBHUL/>`__,
               `19-Sep-2023 <https://discuss.python.org/t/pep-724-stricter-type-guards/34124>`__,
-              `08-Feb-2024 <https://github.com/python/typing-council/issues/10>`__,
 
 Status
 ======


### PR DESCRIPTION
<!--
The Typing Council was unable to come to unanimous agreement on PEP 724. The TC members are in agreement that the “strict semantics” described in PEP 724 are useful and address feedback from developers about the original TypeGuard (introduced in PEP 647). There was disagreement about whether to modify the existing TypeGuard semantics (as proposed in PEP 724) or introduce a new special form that offers different semantics from the original TypeGuard. The majority of TC members are concerned about the backward compatibility implications of modifying the existing TypeGuard semantics and therefore recommend an approach that differs from the current PEP’s proposal.

The authors of the PEP have consequently decided to withdraw PEP 724. This opens the door for alternative proposals to be put forth.

https://github.com/python/typing-council/issues/10
-->



<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3656.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->