### PR TITLE
PEP 692: Mark as Final

### DIFF
--- a/peps/pep-0692.rst
+++ b/peps/pep-0692.rst
@@ -3,10 +3,9 @@ Title: Using TypedDict for more precise \*\*kwargs typing
 Author: Franek Magiera <framagie@gmail.com>
 Sponsor: Jelle Zijlstra <jelle.zijlstra@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-692-using-typeddict-for-more-precise-kwargs-typing/17314
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 29-May-2022
 Python-Version: 3.12
 Post-History: `29-May-2022 <https://mail.python.org/archives/list/typing-sig@python.org/thread/U42MJE6QZYWPVIFHJIGIT7OE52ZGIQV3/>`__,
@@ -14,6 +13,7 @@ Post-History: `29-May-2022 <https://mail.python.org/archives/list/typing-sig@pyt
               `12-Jul-2022 <https://discuss.python.org/t/pep-692-using-typeddict-for-more-precise-kwargs-typing/17314>`__,
 Resolution: https://discuss.python.org/t/pep-692-using-typeddict-for-more-precise-kwargs-typing/17314/81
 
+.. canonical-typing-spec:: :ref:`typing:unpack-kwargs`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps #3579 and #2872.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3679.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->