### PR TITLE
Add the "Discussions-To"/"Post-History" headers and fix a typo.

### DIFF
--- a/peps/pep-0728.rst
+++ b/peps/pep-0728.rst
@@ -2,12 +2,14 @@ PEP: 728
 Title: TypedDict with Typed Extra Items
 Author: Zixuan James Li <p359101898@gmail.com>
 Sponsor: Jelle Zijlstra <jelle.zijlstra@gmail.com>
+Discussions-To: https://discuss.python.org/t/pep-728-typeddict-with-typed-extra-items/45443
 Status: Draft
 Type: Standards Track
 Topic: Typing
 Content-Type: text/x-rst
 Created: 12-Sep-2023
 Python-Version: 3.13
+Post-History: `09-Feb-2024 <https://discuss.python.org/t/pep-728-typeddict-with-typed-extra-items/45443>`__,
 
 
 .. highlight:: rst
@@ -608,7 +610,7 @@ For example:
         [index: string]: number | string
     }
 
-This is a known limitation is discussed in `TypeScript's issue tracker
+This is a known limitation discussed in `TypeScript's issue tracker
 <https://github.com/microsoft/TypeScript/issues/17867>`__,
 where it is suggested that there should be a way to exclude the defined keys
 from the index signature, so that it is possible to define a type like


### PR DESCRIPTION
I have posted the thread at https://discuss.python.org/t/pep-728-typeddict-with-typed-extra-items/45443.
The headers have been updated. This should be ready for review, thanks! @JelleZijlstra 


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3658.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->