### PR TITLE
PEP 698: Mark as Final

### DIFF
--- a/peps/pep-0698.rst
+++ b/peps/pep-0698.rst
@@ -5,10 +5,9 @@ Author: Steven Troxler <steven.troxler@gmail.com>,
         Shannon Zhu <szhu@fb.com>
 Sponsor: Jelle Zijlstra <jelle.zijlstra at gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-698-a-typing-override-decorator/20839
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 05-Sep-2022
 Python-Version: 3.12
 Post-History: `20-May-2022 <https://mail.python.org/archives/list/typing-sig@python.org/thread/V23I4D6DEOFW4BBPWBMYTHZUOMKR7KQE/>`__,
@@ -16,6 +15,8 @@ Post-History: `20-May-2022 <https://mail.python.org/archives/list/typing-sig@pyt
               `11-Oct-2022 <https://mail.python.org/archives/list/typing-sig@python.org/thread/TOIYZ3SNPBJZDBRU3ZSBREXV2NNHF4KW/>`__,
               `07-Nov-2022 <https://discuss.python.org/t/pep-698-a-typing-override-decorator/20839>`__,
 Resolution: https://discuss.python.org/t/pep-698-a-typing-override-decorator/20839/11
+
+.. canonical-typing-spec:: :ref:`typing:override`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps #3579 and #2872.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3676.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->