### PR TITLE
PEP 613: Mark as Final

### DIFF
--- a/peps/pep-0613.rst
+++ b/peps/pep-0613.rst
@@ -3,14 +3,14 @@ Title: Explicit Type Aliases
 Author: Shannon Zhu <szhu@fb.com>
 Sponsor: Guido van Rossum <guido@python.org>
 Discussions-To: https://mail.python.org/archives/list/typing-sig@python.org/thread/MWRJOBEEEMFVXE7CAKO7B4P46IPM4AN3/
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 21-Jan-2020
 Python-Version: 3.10
 Post-History: 21-Jan-2020
 
+.. canonical-typing-spec:: :ref:`typing:type-aliases`
 
 Abstract
 ========
@@ -226,13 +226,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/peps/pep-0613.rst
+++ b/peps/pep-0613.rst
@@ -218,7 +218,7 @@ Version History
 
 * 2021-11-16
 
-    * Allow TypeAlias inside class scope
+  * Allow ``TypeAlias`` inside class scope
 
 
 Copyright


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps #3579 and #2872.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3670.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->