### PR TITLE
📝 Fix "Superseded" status in a diagram in PEP 1

### DIFF
--- a/peps/pep-0001/process_flow.svg
+++ b/peps/pep-0001/process_flow.svg
@@ -513,9 +513,9 @@
        xml:space="preserve"><tspan
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:22px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.75px"
          y="115.269"
-         x="387.37521"
+         x="379"
          id="tspan4668"
-         sodipodi:role="line">Replaced</tspan></text>
+         sodipodi:role="line">Superseded</tspan></text>
   </g>
   <path
      style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Mend)"


### PR DESCRIPTION
_Hello everyone,_

The process flow diagram contains the non-existent `Replaced` PEP status.
The correct one is the `Superseded`.

Fixes #1127

_Best regards!_