### PR TITLE
PEP 604: Mark as Final

### DIFF
--- a/peps/pep-0604.rst
+++ b/peps/pep-0604.rst
@@ -4,14 +4,14 @@ Author: Philippe PRADOS <python@prados.fr>, Maggie Moss <maggiebmoss@gmail.com>
 Sponsor: Chris Angelico <rosuav@gmail.com>
 BDFL-Delegate: Guido van Rossum <guido@python.org>
 Discussions-To: typing-sig@python.org
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 28-Aug-2019
 Python-Version: 3.10
 Post-History: 28-Aug-2019, 05-Aug-2020
 
+.. canonical-typing-spec:: :ref:`python:types-union`
 
 Abstract
 ========
@@ -250,13 +250,3 @@ Copyright
 =========
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/peps/pep-0604.rst
+++ b/peps/pep-0604.rst
@@ -11,7 +11,7 @@ Created: 28-Aug-2019
 Python-Version: 3.10
 Post-History: 28-Aug-2019, 05-Aug-2020
 
-.. canonical-typing-spec:: :ref:`python:types-union`
+.. canonical-doc:: :ref:`python:types-union`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps #3579 and #2872.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3677.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->