### PR TITLE
PEP 3156: Fix a typo — "ipv4_address" -> "ipv6_address"

### DIFF
--- a/peps/pep-3156.rst
+++ b/peps/pep-3156.rst
@@ -564,7 +564,7 @@ usually called implicitly by ``create_connection()``,
   format as returned by ``socket.getaddrinfo()``, i.e. a list of
   ``(address_family, socket_type, socket_protocol, canonical_name,
   address)`` where ``address`` is a 2-tuple ``(ipv4_address, port)``
-  for IPv4 addresses and a 4-tuple ``(ipv4_address, port, flow_info,
+  for IPv4 addresses and a 4-tuple ``(ipv6_address, port, flow_info,
   scope_id)`` for IPv6 addresses.  If the ``family`` argument is zero
   or unspecified, the list returned may contain a mixture of IPv4 and
   IPv6 addresses; otherwise the addresses returned are constrained by


### PR DESCRIPTION
* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)
