### PR TITLE
PEP 3156: Fix a style error caused by extra spaces

### DIFF
--- a/peps/pep-3156.rst
+++ b/peps/pep-3156.rst
@@ -708,10 +708,10 @@ use a different transport and protocol interface.
     Windows.
 
   - ``family``, ``flags``: Address family and flags to be passed
-     through to ``getaddrinfo()``.  The family defaults to
-     ``AF_UNSPEC``; the flags default to ``AI_PASSIVE``.  (The socket
-     type is always ``SOCK_STREAM``; the socket protocol always set to
-     ``0``, to let ``getaddrinfo()`` choose.)
+    through to ``getaddrinfo()``.  The family defaults to
+    ``AF_UNSPEC``; the flags default to ``AI_PASSIVE``.  (The socket
+    type is always ``SOCK_STREAM``; the socket protocol always set to
+    ``0``, to let ``getaddrinfo()`` choose.)
 
   - ``sock``: An optional socket to be used instead of using the
     ``host``, ``port``, ``family`` and ``flags`` arguments.  If this


### PR DESCRIPTION

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3733.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->