### PR TITLE
PEP 593: Mark as Final

### DIFF
--- a/peps/pep-0593.rst
+++ b/peps/pep-0593.rst
@@ -3,13 +3,14 @@ Title: Flexible function and variable annotations
 Author: Till Varoquaux <till@fb.com>, Konstantin Kashin <kkashin@fb.com>
 Sponsor: Ivan Levkivskyi <levkivskyi@gmail.com>
 Discussions-To: typing-sig@python.org
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 26-Apr-2019
 Python-Version: 3.9
 Post-History: 20-May-2019
+
+.. canonical-typing-spec:: :ref:`annotated`
 
 Abstract
 --------


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps https://github.com/python/peps/issues/3579 and #2872.
