### PR TITLE
Infra: Increase spacing between complex list items

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -74,6 +74,15 @@ section#pep-page-section {
     padding: 0.25rem;
 }
 
+/* This is likely very close to the browser default, but we make it a variable
+ * so it can be used in other rules. */
+:root {
+    --paragraph-margin-vertical: 1em;
+}
+p {
+    margin: var(--paragraph-margin-vertical) 0;
+}
+
 /* Header rules */
 h1 {
     font-size: 2rem;
@@ -196,6 +205,18 @@ ol.loweralpha {list-style: lower-alpha}
 ol.upperalpha {list-style: upper-alpha}
 ol.lowerroman {list-style: lower-roman}
 ol.upperroman {list-style: upper-roman}
+
+/* We can't express this as a single rule using `not(.simple)`, because when a
+ * simple list is nested inside another simple list, the inner list is not given
+ * a class. So instead we use two rules, one more specific than the other. */
+#pep-content ol li,
+#pep-content ul li {
+    margin: var(--paragraph-margin-vertical) 0;
+}
+#pep-content ol.simple li,
+#pep-content ul.simple li {
+    margin: 0 0;
+}
 
 /* Maths rules */
 sub,


### PR DESCRIPTION
A "simple" list is one whose items all consist of a single paragraph, optionally followed by a nested list which is itself simple. Sphinx detects such lists and gives them the `simple` class, but does not make any other structural changes to the HTML output. 

The PEP style sheet currently does nothing with this class. As a result, when a list contains a mixture of single-paragraph and multi-paragraph items, it's common for a paragraph to appear closer to paragraphs of a different item than it is to other paragraphs of the same item. This obscures the logical structure of the text.

This PR fixes that by adding spacing between the items of "complex" (i.e. non-simple) lists, equal to the spacing between regular paragraphs. For example, in PEP 595:

<table><tr>
<td>
<a href="https://peps.python.org/pep-0595/">BEFORE</a>
<img width="350" alt="Screenshot 2024-02-12 at 20 32 51" src="https://github.com/python/peps/assets/166954/8ba57003-2f9c-4859-a884-b9ad95b979e2">
</td>
<td>
<a href="https://pep-previews--3662.org.readthedocs.build/pep-0595/">AFTER</a>
<img width="350" alt="Screenshot 2024-02-12 at 20 33 24" src="https://github.com/python/peps/assets/166954/fbeb248f-0b6f-42f5-bf4d-e9481eede39c">
</td>
</tr></table>

By definition, a simple list cannot contain a complex list. But if a complex list contains a simple list, it is still rendered compactly. For example, in PEP 572:

<table><tr>
<td>
<a href="https://peps.python.org/pep-0572/">BEFORE</a>
<img width="350" alt="Screenshot 2024-02-12 at 20 34 23" src="https://github.com/python/peps/assets/166954/a5d30c67-30d7-4d96-92e2-fc74bba690a8">
</td>
<td>
<a href="https://pep-previews--3662.org.readthedocs.build/pep-0572/">AFTER</a>
<img width="350" alt="Screenshot 2024-02-12 at 20 34 40" src="https://github.com/python/peps/assets/166954/8cb1ed7d-f194-4d8d-8fce-25da0e6e0409">
</td>
</tr></table>

A multi-level simple list only has the `simple` class on its top-level element. The rendering of such lists has not changed. For example, in PEP 432 (<a href="https://peps.python.org/pep-0432/">BEFORE</a> / <a href="https://pep-previews--3662.org.readthedocs.build/pep-0432/">AFTER</a>):

<img width="350" alt="Screenshot 2024-02-12 at 20 35 56" src="https://github.com/python/peps/assets/166954/c21a2cf4-a284-466f-bee8-ad110f082f5e">


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3662.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->