### PR TITLE
PEP 649 replaces 563

### DIFF
--- a/peps/pep-0563.rst
+++ b/peps/pep-0563.rst
@@ -11,6 +11,7 @@ Content-Type: text/x-rst
 Created: 08-Sep-2017
 Python-Version: 3.7
 Post-History: 01-Nov-2017, 21-Nov-2017
+Superseded-By: 649
 Resolution: https://mail.python.org/pipermail/python-dev/2017-December/151042.html
 
 

--- a/peps/pep-0649.rst
+++ b/peps/pep-0649.rst
@@ -19,6 +19,7 @@ Post-History: `11-Jan-2021 <https://mail.python.org/archives/list/python-dev@pyt
               `23-Nov-2022 <https://discuss.python.org/t/pep-649-deferred-evaluation-of-annotations-tentatively-accepted/21331>`__,
               `07-Feb-2023 <https://discuss.python.org/t/two-polls-on-how-to-revise-pep-649/23628>`__,
               `11-Apr-2023 <https://discuss.python.org/t/a-massive-pep-649-update-with-some-major-course-corrections/25672>`__,
+Replaces: 563
 Resolution: https://discuss.python.org/t/pep-649-deferred-evaluation-of-annotations-tentatively-accepted/21331/43
 
 ********


### PR DESCRIPTION
According to PEP 649, which is now Accepted:

> If accepted, this PEP would supersede [PEP 563](https://peps.python.org/pep-0563/), and [PEP 563](https://peps.python.org/pep-0563/)’s behavior would be deprecated and eventually removed.

Therefore I'm updating the metadata:
* on PEP 649 to reflect that it supersedes PEP 563 and
* on PEP 563 to reflect that it is replaced by PEP 649.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3701.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->