### PR TITLE
docs: announce venv creation before installing packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ venv:
 		echo "venv already exists."; \
 		echo "To recreate it, remove it first with \`make clean-venv'."; \
 	else \
+		echo "Creating venv in $(VENVDIR)"; \
 		$(PYTHON) -m venv $(VENVDIR); \
 		$(VENVDIR)/bin/python3 -m pip install -U pip wheel; \
 		$(VENVDIR)/bin/python3 -m pip install -r requirements.txt; \


### PR DESCRIPTION
Similar to https://github.com/python/devguide/pull/1291, announce the creation of the venv before a stream of scary package installation messages appear.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3729.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->