### PR TITLE
PEP 736: Add reference to new discussion

### DIFF
--- a/peps/pep-0736.rst
+++ b/peps/pep-0736.rst
@@ -9,7 +9,7 @@ Type: Standards Track
 Created: 28-Nov-2023
 Python-Version: 3.13
 Post-History: `14-Oct-2023 <https://discuss.python.org/t/syntactic-sugar-to-encourage-use-of-named-arguments/36217>`__,
-              `18-Jan-2024 <https://discuss.python.org/t/pep-736-shorthand-syntax-for-keyword-arguments-at-invocation/43432>`__,
+              `17-Jan-2024 <https://discuss.python.org/t/pep-736-shorthand-syntax-for-keyword-arguments-at-invocation/43432>`__,
 
 Abstract
 ========

--- a/peps/pep-0736.rst
+++ b/peps/pep-0736.rst
@@ -3,12 +3,13 @@ Title: Shorthand syntax for keyword arguments at invocation
 Author: Joshua Bambrick <jbambrick@google.com>,
         Chris Angelico <rosuav@gmail.com>
 Sponsor: Guido van Rossum <guido@python.org>
-Discussions-To: https://discuss.python.org/t/syntactic-sugar-to-encourage-use-of-named-arguments/36217 https://discuss.python.org/t/pep-736-shorthand-syntax-for-keyword-arguments-at-invocation/43432
+Discussions-To: https://discuss.python.org/t/pep-736-shorthand-syntax-for-keyword-arguments-at-invocation/43432
 Status: Draft
 Type: Standards Track
 Created: 28-Nov-2023
 Python-Version: 3.13
-Post-History: 14-Oct-2023
+Post-History: `14-Oct-2023 <https://discuss.python.org/t/syntactic-sugar-to-encourage-use-of-named-arguments/36217>`__, 
+              `18-Jan-2024 <https://discuss.python.org/t/pep-736-shorthand-syntax-for-keyword-arguments-at-invocation/43432>`__, 
 
 Abstract
 ========

--- a/peps/pep-0736.rst
+++ b/peps/pep-0736.rst
@@ -3,7 +3,7 @@ Title: Shorthand syntax for keyword arguments at invocation
 Author: Joshua Bambrick <jbambrick@google.com>,
         Chris Angelico <rosuav@gmail.com>
 Sponsor: Guido van Rossum <guido@python.org>
-Discussions-To: https://discuss.python.org/t/syntactic-sugar-to-encourage-use-of-named-arguments/36217
+Discussions-To: https://discuss.python.org/t/syntactic-sugar-to-encourage-use-of-named-arguments/36217 https://discuss.python.org/t/pep-736-shorthand-syntax-for-keyword-arguments-at-invocation/43432
 Status: Draft
 Type: Standards Track
 Created: 28-Nov-2023

--- a/peps/pep-0736.rst
+++ b/peps/pep-0736.rst
@@ -8,8 +8,8 @@ Status: Draft
 Type: Standards Track
 Created: 28-Nov-2023
 Python-Version: 3.13
-Post-History: `14-Oct-2023 <https://discuss.python.org/t/syntactic-sugar-to-encourage-use-of-named-arguments/36217>`__, 
-              `18-Jan-2024 <https://discuss.python.org/t/pep-736-shorthand-syntax-for-keyword-arguments-at-invocation/43432>`__, 
+Post-History: `14-Oct-2023 <https://discuss.python.org/t/syntactic-sugar-to-encourage-use-of-named-arguments/36217>`__,
+              `18-Jan-2024 <https://discuss.python.org/t/pep-736-shorthand-syntax-for-keyword-arguments-at-invocation/43432>`__,
 
 Abstract
 ========


### PR DESCRIPTION
Adds a reference to the new discourse discussion.

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [ ] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3708.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->