### PR TITLE
PEP 646: Mark as Final

### DIFF
--- a/peps/pep-0646.rst
+++ b/peps/pep-0646.rst
@@ -5,14 +5,15 @@ Author: Mark Mendoza <mendoza.mark.a@gmail.com>,
         Pradeep Kumar Srinivasan <gohanpra@gmail.com>,
         Vincent Siles <vsiles@fb.com>
 Sponsor: Guido van Rossum <guido@python.org>
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 16-Sep-2020
 Python-Version: 3.11
 Post-History: 07-Oct-2020, 23-Dec-2020, 29-Dec-2020
 Resolution: https://mail.python.org/archives/list/python-dev@python.org/message/OR5RKV7GAVSGLVH3JAGQ6OXFAXIP5XDX/
+
+.. canonical-typing-spec:: :ref:`typevartuple`
 
 Abstract
 ========
@@ -1693,13 +1694,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps #3579 and #2872.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3671.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->