### PR TITLE
PEP 11: Promote `aarch64-apple-darwin` to tier 1

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -80,6 +80,7 @@ Tier 1
 ======================== =====
 Target Triple            Notes
 ======================== =====
+aarch64-apple-darwin     clang
 i686-pc-windows-msvc
 x86_64-pc-windows-msvc
 x86_64-apple-darwin      BSD libc, clang
@@ -100,7 +101,6 @@ Tier 2
 ============================= ========================== ========
 Target Triple                 Notes                      Contacts
 ============================= ========================== ========
-aarch64-apple-darwin          clang                      Ned Deily, Ronald Oussoren, Dong-hee Na
 aarch64-unknown-linux-gnu     glibc, gcc                 Petr Viktorin, Victor Stinner
 
                               glibc, clang               Victor Stinner, Gregory P. Smith


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->
This PR has been created after the discussion we had in discourse: https://discuss.python.org/t/pep-11-proposal-to-promote-aarch64-plaftorms-to-tier-1/44774

I'm not sure what to select from the template. 

* Change is either:
    * [ ] To a Draft PEP
    * [X] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [ ] PR title prefixed with PEP number: "PEP 11 – CPython platform support"
