### PR TITLE
PEP 7: Remove Python 2.2 advice, add C syntax highlighting and green/red sidebars

### DIFF
--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -78,18 +78,18 @@ Code lay-out
   declarations.
 
   .. code-block::
-    :class: good
+     :class: good
 
-      static int
-      extra_ivars(PyTypeObject *type, PyTypeObject *base)
-      {
-          int t_size = PyType_BASICSIZE(type);
-          int b_size = PyType_BASICSIZE(base);
+     static int
+     extra_ivars(PyTypeObject *type, PyTypeObject *base)
+     {
+         int t_size = PyType_BASICSIZE(type);
+         int b_size = PyType_BASICSIZE(base);
 
-          assert(t_size >= b_size); /* type smaller than base! */
-          ...
-          return 1;
-      }
+         assert(t_size >= b_size); /* type smaller than base! */
+         ...
+         return 1;
+     }
 
 * Code structure: one space between keywords like ``if``, ``for`` and
   the following left paren; no spaces inside the paren; braces are
@@ -98,28 +98,28 @@ Code lay-out
   code requires braces.  Braces should be formatted as shown:
 
   .. code-block::
-    :class: good
+     :class: good
 
-      if (mro != NULL) {
-          ...
-      }
-      else {
-          ...
-      }
+     if (mro != NULL) {
+         ...
+     }
+     else {
+         ...
+     }
 
 * The return statement should *not* get redundant parentheses:
 
   .. code-block::
-    :class: bad
+     :class: bad
 
-      return(albatross); /* incorrect */
+     return(albatross); /* incorrect */
 
   Instead:
 
   .. code-block::
-    :class: good
+     :class: good
 
-      return albatross; /* correct */
+     return albatross; /* correct */
 
 * Function and macro call style: ``foo(a, b, c)`` -- no space before
   the open paren, no spaces inside the parens, no spaces before
@@ -134,25 +134,25 @@ Code lay-out
   e.g.:
 
   .. code-block::
-    :class: good
+     :class: good
 
-      PyErr_Format(PyExc_TypeError,
-                   "cannot create '%.100s' instances",
-                   type->tp_name);
+     PyErr_Format(PyExc_TypeError,
+                  "cannot create '%.100s' instances",
+                  type->tp_name);
 
 * When you break a long expression at a binary operator, the
   operator goes at the end of the previous line, and braces should be
   formatted as shown.  E.g.:
 
   .. code-block::
-    :class: good
+     :class: good
 
-      if (type->tp_dictoffset != 0 && base->tp_dictoffset == 0 &&
-          type->tp_dictoffset == b_size &&
-          (size_t)t_size == b_size + sizeof(PyObject *))
-      {
-          return 0; /* "Forgive" adding a __dict__ only */
-      }
+     if (type->tp_dictoffset != 0 && base->tp_dictoffset == 0 &&
+         type->tp_dictoffset == b_size &&
+         (size_t)t_size == b_size + sizeof(PyObject *))
+     {
+         return 0; /* "Forgive" adding a __dict__ only */
+     }
 
 * Vertically align line continuation characters in multi-line macros.
 
@@ -162,17 +162,17 @@ Code lay-out
   Example:
 
   .. code-block::
-    :class: good
+     :class: good
 
