### PR TITLE
PEP 695: Mark as Final

### DIFF
--- a/peps/pep-0695.rst
+++ b/peps/pep-0695.rst
@@ -12,7 +12,10 @@ Post-History: `20-Jun-2022 <https://mail.python.org/archives/list/typing-sig@pyt
               `04-Dec-2022 <https://discuss.python.org/t/pep-695-type-parameter-syntax/21646>`__
 Resolution: https://discuss.python.org/t/pep-695-type-parameter-syntax/21646/92
 
-.. canonical-typing-spec:: :ref:`typing:variance-inference`
+.. canonical-typing-spec:: :ref:`typing:variance-inference`,
+                           :ref:`python:type-params`,
+                           :ref:`python:type` and
+                           :ref:`python:annotation-scopes`.
 
 Abstract
 ========

--- a/peps/pep-0695.rst
+++ b/peps/pep-0695.rst
@@ -3,16 +3,16 @@ Title: Type Parameter Syntax
 Author: Eric Traut <erictr at microsoft.com>
 Sponsor: Guido van Rossum <guido@python.org>
 Discussions-To: https://mail.python.org/archives/list/typing-sig@python.org/thread/BB2BGYJY2YG5IWESKGTAPUQL3N27ZKVW/
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 15-Jun-2022
 Python-Version: 3.12
 Post-History: `20-Jun-2022 <https://mail.python.org/archives/list/typing-sig@python.org/thread/BB2BGYJY2YG5IWESKGTAPUQL3N27ZKVW/>`__,
               `04-Dec-2022 <https://discuss.python.org/t/pep-695-type-parameter-syntax/21646>`__
 Resolution: https://discuss.python.org/t/pep-695-type-parameter-syntax/21646/92
 
+.. canonical-typing-spec:: :ref:`typing:variance-inference`
 
 Abstract
 ========

--- a/peps/pep-0695.rst
+++ b/peps/pep-0695.rst
@@ -13,6 +13,7 @@ Post-History: `20-Jun-2022 <https://mail.python.org/archives/list/typing-sig@pyt
 Resolution: https://discuss.python.org/t/pep-695-type-parameter-syntax/21646/92
 
 .. canonical-typing-spec:: :ref:`typing:variance-inference`,
+                           :ref:`typing:type-aliases`,
                            :ref:`python:type-params`,
                            :ref:`python:type` and
                            :ref:`python:annotation-scopes`.


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps #3579 and #2872.



<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3675.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->