### PR TITLE
PEP 742: Allow inferring the intersection type; carry over TypeGuard spec change

### DIFF
--- a/peps/pep-0742.rst
+++ b/peps/pep-0742.rst
@@ -190,6 +190,8 @@ argument's previously-known type::
 
     def f(x: Awaitable[int] | int) -> None:
         if isawaitable(x):
+            # Type checkers may also infer the more precise type
+            # "Awaitable[int] | (int & Awaitable[Any])"
             assert_type(x, Awaitable[int])
         else:
             assert_type(x, int)
@@ -204,11 +206,10 @@ It is an error to narrow to a type that is not consistent with the input type::
 Subtyping
 ---------
 
-``TypeIs`` is not a subtype of ``bool``.
-The type ``Callable[..., TypeIs[int]]`` is not assignable to
-``Callable[..., bool]`` or ``Callable[..., TypeGuard[int]]``, and vice versa.
-This restriction is carried over from :pep:`647`. It may be possible to relax
-it in the future, but that is outside the scope of this PEP.
+``TypeIs`` is also valid as the return type of a callable, for example
+in callback protocols and in the ``Callable`` special form. In these
+contexts, it is treated as a subtype of bool. For example, ``Callable[..., TypeIs[int]]``
+is assignable to ``Callable[..., bool]``.
 
 Unlike ``TypeGuard``, ``TypeIs`` is invariant in its argument type:
 ``TypeIs[B]`` is not a subtype of ``TypeIs[A]``,


### PR DESCRIPTION
* Awaitable example changed in accordance with https://discuss.python.org/t/pep-742-narrowing-types-with-typeis/45613/22
* bool compatibility rule changed following python/typing#1637

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3696.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->