### PR TITLE
PEP 591: Mark as Final

### DIFF
--- a/peps/pep-0591.rst
+++ b/peps/pep-0591.rst
@@ -3,15 +3,15 @@ Title: Adding a final qualifier to typing
 Author: Michael J. Sullivan <sully@msully.net>, Ivan Levkivskyi <levkivskyi@gmail.com>
 BDFL-Delegate: Guido van Rossum <guido@python.org>
 Discussions-To: typing-sig@python.org
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 15-Mar-2019
 Python-Version: 3.8
 Post-History:
 Resolution: https://mail.python.org/archives/list/typing-sig@python.org/message/FDO4KFYWYQEP3U2HVVBEBR3SXPHQSHYR/
 
+.. canonical-typing-spec:: :ref:`typing:at-final` and :ref:`typing:uppercase-final`
 
 Abstract
 ========
@@ -288,12 +288,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps https://github.com/python/peps/issues/3579 and #2872.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3668.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->