### PR TITLE
PEP 647: Mark as Final (take 2)

### DIFF
--- a/peps/pep-0647.rst
+++ b/peps/pep-0647.rst
@@ -3,7 +3,7 @@ Title: User-Defined Type Guards
 Author: Eric Traut <erictr at microsoft.com>
 Sponsor: Guido van Rossum <guido@python.org>
 Discussions-To: typing-sig@python.org
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
 Created: 07-Oct-2020
@@ -94,7 +94,7 @@ are supported by type checkers.
 Using this new mechanism, the ``is_str_list`` function in the above example
 would be modified slightly. Its return type would be changed from ``bool``
 to ``TypeGuard[List[str]]``.  This promises not merely that the return value
-is boolean, but that a true indicates the input to the function was of the 
+is boolean, but that a true indicates the input to the function was of the
 specified type.
 
 ::
@@ -200,9 +200,9 @@ allows for cases like the example above where ``List[str]`` is not assignable
 to ``List[object]``.
 
 When a conditional statement includes a call to a user-defined type guard
-function, and that function returns true, the expression passed as the first 
-positional argument to the type guard function should be assumed by a static 
-type checker to take on the type specified in the TypeGuard return type, 
+function, and that function returns true, the expression passed as the first
+positional argument to the type guard function should be assumed by a static
+type checker to take on the type specified in the TypeGuard return type,
 unless and until it is further narrowed within the conditional code block.
 
 Some built-in type guards provide narrowing for both positive and negative
@@ -223,7 +223,7 @@ is not narrowed in the negative case.
         else:
             reveal_type(val)   # OneOrTwoStrs
             ...
-        
+
         if not is_two_element_tuple(val):
             reveal_type(val)   # OneOrTwoStrs
             ...


### PR DESCRIPTION
Was meant to be be marked as Final in https://github.com/python/peps/pull/3577, I added the link to the canonical docs there but I forgot to actually change the status...

Take 2!


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3737.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->