### PR TITLE
PEP 738: clarify Android CI availability

### DIFF
--- a/peps/pep-0738.rst
+++ b/peps/pep-0738.rst
@@ -205,6 +205,10 @@ an Android-compatible build from the unpatched CPython source code. It does not
 necessarily require there to be any officially distributed Android artifacts on
 python.org, although these could be added in the future.
 
+Android will be built using the same configure and Makefile system as other
+POSIX platforms, and must therefore be built *on* a POSIX platform. Both Linux
+and macOS will be supported.
+
 A Gradle project will be provided for the purpose of running the CPython test
 suite. Tooling will be provided to automate the process of building the test
 suite app, starting the emulator, installing the test suite, and executing
@@ -323,13 +327,17 @@ identical or very similar operating system binaries, testing on emulators will
 be adequate. x86_64 emulators can be run on Linux, macOS or Windows, but ARM64
 emulators are only supported on ARM64 Macs.
 
-GitHub Actions is able to host Android emulators on their Linux and macOS
-runners. The free tier currently only provides x86_64 machines; however ARM64
-macOS runners `recently became available on paid plans <https://github.blog/
-2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/>`__.
+Anaconda `has offered
+<https://discuss.python.org/t/pep-738-adding-android-as-a-supported-platform/40975/20>`__
+to provide physical hardware to run Android buildbots. These will include both
+Linux x86_64 and macOS ARM64 machines, which would cover both supported runtime
+architectures and both supported build platforms.
 
-If necessary, `Anaconda <https://anaconda.com>`__ has also offered to provide
-Android CI resources.
+CPython does not currently test Tier 3 platforms on GitHub Actions, but if this
+ever changes, their Linux and macOS runners are also able to host Android
+emulators. macOS ARM64 runners have been free to all public repositories
+`since January 2024
+<https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/>`__.
 
 
 Packaging


### PR DESCRIPTION
This PR clarifies the following points which were [raised on Discourse](https://discuss.python.org/t/pep-738-adding-android-as-a-supported-platform/40975/19):

* The availability of buildbots and GitHub Actions resources for testing Python on Android. 
* That the supported build platforms for Android will be Linux and macOS.

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3700.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->