### PR TITLE
PEP 655: Mark as Final

### DIFF
--- a/peps/pep-0655.rst
+++ b/peps/pep-0655.rst
@@ -6,12 +6,12 @@ Discussions-To: https://mail.python.org/archives/list/typing-sig@python.org/thre
 Status: Accepted
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 30-Jan-2021
 Python-Version: 3.11
 Post-History: 31-Jan-2021, 11-Feb-2021, 20-Feb-2021, 26-Feb-2021, 17-Jan-2022, 28-Jan-2022
 Resolution: https://mail.python.org/archives/list/python-dev@python.org/message/AJEDNVC3FXM5QXNNW5CR4UCT4KI5XVUE/
 
+.. canonical-typing-spec:: :ref:`typing:required-notrequired`
 
 Abstract
 ========
@@ -667,13 +667,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/peps/pep-0655.rst
+++ b/peps/pep-0655.rst
@@ -3,7 +3,7 @@ Title: Marking individual TypedDict items as required or potentially-missing
 Author: David Foster <david at dafoster.net>
 Sponsor: Guido van Rossum <guido at python.org>
 Discussions-To: https://mail.python.org/archives/list/typing-sig@python.org/thread/53XVOD5ZUKJ263MWA6AUPEA6J7LBBLNV/
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
 Created: 30-Jan-2021

--- a/peps/pep-0655.rst
+++ b/peps/pep-0655.rst
@@ -309,7 +309,8 @@ within the same TypedDict definition:
 
 Yes:
 
-::
+.. code-block::
+   :class: good
 
    from __future__ import annotations  # for Python 3.7-3.9
 
@@ -319,7 +320,8 @@ Yes:
 
 Okay (required for Python 3.5.3-3.6):
 
-::
+.. code-block::
+   :class: maybe
 
    class Dog(TypedDict):
        name: str
@@ -327,7 +329,8 @@ Okay (required for Python 3.5.3-3.6):
 
 No:
 
-::
+.. code-block::
+   :class: bad
 
    class Dog(TypedDict):
        name: str
@@ -345,7 +348,8 @@ than ``typing.TypedDict`` because the latter will not understand
 
 Yes (Python 3.11+ only):
 
-::
+.. code-block::
+   :class: good
 
    from typing import NotRequired, TypedDict
 
@@ -355,7 +359,8 @@ Yes (Python 3.11+ only):
 
 Yes (Python <3.11 and 3.11+):
 
-::
+.. code-block::
+   :class: good
 
    from __future__ import annotations  # for Python 3.7-3.9
 
@@ -367,7 +372,8 @@ Yes (Python <3.11 and 3.11+):
 
 No (Python <3.11 and 3.11+):
 
-::
+.. code-block::
+   :class: bad
 
    from typing import TypedDict  # oops: should import from typing_extensions instead
    from typing_extensions import NotRequired


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps #3579 and #2872.

Also add green/yellow/red sidebars for the yes/okay/no codeblocks, similar to [PEP 8](https://peps.python.org/pep-0008/):

![image](https://github.com/python/peps/assets/1324225/8ab32c0d-1cfb-48e3-a281-44cd78c632d6)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3672.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->