### PR TITLE
Meta: Reduce CODEOWNERS for hugovk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,8 +6,8 @@
 *             @python/pep-editors
 
 # PEP infrastructure
+.github/dependabot.yml  @hugovk
 .github/workflows/      @AA-Turner @CAM-Gerlach
-.github/                @hugovk
 Makefile                @AA-Turner @hugovk
 requirements.txt        @AA-Turner @hugovk
 infra/                  @ewdurbin


### PR DESCRIPTION
I don't need to be specifically assigned each time someone adds a new PEP and themselves to CODEOWNERS.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3716.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->