### PR TITLE
fix: Redundant else statement in function foo #3738

### DIFF
--- a/peps/pep-0008.rst
+++ b/peps/pep-0008.rst
@@ -1413,8 +1413,7 @@ Programming Recommendations
      def foo(x):
          if x >= 0:
              return math.sqrt(x)
-         else:
-             return None
+         return None
 
      def bar(x):
          if x < 0:


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [ ] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

Related Issue: #3738

I have removed the redundant else statement in the example of `foo()`

```py
# Correct:

def foo(x):
    if x >= 0:
        return math.sqrt(x)
    return None

def bar(x):
    if x < 0:
        return None
    return math.sqrt(x)
```

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3739.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->