### PR TITLE
PEP 732: Specify that the Python Wiki is not in scope

### DIFF
--- a/peps/pep-0732.rst
+++ b/peps/pep-0732.rst
@@ -96,6 +96,9 @@ The Editorial board oversees the content and strategy for the following:
      - PyPA documentation
    * - 
      - www.python.org
+   * - 
+     - The Python Wiki (wiki.python.org)
+
 
 Composition
 ~~~~~~~~~~~


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [x] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3663.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->