-      #define ADD_INT_MACRO(MOD, INT)                                   \
-          do {                                                          \
-              if (PyModule_AddIntConstant((MOD), (#INT), (INT)) < 0) {  \
-                  goto error;                                           \
-              }                                                         \
-          } while (0)
+     #define ADD_INT_MACRO(MOD, INT)                                   \
+         do {                                                          \
+             if (PyModule_AddIntConstant((MOD), (#INT), (INT)) < 0) {  \
+                 goto error;                                           \
+             }                                                         \
+         } while (0)
 
-      // To be used like a statement with a semicolon:
-      ADD_INT_MACRO(m, SOME_CONSTANT);
+     // To be used like a statement with a semicolon:
+     ADD_INT_MACRO(m, SOME_CONSTANT);
 
 * ``#undef`` file local macros after use.
 
@@ -189,11 +189,11 @@ Code lay-out
   the ``PyAPI_FUNC()`` macro and ``PyAPI_DATA()`` macro, like this:
 
   .. code-block::
-    :class: good
+     :class: good
 
-      PyAPI_FUNC(PyObject *) PyObject_Repr(PyObject *);
+     PyAPI_FUNC(PyObject *) PyObject_Repr(PyObject *);
 
-      PyAPI_DATA(PyTypeObject) PySuper_Type;
+     PyAPI_DATA(PyTypeObject) PySuper_Type;
 
 
 Naming conventions
@@ -230,11 +230,11 @@ Documentation Strings
   For example:
 
   .. code-block::
-    :class: good
+     :class: good
 
-      PyDoc_STRVAR(myfunction__doc__,
-      "myfunction(name, value) -> bool\n\n\
-      Determine whether name and value make a valid pair.");
+     PyDoc_STRVAR(myfunction__doc__,
+     "myfunction(name, value) -> bool\n\n\
+     Determine whether name and value make a valid pair.");
 
   Always include a blank line between the signature line and the text
   of the description.
@@ -248,21 +248,21 @@ Documentation Strings
   concatenation:
 
   .. code-block::
-    :class: good
+     :class: good
 
-      PyDoc_STRVAR(myfunction__doc__,
-      "myfunction(name, value) -> bool\n\n"
-      "Determine whether name and value make a valid pair.");
+     PyDoc_STRVAR(myfunction__doc__,
+     "myfunction(name, value) -> bool\n\n"
+     "Determine whether name and value make a valid pair.");
 
   Though some C compilers accept string literals without either:
 
   .. code-block::
      :class: bad
 
-      /* BAD -- don't do this! */
-      PyDoc_STRVAR(myfunction__doc__,
-      "myfunction(name, value) -> bool\n\n
-      Determine whether name and value make a valid pair.");
+     /* BAD -- don't do this! */
+     PyDoc_STRVAR(myfunction__doc__,
+     "myfunction(name, value) -> bool\n\n
+     Determine whether name and value make a valid pair.");
 
   not all do; the MSVC compiler is known to complain about this.
 

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -225,18 +225,6 @@ Documentation Strings
   to support building Python without docstrings (``./configure
   --without-doc-strings``).
 
-  For C code that needs to support versions of Python older than 2.3,
-  you can include this after including ``Python.h``:
-
-  .. code-block::
-    :class: good
-
-      #ifndef PyDoc_STR
-      #define PyDoc_VAR(name)         static char name[]
-      #define PyDoc_STR(str)          (str)
-      #define PyDoc_STRVAR(name, str) PyDoc_VAR(name) = PyDoc_STR(str)
-      #endif
-
 * The first line of each function docstring should be a "signature
   line" that gives a brief synopsis of the arguments and return value.
   For example:

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -1,14 +1,12 @@
 PEP: 7
 Title: Style Guide for C Code
-Version: $Revision$
-Last-Modified: $Date$
 Author: Guido van Rossum <guido@python.org>, Barry Warsaw <barry@python.org>
 Status: Active
 Type: Process
-Content-Type: text/x-rst
 Created: 05-Jul-2001
 Post-History:
 
+.. highlight:: c
 
 Introduction
 ============
@@ -246,14 +244,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -75,7 +75,10 @@ Code lay-out
 
 * Function definition style: function name in column 1, outermost
   curly braces in column 1, blank line after local variable
-  declarations.  ::
+  declarations.
+
+  .. code-block::
+    :class: good
 
       static int
       extra_ivars(PyTypeObject *type, PyTypeObject *base)
@@ -92,7 +95,10 @@ Code lay-out
   the following left paren; no spaces inside the paren; braces are
   required everywhere, even where C permits them to be omitted, but do
   not add them to code you are not otherwise modifying.  All new C
-  code requires braces.  Braces should be formatted as shown::
+  code requires braces.  Braces should be formatted as shown:
+
+  .. code-block::
+    :class: good
 
       if (mro != NULL) {
           ...
@@ -116,7 +122,10 @@ Code lay-out
 
 * Breaking long lines: if you can, break after commas in the outermost
   argument list.  Always indent continuation lines appropriately,
-  e.g.::
+  e.g.:
+
+  .. code-block::
+    :class: good
 
       PyErr_Format(PyExc_TypeError,
                    "cannot create '%.100s' instances",
@@ -124,7 +133,10 @@ Code lay-out
 
 * When you break a long expression at a binary operator, the
   operator goes at the end of the previous line, and braces should be
-  formatted as shown.  E.g.::
+  formatted as shown.  E.g.:
+
+  .. code-block::
+    :class: good
 
       if (type->tp_dictoffset != 0 && base->tp_dictoffset == 0 &&
           type->tp_dictoffset == b_size &&
@@ -138,7 +150,10 @@ Code lay-out
 * Macros intended to be used as a statement should use the
   ``do { ... } while (0)`` macro idiom,
   without a final semicolon.
-  Example::
+  Example:
+
+  .. code-block::
+    :class: good
 
       #define ADD_INT_MACRO(MOD, INT)                                   \
           do {                                                          \
@@ -162,7 +177,10 @@ Code lay-out
 
 * For external functions and variables, we always have a declaration
   in an appropriate header file in the "Include" directory, which uses
-  the ``PyAPI_FUNC()`` macro and ``PyAPI_DATA()`` macro, like this::
+  the ``PyAPI_FUNC()`` macro and ``PyAPI_DATA()`` macro, like this:
+
+  .. code-block::
+    :class: good
 
       PyAPI_FUNC(PyObject *) PyObject_Repr(PyObject *);
 
@@ -199,7 +217,10 @@ Documentation Strings
   --without-doc-strings``).
 
   For C code that needs to support versions of Python older than 2.3,
-  you can include this after including ``Python.h``::
+  you can include this after including ``Python.h``:
+
+  .. code-block::
+    :class: good
 
       #ifndef PyDoc_STR
       #define PyDoc_VAR(name)         static char name[]
@@ -209,7 +230,10 @@ Documentation Strings
 
 * The first line of each function docstring should be a "signature
   line" that gives a brief synopsis of the arguments and return value.
-  For example::
+  For example:
+
+  .. code-block::
+    :class: good
 
       PyDoc_STRVAR(myfunction__doc__,
       "myfunction(name, value) -> bool\n\n\
@@ -224,13 +248,19 @@ Documentation Strings
 
 * When writing multi-line docstrings, be sure to always use backslash
   continuations, as in the example above, or string literal
-  concatenation::
+  concatenation:
+
+  .. code-block::
+    :class: good
 
       PyDoc_STRVAR(myfunction__doc__,
       "myfunction(name, value) -> bool\n\n"
       "Determine whether name and value make a valid pair.");
 
-  Though some C compilers accept string literals without either::
+  Though some C compilers accept string literals without either:
+
+  .. code-block::
+     :class: bad
 
       /* BAD -- don't do this! */
       PyDoc_STRVAR(myfunction__doc__,

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -158,7 +158,7 @@ Code lay-out
 * Comments go before the code they describe.
 
 * All functions and global variables should be declared static unless
-  they are to be part of a published interface
+  they are to be part of a published interface.
 
 * For external functions and variables, we always have a declaration
   in an appropriate header file in the "Include" directory, which uses
@@ -218,7 +218,7 @@ Documentation Strings
   Always include a blank line between the signature line and the text
   of the description.
 
-  If the return value for the function is always None (because there
+  If the return value for the function is always ``None`` (because there
   is no meaningful return value), do not include the indication of the
   return type.
 

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -107,10 +107,19 @@ Code lay-out
           ...
       }
 
-* The return statement should *not* get redundant parentheses::
+* The return statement should *not* get redundant parentheses:
+
+  .. code-block::
+    :class: bad
+
+      return(albatross); /* incorrect */
+
+  Instead:
+
+  .. code-block::
+    :class: good
 
       return albatross; /* correct */
-      return(albatross); /* incorrect */
 
 * Function and macro call style: ``foo(a, b, c)`` -- no space before
   the open paren, no spaces inside the parens, no spaces before


### PR DESCRIPTION
* Remove the section "For C code that needs to support versions of Python older than 2.3...". I can add it back if needed.

* Highlight the example C code with C syntax instead of Python.

* Like PEP 8 (https://github.com/python/peps/pull/3567), add green and red side borders "good" and "bad" examples. For this, I split this example into two blocks:

```c
      return albatross; /* correct */
      return(albatross); /* incorrect */
```

* Format None as `None`, add a missing full stop. Remove some redundant PEP fields.

# Example

<table>
<tr>
<th>Before
<th>After
<tr>
<td>
<img width="787" alt="image" src="https://github.com/python/peps/assets/1324225/0fc50d80-1448-4b95-8070-c53df4b6a0c8">
<td>
<img width="786" alt="image" src="https://github.com/python/peps/assets/1324225/888f6481-f405-4b60-9bf2-5f8b0e36cdd3">
</table>


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3702.org.readthedocs.build/pep-0007/

<!-- readthedocs-preview pep-previews end -->