### PR TITLE
PEPs 569, 596, 619, 719: Update release dates

### DIFF
--- a/peps/pep-0569.rst
+++ b/peps/pep-0569.rst
@@ -4,7 +4,6 @@ Author: Łukasz Langa <lukasz@python.org>
 Status: Active
 Type: Informational
 Topic: Release
-Content-Type: text/x-rst
 Created: 27-Jan-2018
 Python-Version: 3.8
 
@@ -97,6 +96,7 @@ Provided irregularly on an "as-needed" basis until October 2024.
 - 3.8.16: Tuesday, 2022-12-06
 - 3.8.17: Tuesday, 2023-06-06
 - 3.8.18: Thursday, 2023-08-24
+- 3.8.19: Tuesday, 2024-03-19
 
 
 Features for 3.8

--- a/peps/pep-0596.rst
+++ b/peps/pep-0596.rst
@@ -5,7 +5,6 @@ Discussions-To: https://discuss.python.org/t/pep-596-python-3-9-release-schedule
 Status: Active
 Type: Informational
 Topic: Release
-Content-Type: text/x-rst
 Created: 04-Jun-2019
 Python-Version: 3.9
 
@@ -94,6 +93,7 @@ Provided irregularly on an "as-needed" basis until October 2025.
 - 3.9.16: Tuesday, 2022-12-06
 - 3.9.17: Tuesday, 2023-06-06
 - 3.9.18: Thursday, 2023-08-24
+- 3.9.19: Tuesday, 2024-03-19
 
 
 3.9 Lifespan

--- a/peps/pep-0619.rst
+++ b/peps/pep-0619.rst
@@ -4,7 +4,6 @@ Author: Pablo Galindo Salgado <pablogsal@python.org>
 Status: Active
 Type: Informational
 Topic: Release
-Content-Type: text/x-rst
 Created: 25-May-2020
 Python-Version: 3.10
 
@@ -82,6 +81,7 @@ Provided irregularly on an "as-needed" basis until October 2026.
 
 - 3.10.12: Tuesday, 2023-06-06
 - 3.10.13: Thursday, 2023-08-24
+- 3.10.14: Tuesday, 2024-03-19
 
 3.10 Lifespan
 -------------

--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -40,10 +40,10 @@ Actual:
 - 3.13.0 alpha 2: Wednesday, 2023-11-22
 - 3.13.0 alpha 3: Wednesday, 2024-01-17
 - 3.13.0 alpha 4: Thursday, 2024-02-15
+- 3.13.0 alpha 5: Tuesday, 2024-03-12
 
 Expected:
 
-- 3.13.0 alpha 5: Tuesday, 2024-03-12
 - 3.13.0 alpha 6: Tuesday, 2024-04-09
 - 3.13.0 beta 1: Tuesday, 2024-05-07
   (No new features beyond this point.)


### PR DESCRIPTION
Python 3.8.19, 3.9.19, and 3.10.14 were released on March 19, 2024:

* https://discuss.python.org/t/python-3-10-14-3-9-19-and-3-8-19-is-now-available/48993
* https://www.python.org/downloads/release/python-3819/
* https://www.python.org/downloads/release/python-3919/
* https://www.python.org/downloads/release/python-31014/

Python 3.13a5 was released on March 12, 2024:

* https://discuss.python.org/t/python-3-13-0-alpha-5/48341
* https://www.python.org/downloads/release/python-3130a5/

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3735.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->