### PR TITLE
PEP 681: Mark as Final

### DIFF
--- a/peps/pep-0681.rst
+++ b/peps/pep-0681.rst
@@ -4,10 +4,9 @@ Author: Erik De Bonte <erikd at microsoft.com>,
         Eric Traut <erictr at microsoft.com>
 Sponsor: Jelle Zijlstra <jelle.zijlstra at gmail.com>
 Discussions-To: https://mail.python.org/archives/list/typing-sig@python.org/thread/EAALIHA3XEDFDNG2NRXTI3ERFPAD65Z4/
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 02-Dec-2021
 Python-Version: 3.11
 Post-History: `24-Apr-2021 <https://mail.python.org/archives/list/typing-sig@python.org/thread/TXL5LEHYX5ZJAZPZ7YHZU7MVFXMVUVWL/>`__,
@@ -15,6 +14,7 @@ Post-History: `24-Apr-2021 <https://mail.python.org/archives/list/typing-sig@pyt
               `22-Feb-2022 <https://mail.python.org/archives/list/typing-sig@python.org/thread/BW6CB6URC4BCN54QSG2STINU2M7V4TQQ/>`__
 Resolution: https://mail.python.org/archives/list/python-dev@python.org/message/R4A2IYLGFHKFDYJPSDA5NFJ6N7KRPJ6D/
 
+.. canonical-typing-spec:: :ref:`typing:dataclass-transform`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps #3579 and #2872.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3674.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->