### PR TITLE
PEP 602: Mark as Active Process

### DIFF
--- a/peps/pep-0602.rst
+++ b/peps/pep-0602.rst
@@ -1,13 +1,10 @@
 PEP: 602
 Title: Annual Release Cycle for Python
-Version: $Revision$
-Last-Modified: $Date$
 Author: Łukasz Langa <lukasz@python.org>
 PEP-Delegate: Brett Cannon <brett@python.org>
 Discussions-To: https://discuss.python.org/t/pep-602-annual-release-cycle-for-python/2296/
-Status: Accepted
-Type: Informational
-Content-Type: text/x-rst
+Status: Active
+Type: Process
 Created: 04-Jun-2019
 Python-Version: 3.9
 Post-History: `09-Oct-2023 <https://discuss.python.org/t/27002>`__
@@ -340,13 +337,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 72
-  coding: utf-8
-  End:


### PR DESCRIPTION
Helps https://github.com/python/peps/issues/2872.

PEP 602 is a [Process PEP](https://peps.python.org/pep-0001/#pep-types) rather than Informational or Standards Track:

> A **Process** PEP describes a process surrounding Python, or proposes a change to (or an event in) a process. Process PEPs are like Standards Track PEPs but apply to areas other than the Python language itself. They may propose an implementation, but not to Python’s codebase; they often require community consensus; unlike Informational PEPs, they are more than recommendations, and users are typically not free to ignore them. Examples include procedures, guidelines, changes to the decision-making process, and changes to the tools or environment used in Python development. Any meta-PEP is also considered a Process PEP.

And as such won't ever be be "fully implemented" and marked as Final. 

Instead, it should be set to [Active](https://peps.python.org/pep-0001/#pep-review-resolution):

> Some Informational and Process PEPs may also have a status of “Active” if they are never meant to be completed. E.g. [PEP 1](https://peps.python.org/pep-0001/) (this PEP).

Also remove some redundant headers/emacs metadata.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3736.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->