### PR TITLE
PEP 735: Refine phrasing around 'non-standard' tool features

### DIFF
--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -168,8 +168,10 @@ Regarding Poetry and PDM Dependency Groups
 ------------------------------------------
 
 The existing Poetry and PDM tools already offer a feature which each calls
-"Dependency Groups", but using non-standard data belonging to the ``poetry``
-and ``pdm`` tools.
+"Dependency Groups". However, absent any standard for specifying collections
+of dependencies, each tool defines these in a tool-specific way, in the
+relevant sections of the ``[tool]`` table.
+
 (PDM also uses extras for some Dependency Groups, and overlaps the notion
 heavily with extras.)
 
@@ -180,8 +182,9 @@ to common dependency specifiers.
 It should be possible for such tools to use standardized Dependency Groups as
 extensions of their own Dependency Group mechanisms.
 However, defining a new data format which replaces the existing Poetry and PDM
-solutions is a non-goal, as it would require standardizing their various
-non-standard features.
+solutions is a non-goal. Doing so would require standardizing several
+additional features, such as path dependencies, which are supported by these
+tools.
 
 Dependency Groups are not Hidden Extras
 ---------------------------------------


### PR DESCRIPTION
One of the Poetry maintainers noted that the current phrasing could be read as a negative take on `poetry` and `pdm` using "non-standard" data.

At the same time, it's important to be clear that the problem being solved here is not adequately solved by the existing tools due to the lack of an existing underlying standard.

This rephrasing tries to balance these two concerns, describing the current behaviors as 'tool specific' and focusing on "standardization" (positive) rather than "non-standardization" (negative).


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3689.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->