### PR TITLE
PEP 639: Post-split edits (language simplification, deeper edits of sections)

### DIFF
--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -441,12 +441,8 @@ Examples of invalid SPDX expressions:
 Core Metadata
 -------------
 
-The :term:`Core Metadata` `specification <coremetadataspec_>`__
-defines the names and semantics of each of the supported
-:term:`fields <Core Metadata field>` in the :term:`built metadata`
-of Python :term:`distribution package`\s and :term:`installed project`\s.
-
-This PEP:
+This PEP specifies following changes to the
+:term:`Core Metadata` `specification <coremetadataspec_>`__:
 
 - :ref:`adds <639-spec-field-license-expression>` the
   ``License-Expression`` field,
@@ -459,7 +455,7 @@ This PEP:
   in the ``Classifier`` field.
 
 The error and warning guidance in this section applies to build and
-publishing tools; end-user-facing install tools MAY be more lenient than
+publishing tools; end-user-facing install tools MAY be less strict than
 mentioned here when encountering malformed metadata
 that does not conform to this specification.
 
@@ -473,13 +469,11 @@ Add ``License-Expression`` field
 
 The ``License-Expression`` optional :term:`Core Metadata field`
 is specified to contain a text string
-that is a valid SPDX :term:`license expression`, as defined herein.
+that is a valid SPDX :term:`license expression`, as defined by this PEP.
 
 Publishing tools SHOULD issue an informational warning if this field is
 missing, and MAY raise an error. Build tools MAY issue a similar warning,
 but MUST NOT raise an error.
-
-.. _639-license-expression-definition:
 
 A license expression is an SPDX expression as :ref:`defined above <639-spdx>`.
 
@@ -491,7 +485,7 @@ a valid license expression, build and publishing tools:
   - The field does not contain a valid license expression
 
   - One or more license identifiers are not valid
-    (as :ref:`defined above <639-license-expression-definition>`)
+    (as :ref:`defined above <639-spdx>`)
 
 - SHOULD report an informational warning, and publishing tools MAY raise an
   error, if one or more license identifiers have been marked as deprecated in
@@ -505,11 +499,11 @@ a valid license expression, build and publishing tools:
   the normalization process results in changes to the
   ``License-Expression`` field contents.
 
-For all newly-upload :term:`distribution archive`\s
+For all newly-uploaded :term:`distribution archive`\s
 that include a ``License-Expression`` field,
 the `Python Package Index (PyPI) <pypi_>`__ MUST
-validate that it contains a valid, case-normalized license expression with
-valid identifiers (as :ref:`defined here <639-license-expression-definition>`)
+validate that they contain a valid, case-normalized license expression with
+valid identifiers (as :ref:`defined above <639-spdx>`)
 and MUST reject uploads that do not.
 PyPI MAY reject an upload for using a deprecated license identifier,
 so long as it was deprecated as of the above-mentioned SPDX License List
@@ -589,7 +583,7 @@ For all newly-uploaded :term:`distribution archive`\s that include a
 ``License-Expression`` field, the `Python Package Index (PyPI) <pypi_>`__ MUST
 reject any that specify a ``License`` field and the text of which is not
 identical to that of ``License-Expression``,
-as :ref:`defined here <639-license-expression-definition>`.
+as :ref:`defined here <639-spdx>`.
 
 The ``License`` field may be removed from a new version of the specification
 in a future PEP.
@@ -632,21 +626,17 @@ in a future PEP.
 Project source metadata
 -----------------------
 
-The `PyPUG Declaring Project Metadata specification <pyprojecttoml_>`__,
-introduced in :pep:`621`, defines how to declare a project's source
-metadata under a ``[project]`` table in the ``pyproject.toml`` file for
-build tools to consume and output distribution Core Metadata.
-
-This PEP:
+This PEP specifies the following changes to the project's source
+metadata under a ``[project]`` table in the ``pyproject.toml`` file:
 
 - :ref:`adds <639-spec-key-license-text>`
   a top-level string value for the ``license`` key,
 
+- :ref:`adds <639-spec-key-license-files>` the new ``license-files`` key,
+
 - :ref:`deprecates <639-spec-key-license-table>` the table value for the
   ``license`` key along with its corresponding table subkeys, ``text`` and
-  ``file``,
-
-- :ref:`adds <639-spec-key-license-files>` the new ``license-files`` key.
+  ``file``.
 
 
 .. _639-spec-key-license-text:
@@ -670,43 +660,6 @@ tools MAY back-fill the ``License`` Core Metadata field
 with the normalized value of the ``license`` key.
 
 
-.. _639-spec-key-license-table:
-
-Deprecate ``license`` key table subkeys
-'''''''''''''''''''''''''''''''''''''''
-
-Table values for the ``license`` key in the ``[project]`` table,
-including the ``text`` and ``file`` table subkeys, are now deprecated.
-If the new ``license-files`` key is present,
-build tools MUST raise an error if the ``license`` key is defined
-and has a value other than a single top-level string.
-
-If the new ``license-files`` key is not present
-and the ``text`` subkey is present in a ``license`` table,
-tools SHOULD issue a warning informing users it is deprecated
-and recommending a license expression as a top-level string key instead.
-
-Likewise, if the new ``license-files`` key is not present
-and the ``file`` subkey is present in the ``license`` table,
-tools SHOULD issue a warning informing users it is deprecated and recommending
-the ``license-files`` key instead.
-
-If the specified license ``file`` is present in the source tree,
-build tools SHOULD use it to fill the ``License-File`` field
-in the core metadata, and MUST include the specified file
-as if it were specified in a ``license-file.paths`` field.
-If the file does not exist at the specified path,
-tools MUST raise an informative error as previously specified.
-However, tools MUST also still assume the
-:ref:`specified default value <639-default-patterns>`
-for the ``license-files`` key and also include,
-in addition to a license file specified under the ``license.file`` subkey,
-any license files that match the specified list of patterns.
-
-Table values for the ``license`` key MAY be removed
-from a new version of the specification in a future PEP.
-
-
 .. _639-spec-key-license-files:
 
 Add ``license-files`` key
@@ -723,11 +676,6 @@ tools MUST raise an error. Both are arrays of strings; the ``paths`` subkey
 contains verbatim file paths, and the ``globs`` subkey valid glob patterns,
 which MUST be parsable by the ``glob`` `module <globmodule_>`__ in the
 Python standard library.
-
-**Note**: To avoid ambiguity, confusion and (per :pep:`20`, the Zen of Python)
-"more than one (obvious) way to do it", allowing a flat array of strings
-as the value for the ``license-files`` key has been
-:ref:`left out for now <639-license-files-allow-flat-array>`.
 
 Path delimiters MUST be the forward slash character (``/``),
 and parent directory indicators (``..``) MUST NOT be used.
@@ -791,19 +739,52 @@ including at least the license files matching the above patterns, unless the
 user has explicitly specified their own.
 
 
+.. _639-spec-key-license-table:
+
+Deprecate ``license`` key table subkeys
+'''''''''''''''''''''''''''''''''''''''
+
+Table values for the ``license`` key in the ``[project]`` table,
+including the ``text`` and ``file`` table subkeys, are now deprecated.
+If the new ``license-files`` key is present,
+build tools MUST raise an error if the ``license`` key is defined
+and has a value other than a single top-level string.
+
+If the new ``license-files`` key is not present
+and the ``text`` subkey is present in a ``license`` table,
+tools SHOULD issue a warning informing users it is deprecated
+and recommending a license expression as a top-level string key instead.
+
+Likewise, if the new ``license-files`` key is not present
+and the ``file`` subkey is present in the ``license`` table,
+tools SHOULD issue a warning informing users it is deprecated and recommending
+the ``license-files`` key instead.
+
+If the specified license ``file`` is present in the source tree,
+build tools SHOULD use it to fill the ``License-File`` field
+in the core metadata, and MUST include the specified file
+as if it were specified in a ``license-file.paths`` field.
+If the file does not exist at the specified path,
+tools MUST raise an informative error as previously specified.
+However, tools MUST also still assume the
+:ref:`specified default value <639-default-patterns>`
+for the ``license-files`` key and also include,
+in addition to a license file specified under the ``license.file`` subkey,
+any license files that match the specified list of patterns.
+
+Table values for the ``license`` key MAY be removed
+from a new version of the specification in a future PEP.
+
+
 .. _639-spec-project-formats:
 
 License files in project formats
 --------------------------------
 
-A few minor additions will be made to the relevant existing specifications
-to standardize what is already currently supported behavior, as well as
-explicitly mention the root license directory the license files are located in
-and relative to for each format, per the :ref:`639-spec-field-license-file`
-section.
+A few additions will be made to the relevant existing specifications.
 
 :term:`project source tree`
-  As described in the :ref:`639-spec-source-metadata` section, the
+  Per :ref:`639-spec-source-metadata` section, the
   `Declaring Project Metadata specification <pyprojecttoml_>`__
   will be updated to reflect that license file paths MUST be relative to the
   project root directory; i.e. the directory containing the ``pyproject.toml``

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -962,44 +962,37 @@ Neither introduces any known new security concerns.
 How to Teach This
 =================
 
-The simple cases are simple: a single license identifier is a valid license
-expression, and a large majority of packages use a single license.
+A majority of packages use a single license which makes the case simple:
+a single license identifier is a valid license expression.
 
-The plan to teach users of packaging tools how to express their package's
-license with a valid license expression is to have tools issue informative
-messages when they detect invalid license expressions, or when the deprecated
-``License`` field or license classifiers are used.
+Users of packaging tools will learn the valid license expression of their
+package through the messages issued by the tools when they detect invalid
+ones, or when the deprecated ``License`` field or license classifiers are used.
 
-An immediate, descriptive error message if an invalid ``License-Expression``
-is used will help users understand they need to use SPDX identifiers in
-this field, and catch them if they make a mistake.
-For authors still using the now-deprecated, less precise and more redundant
-``License`` field or license classifiers, packaging tools will warn
-them and inform them of the modern replacement, ``License-Expression``.
-Finally, for users who may have forgotten or not be aware they need to do so,
-publishing tools will gently guide them toward including ``license``
-and ``license-files`` in their project source metadata.
+If an invalid ``License-Expression`` is used, an error message will help users
+understand they need to use SPDX identifiers. For authors using the
+now-deprecated ``License`` field or license classifiers, packaging tools will
+warn them and inform them of the modern replacement, ``License-Expression``.
+Finally, the users who may not be aware of this PEP will be guided by the
+publishing tools toward including ``license`` and ``license-files`` in their
+project source metadata.
 
 Tools may also help with the conversion and suggest a license expression in
-many, if not most common cases:
+many common cases:
 
 - The appendix :ref:`639-spec-mapping-classifiers-identifiers` provides
-  tool authors with recommendation on how to suggest a license expression produced
-  from legacy classifiers.
+  tool authors with recommendation on how to suggest a license expression
+  produced from legacy classifiers.
 
-- Tools may also be able to infer and suggest how to update
-  an existing ``License`` value in project source metadata
-  and convert that to a license expression,
+- Tools may be able to suggest how to update an existing ``License`` value
+  in project source metadata and convert that to a license expression,
   as also :ref:`specified in this PEP <639-spec-converting-metadata>`.
-  For instance, a tool may suggest converting a value of ``MIT``
-  in the ``license.text`` key in ``[project]``
-  (or the equivalent in tool-specific formats)
-  to a top-level string value of the ``license`` key (or equivalent).
+  For instance, a tool may suggest converting a value of ``MIT`` in the
+  ``license.text`` key in ``[project]`` (or the equivalent in tool-specific
+  formats) to a top-level string value of the ``license`` key (or equivalent).
   Likewise, a tool could suggest converting from a ``License`` of ``Apache2``
-  (which is not a valid license expression
-  as :ref:`defined in this PEP <639-spec-field-license-expression>`)
-  to a ``License-Expression`` of ``Apache-2.0``
-  (the equivalent valid license expression using an SPDX license identifier).
+  (which is not a valid license expression as :ref:`defined in this PEP
+  <639-spdx>`) to a ``License-Expression`` of ``Apache-2.0``.
 
 
 .. _639-reference-implementation:

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -693,7 +693,7 @@ License files in project formats
 
 A few additions will be made to the existing specifications.
 
-:term:`project source tree`
+:term:`Project source tree`\s
   Per :ref:`639-spec-source-metadata` section, the
   `Declaring Project Metadata specification <pyprojecttoml_>`__
   will be updated to reflect that license file paths MUST be relative to the
@@ -701,7 +701,7 @@ A few additions will be made to the existing specifications.
   (or equivalently, other legacy project configuration,
   e.g. ``setup.py``, ``setup.cfg``, etc).
 
-:term:`Source distribution (sdists) <Source Distribution (or "sdist")>`
+:term:`Source distributions (sdists) <Source Distribution (or "sdist")>`
   The `sdist specification <sdistspec_>`__ will be updated to reflect that if
   the ``Metadata-Version`` is ``2.4`` or greater,
   the sdist MUST contain any license files specified by
@@ -710,7 +710,7 @@ A few additions will be made to the existing specifications.
   relative to the  of the sdist
   (containing the ``pyproject.toml`` and the ``PKG-INFO`` Core Metadata).
 
-:term:`Built distribution` (:term:`wheel`\s)
+:term:`Built distribution`\s (:term:`wheel`\s)
   The `Wheel specification <wheelspec_>`__ will be updated to reflect that if
   the ``Metadata-Version`` is ``2.4`` or greater and one or more
   ``License-File`` fields is specified, the ``.dist-info`` directory MUST
@@ -718,7 +718,7 @@ A few additions will be made to the existing specifications.
   in the ``License-File`` fields in the ``METADATA`` file at their respective
   paths relative to the ``licenses`` directory.
 
-:term:`Installed project`
+:term:`Installed project`\s
   The `Recording Installed Projects specification <installedspec_>`__ will be
   updated to reflect that if the ``Metadata-Version`` is ``2.4`` or greater
   and one or more ``License-File`` fields is specified, the ``.dist-info``

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -434,12 +434,17 @@ defines the names and semantics of each of the supported
 :term:`fields <Core Metadata field>` in the :term:`built metadata`
 of Python :term:`distribution package`\s and :term:`installed project`\s.
 
-This PEP :ref:`adds <639-spec-field-license-expression>` the
-``License-Expression`` field,
-:ref:`adds <639-spec-field-license-file>` the ``License-File`` field,
-:ref:`deprecates <639-spec-field-license>` the ``License`` field,
-and :ref:`deprecates <639-spec-field-classifier>`
-the :term:`license classifier`\s in the ``Classifier`` field.
+This PEP:
+
+- :ref:`adds <639-spec-field-license-expression>` the
+  ``License-Expression`` field,
+
+- :ref:`adds <639-spec-field-license-file>` the ``License-File`` field,
+
+- :ref:`deprecates <639-spec-field-license>` the ``License`` field,
+
+- :ref:`deprecates <639-spec-field-classifier>` the :term:`license classifier`\s
+  in the ``Classifier`` field.
 
 The error and warning guidance in this section applies to build and
 publishing tools; end-user-facing install tools MAY be more lenient than

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -424,6 +424,50 @@ they MAY operate more strictly if users explicitly configure them to do so,
 such as by a CLI flag or a configuration option.
 
 
+.. _639-spdx:
+
+SPDX license expression syntax
+------------------------------
+
+This PEP adopts the SPDX license expression syntax as
+documented in the `SPDX specification <spdxpression_>`__, either
+Version 2.2 or a later compatible version.
+
+A license expression can use the following :term:`license identifier`\s:
+
+- Any SPDX-listed license short-form identifiers that are published in the
+  `SPDX License List <spdxlist_>`__, version 3.17 or any later compatible
+  version. Note that the SPDX working group never removes any license
+  identifiers; instead, they may choose to mark an identifier as "deprecated".
+
+- The ``LicenseRef-Public-Domain`` and ``LicenseRef-Proprietary`` strings, to
+  identify licenses that are not included in the SPDX license list.
+
+
+Examples
+''''''''
+
+Examples of valid SPDX expressions:
+
+.. code-block:: email
+
+    MIT
+    BSD-3-Clause
+    MIT AND (Apache-2.0 OR BSD-2-clause)
+    MIT OR GPL-2.0-or-later OR (FSFUL AND BSD-2-Clause)
+    GPL-3.0-only WITH Classpath-Exception-2.0 OR BSD-3-Clause
+    LicenseRef-Public-Domain OR CC0-1.0 OR Unlicense
+    LicenseRef-Proprietary
+
+
+Examples of invalid SPDX expressions:
+
+.. code-block:: email
+
+    Use-it-after-midnight
+    Apache-2.0 OR 2-BSD-Clause
+
+
 .. _639-spec-core-metadata:
 
 Core Metadata
@@ -469,20 +513,7 @@ but MUST NOT raise an error.
 
 .. _639-license-expression-definition:
 
-A license expression is a string using the SPDX license expression syntax as
-documented in the `SPDX specification <spdxpression_>`__, either
-Version 2.2 or a later compatible version.
-
-When used in the ``License-Expression`` field, a license expression can use the
-following :term:`license identifier`\s:
-
-- Any SPDX-listed license short-form identifiers that are published in the
-  `SPDX License List <spdxlist_>`__, version 3.17 or any later compatible
-  version. Note that the SPDX working group never removes any license
-  identifiers; instead, they may choose to mark an identifier as "deprecated".
-
-- The ``LicenseRef-Public-Domain`` and ``LicenseRef-Proprietary`` strings, to
-  identify licenses that are not included in the SPDX license list.
+A license expression is an SPDX expression as :ref:`defined above <639-spdx>`.
 
 When processing the ``License-Expression`` field to determine if it contains
 a valid license expression, build and publishing tools:
@@ -515,30 +546,6 @@ and MUST reject uploads that do not.
 PyPI MAY reject an upload for using a deprecated license identifier,
 so long as it was deprecated as of the above-mentioned SPDX License List
 version.
-
-
-Examples
-''''''''
-
-Examples of valid ``License-Expression`` values:
-
-.. code-block:: email
-
-    License-Expression: MIT
-    License-Expression: BSD-3-Clause
-    License-Expression: MIT AND (Apache-2.0 OR BSD-2-clause)
-    License-Expression: MIT OR GPL-2.0-or-later OR (FSFUL AND BSD-2-Clause)
-    License-Expression: GPL-3.0-only WITH Classpath-Exception-2.0 OR BSD-3-Clause
-    License-Expression: LicenseRef-Public-Domain OR CC0-1.0 OR Unlicense
-    License-Expression: LicenseRef-Proprietary
-
-
-Examples of invalid ``License-Expression`` values:
-
-.. code-block:: email
-
-    License-Expression: Use-it-after-midnight
-    License-Expression: Apache-2.0 OR 2-BSD-Clause
 
 
 .. _639-spec-field-license-file:
@@ -685,11 +692,10 @@ This PEP:
 Add string value to ``license`` key
 '''''''''''''''''''''''''''''''''''
 
-A top-level string value is defined
-for the ``license`` key in the ``[project]`` table,
-which is specified to be a valid SPDX license expression,
-as :ref:`defined previously <639-license-expression-definition>`.
-Its value maps to the ``License-Expression`` field in the Core Metadata.
+``license`` key in the ``[project]`` table is defined to contain a top-level
+string value. It is a valid SPDX license expression as
+:ref:`defined in this PEP <639-spdx>`.
+Its value maps to the ``License-Expression`` field in the core metadata.
 
 Build tools SHOULD validate the expression as described in the
 :ref:`639-spec-field-license-expression` section,

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -517,6 +517,30 @@ so long as it was deprecated as of the above-mentioned SPDX License List
 version.
 
 
+Examples
+''''''''
+
+Examples of valid ``License-Expression`` values:
+
+.. code-block:: email
+
+    License-Expression: MIT
+    License-Expression: BSD-3-Clause
+    License-Expression: MIT AND (Apache-2.0 OR BSD-2-clause)
+    License-Expression: MIT OR GPL-2.0-or-later OR (FSFUL AND BSD-2-Clause)
+    License-Expression: GPL-3.0-only WITH Classpath-Exception-2.0 OR BSD-3-Clause
+    License-Expression: LicenseRef-Public-Domain OR CC0-1.0 OR Unlicense
+    License-Expression: LicenseRef-Proprietary
+
+
+Examples of invalid ``License-Expression`` values:
+
+.. code-block:: email
+
+    License-Expression: Use-it-after-midnight
+    License-Expression: Apache-2.0 OR 2-BSD-Clause
+
+
 .. _639-spec-field-license-file:
 
 Add ``License-File`` field

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -18,37 +18,39 @@ Post-History: `15-Aug-2019 <https://discuss.python.org/t/2154>`__,
 Abstract
 ========
 
-This PEP defines a specification for how licenses are documented in the
-`core metadata <coremetadataspec_>`__, with
-:ref:`license expression strings <639-spec-field-license-expression>` using
-`SPDX identifiers <spdxid_>`__ in a new ``License-Expression`` field.
-This will make license declarations simpler and less ambiguous for
-package authors to create, end users to read and understand, and
-tools to programmatically process.
+This PEP defines a specification for
+how licenses are documented in the :term:`Core Metadata`,
+with :term:`license expression` strings using :term:`SPDX identifier`\s
+in a new :ref:`License-Expression field <639-spec-field-license-expression>`.
+This will make license declaration simpler and less ambiguous for
+package authors to create, end users to read and understand,
+and tools to programmatically process.
 
 The PEP also:
 
 - :ref:`Formally specifies <639-spec-field-license-file>`
-  a new ``License-File`` field, and defines how license files should be
-  :ref:`included in distributions <639-spec-project-formats>`,
-  as already used by the Wheel and Setuptools projects.
+  a new ``License-File`` :term:`Core Metadata field`,
+  and :ref:`defines <639-spec-project-formats>` how license files should be
+  included in various :term:`Project` and :term:`distribution package` formats,
+  as already used by the Setuptools and Wheel projects.
 
-- Deprecates the legacy ``License`` :ref:`field <639-spec-field-license>`
+- :ref:`Deprecates <639-spec-field-license>`
+  the legacy ``License`` :term:`Core Metadata field`
   and ``license ::`` :ref:`classifiers <639-spec-field-classifier>`.
 
-- :ref:`Adds and deprecates <639-spec-source-metadata>` the corresponding keys
-  in the ``pyproject.toml`` ``[project]`` table.
+- :ref:`Adds and deprecates <639-spec-source-metadata>` the corresponding
+  :term:`Pyproject Metadata key`\s.
 
-- :ref:`Provides clear guidance <639-spec-converting-metadata>` for authors and
-  tools converting legacy license metadata, adding license files and
-  validating license expressions.
+- :ref:`Provides clear guidance <639-spec-converting-metadata>`
+  for authors and tools converting legacy license metadata,
+  adding license files and validating license expressions.
 
 - Describes a :ref:`reference implementation <639-reference-implementation>`
   and analyzes numerous :ref:`potential alternatives <639-rejected-ideas>`.
 
 The changes in this PEP will update the
-`core metadata <coremetadataspec_>`__ to version 2.4, modify the
-`project (source) metadata specification <pyprojecttoml_>`__,
+`Core Metadata specification <coremetadataspec_>`__ to version 2.4,
+extend the `Pyproject Metadata specification <pyprojecttoml_>`__,
 and make minor additions to the `source distribution (sdist) <sdistspec_>`__,
 `built distribution (wheel) <wheelspec_>`__ and
 `installed project <installedspec_>`__ standards.
@@ -60,17 +62,19 @@ Goals
 =====
 
 This PEP's scope is limited to covering new mechanisms for documenting
-the license of a distribution package, specifically defining:
+the license of a :term:`distribution package`, specifically defining:
 
-- A means of specifying a SPDX license expression.
-- A method of including license texts in distributions and installed projects.
+- A means of specifying a SPDX :term:`license expression`.
+- A method of including license texts in :term:`distribution`\s
+  and installed :term:`Projects`.
 
-The changes to the core metadata specification that this PEP requires have been
-designed to minimize impact and maximize backward compatibility.
-This specification builds off of existing ways to document licenses that are
-already in use in popular tools (e.g. adding support to core metadata for the
-``License-File`` field :ref:`already used <639-license-doc-setuptools-wheel>`
-in the Wheel and Setuptools projects) and by some package authors
+The changes to the :term:`Core Metadata` specification that this PEP requires
+have been designed to minimize impact and maximize backward compatibility.
+This specification builds off of existing ways to document licenses
+that are already in use in popular tools
+(e.g. :ref:`639-spec-field-license-file` to Core Metadata
+:ref:`already used <639-license-doc-setuptools-wheel>`
+in the Setuptools and Wheel projects) and by some package authors
 (e.g. storing an SPDX license expression in the existing ``License`` field).
 
 In addition to these proposed changes, this PEP contains guidance for tools
@@ -92,10 +96,10 @@ This PEP is neutral regarding the choice of license by any particular
 package author. This PEP makes no recommendation for specific licenses,
 and does not require the use of a particular license documentation convention.
 
-Rather, the SPDX license expression syntax proposed in this PEP provides a
-simpler and more expressive mechanism to accurately document any kind of
-license that applies to a Python package, whether it is open source,
-free/libre, proprietary, or a combination of such.
+Rather, the SPDX :term:`license expression` syntax proposed in this PEP
+provides a simpler and more expressive mechanism to accurately document
+any kind of license that applies to a Python :term:`distribution package`,
+whether it is open source, free/libre, proprietary, or a combination of such.
 
 This PEP also does not impose any additional restrictions when uploading to
 PyPI, unless projects choose to make use of the new fields.
@@ -104,11 +108,11 @@ Instead, it is intended to document best practices already in use, extend them
 to use a new formally-specified and supported mechanism, and provide guidance
 for packaging tools on how to hand the transition and inform users accordingly.
 
-This PEP also is not about license documentation in files inside projects,
+This PEP also is not about license documentation for individual files,
 though this is a :ref:`surveyed topic <639-license-doc-source-files>`
-in an appendix, and nor does it intend to cover cases where the source and
-binary distribution packages don't have :ref:`the same licenses
-<639-rejected-ideas-difference-license-source-binary>`.
+in an appendix, and nor does it intend to cover cases where the
+:term:`source distribution` and :term:`binary distribution` packages don't have
+:ref:`the same licenses <639-rejected-ideas-difference-license-source-binary>`.
 
 
 .. _639-motivation:
@@ -119,14 +123,15 @@ Motivation
 Software must be licensed in order for anyone other than its creator to
 download, use, share and modify it, so providing accurate license information
 to Python package users is an important matter.
-Today, there are multiple fields where
-licenses are documented in core metadata, and there are limitations to what
-can be expressed in each of them. This often leads to confusion and a lack of
-clarity, both for package authors and end users.
+Today, there are multiple :term:`fields <Core Metadata field>`
+where licenses are documented in :term:`Core Metadata`,
+and there are limitations to what can be expressed in each of them.
+This often leads to confusion and a lack of clarity,
+both for package authors and end users.
 
 Many package authors have expressed difficulty and frustrations due to the
-limited capabilities to express licensing in project metadata, and this
-creates further trouble for Linux and BSD distribution re-packagers.
+limited capabilities to express licensing in package metadata,
+and this creates further trouble for Linux and BSD re-packagers.
 This has triggered a number of license-related discussions and issues,
 including on `outdated and ambiguous PyPI classifiers <classifierissue_>`__,
 `license interoperability with other ecosystems <interopissue_>`__,
@@ -134,9 +139,10 @@ including on `outdated and ambiguous PyPI classifiers <classifierissue_>`__,
 `limited support for license files in the Wheel project <wheelfiles_>`__, and
 `the lack of clear, precise and standardized license metadata <pepissue_>`__.
 
-The current license classifiers address some common cases, and could
-be extended to include the full range of current SPDX identifiers
-while deprecating the many ambiguous classifiers
+The current :term:`license classifier`\s address some common cases,
+and could be extended to include the full range of :term:`SPDX identifiers`
+while deprecating the many
+:ref:`ambiguous classifiers <639-spec-mapping-classifiers-identifiers>`
 (including some popular and problematic ones,
 such as ``License :: OSI Approved :: BSD License``).
 However, this requires a substantial amount of effort
@@ -159,8 +165,8 @@ Finally, this does not provide as clear an indicator that a package
 has adopted the new system, and should be treated accordingly.
 
 On average, Python packages tend to have more ambiguous and missing license
-information than other common ecosystems (such as npm, Maven or
-Gem). This is supported by the `statistics page <cdstats_>`__ of the
+information than other common ecosystems (such as npm, Maven or Gem).
+This is supported by the `statistics page <cdstats_>`__ of the
 `ClearlyDefined project <clearlydefined_>`__, an
 `Open Source Initiative <osi_>`__ incubated effort to help
 improve licensing clarity of other FOSS projects, covering all packages
@@ -184,8 +190,8 @@ and recommendations of this PEP:
 
 - Most package formats use a single ``License`` field.
 
-- Many modern package systems use some form of license expression syntax to
-  optionally combine more than one license identifier together.
+- Many modern package systems use some form of :term:`license expression`
+  to optionally combine more than one :term:`license identifier` together.
   SPDX and SPDX-like syntaxes are the most popular in use.
 
 - SPDX license identifiers are becoming the de facto way to reference common
@@ -194,15 +200,19 @@ and recommendations of this PEP:
 - Several package formats support documenting both a license expression and the
   paths of the corresponding files that contain the license text. Most Free and
   Open Source Software licenses require package authors to include their full
-  text in a distribution.
+  text in a :term:`Distribution Package`.
 
-The use of a new ``License-Expression`` field will provide an intuitive,
-structured and unambiguous way to express the license of a
-package using a well-defined syntax and well-known license identifiers.
-Similarly, a formally-specified ``License-File`` field offers a standardized
-way to ensure that the full text of the license(s) are included with the
-package when distributed, as legally required, and allows other tools consuming
-the core metadata to unambiguously locate a distribution's license files.
+The use of
+:ref:`a new License-Expression field <639-spec-field-license-expression>
+will provide an intuitive, structured and unambiguous way
+to express the license of a package
+using a well-defined syntax and well-known license identifiers.
+Similarly, a
+:ref:`formally-specified License-File field <639-spec-field-license-file>`
+offers a standardized way to ensure that the full text of the license(s)
+are included with the package when distributed, as legally required,
+and allows other tools consuming the :term:`Core Metadata`
+to unambiguously locate a :term:`distribution archive`'s license files.
 
 While dramatically simplifying and improving the present Python license
 metadata story, this specification standardizes and builds upon
@@ -211,7 +221,8 @@ existing practice in the `Setuptools <setuptoolsfiles_>`__ and
 Furthermore, an up-to-date version of the current draft of this PEP is
 `already successfully implemented <hatchimplementation_>`__ in the popular
 PyPA `Hatch <hatch_>`__ packaging tool, and an earlier draft of the
-license files portion is `implemented in Setuptools <setuptoolspep639_>`__.
+:ref:`license files portion <639-spec-field-license-file>
+is `implemented in Setuptools <setuptoolspep639_>`__.
 
 Over time, encouraging the use of these fields and deprecating the ambiguous,
 duplicative and confusing legacy alternatives will help Python software
@@ -261,8 +272,7 @@ that aren't currently listed there:
 
     project root directory
         The filesystem directory in which
-        a :term:`Project`'s :term:`source tree` is located
-        and which contains the ``pyproject.toml`` file.
+        a :term:`Project`'s :term:`source tree` is located.
 
     project source tree
     source tree
@@ -379,7 +389,8 @@ particularly :term:`license identifier` and :term:`license expression`.
     SPDX expression
         A string with valid `SPDX license expression syntax <spdxpression_>`__
         including one or more SPDX :term:`license identifier`\(s),
-        which describes a project's license(s) and how they inter-relate.
+        which describes a :term:`Project`'s license(s)
+        and how they inter-relate.
         Examples:
         ``GPL-3.0-or-later``,
         ``MIT AND (Apache-2.0 OR BSD-2-clause)``
@@ -417,20 +428,24 @@ Specification
 =============
 
 The changes necessary to implement the improved license handling outlined in
-this PEP include those in both
-:ref:`distribution package metadata <639-spec-core-metadata>`,
-as defined in the `core metadata specification <coremetadataspec_>`__, and
-:ref:`author-provided project source metadata <639-spec-source-metadata>`,
-as defined in the `project source metadata specification <pyprojecttoml_>`__
-(and originally introduced in :pep:`621`).
+this PEP include both :ref:`those in <639-spec-core-metadata>`
+the :term:`build metadata` for :term:`Distribution Packages`,
+as defined in the :term:`Core Metadata` `specification <coremetadataspec_>`__,
+and :ref:`those in <639-spec-source-metadata>` :term:`project source metadata`,
+as defined in the
+:term:`Pyproject Metadata` `specification <pyprojecttoml_>`__
+(originally introduced in :pep:`621`).
 
 Further, :ref:`minor additions <639-spec-project-formats>` to the
-source distribution (sdist), built distribution (wheel) and installed project
-specifications will help document and clarify the already allowed,
+:term:`source distribution` (:term:`sdist`),
+:term:`built distribution` (:term:`Wheel`)
+and :term:`installed project` specifications
+will help document and clarify the already-allowed,
 now formally standardized behavior in these respects.
 Finally, :ref:`guidance is established <639-spec-converting-metadata>`
-for tools handling and converting legacy license metadata to license
-expressions, to ensure the results are consistent, correct and unambiguous.
+for tools handling and converting legacy license metadata
+to :term:`license expressions`,
+to ensure the results are consistent, correct and unambiguous.
 
 Note that the guidance on errors and warnings is for tools' default behavior;
 they MAY operate more strictly if users explicitly configure them to do so,
@@ -439,26 +454,27 @@ such as by a CLI flag or a configuration option.
 
 .. _639-spec-core-metadata:
 
-Core metadata
+Core Metadata
 -------------
 
-The `PyPA Core Metadata specification <coremetadataspec_>`__ defines the names
-and semantics of each of the supported fields in the distribution metadata of
-Python distribution packages and installed projects.
+The :term:`Core Metadata` `specification <coremetadataspec_>`__
+defines the names and semantics of each of the supported
+:term:`fields <Core Metadata field>` in the :term:`built metadata`
+of Python :term:`distribution package`\s and :term:`installed project`\s.
 
 This PEP :ref:`adds <639-spec-field-license-expression>` the
 ``License-Expression`` field,
 :ref:`adds <639-spec-field-license-file>` the ``License-File`` field,
 :ref:`deprecates <639-spec-field-license>` the ``License`` field,
-and :ref:`deprecates <639-spec-field-classifier>` the license classifiers
-in the ``Classifier`` field.
+and :ref:`deprecates <639-spec-field-classifier>`
+the :term:`license classifier`\s in the ``Classifier`` field.
 
 The error and warning guidance in this section applies to build and
 publishing tools; end-user-facing install tools MAY be more lenient than
 mentioned here when encountering malformed metadata
 that does not conform to this specification.
 
-As it adds new fields, this PEP updates the core metadata to version 2.4.
+As it adds new fields, this PEP updates the Core Metadata version to 2.4.
 
 
 .. _639-spec-field-license-expression:
@@ -539,7 +555,7 @@ As :ref:`specified by this PEP <639-spec-project-formats>`, its value
 is also that file's path relative to the root license directory in both
 installed projects and the standardized distribution package types.
 In other legacy, non-standard or new distribution package formats and
-mechanisms of accessing and storing core metadata, the value MAY correspond
+mechanisms of accessing and storing Core Metadata, the value MAY correspond
 to the license file path relative to a format-defined root license directory.
 Alternatively, it MAY be treated as a unique abstract key to access the
 license file contents by another means, as specified by the format.
@@ -550,8 +566,9 @@ relative to the root license directory, and MUST be installed with the
 distribution at that same relative path.
 
 The specified relative path MUST be consistent between project source trees,
-source distributions (sdists), built distributions (wheels) and installed
-projects. Therefore, inside the root license directory, packaging tools
+source distributions (sdists), built distributions (:term:`Wheel`\s)
+and installed projects.
+Therefore, inside the root license directory, packaging tools
 MUST reproduce the directory structure under which the
 source license files are located relative to the project root.
 
@@ -598,7 +615,7 @@ Deprecate license classifiers
 '''''''''''''''''''''''''''''
 
 Using license `classifiers <classifiers_>`__ in the ``Classifier`` field
-(`described in the core metadata specification <coremetadataclassifiers_>`__)
+(`described in the Core Metadata specification <coremetadataclassifiers_>`__)
 is deprecated and replaced by the more precise ``License-Expression`` field.
 
 If the ``License-Expression`` field is present, build tools SHOULD and
@@ -632,7 +649,7 @@ As originally introduced in :pep:`621`, the
 `PyPA Declaring Project Metadata specification <pyprojecttoml_>`__
 defines how to declare a project's source
 metadata under a ``[project]`` table in the ``pyproject.toml`` file for
-build tools to consume and output distribution core metadata.
+build tools to consume and output distribution Core Metadata.
 
 This PEP :ref:`adds <639-spec-key-license-expression>`
 a top-level string value for the ``license`` key,
@@ -651,16 +668,16 @@ A top-level string value is defined
 for the ``license`` key in the ``[project]`` table,
 which is specified to be a valid SPDX license expression,
 as :ref:`defined previously <639-license-expression-definition>`.
-Its value maps to the ``License-Expression`` field in the core metadata.
+Its value maps to the ``License-Expression`` field in the Core Metadata.
 
 Build tools SHOULD validate the expression as described in the
 :ref:`639-spec-field-license-expression` section,
 outputting an error or warning as specified.
-When generating the core metadata, tools MUST perform case normalization.
+When generating the Core Metadata, tools MUST perform case normalization.
 
 If a top-level string value for the ``license`` key is present and valid,
 for purposes of backward compatibility
-tools MAY back-fill the ``License`` core metadata field
+tools MAY back-fill the ``License`` Core Metadata field
 with the normalized value of the ``license`` key.
 
 
@@ -672,7 +689,7 @@ Add ``license-files`` key
 A new ``license-files`` key is added to the ``[project]`` table for specifying
 paths in the project source tree relative to ``pyproject.toml`` to file(s)
 containing licenses and other legal notices to be distributed with the package.
-It corresponds to the ``License-File`` fields in the core metadata.
+It corresponds to the ``License-File`` fields in the Core Metadata.
 
 Its value is a table, which if present MUST contain one of two optional,
 mutually exclusive subkeys, ``paths`` and ``globs``; if both are specified,
@@ -701,7 +718,7 @@ If the ``paths`` subkey is a non-empty array, build tools:
 - MUST NOT match any additional license files beyond those explicitly
   statically specified by the user under the ``paths`` subkey.
 
-- MUST list each file path under a ``License-File`` field in the core metadata.
+- MUST list each file path under a ``License-File`` field in the Core Metadata.
 
 - MUST raise an error if one or more paths do not correspond to a valid file
   in the project source that can be copied into the distribution archive.
@@ -718,7 +735,7 @@ If the ``globs`` subkey is a non-empty array, build tools:
   determined to be backup, temporary, hidden, OS-generated or VCS-ignored.
 
 - MUST list each matched file path under a ``License-File`` field in the
-  core metadata.
+  Core Metadata.
 
 - SHOULD issue a warning and MAY raise an error if no files are matched.
 
@@ -771,7 +788,7 @@ the ``license-files`` key instead.
 
 If the specified license ``file`` is present in the source tree,
 build tools SHOULD use it to fill the ``License-File`` field
-in the core metadata, and MUST include the specified file
+in the Core Metadata, and MUST include the specified file
 as if it were specified in a ``license-file.paths`` field.
 If the file does not exist at the specified path,
 tools MUST raise an informative error as previously specified.
@@ -796,7 +813,7 @@ allowed and implemented behavior, as well as explicitly mention the root
 license directory the license files are located in and relative to for
 each format, per the :ref:`639-spec-field-license-file` section.
 
-**Project source trees**
+:term:`project source tree`
   As described in the :ref:`639-spec-source-metadata` section, the
   `Declaring Project Metadata specification <pyprojecttoml_>`__
   will be updated to reflect that license file paths MUST be relative to the
@@ -804,15 +821,17 @@ each format, per the :ref:`639-spec-field-license-file` section.
   (or equivalently, other legacy project configuration,
   e.g. ``setup.py``, ``setup.cfg``, etc).
 
-**Source distributions** *(sdists)*
-  The `sdist specification <sdistspec_>`__ will be updated to reflect that for
-  ``Metadata-Version`` is ``2.4`` or greater, the sdist MUST contain any
-  license files specified by ``License-File`` in the ``PKG-INFO`` at their
-  respective paths relative to the top-level directory of the sdist
-  (containing the ``pyproject.toml`` and the ``PKG-INFO`` core metadata).
+:term:`Source distribution` (:term:`sdist`)
+  The `sdist specification <sdistspec_>`__ will be updated to reflect that if
+  the ``Metadata-Version`` is ``2.4`` or greater,
+  the sdist MUST contain any license files specified by
+  the :ref:`License-File field <639-spec-field-license-file>`
+  in the ``PKG-INFO`` at their respective paths
+  relative to the  of the sdist
+  (containing the ``pyproject.toml`` and the ``PKG-INFO`` Core Metadata).
 
 **Built distributions** *(wheels)*
-  The `wheel specification <wheelspec_>`__ will be updated to reflect that if
+  The `Wheel specification <wheelspec_>`__ will be updated to reflect that if
   the ``Metadata-Version`` is ``2.4`` or greater and one or more
   ``License-File`` fields is specified, the ``.dist-info`` directory MUST
   contain a ``licenses`` subdirectory, which MUST contain the files listed
@@ -837,9 +856,9 @@ Converting legacy metadata
 
 Tools MUST NOT use the contents of the ``license.text`` ``[project]`` key
 (or equivalent tool-specific format),
-license classifiers or the value of the core metadata ``License`` field
+license classifiers or the value of the Core Metadata ``License`` field
 to fill the top-level string value of the ``license`` key
-or the core metadata ``License-Expression`` field
+or the Core Metadata ``License-Expression`` field
 without informing the user and requiring unambiguous, affirmative user action
 to select and confirm the desired license expression value before proceeding.
 
@@ -854,7 +873,7 @@ the PEP authors.
 Backwards Compatibility
 =======================
 
-Adding a new, dedicated ``License-Expression`` core metadata field
+Adding a new, dedicated ``License-Expression`` Core Metadata field
 and a top-level string value for the ``license`` key reserved for this purpose
 in the ``pyproject.toml`` ``[project]`` table
 unambiguously signals support for the specification in this PEP.
@@ -863,15 +882,15 @@ misinterpreting a license expression as a free-form license description
 or vice versa, and raises an error if and only if the user affirmatively
 upgrades to the latest metadata version and adds the new field/key.
 
-The legacy ``License`` core metadata field
+The legacy ``License`` Core Metadata field
 and the ``license`` key table subkeys (``text`` and ``file``)
 in the ``pyproject.toml`` ``[project]`` table
 will be deprecated along with the license classifiers,
 retaining backwards compatibility while gently preparing users for their
 future removal. Such a removal would follow a suitable transition period, and
-be left to a future PEP and a new version of the core metadata specification.
+be left to a future PEP and a new version of the Core Metadata specification.
 
-Formally specifying the new ``License-File`` core metadata field and the
+Formally specifying the new ``License-File`` Core Metadata field and the
 inclusion of the listed files in the distribution merely codifies and
 refines the existing practices in popular packaging tools, including the Wheel
 and Setuptools projects, and is designed to be largely backwards-compatible
@@ -1012,7 +1031,7 @@ Should the ``License`` field be back-filled, or mutually exclusive?
 -------------------------------------------------------------------
 
 At present, this PEP explicitly allows, but does not formally recommend or
-require, build tools to back-fill the ``License`` core metadata field with
+require, build tools to back-fill the ``License`` Core Metadata field with
 the verbatim text from the ``License-Expression`` field. This would
 presumably improve backwards compatibility and was suggested
 by some on the Discourse thread. On the other hand, allowing it does

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -87,12 +87,11 @@ Motivation
 ==========
 
 Software must be licensed in order for anyone other than its creator to
-download, use, share and modify it, so providing accurate license information
-to Python package users is an important matter.
+download, use, share and modify it.
 Today, there are multiple fields where licenses
 are documented in :term:`Core Metadata`,
 and there are limitations to what can be expressed in each of them.
-This often leads to confusion and a lack of clarity, both for package authors
+This often leads to confusion both for package authors
 and end users, including distribution re-packagers.
 
 This has triggered a number of license-related discussions and issues,
@@ -119,18 +118,17 @@ However, there are multiple reasons against such approach:
 - It requires a great effort to duplicate the SPDX license list and keep it in
   sync.
 
-- It is a hard break in backward compatibility, forcing a many package authors
+- It is a hard break in backward compatibility, forcing package authors
   to update to new classifiers immediately when PyPI deprecates the old ones.
 
-- It only covers simple packages under a single license;
+- It only covers packages under a single license;
   it doesn't address projects that vendor dependencies (e.g. Setuptools),
   offer a choice of licenses (e.g. Packaging) or were relicensed,
   adapt code from other projects or contain fonts, images,
   examples, binaries or other assets under other licenses.
 
 - It requires both authors and tools understand and implement the PyPI-specific
-  classifier system, rather than using standardized and widely adopted
-  SPDX identifiers in a text field.
+  classifier system.
 
 - It does not provide as clear an indicator that a package
   has adopted the new system, and should be treated accordingly.
@@ -148,29 +146,21 @@ language ecosystems and applications <639-license-doc-other-projects>`.
 
 The takeaways from the survey have guided the recommendations of this PEP:
 
-- Most package formats use a single ``License`` field.
+- SPDX and SPDX-like syntaxes are the most popular :term:`license expression`\s
+  in many modern package systems.
 
-- Many modern package systems use some form of :term:`license expression`
-  to optionally combine more than one :term:`license identifier` together.
-  SPDX and SPDX-like syntaxes are the most popular in use.
-
-- SPDX license identifiers are becoming the de facto way to reference common
-  licenses everywhere, whether or not a full license expression syntax is used.
-
-- Several package formats support documenting both a license expression and the
-  paths of the corresponding files that contain the license text. Most Free and
-  Open Source Software licenses require package authors to include their full
-  text in a :term:`Distribution Package`.
+- Most Free and Open Source Software licenses require package authors to
+  include their full text in a :term:`Distribution Package`.
 
 Therefore, this PEP introduces two new Core Metadata fields:
 
 - :ref:`License-Expression <639-spec-field-license-expression>` that
-  provides a structured and unambiguous way to express the license of a package
-  using a well-defined syntax and well-known license identifiers.
+  provides an unambiguous way to express the license of a package
+  using SPDX license expressions.
 
 - :ref:`License-File <639-spec-field-license-file>` that
   offers a standardized way to include the full text of the license(s)
-  with the package when distributed, as legally required,
+  with the package when distributed,
   and allows other tools consuming the :term:`Core Metadata`
   to locate a :term:`distribution archive`'s license files.
 

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -663,21 +663,24 @@ in a future PEP.
 Project source metadata
 -----------------------
 
-As originally introduced in :pep:`621`, the
-`PyPA Declaring Project Metadata specification <pyprojecttoml_>`__
-defines how to declare a project's source
+The `PyPUG Declaring Project Metadata specification <pyprojecttoml_>`__,
+introduced in :pep:`621`, defines how to declare a project's source
 metadata under a ``[project]`` table in the ``pyproject.toml`` file for
 build tools to consume and output distribution Core Metadata.
 
-This PEP :ref:`adds <639-spec-key-license-expression>`
-a top-level string value for the ``license`` key,
-:ref:`adds <639-spec-key-license-files>` the new ``license-files`` key
-and :ref:`deprecates <639-spec-key-license>`
-the table value for the ``license`` key
-along with its corresponding table subkeys, ``text`` and ``file``.
+This PEP:
+
+- :ref:`adds <639-spec-key-license-text>`
+  a top-level string value for the ``license`` key,
+
+- :ref:`deprecates <639-spec-key-license-table>` the table value for the
+  ``license`` key along with its corresponding table subkeys, ``text`` and
+  ``file``,
+
+- :ref:`adds <639-spec-key-license-files>` the new ``license-files`` key.
 
 
-.. _639-spec-key-license-expression:
+.. _639-spec-key-license-text:
 
 Add string value to ``license`` key
 '''''''''''''''''''''''''''''''''''
@@ -697,6 +700,43 @@ If a top-level string value for the ``license`` key is present and valid,
 for purposes of backward compatibility
 tools MAY back-fill the ``License`` Core Metadata field
 with the normalized value of the ``license`` key.
+
+
+.. _639-spec-key-license-table:
+
+Deprecate ``license`` key table subkeys
+'''''''''''''''''''''''''''''''''''''''
+
+Table values for the ``license`` key in the ``[project]`` table,
+including the ``text`` and ``file`` table subkeys, are now deprecated.
+If the new ``license-files`` key is present,
+build tools MUST raise an error if the ``license`` key is defined
+and has a value other than a single top-level string.
+
+If the new ``license-files`` key is not present
+and the ``text`` subkey is present in a ``license`` table,
+tools SHOULD issue a warning informing users it is deprecated
+and recommending a license expression as a top-level string key instead.
+
+Likewise, if the new ``license-files`` key is not present
+and the ``file`` subkey is present in the ``license`` table,
+tools SHOULD issue a warning informing users it is deprecated and recommending
+the ``license-files`` key instead.
+
+If the specified license ``file`` is present in the source tree,
+build tools SHOULD use it to fill the ``License-File`` field
+in the core metadata, and MUST include the specified file
+as if it were specified in a ``license-file.paths`` field.
+If the file does not exist at the specified path,
+tools MUST raise an informative error as previously specified.
+However, tools MUST also still assume the
+:ref:`specified default value <639-default-patterns>`
+for the ``license-files`` key and also include,
+in addition to a license file specified under the ``license.file`` subkey,
+any license files that match the specified list of patterns.
+
+Table values for the ``license`` key MAY be removed
+from a new version of the specification in a future PEP.
 
 
 .. _639-spec-key-license-files:
@@ -781,43 +821,6 @@ to preserve consistent behavior with current tools and help ensure the packages
 they create are legally distributable, build tools SHOULD default to
 including at least the license files matching the above patterns, unless the
 user has explicitly specified their own.
-
-
-.. _639-spec-key-license:
-
-Deprecate ``license`` key table subkeys
-'''''''''''''''''''''''''''''''''''''''
-
-Table values for the ``license`` key in the ``[project]`` table,
-including the ``text`` and ``file`` table subkeys, are now deprecated.
-If the new ``license-files`` key is present,
-build tools MUST raise an error if the ``license`` key is defined
-and has a value other than a single top-level string.
-
-If the new ``license-files`` key is not present
-and the ``text`` subkey is present in a ``license`` table,
-tools SHOULD issue a warning informing users it is deprecated
-and recommending a license expression as a top-level string key instead.
-
-Likewise, if the new ``license-files`` key is not present
-and the ``file`` subkey is present in the ``license`` table,
-tools SHOULD issue a warning informing users it is deprecated and recommending
-the ``license-files`` key instead.
-
-If the specified license ``file`` is present in the source tree,
-build tools SHOULD use it to fill the ``License-File`` field
-in the Core Metadata, and MUST include the specified file
-as if it were specified in a ``license-file.paths`` field.
-If the file does not exist at the specified path,
-tools MUST raise an informative error as previously specified.
-However, tools MUST also still assume the
-:ref:`specified default value <639-default-patterns>`
-for the ``license-files`` key and also include,
-in addition to a license file specified under the ``license.file`` subkey,
-any license files that match the specified list of patterns.
-
-Table values for the ``license`` key MAY be removed
-from a new version of the specification in a future PEP.
 
 
 .. _639-spec-project-formats:

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -545,12 +545,6 @@ As :ref:`specified by this PEP <639-spec-project-formats>`, its value
 is also that file's path relative to the :term:`root license directory`
 in both :term:`installed project`\s
 and the standardized :term:`Distribution Package` types.
-In other legacy, non-standard or new distribution package formats and
-mechanisms of accessing and storing :term:`Core Metadata`,
-the value MAY correspond to the license file path
-relative to a format-defined root license directory.
-Alternatively, it MAY be treated as a unique abstract key to access the
-license file contents by another means, as specified by the format.
 
 If a ``License-File`` is listed in a :term:`source distribution` or
 :term:`Built Distribution`'s Core Metadata:

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -76,7 +76,8 @@ imposed by this PEP when uploading to PyPI.
 This PEP also is not about license documentation for individual files,
 though this is a :ref:`surveyed topic <639-license-doc-source-files>`
 in an appendix, nor does it intend to cover cases where the
-:term:`source distribution` and :term:`binary distribution` packages don't have
+:term:`source distribution <Source Distribution (or "sdist")>` and
+:term:`binary distribution` packages don't have
 :ref:`the same licenses <639-rejected-ideas-difference-license-source-binary>`.
 
 
@@ -183,134 +184,6 @@ The keywords "MUST", "MUST NOT", "REQUIRED",
 in this document are to be interpreted as described in :rfc:`2119`.
 
 
-.. _639-terminology-packaging:
-
-Packaging terms
----------------
-
-The basis for this PEP's general packaging terminology is
-the :doc:`PyPA PyPUG Glossary <packaging:glossary>`,
-and a number of its terms are used directly, including
-:term:`Binary Distribution`,
-:term:`Built Distribution`,
-:term:`Distribution Package`,
-and :term:`Project`.
-We include additional definitions here
-to accurately reflect the modern packaging ecosystem,
-and adding terms defined/used in :ref:`packaging:packaging-specifications`
-that aren't currently listed there:
-
-.. glossary::
-
-    distribution archive
-        The physical distribution artifact (i.e. a file on disk)
-        for a :term:`Distribution Package`.
-
-    installed project
-        A :term:`Project` that is installed for use with
-        a Python interpreter or :term:`Virtual Environment`,
-        as described in the PyPA spec
-        :ref:`packaging:recording-installed-packages`.
-
-    project root directory
-        The filesystem directory in which
-        a :term:`Project`'s :term:`source tree` is located.
-
-    project source tree
-    source tree
-        The on-disk format of a :term:`Project` used for development,
-        containing its raw source code before being packaged
-        into a :term:`source distribution` or :term:`Built Distribution`.
-
-    source distribution
-    sdist
-        A :term:`distribution archive` format
-        (generated using, e.g., ``python -m build --sdist``)
-        that provides the :term:`Core Metadata` and essential source files
-        needed by a build backend (as defined in :pep:`517`)
-        to generate a :term:`Built Distribution`.
-
-    Wheel format
-    Wheel
-        The standard :term:`Built Distribution` format
-        originally introduced in :pep:`427`
-        and currently defined by
-        the PyPA spec :ref:`packaging:binary-distribution-format`.
-        Not to be confused with its reference implementation,
-        the :term:`Wheel project`.
-
-    Wheel project
-        The PyPA reference implementation of the :term:`Wheel format`.
-        To avoid ambiguity with the latter,
-        the project will be consistently referred to as such here.
-
-
-.. _639-terminology-metadata:
-
-Metadata terms
---------------
-
-The :doc:`PyPA PyPUG Glossary <packaging:glossary>` is
-(at the time of this PEP's writing)
-largely lacking in specific terminology to refer to packaging metadata.
-Therefore, we explicitly define the following metadata-related terms:
-
-.. glossary::
-
-    built metadata
-        The concrete form :term:`Core Metadata` takes
-        when included inside an installed :term:`Project` (``METADATA`` file)
-        or a :term:`distribution archive`
-        (``PKG-INFO`` in a :term:`sdist` and ``METADATA`` in a :term:`Wheel`).
-
-    Core Metadata
-        The :ref:`PyPA specification <packaging:core-metadata>`
-        and the set of :term:`metadata field`\s it defines
-        that describe key static attributes of
-        a :term:`distribution package` or :term:`installed project`.
-
-    Core Metadata field
-    metadata field
-        A single key-value pair
-        (or sequence of such with the same name, for multiple-use fields)
-        defined in the :term:`Core Metadata` spec
-        and stored in the :term:`built metadata`.
-        Notably, distinct from a :term:`Pyproject Metadata key`.
-
-    project source metadata
-    source metadata
-        Metadata defined by the package author
-        in a :term:`Project`'s :term:`source tree`,
-        to be transformed into :term:`Core Metadata field`\s
-        in the :term:`built metadata`
-        by the project's build backend.
-        Can be written as :term:`Pyproject Metadata`,
-        or in a tool-specific format
-        (under the ``[tool]`` table in ``pyproject.toml``,
-        or in a tool's own configuration file).
-
-    Pyproject Metadata
-        The :term:`source metadata` format
-        defined by the PyPA spec :ref:`packaging:declaring-project-metadata`
-        and originally introduced in :pep:`621`,
-        stored as :term:`metadata key`\s
-        under the ``[project]`` table of a ``pyproject.toml`` file
-        Notably, *not* a tool-specific source metadata format
-        under the ``[tool]`` table in ``pyproject.toml``.
-
-    Pyproject Metadata key
-    metadata key
-        A top-level TOML key in the ``[project]`` table in ``pyproject.toml``;
-        part of the :term:`Pyproject Metadata`.
-        Notably, distinct from a :term:`Core Metadata field`.
-
-    Pyproject Metadata subkey
-    metadata subkey
-    table subkey
-        A second-level TOML key under a table-valued
-        :term:`Pyproject Metadata key`.
-
-
 .. _639-terminology-license:
 
 License terms
@@ -357,7 +230,8 @@ particularly :term:`license identifier` and :term:`license expression`.
         recorded in the :ref:`License-File <639-spec-field-license-file>`
         :term:`Core Metadata field` are relative to.
         Defined to be the :term:`project root directory`
-        for a :term:`source tree` or :term:`source distribution`;
+        for a :term:`project source tree` or
+        :term:`source distribution <Source Distribution (or "sdist")>`;
         and a subdirectory named ``licenses`` of
         the directory containing the :term:`built metadata`—
         i.e., the ``.dist-info/licenses`` directory—
@@ -529,7 +403,8 @@ is also that file's path relative to the :term:`root license directory`
 in both :term:`installed project`\s
 and the standardized :term:`Distribution Package` types.
 
-If a ``License-File`` is listed in a :term:`source distribution` or
+If a ``License-File`` is listed in a
+:term:`Source Distribution <Source Distribution (or "sdist")>` or
 :term:`Built Distribution`'s Core Metadata:
 
 - That file MUST be included in the :term:`distribution archive` at the
@@ -848,7 +723,7 @@ A few additions will be made to the relevant existing specifications.
   (or equivalently, other legacy project configuration,
   e.g. ``setup.py``, ``setup.cfg``, etc).
 
-:term:`Source distribution` (:term:`sdist`)
+:term:`Source distribution (sdist) <Source Distribution (or "sdist")>`
   The `sdist specification <sdistspec_>`__ will be updated to reflect that if
   the ``Metadata-Version`` is ``2.4`` or greater,
   the sdist MUST contain any license files specified by

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -2,6 +2,7 @@ PEP: 639
 Title: Improving License Clarity with Better Package Metadata
 Author: Philippe Ombredanne <pombredanne@nexb.com>,
         C.A.M. Gerlach <CAM.Gerlach@Gerlach.CAM>,
+        Karolina Surma <karolina.surma@gazeta.pl>,
 PEP-Delegate: Brett Cannon <brett@python.org>
 Discussions-To: https://discuss.python.org/t/12622
 Status: Draft

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -70,8 +70,8 @@ This PEP's scope is limited to covering new mechanisms for documenting
 the license of a :term:`distribution package`, specifically defining:
 
 - A means of specifying a SPDX :term:`license expression`.
-- A method of including license texts in :term:`distribution`\s
-  and installed :term:`Projects`.
+- A method of including license texts in :term:`distribution package`\s
+  and installed :term:`Project`\s.
 
 The changes that this PEP requires have been designed to minimize impact and
 maximize backward compatibility.
@@ -202,7 +202,7 @@ existing practice in the `Setuptools <setuptoolsfiles_>`__ and
 An up-to-date version of the current draft of this PEP is
 `already successfully implemented <hatchimplementation_>`__ in the popular
 PyPA `Hatch <hatch_>`__ packaging tool, and an earlier draft of the
-:ref:`license files portion <639-spec-field-license-file>
+:ref:`license files portion <639-spec-field-license-file>`
 is `implemented in Setuptools <setuptoolspep639_>`__.
 
 
@@ -449,7 +449,7 @@ Examples
 
 Examples of valid SPDX expressions:
 
-.. code-block:: email
+.. code-block:: none
 
     MIT
     BSD-3-Clause
@@ -462,7 +462,7 @@ Examples of valid SPDX expressions:
 
 Examples of invalid SPDX expressions:
 
-.. code-block:: email
+.. code-block:: none
 
     Use-it-after-midnight
     Apache-2.0 OR 2-BSD-Clause
@@ -857,7 +857,7 @@ section.
   relative to the  of the sdist
   (containing the ``pyproject.toml`` and the ``PKG-INFO`` Core Metadata).
 
-**Built distributions** *(wheels)*
+:term:`Built distribution` (:term:`wheel`\s)
   The `Wheel specification <wheelspec_>`__ will be updated to reflect that if
   the ``Metadata-Version`` is ``2.4`` or greater and one or more
   ``License-File`` fields is specified, the ``.dist-info`` directory MUST
@@ -865,7 +865,7 @@ section.
   in the ``License-File`` fields in the ``METADATA`` file at their respective
   paths relative to the ``licenses`` directory.
 
-**Installed projects**
+:term:`Installed project`
   The `Recording Installed Projects specification <installedspec_>`__ will be
   updated to reflect that if the ``Metadata-Version`` is ``2.4`` or greater
   and one or more ``License-File`` fields is specified, the ``.dist-info``

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -761,13 +761,13 @@ Examples of valid license files declaration:
     license-files = { globs = ["LICEN[CS]E*", "AUTHORS*"] }
 
     [project]
-    license-files = { paths = ["licenses/LICENSE.MIT", "licenses/LICENSE.CC0"] }
+    license-files.paths = ["licenses/LICENSE.MIT", "licenses/LICENSE.CC0"]
 
     [project]
     license-files = { paths = [] }
 
     [project]
-    license-files = { globs = [] }
+    license-files.globs = []
 
 Examples of invalid license files declaration:
 

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -18,48 +18,34 @@ Post-History: `15-Aug-2019 <https://discuss.python.org/t/2154>`__,
 Abstract
 ========
 
-This PEP defines a specification for
-how licenses are documented in the :term:`Core Metadata` and the corresponding
-:term:`Pyproject Metadata key`\s.
-with :term:`license expression` strings using :term:`SPDX identifier`\s.
+This PEP defines a specification how licenses are documented in the Python
+projects.
+
+To achieve that, it:
+
+- Adopts the `SPDX license expression syntax <639-spdx_>`__ as
+  means of expressing Python projects' license.
+
+- Defines how to include license files within the projects, source and built
+  distributions.
+
+- Specifies the necessary changes to :term:`Core Metadata` and
+  the corresponding :term:`Pyproject Metadata key`\s
+
+- Describes the necessary changes to related specifications,
+  namely the `source distribution (sdist) <sdistspec_>`__,
+  `built distribution (wheel) <wheelspec_>`__ and
+  `installed project <installedspec_>`__ standards.
+
+- :ref:`Provides clear guidance <639-spec-converting-metadata>`
+  for authors and tools converting legacy license metadata.
+
 This will make license declaration simpler and less ambiguous for
 package authors to create, end users to understand,
 and tools to programmatically process.
 
-This PEP:
-
-- Formally specifies a new ``License-Expression`` field containing
-  :ref:`license expression strings <639-spec-field-license-expression>`
-  consisting of `SPDX identifiers <spdxid_>`__ and defines how license files
-  should be :ref:`included in distributions <639-spec-project-formats>`.
-
-- :ref:`Formally specifies <639-spec-field-license-file>`
-  a new ``License-File`` :term:`Core Metadata field`,
-  and :ref:`defines <639-spec-project-formats>` how license files should be
-  included in various :term:`Project` and :term:`distribution package` formats,
-  as already used by the Setuptools and Wheel projects.
-
-- :ref:`Deprecates <639-spec-field-license>`
-  the legacy ``License`` :term:`Core Metadata field`
-  and ``license ::`` :ref:`classifiers <639-spec-field-classifier>`.
-
-- :ref:`Adds and deprecates <639-spec-source-metadata>` the corresponding
-  :term:`Pyproject Metadata key`\s.
-
-- :ref:`Provides clear guidance <639-spec-converting-metadata>`
-  for authors and tools converting legacy license metadata,
-  adding license files and validating license expressions.
-
-- Describes a :ref:`reference implementation <639-reference-implementation>`
-  and analyzes numerous :ref:`potential alternatives <639-rejected-ideas>`.
-
 The changes will update the
-`Core Metadata specification <coremetadataspec_>`__ to version 2.4,
-extend the `Pyproject Metadata specification <pyprojecttoml_>`__,
-and make minor additions to the `source distribution (sdist) <sdistspec_>`__,
-`built distribution (wheel) <wheelspec_>`__ and
-`installed project <installedspec_>`__ standards.
-
+`Core Metadata specification <coremetadataspec_>`__ to version 2.4.
 
 .. _639-goals:
 
@@ -82,16 +68,11 @@ maximize backward compatibility.
 Non-Goals
 =========
 
-This PEP is neutral regarding the choice of license by any particular
-package author. This PEP makes no recommendation for specific licenses,
-and does not require the use of a particular license documentation convention.
+This PEP is doesn't recommend any particular license to be chosen by
+any particular package author.
 
-This PEP also does not impose any additional restrictions when uploading to
-PyPI, unless projects choose to make use of the new fields.
-
-Instead, it is intended to document best practices already in use, extend them
-to use a new formally-specified mechanism, and provide guidance for packaging
-tools and authors on how to handle the transition.
+If projects decide not to use the new fields, no additional restrictions are
+imposed by this PEP when uploading to PyPI.
 
 This PEP also is not about license documentation for individual files,
 though this is a :ref:`surveyed topic <639-license-doc-source-files>`
@@ -108,7 +89,7 @@ Motivation
 Software must be licensed in order for anyone other than its creator to
 download, use, share and modify it, so providing accurate license information
 to Python package users is an important matter.
-Today, there are multiple :term:`fields <Core Metadata field>` where licenses
+Today, there are multiple fields where licenses
 are documented in :term:`Core Metadata`,
 and there are limitations to what can be expressed in each of them.
 This often leads to confusion and a lack of clarity, both for package authors
@@ -133,7 +114,7 @@ The current license classifiers could be extended to include the full range of
 the SPDX identifiers while deprecating the ambiguous classifiers
 (such as ``License :: OSI Approved :: BSD License``).
 
-There are multiple reasons against such approach:
+However, there are multiple reasons against such approach:
 
 - It requires a great effort to duplicate the SPDX license list and keep it in
   sync.
@@ -160,15 +141,12 @@ There are multiple reasons against such approach:
 Rationale
 =========
 
-A survey of existing license metadata definitions in use in the Python
-ecosystem today is provided in
-:ref:`an appendix <639-license-doc-python>` of this PEP,
-and license documentation in a variety of other packaging systems,
-Linux distributions, languages ecosystems and applications is surveyed in
-:ref:`another appendix <639-license-doc-other-projects>`.
+A survey was conducted to map the existing license metadata
+definitions in the :ref:`Python ecosystem <639-license-doc-python>` and a
+:ref:`variety of other packaging systems, Linux distributions,
+language ecosystems and applications <639-license-doc-other-projects>`.
 
-There are a few takeaways from the survey, which have guided the recommendations
-of this PEP:
+The takeaways from the survey have guided the recommendations of this PEP:
 
 - Most package formats use a single ``License`` field.
 
@@ -184,19 +162,19 @@ of this PEP:
   Open Source Software licenses require package authors to include their full
   text in a :term:`Distribution Package`.
 
-The use of
-:ref:`a new License-Expression field <639-spec-field-license-expression>`
-will provide a structured and unambiguous way
-to express the license of a package
-using a well-defined syntax and well-known license identifiers.
-Similarly, a
-:ref:`formally-specified License-File field <639-spec-field-license-file>`
-offers a standardized way to include the full text of the license(s)
-with the package when distributed, as legally required,
-and allows other tools consuming the :term:`Core Metadata`
-to locate a :term:`distribution archive`'s license files.
+Therefore, this PEP introduces two new Core Metadata fields:
 
-Furthermore, this specification standardizes and builds upon
+- :ref:`License-Expression <639-spec-field-license-expression>` that
+  provides a structured and unambiguous way to express the license of a package
+  using a well-defined syntax and well-known license identifiers.
+
+- :ref:`License-File <639-spec-field-license-file>` that
+  offers a standardized way to include the full text of the license(s)
+  with the package when distributed, as legally required,
+  and allows other tools consuming the :term:`Core Metadata`
+  to locate a :term:`distribution archive`'s license files.
+
+Furthermore, this specification builds upon
 existing practice in the `Setuptools <setuptoolsfiles_>`__ and
 `Wheel <wheelfiles_>`__ projects.
 An up-to-date version of the current draft of this PEP is

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -68,8 +68,8 @@ maximize backward compatibility.
 Non-Goals
 =========
 
-This PEP is doesn't recommend any particular license to be chosen by
-any particular package author.
+This PEP doesn't recommend any particular license to be chosen by any
+particular package author.
 
 If projects decide not to use the new fields, no additional restrictions are
 imposed by this PEP when uploading to PyPI.

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -48,7 +48,7 @@ The PEP also:
 
 The changes in this PEP will update the
 `core metadata <coremetadataspec_>`__ to version 2.4, modify the
-`project (source) metadata specification <pep621spec_>`__,
+`project (source) metadata specification <pyprojecttoml_>`__,
 and make minor additions to the `source distribution (sdist) <sdistspec_>`__,
 `built distribution (wheel) <wheelspec_>`__ and
 `installed project <installedspec_>`__ standards.
@@ -305,7 +305,7 @@ for the purposes of this PEP (``Syn:``).
 
   The **Project Table Metadata**, or ``pyproject.toml`` ``[project]`` metadata,
   refers specifically to the former, as defined by the
-  `PyPA Declaring Project Metadata specification <pep621spec_>`__
+  `PyPA Declaring Project Metadata specification <pyprojecttoml_>`__
   and originally specified in :pep:`621`.
   A **Project Table Key**, or an unqualified *key* refers specifically to
   a top-level ``[project]`` key
@@ -359,7 +359,7 @@ this PEP include those in both
 :ref:`distribution package metadata <639-spec-core-metadata>`,
 as defined in the `core metadata specification <coremetadataspec_>`__, and
 :ref:`author-provided project source metadata <639-spec-source-metadata>`,
-as defined in the `project source metadata specification <_pep621spec>`__
+as defined in the `project source metadata specification <pyprojecttoml_>`__
 (and originally introduced in :pep:`621`).
 
 Further, :ref:`minor additions <639-spec-project-formats>` to the
@@ -567,7 +567,7 @@ Project source metadata
 -----------------------
 
 As originally introduced in :pep:`621`, the
-`PyPA Declaring Project Metadata specification <pep621spec_>`__
+`PyPA Declaring Project Metadata specification <pyprojecttoml_>`__
 defines how to declare a project's source
 metadata under a ``[project]`` table in the ``pyproject.toml`` file for
 build tools to consume and output distribution core metadata.
@@ -736,7 +736,7 @@ each format, per the :ref:`639-spec-field-license-file` section.
 
 **Project source trees**
   As described in the :ref:`639-spec-source-metadata` section, the
-  `Declaring Project Metadata specification <pep621spec_>`__
+  `Declaring Project Metadata specification <pyprojecttoml_>`__
   will be updated to reflect that license file paths MUST be relative to the
   project root directory; i.e. the directory containing the ``pyproject.toml``
   (or equivalently, other legacy project configuration,
@@ -1073,8 +1073,7 @@ References
 .. _licenseexplib: https://github.com/nexB/license-expression/
 .. _osi: https://opensource.org
 .. _packagingissue: https://github.com/pypa/packaging-problems/issues/41
-.. _pep621spec: https://packaging.python.org/specifications/declaring-project-metadata/
-.. _pep621specdynamic: https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#dynamic
+.. _pyprojecttoml: https://packaging.python.org/en/latest/specifications/pyproject-toml/
 .. _pepissue: https://github.com/pombredanne/spdx-pypi-pep/issues/1
 .. _pypi: https://pypi.org/
 .. _pypugdistributionpackage: https://packaging.python.org/en/latest/glossary/#term-Distribution-Package

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -546,13 +546,14 @@ Examples of invalid ``License-Expression`` values:
 Add ``License-File`` field
 ''''''''''''''''''''''''''
 
-Each instance of the ``License-File`` optional :term:`Core Metadata field`
-is specified to contain
-the string representation of the path in the :term:`project source tree`,
-relative to the :term:`project root directory`, of a license-related file.
+``License-File`` is an optional :term:`Core Metadata field`.
+Each instance contains the string
+representation of the path of a license-related file. The path is located
+within the :term:`project source tree`, relative to the
+:term:`project root directory`.
 It is a multi-use field that may appear zero or
-more times, each instance listing the path to one such file. Files specified
-by this field could include license text, author/attribution information,
+more times and each instance lists the path to one such file. Files specified
+under this field could include license text, author/attribution information,
 or other legal notices that need to be distributed with the package.
 
 As :ref:`specified by this PEP <639-spec-project-formats>`, its value
@@ -566,22 +567,27 @@ relative to a format-defined root license directory.
 Alternatively, it MAY be treated as a unique abstract key to access the
 license file contents by another means, as specified by the format.
 
-If a ``License-File`` is listed in a :term:`source distribution`
-or :term:`Built Distribution`'s Core Metadata,
-that file MUST be included in the :term:`distribution archive`
-at the specified path relative to the root license directory,
-and MUST be installed with the :term:`project` at that same relative path.
+If a ``License-File`` is listed in a :term:`source distribution` or
+:term:`Built Distribution`'s Core Metadata:
 
-The specified relative path MUST be consistent between project source trees,
-source distributions (sdists), built distributions (:term:`Wheel`\s)
-and installed projects.
-Therefore, inside the root license directory, packaging tools
-MUST reproduce the directory structure under which the
-source license files are located relative to the project root directory.
+- That file MUST be included in the :term:`distribution archive` at the
+  specified path relative to the root license directory.
 
-Path delimiters MUST be the forward slash character (``/``),
-and parent directory indicators (``..``) MUST NOT be used.
-License file content MUST be UTF-8 encoded text.
+- That file MUST be installed with the :term:`project` at that same relative
+  path.
+
+- The specified relative path MUST be consistent between project source trees,
+  source distributions (sdists), built distributions (:term:`Wheel`\s) and
+  installed projects.
+
+- Inside the root license directory, packaging tools MUST reproduce the
+  directory structure under which the source license files are located
+  relative to the project root.
+
+- Path delimiters MUST be the forward slash character (``/``),
+  and parent directory indicators (``..``) MUST NOT be used.
+
+- License file content MUST be UTF-8 encoded text.
 
 Build tools MAY and publishing tools SHOULD produce an informative warning
 if a built distribution's metadata contains no ``License-File`` entries,

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -286,9 +286,6 @@ A license expression can use the following :term:`license identifier`\s:
   identify licenses that are not included in the SPDX license list.
 
 
-Examples
-''''''''
-
 Examples of valid SPDX expressions:
 
 .. code-block:: none

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -7,7 +7,6 @@ Discussions-To: https://discuss.python.org/t/12622
 Status: Draft
 Type: Standards Track
 Topic: Packaging
-Content-Type: text/x-rst
 Created: 15-Aug-2019
 Post-History: `15-Aug-2019 <https://discuss.python.org/t/2154>`__,
               `17-Dec-2021 <https://discuss.python.org/t/12622>`__,

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -482,8 +482,9 @@ As it adds new fields, this PEP updates the Core Metadata version to 2.4.
 Add ``License-Expression`` field
 ''''''''''''''''''''''''''''''''
 
-The ``License-Expression`` optional field is specified to contain a text string
-that is a valid SPDX license expression, as defined herein.
+The ``License-Expression`` optional :term:`Core Metadata field`
+is specified to contain a text string
+that is a valid SPDX :term:`license expression`, as defined herein.
 
 Publishing tools SHOULD issue an informational warning if this field is
 missing, and MAY raise an error. Build tools MAY issue a similar warning,
@@ -497,7 +498,7 @@ Version 2.2 or a later compatible version.
 
 When used in the ``License-Expression`` field and as a specialization of
 the SPDX license expression definition, a license expression can use the
-following license identifiers:
+following :term:`license identifier`\s:
 
 - Any SPDX-listed license short-form identifiers that are published in the
   `SPDX License List <spdxlist_>`__, version 3.17 or any later compatible
@@ -529,10 +530,12 @@ a valid license expression, build and publishing tools:
   the normalization process results in changes to the
   ``License-Expression`` field contents.
 
-For all newly-upload distributions that include a
-``License-Expression`` field, the `Python Package Index (PyPI) <pypi_>`__ MUST
+For all newly-upload :term:`distribution archive`\s
+that include a ``License-Expression`` field,
+the `Python Package Index (PyPI) <pypi_>`__ MUST
 validate that it contains a valid, case-normalized license expression with
-valid identifiers (as defined here) and MUST reject uploads that do not.
+valid identifiers (as :ref:`defined here <639-license-expression-definition>`)
+and MUST reject uploads that do not.
 PyPI MAY reject an upload for using a deprecated license identifier,
 so long as it was deprecated as of the above-mentioned SPDX License List
 version.
@@ -543,34 +546,38 @@ version.
 Add ``License-File`` field
 ''''''''''''''''''''''''''
 
-Each instance of the ``License-File`` optional field is specified to contain
-the string representation of the path in the project source tree, relative to
-the project root directory, of a license-related file.
+Each instance of the ``License-File`` optional :term:`Core Metadata field`
+is specified to contain
+the string representation of the path in the :term:`project source tree`,
+relative to the :term:`project root directory`, of a license-related file.
 It is a multi-use field that may appear zero or
 more times, each instance listing the path to one such file. Files specified
-under this field could include license text, author/attribution information,
+by this field could include license text, author/attribution information,
 or other legal notices that need to be distributed with the package.
 
 As :ref:`specified by this PEP <639-spec-project-formats>`, its value
-is also that file's path relative to the root license directory in both
-installed projects and the standardized distribution package types.
+is also that file's path relative to the :term:`root license directory`
+in both :term:`installed project`\s
+and the standardized :term:`Distribution Package` types.
 In other legacy, non-standard or new distribution package formats and
-mechanisms of accessing and storing Core Metadata, the value MAY correspond
-to the license file path relative to a format-defined root license directory.
+mechanisms of accessing and storing :term:`Core Metadata`,
+the value MAY correspond to the license file path
+relative to a format-defined root license directory.
 Alternatively, it MAY be treated as a unique abstract key to access the
 license file contents by another means, as specified by the format.
 
-If a ``License-File`` is listed in a source or built distribution's core
-metadata, that file MUST be included in the distribution at the specified path
-relative to the root license directory, and MUST be installed with the
-distribution at that same relative path.
+If a ``License-File`` is listed in a :term:`source distribution`
+or :term:`Built Distribution`'s Core Metadata,
+that file MUST be included in the :term:`distribution archive`
+at the specified path relative to the root license directory,
+and MUST be installed with the :term:`project` at that same relative path.
 
 The specified relative path MUST be consistent between project source trees,
 source distributions (sdists), built distributions (:term:`Wheel`\s)
 and installed projects.
 Therefore, inside the root license directory, packaging tools
 MUST reproduce the directory structure under which the
-source license files are located relative to the project root.
+source license files are located relative to the project root directory.
 
 Path delimiters MUST be the forward slash character (``/``),
 and parent directory indicators (``..``) MUST NOT be used.
@@ -580,10 +587,12 @@ Build tools MAY and publishing tools SHOULD produce an informative warning
 if a built distribution's metadata contains no ``License-File`` entries,
 and publishing tools MAY but build tools MUST NOT raise an error.
 
-For all newly-uploaded distribution packages that include one or more
-``License-File`` fields and declare a ``Metadata-Version`` of ``2.4`` or
-higher, PyPI SHOULD validate that the specified files are present in all
-uploaded distributions, and MUST reject uploads that do not validate.
+For all newly-uploaded :term:`distribution archive`\s that include one or more
+``License-File`` fields in their Core Metadata
+and declare a ``Metadata-Version`` of ``2.4`` or higher,
+PyPI SHOULD validate that all specified files are present in that
+:term:`distribution archive`\s,
+and MUST reject uploads that do not validate.
 
 
 .. _639-spec-field-license:
@@ -591,19 +600,21 @@ uploaded distributions, and MUST reject uploads that do not validate.
 Deprecate ``License`` field
 '''''''''''''''''''''''''''
 
-The legacy unstructured-text ``License`` field is deprecated and replaced by
-the new ``License-Expression`` field. Build and publishing tools MUST raise
-an error if both these fields are present and their values are not identical,
+The legacy unstructured-text ``License`` :term:`Core Metadata field`
+is deprecated and replaced by the new ``License-Expression`` field.
+Build and publishing tools MUST raise an error
+if both these fields are present and their values are not identical,
 including capitalization and excluding leading and trailing whitespace.
 
 If only the ``License`` field is present, such tools SHOULD issue a warning
 informing users it is deprecated and recommending ``License-Expression``
 instead.
 
-For all newly-uploaded distributions that include a
+For all newly-uploaded :term:`distribution archive`\s that include a
 ``License-Expression`` field, the `Python Package Index (PyPI) <pypi_>`__ MUST
 reject any that specify a ``License`` field and the text of which is not
-identical to that of ``License-Expression``, as defined in this section.
+identical to that of ``License-Expression``,
+as :ref:`defined here <639-license-expression-definition>`.
 
 Along with license classifiers, the ``License`` field may be removed from a
 new version of the specification in a future PEP.
@@ -614,7 +625,8 @@ new version of the specification in a future PEP.
 Deprecate license classifiers
 '''''''''''''''''''''''''''''
 
-Using license `classifiers <classifiers_>`__ in the ``Classifier`` field
+Using :term:`license classifier`\s
+in the ``Classifier`` :term:`Core Metadata field`
 (`described in the Core Metadata specification <coremetadataclassifiers_>`__)
 is deprecated and replaced by the more precise ``License-Expression`` field.
 

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -1029,96 +1029,69 @@ Open Issues
 Should the ``License`` field be back-filled, or mutually exclusive?
 -------------------------------------------------------------------
 
-At present, this PEP explicitly allows, but does not formally recommend or
-require, build tools to back-fill the ``License`` Core Metadata field with
-the verbatim text from the ``License-Expression`` field. This would
-presumably improve backwards compatibility and was suggested
-by some on the Discourse thread. On the other hand, allowing it does
-increase complexity and is less of a clean, consistent separation,
-preventing the ``License`` field from being completely mutually exclusive
-with the new ``License-Expression`` field and requiring that their values
-match.
+At present, this PEP explicitly allows, but does not require, build tools to
+back-fill the ``License`` Core Metadata field with the verbatim text from the 
+``License-Expression`` field. This would improve backwards compatibility and was
+suggested by some on the Discourse thread. On the other hand, allowing it does
+increase complexity and is less of a clean separation, preventing the
+``License`` field from being mutually exclusive with the new
+``License-Expression`` field and requiring that their values match.
 
-As such, it would be very useful to have a more concrete and specific
-rationale and use cases for the back-filled data, and give fuller
-consideration to any potential benefits or drawbacks of this approach,
-in order to come to a final consensus on this matter that can be appropriately
-justified here.
+As such, it would be useful to have a more concrete rationale and use cases for
+the back-filled data in order to come to a final consensus on this matter.
 
-Therefore, is the status quo expressed here acceptable, allowing tools
-leeway to decide this for themselves? Should this PEP formally recommend,
-or even require, that tools back-fill this metadata (which would presumably
-be reversed once a breaking revision of the metadata spec is issued)?
-Or should this not be explicitly allowed, discouraged or even prohibited?
+Therefore, is the status quo acceptable, allowing tools to decide this for
+themselves? Should this PEP recommend, or even require, that tools back-fill
+this metadata (which would presumably be reversed once a breaking revision of
+the metadata spec is issued)? Or should this not be explicitly allowed, or even
+prohibited?
 
 
 Should custom license identifiers be allowed?
 ---------------------------------------------
 
-The current version of this PEP retains the behavior of only specifying
-the use of SPDX-defined license identifiers, as well as the explicitly defined
+The current version of this PEP specifies the possibility to use the
 custom identifiers ``LicenseRef-Public-Domain`` and ``LicenseRef-Proprietary``
-to handle the two common cases where projects have a license, but it is not
-one that has a recognized SPDX license identifier.
+to handle the cases where projects have a license, but there is not a
+recognized SPDX license identifier for it. For maximum flexibility, custom
+``LicenseRef-<CUSTOM-TEXT>`` license identifiers could be allowed. In some cases
+``LicenseRef-Proprietary`` may not be appropriate or specific enough, but
+package authors could still want to benefit from the mainstream Python build
+tooling.
 
-For maximum flexibility, custom ``LicenseRef-<CUSTOM-TEXT>`` license
-identifiers could be allowed, which could potentially be useful for niche
-cases or corporate environments where ``LicenseRef-Proprietary`` is not
-appropriate or insufficiently specific, but relying on mainstream Python
-build tooling and the ``License-Expression`` metadata field is still
-desirable to use for this purpose.
+However, this could increase the confusion about licensing. Custom identifiers
+can not be checked for correctness and users may think they always have to
+prepend identifiers with ``LicenseRef``. This would lead to tools producing
+invalid metadata. Additionally, this promotes the use of custom license
+identifiers, leading to even more ambiguity.
 
-This has the downsides, however, of not catching misspellings of the
-canonically defined license identifiers and thus producing license metadata
-that is not a valid match for what the author intended, as well as users
-potentially thinking they have to prepend ``LicenseRef`` in front of valid
-license identifiers, as there seems to be some previous confusion about.
-Furthermore, this encourages the proliferation of bespoke license identifiers,
-which obviates the purpose of enabling clear, unambiguous and well
-understood license metadata for which this PEP was created.
+Standards-conforming tools should not be required to allow custom license
+identifiers, since they will not recognize or know how to treat them. By
+contrast, custom tools, which would be required to understand custom
+identifiers, don't have to follow the listed rules for license identifiers This
+specification already allows such use in specific ecosystems, which avoids the
+disadvantages of forcing them on all mainstream packaging tools.
 
-Indeed, for niche cases that need specific, proprietary custom licenses,
-they could always simply specify ``LicenseRef-Proprietary``, and then
-include the actual license files needed to unambiguously identify the license
-regardless (if not using SPDX license identifiers) under the ``License-File``
-fields. Requiring standards-conforming tools to allow custom license
-identifiers does not seem very useful, since standard tools will not recognize
-bespoke ones or know how to treat them. By contrast, bespoke tools, which
-would be required in any case to understand and act on custom identifiers,
-are explicitly allowed, with good reason (thus the ``SHOULD`` keyword)
-to not require that license identifiers conform to those listed here.
-Therefore, this specification still allows such use in private corporate
-environments or specific ecosystems, while avoiding the disadvantages of
-imposing them on all mainstream packaging tools.
+As an alternative, a ``LicenseRef-Custom`` identifier could be defined, which
+would more explicitly indicate that the license cannot be expressed with
+existing identifiers and the license text should be referenced for details,
+in cases where ``LicenseRef-Proprietary`` is not appropriate. This would avoid
+the main downsides of the approach of allowing an arbitrary ``LicenseRef``,
+while addressing several of the potential scenarios cited for it.
 
-As an alternative, a literal ``LicenseRef-Custom`` identifier could be
-defined, which would more explicitly indicate that the license cannot be
-expressed with defined identifiers and the license text should be referenced
-for details, without carrying the negative and potentially inappropriate
-implications of ``LicenseRef-Proprietary``. This would avoid the main
-mentioned downsides (misspellings, confusion, license proliferation) of
-the approve approach of allowing an arbitrary ``LicenseRef``, while
-addressing several of the potential theoretical scenarios cited for it.
+On the other hand, as SPDX aims to encompass all FSF-recognized "Free" and
+OSI-approved "Open Source" licenses, anything outside those bounds would
+generally be covered by ``LicenseRef-Proprietary``, thus making
+``LicenseRef-Custom`` somewhat redundant to it. Furthermore, it may mislead
+authors of projects with  complex/multiple licenses that they should use it over
+specifying a license expression.
 
-On the other hand, as SPDX aims to (and generally does) encompass all
-FSF-recognized "Free" and OSI-approved "Open Source" licenses,
-and those sources are kept closely in sync and are now relatively stable,
-anything outside those bounds would generally be covered by
-``LicenseRef-Proprietary``, thus making ``LicenseRef-Custom`` less specific
-in that regard, and somewhat redundant to it. Furthermore, it may mislead
-authors of projects with complex/multiple licenses that they should use it
-over specifying a license expression.
-
-At present, the PEP retains the existing approach over either of these, given
-the use cases and benefits were judged to be sufficiently marginal based
-on the current understanding of the packaging landscape. For both these
-proposals, however, if more concrete use cases emerge, this can certainly
-be reconsidered, either for this current PEP or a future one (before or
-in tandem with actually removing the legacy unstructured ``License``
-metadata field). Not defining this now enables allowing it later
-(or still now, with custom packaging tools), without affecting backward
-compatibility, while the same is not so if they are allowed now and later
-determined to be unnecessary or too problematic in practice.
+At present, the PEP retains the existing approach over either of these, since
+based on the current understanding of the packaging landscape the benefits
+otherwise seem marginal. Not defining this now enables allowing it later (or
+even now, with custom packaging tools) without affecting backward compatibility.
+This would be problematic, if they were allowed now and later determined to be
+unnecessary.
 
 
 Appendices

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -659,6 +659,22 @@ for purposes of backward compatibility
 tools MAY back-fill the ``License`` Core Metadata field
 with the normalized value of the ``license`` key.
 
+Examples:
+
+.. code-block:: toml
+
+    [project]
+    license = "MIT"
+
+    [project]
+    license = "MIT AND (Apache-2.0 OR BSD-2-clause)"
+
+    [project]
+    license = "MIT OR GPL-2.0-or-later OR (FSFUL AND BSD-2-Clause)"
+
+    [project]
+    license = "LicenseRef-Proprietary"
+
 
 .. _639-spec-key-license-files:
 
@@ -737,6 +753,48 @@ to preserve consistent behavior with current tools and help ensure the packages
 they create are legally distributable, build tools SHOULD default to
 including at least the license files matching the above patterns, unless the
 user has explicitly specified their own.
+
+Examples of valid license files declaration:
+
+.. code-block:: toml
+
+    [project]
+    license-files = { globs = ["LICEN[CS]E*", "AUTHORS*"] }
+
+    [project]
+    license-files = { paths = ["licenses/LICENSE.MIT", "licenses/LICENSE.CC0"] }
+
+    [project]
+    license-files = { paths = [] }
+
+    [project]
+    license-files = { globs = [] }
+
+Examples of invalid license files declaration:
+
+.. code-block:: toml
+
+    [project]
+    license-files.globs = ["LICEN[CS]E*", "AUTHORS*"]
+    license-file.paths = ["LICENSE.MIT"]
+
+Reason: license-files.paths and license-files.globs are mutually exclusive.
+
+.. code-block:: toml
+
+    [project]
+    license-files = { paths = ["..\LICENSE.MIT"] }
+
+Reason: ``..`` must not be used.
+``\`` is invalid path delimiter, ``/`` must be used.
+
+
+.. code-block:: toml
+
+    [project]
+    license-files = { globs = ["LICEN{CSE*"] }
+
+Reason: "LICEN{CSE*" is not a valid glob.
 
 
 .. _639-spec-key-license-table:

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -22,8 +22,8 @@ projects.
 
 To achieve that, it:
 
-- Adopts the `SPDX license expression syntax <639-spdx_>`__ as
-  means of expressing Python projects' license.
+- Adopts the `SPDX license expression syntax <639-spdx_>`__ as a
+  means of expressing the license for a Python project.
 
 - Defines how to include license files within the projects, source and built
   distributions.
@@ -36,7 +36,7 @@ To achieve that, it:
   `built distribution (wheel) <wheelspec_>`__ and
   `installed project <installedspec_>`__ standards.
 
-- :ref:`Provides clear guidance <639-spec-converting-metadata>`
+- :ref:`Provides guidance <639-spec-converting-metadata>`
   for authors and tools converting legacy license metadata.
 
 This will make license declaration simpler and less ambiguous for
@@ -75,7 +75,7 @@ imposed by this PEP when uploading to PyPI.
 
 This PEP also is not about license documentation for individual files,
 though this is a :ref:`surveyed topic <639-license-doc-source-files>`
-in an appendix, and nor does it intend to cover cases where the
+in an appendix, nor does it intend to cover cases where the
 :term:`source distribution` and :term:`binary distribution` packages don't have
 :ref:`the same licenses <639-rejected-ideas-difference-license-source-binary>`.
 
@@ -112,7 +112,7 @@ The current license classifiers could be extended to include the full range of
 the SPDX identifiers while deprecating the ambiguous classifiers
 (such as ``License :: OSI Approved :: BSD License``).
 
-However, there are multiple reasons against such approach:
+However, there are multiple arguments against such an approach:
 
 - It requires a great effort to duplicate the SPDX license list and keep it in
   sync.
@@ -242,7 +242,7 @@ that aren't currently listed there:
     Wheel project
         The PyPA reference implementation of the :term:`Wheel format`.
         To avoid ambiguity with the latter,
-        Will be consistently referred to as such here.
+        the project will be consistently referred to as such here.
 
 
 .. _639-terminology-metadata:
@@ -440,7 +440,7 @@ Examples of invalid SPDX expressions:
 Core Metadata
 -------------
 
-This PEP specifies following changes to the
+This PEP specifies the following changes to the
 :term:`Core Metadata` `specification <coremetadataspec_>`__:
 
 - :ref:`adds <639-spec-field-license-expression>` the
@@ -775,7 +775,7 @@ Examples of invalid license files declaration:
 
     [project]
     license-files.globs = ["LICEN[CS]E*", "AUTHORS*"]
-    license-file.paths = ["LICENSE.MIT"]
+    license-files.paths = ["LICENSE.MIT"]
 
 Reason: license-files.paths and license-files.globs are mutually exclusive.
 
@@ -785,7 +785,7 @@ Reason: license-files.paths and license-files.globs are mutually exclusive.
     license-files = { paths = ["..\LICENSE.MIT"] }
 
 Reason: ``..`` must not be used.
-``\`` is invalid path delimiter, ``/`` must be used.
+``\`` is an invalid path delimiter, ``/`` must be used.
 
 
 .. code-block:: toml
@@ -924,7 +924,7 @@ those produced via the previous installer-specific behavior. This is further
 supported by a new metadata version.
 
 This also resolves current issues where license files are accidentally
-replaced if they have the same names in different places, making wheel
+replaced if they have the same names in different places, making wheels
 undistributable without noticing. It also prevents conflicts with other
 metadata files in the same directory. Without formalizing a solution, adding
 new installer-specific files and folders to the ``.dist-info`` directory could
@@ -1059,7 +1059,7 @@ package authors could still want to benefit from the mainstream Python build
 tooling.
 
 However, this could increase the confusion about licensing. Custom identifiers
-can not be checked for correctness and users may think they always have to
+cannot be checked for correctness and users may think they always have to
 prepend identifiers with ``LicenseRef``. This would lead to tools producing
 invalid metadata. Additionally, this promotes the use of custom license
 identifiers, leading to even more ambiguity.

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -19,14 +19,19 @@ Abstract
 ========
 
 This PEP defines a specification for
-how licenses are documented in the :term:`Core Metadata`,
-with :term:`license expression` strings using :term:`SPDX identifier`\s
-in a new :ref:`License-Expression field <639-spec-field-license-expression>`.
+how licenses are documented in the :term:`Core Metadata` and the corresponding
+:term:`Pyproject Metadata key`\s.
+with :term:`license expression` strings using :term:`SPDX identifier`\s.
 This will make license declaration simpler and less ambiguous for
-package authors to create, end users to read and understand,
+package authors to create, end users to understand,
 and tools to programmatically process.
 
-The PEP also:
+This PEP:
+
+- Formally specifies a new ``License-Expression`` field containing
+  :ref:`license expression strings <639-spec-field-license-expression>`
+  consisting of `SPDX identifiers <spdxid_>`__ and defines how license files
+  should be :ref:`included in distributions <639-spec-project-formats>`.
 
 - :ref:`Formally specifies <639-spec-field-license-file>`
   a new ``License-File`` :term:`Core Metadata field`,
@@ -48,7 +53,7 @@ The PEP also:
 - Describes a :ref:`reference implementation <639-reference-implementation>`
   and analyzes numerous :ref:`potential alternatives <639-rejected-ideas>`.
 
-The changes in this PEP will update the
+The changes will update the
 `Core Metadata specification <coremetadataspec_>`__ to version 2.4,
 extend the `Pyproject Metadata specification <pyprojecttoml_>`__,
 and make minor additions to the `source distribution (sdist) <sdistspec_>`__,
@@ -68,23 +73,8 @@ the license of a :term:`distribution package`, specifically defining:
 - A method of including license texts in :term:`distribution`\s
   and installed :term:`Projects`.
 
-The changes to the :term:`Core Metadata` specification that this PEP requires
-have been designed to minimize impact and maximize backward compatibility.
-This specification builds off of existing ways to document licenses
-that are already in use in popular tools
-(e.g. :ref:`639-spec-field-license-file` to Core Metadata
-:ref:`already used <639-license-doc-setuptools-wheel>`
-in the Setuptools and Wheel projects) and by some package authors
-(e.g. storing an SPDX license expression in the existing ``License`` field).
-
-In addition to these proposed changes, this PEP contains guidance for tools
-handling and converting these metadata, a tutorial for package authors
-covering various common use cases, detailed examples of them in use,
-and a comprehensive survey of license documentation in Python and other
-languages.
-
-It is the intent of the PEP authors to work closely with tool maintainers to
-implement the recommendations for validation and warnings specified here.
+The changes that this PEP requires have been designed to minimize impact and
+maximize backward compatibility.
 
 
 .. _639-non-goals:
@@ -96,17 +86,12 @@ This PEP is neutral regarding the choice of license by any particular
 package author. This PEP makes no recommendation for specific licenses,
 and does not require the use of a particular license documentation convention.
 
-Rather, the SPDX :term:`license expression` syntax proposed in this PEP
-provides a simpler and more expressive mechanism to accurately document
-any kind of license that applies to a Python :term:`distribution package`,
-whether it is open source, free/libre, proprietary, or a combination of such.
-
 This PEP also does not impose any additional restrictions when uploading to
 PyPI, unless projects choose to make use of the new fields.
 
 Instead, it is intended to document best practices already in use, extend them
-to use a new formally-specified and supported mechanism, and provide guidance
-for packaging tools on how to hand the transition and inform users accordingly.
+to use a new formally-specified mechanism, and provide guidance for packaging
+tools and authors on how to handle the transition.
 
 This PEP also is not about license documentation for individual files,
 though this is a :ref:`surveyed topic <639-license-doc-source-files>`
@@ -123,15 +108,12 @@ Motivation
 Software must be licensed in order for anyone other than its creator to
 download, use, share and modify it, so providing accurate license information
 to Python package users is an important matter.
-Today, there are multiple :term:`fields <Core Metadata field>`
-where licenses are documented in :term:`Core Metadata`,
+Today, there are multiple :term:`fields <Core Metadata field>` where licenses
+are documented in :term:`Core Metadata`,
 and there are limitations to what can be expressed in each of them.
-This often leads to confusion and a lack of clarity,
-both for package authors and end users.
+This often leads to confusion and a lack of clarity, both for package authors
+and end users, including distribution re-packagers.
 
-Many package authors have expressed difficulty and frustrations due to the
-limited capabilities to express licensing in package metadata,
-and this creates further trouble for Linux and BSD re-packagers.
 This has triggered a number of license-related discussions and issues,
 including on `outdated and ambiguous PyPI classifiers <classifierissue_>`__,
 `license interoperability with other ecosystems <interopissue_>`__,
@@ -139,38 +121,38 @@ including on `outdated and ambiguous PyPI classifiers <classifierissue_>`__,
 `limited support for license files in the Wheel project <wheelfiles_>`__, and
 `the lack of clear, precise and standardized license metadata <pepissue_>`__.
 
-The current :term:`license classifier`\s address some common cases,
-and could be extended to include the full range of :term:`SPDX identifiers`
-while deprecating the many
-:ref:`ambiguous classifiers <639-spec-mapping-classifiers-identifiers>`
-(including some popular and problematic ones,
-such as ``License :: OSI Approved :: BSD License``).
-However, this requires a substantial amount of effort
-to duplicate the SPDX license list and keep it in sync.
-Furthermore, it is effectively a hard break in backward compatibility,
-forcing a huge proportion of package authors to immediately update to new
-classifiers (in most cases, with many possible choices that require closely
-examining the project's license) immediately when PyPI deprecates the old ones.
-
-Furthermore, this only covers simple packages entirely under a single license;
-it doesn't address the substantial fraction of common projects that vendor
-dependencies (e.g. Setuptools), offer a choice of licenses (e.g. Packaging)
-or were relicensed, adapt code from other projects or contain fonts, images,
-examples, binaries or other assets under other licenses. It also requires
-both authors and tools understand and implement the PyPI-specific bespoke
-classifier system, rather than using short, easy to add and standardized
-SPDX identifiers in a simple text field, as increasingly widely adopted by
-most other packaging systems to reduce the overall burden on the ecosystem.
-Finally, this does not provide as clear an indicator that a package
-has adopted the new system, and should be treated accordingly.
-
-On average, Python packages tend to have more ambiguous and missing license
-information than other common ecosystems (such as npm, Maven or Gem).
-This is supported by the `statistics page <cdstats_>`__ of the
+As a result, on average, Python packages tend to have more ambiguous and
+missing license information than other common ecosystems. This is supported by
+the `statistics page <cdstats_>`__ of the
 `ClearlyDefined project <clearlydefined_>`__, an
 `Open Source Initiative <osi_>`__ incubated effort to help
 improve licensing clarity of other FOSS projects, covering all packages
 from PyPI, Maven, npm and Rubygems.
+
+The current license classifiers could be extended to include the full range of
+the SPDX identifiers while deprecating the ambiguous classifiers
+(such as ``License :: OSI Approved :: BSD License``).
+
+There are multiple reasons against such approach:
+
+- It requires a great effort to duplicate the SPDX license list and keep it in
+  sync.
+
+- It is a hard break in backward compatibility, forcing a many package authors
+  to update to new classifiers immediately when PyPI deprecates the old ones.
+
+- It only covers simple packages under a single license;
+  it doesn't address projects that vendor dependencies (e.g. Setuptools),
+  offer a choice of licenses (e.g. Packaging) or were relicensed,
+  adapt code from other projects or contain fonts, images,
+  examples, binaries or other assets under other licenses.
+
+- It requires both authors and tools understand and implement the PyPI-specific
+  classifier system, rather than using standardized and widely adopted
+  SPDX identifiers in a text field.
+
+- It does not provide as clear an indicator that a package
+  has adopted the new system, and should be treated accordingly.
 
 
 .. _639-rationale:
@@ -182,11 +164,11 @@ A survey of existing license metadata definitions in use in the Python
 ecosystem today is provided in
 :ref:`an appendix <639-license-doc-python>` of this PEP,
 and license documentation in a variety of other packaging systems,
-Linux distros, languages ecosystems and applications is surveyed in
+Linux distributions, languages ecosystems and applications is surveyed in
 :ref:`another appendix <639-license-doc-other-projects>`.
 
-There are a few takeaways from the survey, which have guided the design
-and recommendations of this PEP:
+There are a few takeaways from the survey, which have guided the recommendations
+of this PEP:
 
 - Most package formats use a single ``License`` field.
 
@@ -203,32 +185,25 @@ and recommendations of this PEP:
   text in a :term:`Distribution Package`.
 
 The use of
-:ref:`a new License-Expression field <639-spec-field-license-expression>
-will provide an intuitive, structured and unambiguous way
+:ref:`a new License-Expression field <639-spec-field-license-expression>`
+will provide a structured and unambiguous way
 to express the license of a package
 using a well-defined syntax and well-known license identifiers.
 Similarly, a
 :ref:`formally-specified License-File field <639-spec-field-license-file>`
-offers a standardized way to ensure that the full text of the license(s)
-are included with the package when distributed, as legally required,
+offers a standardized way to include the full text of the license(s)
+with the package when distributed, as legally required,
 and allows other tools consuming the :term:`Core Metadata`
-to unambiguously locate a :term:`distribution archive`'s license files.
+to locate a :term:`distribution archive`'s license files.
 
-While dramatically simplifying and improving the present Python license
-metadata story, this specification standardizes and builds upon
+Furthermore, this specification standardizes and builds upon
 existing practice in the `Setuptools <setuptoolsfiles_>`__ and
 `Wheel <wheelfiles_>`__ projects.
-Furthermore, an up-to-date version of the current draft of this PEP is
+An up-to-date version of the current draft of this PEP is
 `already successfully implemented <hatchimplementation_>`__ in the popular
 PyPA `Hatch <hatch_>`__ packaging tool, and an earlier draft of the
 :ref:`license files portion <639-spec-field-license-file>
 is `implemented in Setuptools <setuptoolspep639_>`__.
-
-Over time, encouraging the use of these fields and deprecating the ambiguous,
-duplicative and confusing legacy alternatives will help Python software
-publishers improve the clarity, accuracy and portability of their licensing
-practices, to the benefit of package authors, consumers and redistributors
-alike.
 
 
 .. _639-terminology:
@@ -496,8 +471,7 @@ A license expression is a string using the SPDX license expression syntax as
 documented in the `SPDX specification <spdxpression_>`__, either
 Version 2.2 or a later compatible version.
 
-When used in the ``License-Expression`` field and as a specialization of
-the SPDX license expression definition, a license expression can use the
+When used in the ``License-Expression`` field, a license expression can use the
 following :term:`license identifier`\s:
 
 - Any SPDX-listed license short-form identifiers that are published in the
@@ -820,10 +794,10 @@ License files in project formats
 --------------------------------
 
 A few minor additions will be made to the relevant existing specifications
-to document, standardize and clarify what is already currently supported,
-allowed and implemented behavior, as well as explicitly mention the root
-license directory the license files are located in and relative to for
-each format, per the :ref:`639-spec-field-license-file` section.
+to standardize what is already currently supported behavior, as well as
+explicitly mention the root license directory the license files are located in
+and relative to for each format, per the :ref:`639-spec-field-license-file`
+section.
 
 :term:`project source tree`
   As described in the :ref:`639-spec-source-metadata` section, the

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -622,8 +622,8 @@ reject any that specify a ``License`` field and the text of which is not
 identical to that of ``License-Expression``,
 as :ref:`defined here <639-license-expression-definition>`.
 
-Along with license classifiers, the ``License`` field may be removed from a
-new version of the specification in a future PEP.
+The ``License`` field may be removed from a new version of the specification
+in a future PEP.
 
 
 .. _639-spec-field-classifier:
@@ -654,8 +654,8 @@ reject any that also specify any license classifiers.
 
 New license classifiers MUST NOT be `added to PyPI <classifiersrepo_>`__;
 users needing them SHOULD use the ``License-Expression`` field instead.
-Along with the ``License`` field, license classifiers may be removed from a
-new version of the specification in a future PEP.
+License classifiers may be removed from a new version of the specification
+in a future PEP.
 
 
 .. _639-spec-source-metadata:

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -901,72 +901,50 @@ the PEP authors.
 Backwards Compatibility
 =======================
 
-Adding a new, dedicated ``License-Expression`` Core Metadata field
-and a top-level string value for the ``license`` key reserved for this purpose
-in the ``pyproject.toml`` ``[project]`` table
-unambiguously signals support for the specification in this PEP.
-This avoids the risk of new tooling
-misinterpreting a license expression as a free-form license description
-or vice versa, and raises an error if and only if the user affirmatively
-upgrades to the latest metadata version and adds the new field/key.
+Adding a new ``License-Expression`` Core Metadata field and a top-level string
+value for the ``license`` key in the ``pyproject.toml`` ``[project]`` table
+unambiguously means support for the specification in this PEP. This avoids the
+risk of new tooling misinterpreting a license expression as a free-form license
+description or vice versa.
 
-The legacy ``License`` Core Metadata field
-and the ``license`` key table subkeys (``text`` and ``file``)
-in the ``pyproject.toml`` ``[project]`` table
-will be deprecated along with the license classifiers,
-retaining backwards compatibility while gently preparing users for their
-future removal. Such a removal would follow a suitable transition period, and
-be left to a future PEP and a new version of the Core Metadata specification.
+The legacy deprecated Core Metadata ``License`` field, ``license`` key table
+subkeys (``text`` and ``file``) in the ``pyproject.toml`` ``[project]`` table
+and license classifiers will retain backwards compatibility. A removal would be
+left to a future PEP and a new version of the Core Metadata specification.
 
-Formally specifying the new ``License-File`` Core Metadata field and the
-inclusion of the listed files in the distribution merely codifies and
-refines the existing practices in popular packaging tools, including the Wheel
-and Setuptools projects, and is designed to be largely backwards-compatible
-with their existing use of that field. Likewise, the new ``license-files``
-key in the ``[project]`` table of ``pyproject.toml``
-standardizes statically specifying the files to include,
-as well as the default behavior, and allows other tools to make use of them,
-while only having an effect once users and tools expressly adopt it.
+Specification of the new ``License-File`` Core Metadata field and adding the
+files in the distribution codifies the existing practices of many packaging
+tools. It is designed to be largely backwards-compatible with their existing
+use of that field. The new ``license-files`` key in the ``[project]`` table of
+``pyproject.toml`` will only have an effect once users and tools adopt it.
 
-Due to requiring license files not be flattened into ``.dist-info`` and
-specifying that they should be placed in a dedicated ``licenses`` subdir,
-wheels produced following this change will have differently-located
-licenses relative to those produced via the previous unspecified,
-installer-specific behavior, but as until this PEP there was no way of
-discovering these files or accessing them programmatically, and this will
-be further discriminated by a new metadata version, there aren't any foreseen
-mechanism for this to pose a practical issue.
+This PEP specifies that license files should be placed in a dedicated
+``licenses`` subdir of ``.dist-info`` directory. This is new and ensures that
+wheels following this PEP will have differently-located licenses relative to
+those produced via the previous installer-specific behavior. This is further
+supported by a new metadata version.
 
-Furthermore, this resolves existing compatibility issues with the current
-ad hoc behavior, namely license files being silently clobbered if they have
-the same names as others at different paths, unknowingly rendering the wheel
-undistributable, and conflicting with the names of other metadata files in
-the same directory. Formally specifying otherwise would in fact block full
-forward compatibility with additional standard or installer-specified files
-and directories added to ``.dist-info``, as they too could conflict with
-the names of existing licenses.
+This also resolves current issues where license files are accidentally
+replaced if they have the same names in different places, making wheel
+undistributable without noticing. It also prevents conflicts with other
+metadata files in the same directory. Without formalizing a solution, adding
+new installer-specific files and folders to the ``.dist-info`` directory could
+create conflicts with the names of existing licenses.
 
-While minor additions will be made to the source distribution (sdist),
-built distribution (wheel) and installed project specifications, all of these
-are merely documenting, clarifying and formally specifying behaviors explicitly
-allowed under their current respective specifications, and already implemented
-in practice, and gating them behind the explicit presence of both the new
-metadata versions and the new fields. In particular, sdists may contain
-arbitrary files following the project source tree layout, and formally
-mentioning that these must include the license files listed in the metadata
-merely documents and codifies existing Setuptools practice. Likewise, arbitrary
-installer-specific files are allowed in the ``.dist-info`` directory of wheels
-and copied to installed projects, and again this PEP just formally clarifies
-and standardizes what is already being done.
+The additions will be made to the source distribution (sdist), built
+distribution (wheel) and installed project specifications. They document
+behaviors allowed under their current specifications, and gate them behind the
+new metadata version. This PEP standardizes the already existing Setuptools
+practice and formalizes the way in which license files listed in the metadata
+must be included in the distribution.
 
-Finally, while this PEP does propose PyPI implement validation of the new
-``License-Expression`` and ``License-File`` fields, this has no effect on
-existing packages, nor any effect on any new distributions uploaded unless they
-explicitly choose to opt in to using these new fields while not
-following the requirements in the specification. Therefore, this does not have
-a backward compatibility impact, and in fact ensures forward compatibility with
-any future changes by ensuring all distributions uploaded to PyPI with the new
-fields are valid and conform to the specification.
+This PEP proposes PyPI implement validation of the new
+``License-Expression`` and ``License-File`` fields, which has no effect on
+new and existing packages uploaded unless they explicitly opt in to using
+these new fields and fail to follow the specification correctly.
+Therefore, this does not have a backward compatibility impact, and guarantees
+forward compatibility by ensuring all distributions uploaded to PyPI with the
+new fields conform to the specification.
 
 
 .. _639-security-implications:

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -105,7 +105,7 @@ As a result, on average, Python packages tend to have more ambiguous and
 missing license information than other common ecosystems. This is supported by
 the `statistics page <cdstats_>`__ of the
 `ClearlyDefined project <clearlydefined_>`__, an
-`Open Source Initiative <osi_>`__ incubated effort to help
+`Open Source Initiative <osi_>`__ effort to help
 improve licensing clarity of other FOSS projects, covering all packages
 from PyPI, Maven, npm and Rubygems.
 
@@ -168,8 +168,8 @@ Furthermore, this specification builds upon
 existing practice in the `Setuptools <setuptoolsfiles_>`__ and
 `Wheel <wheelfiles_>`__ projects.
 An up-to-date version of the current draft of this PEP is
-`already successfully implemented <hatchimplementation_>`__ in the popular
-PyPA `Hatch <hatch_>`__ packaging tool, and an earlier draft of the
+`implemented <hatchimplementation_>`__ in the
+`Hatch <hatch_>`__ packaging tool, and an earlier draft of the
 :ref:`license files portion <639-spec-field-license-file>`
 is `implemented in Setuptools <setuptoolspep639_>`__.
 
@@ -314,19 +314,6 @@ Examples of invalid SPDX expressions:
 Core Metadata
 -------------
 
-This PEP specifies the following changes to the
-:term:`Core Metadata` `specification <coremetadataspec_>`__:
-
-- :ref:`adds <639-spec-field-license-expression>` the
-  ``License-Expression`` field,
-
-- :ref:`adds <639-spec-field-license-file>` the ``License-File`` field,
-
-- :ref:`deprecates <639-spec-field-license>` the ``License`` field,
-
-- :ref:`deprecates <639-spec-field-classifier>` the :term:`license classifier`\s
-  in the ``Classifier`` field.
-
 The error and warning guidance in this section applies to build and
 publishing tools; end-user-facing install tools MAY be less strict than
 mentioned here when encountering malformed metadata
@@ -350,8 +337,7 @@ but MUST NOT raise an error.
 
 A license expression is an SPDX expression as :ref:`defined above <639-spdx>`.
 
-When processing the ``License-Expression`` field to determine if it contains
-a valid license expression, build and publishing tools:
+When processing the ``License-Expression`` field, build and publishing tools:
 
 - SHOULD halt execution and raise an error if:
 
@@ -500,17 +486,8 @@ in a future PEP.
 Project source metadata
 -----------------------
 
-This PEP specifies the following changes to the project's source
-metadata under a ``[project]`` table in the ``pyproject.toml`` file:
-
-- :ref:`adds <639-spec-key-license-text>`
-  a top-level string value for the ``license`` key,
-
-- :ref:`adds <639-spec-key-license-files>` the new ``license-files`` key,
-
-- :ref:`deprecates <639-spec-key-license-table>` the table value for the
-  ``license`` key along with its corresponding table subkeys, ``text`` and
-  ``file``.
+This PEP specifies changes to the project's source
+metadata under a ``[project]`` table in the ``pyproject.toml`` file.
 
 
 .. _639-spec-key-license-text:
@@ -713,7 +690,7 @@ from a new version of the specification in a future PEP.
 License files in project formats
 --------------------------------
 
-A few additions will be made to the relevant existing specifications.
+A few additions will be made to the existing specifications.
 
 :term:`project source tree`
   Per :ref:`639-spec-source-metadata` section, the
@@ -723,7 +700,7 @@ A few additions will be made to the relevant existing specifications.
   (or equivalently, other legacy project configuration,
   e.g. ``setup.py``, ``setup.cfg``, etc).
 
-:term:`Source distribution (sdist) <Source Distribution (or "sdist")>`
+:term:`Source distribution (sdists) <Source Distribution (or "sdist")>`
   The `sdist specification <sdistspec_>`__ will be updated to reflect that if
   the ``Metadata-Version`` is ``2.4`` or greater,
   the sdist MUST contain any license files specified by
@@ -783,7 +760,7 @@ description or vice versa.
 
 The legacy deprecated Core Metadata ``License`` field, ``license`` key table
 subkeys (``text`` and ``file``) in the ``pyproject.toml`` ``[project]`` table
-and license classifiers will retain backwards compatibility. A removal would be
+and license classifiers retain backwards compatibility. A removal is
 left to a future PEP and a new version of the Core Metadata specification.
 
 Specification of the new ``License-File`` Core Metadata field and adding the
@@ -801,16 +778,12 @@ supported by a new metadata version.
 This also resolves current issues where license files are accidentally
 replaced if they have the same names in different places, making wheels
 undistributable without noticing. It also prevents conflicts with other
-metadata files in the same directory. Without formalizing a solution, adding
-new installer-specific files and folders to the ``.dist-info`` directory could
-create conflicts with the names of existing licenses.
+metadata files in the same directory.
 
 The additions will be made to the source distribution (sdist), built
 distribution (wheel) and installed project specifications. They document
 behaviors allowed under their current specifications, and gate them behind the
-new metadata version. This PEP standardizes the already existing Setuptools
-practice and formalizes the way in which license files listed in the metadata
-must be included in the distribution.
+new metadata version.
 
 This PEP proposes PyPI implement validation of the new
 ``License-Expression`` and ``License-File`` fields, which has no effect on
@@ -942,7 +915,7 @@ identifiers, leading to even more ambiguity.
 Standards-conforming tools should not be required to allow custom license
 identifiers, since they will not recognize or know how to treat them. By
 contrast, custom tools, which would be required to understand custom
-identifiers, don't have to follow the listed rules for license identifiers This
+identifiers, don't have to follow the listed rules for license identifiers. This
 specification already allows such use in specific ecosystems, which avoids the
 disadvantages of forcing them on all mainstream packaging tools.
 
@@ -957,11 +930,11 @@ On the other hand, as SPDX aims to encompass all FSF-recognized "Free" and
 OSI-approved "Open Source" licenses, anything outside those bounds would
 generally be covered by ``LicenseRef-Proprietary``, thus making
 ``LicenseRef-Custom`` somewhat redundant to it. Furthermore, it may mislead
-authors of projects with  complex/multiple licenses that they should use it over
+authors of projects with complex/multiple licenses that they should use it over
 specifying a license expression.
 
 At present, the PEP retains the existing approach over either of these, since
-based on the current understanding of the packaging landscape the benefits
+the benefits
 otherwise seem marginal. Not defining this now enables allowing it later (or
 even now, with custom packaging tools) without affecting backward compatibility.
 This would be problematic, if they were allowed now and later determined to be

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -225,128 +225,190 @@ alike.
 Terminology
 ===========
 
-This PEP seeks to clearly define the terms it uses, given that some have
-multiple established meanings (e.g. import vs. distribution package,
-wheel *format* vs. Wheel *project*); are related and often used
-interchangeably, but have critical distinctions in meaning
-(e.g. ``[project]`` *key* vs. core metadata *field*); are existing concepts
-that don't have formal terms/definitions (e.g. project/source metadata vs.
-distribution/built metadata, build vs. publishing tools), or are new concepts
-introduced here (e.g. license expression/identifier).
-
-This PEP also uses terms defined in the
-`PyPA PyPUG Glossary <pypugglossary_>`__
-(specifically *built/binary distribution*, *distribution package*,
-*project* and *source distribution*), and by the `SPDX Project <spdx_>`__
-(*license identifier*, *license expression*).
-
 The keywords "MUST", "MUST NOT", "REQUIRED",
 "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL"
 in this document are to be interpreted as described in :rfc:`2119`.
 
-Terms are listed here in their full versions;
-related words (``Rel:``) are in parenthesis,
-including short forms (``Short:``), sub-terms (``Sub:``) and common synonyms
-for the purposes of this PEP (``Syn:``).
 
-**Core Metadata** *(Syn: Package Metadata, Sub: Distribution Metadata)*
-  The `PyPA specification <coremetadataspec_>`__ and the set of metadata fields
-  it defines that describe key static attributes of distribution packages
-  and installed projects.
+.. _639-terminology-packaging:
 
-  The **distribution metadata** refers to, more specifically, the concrete form
-  core metadata takes when included inside a distribution archive
-  (``PKG-INFO`` in a sdist and ``METADATA`` in a wheel) or installed project
-  (``METADATA``).
+Packaging terms
+---------------
 
-**Core Metadata Field** *(Short: Metadata Field/Field)*
-  A single key-value pair, or sequence of such with the same key, as defined
-  by the `core metadata specification <coremetadataspec_>`__.
-  Notably, distinct from a ``pyproject.toml`` ``[project]`` table *key*.
+The basis for this PEP's general packaging terminology is
+the :doc:`PyPA PyPUG Glossary <packaging:glossary>`,
+and a number of its terms are used directly, including
+:term:`Binary Distribution`,
+:term:`Built Distribution`,
+:term:`Distribution Package`,
+and :term:`Project`.
+We include additional definitions here
+to accurately reflect the modern packaging ecosystem,
+and adding terms defined/used in :ref:`packaging:packaging-specifications`
+that aren't currently listed there:
 
-**Distribution Package** *(Sub: Package, Distribution Archive)*
-  (`See PyPUG <pypugdistributionpackage_>`__)
-  In this PEP, **package** is used to refer to the abstract concept of a
-  distributable form of a Python project, while **distribution** more
-  specifically references the physical **distribution archive**.
+.. glossary::
 
-**License Classifier**
-  A `PyPI Trove classifier <classifiers_>`__
-  (as `described in the core metadata specification
-  <coremetadataclassifiers_>`__)
-  which begins with ``License ::``, currently used to indicate
-  a project's license status by including it as a ``Classifier``
-  in the core metadata.
+    distribution archive
+        The physical distribution artifact (i.e. a file on disk)
+        for a :term:`Distribution Package`.
 
-**License Expression** *(Syn: SPDX Expression)*
-  A string with valid `SPDX license expression syntax <spdxpression_>`__
-  including any SPDX license identifiers as defined here, which describes
-  a project's license(s) and how they relate to one another. Examples:
-  ``GPL-3.0-or-later``, ``MIT AND (Apache-2.0 OR BSD-2-clause)``
+    installed project
+        A :term:`Project` that is installed for use with
+        a Python interpreter or :term:`Virtual Environment`,
+        as described in the PyPA spec
+        :ref:`packaging:recording-installed-packages`.
 
-**License Identifier** *(Syn: License ID/SPDX Identifier)*
-  A valid `SPDX short-form license identifier <spdxid_>`__, as described in the
-  :ref:`639-spec-field-license-expression` section of this PEP; briefly,
-  this includes all valid SPDX identifiers and the ``LicenseRef-Public-Domain``
-  and ``LicenseRef-Proprietary`` strings. Examples: ``MIT``, ``GPL-3.0-only``
+    project root directory
+        The filesystem directory in which
+        a :term:`Project`'s :term:`source tree` is located
+        and which contains the ``pyproject.toml`` file.
 
-**Project** *(Sub: Project Source Tree, Installed Project)*
-  (`See PyPUG <pypugproject_>`__)
-  Here, a **project source tree** refers to the on-disk format of
-  a project used for development, while an **installed project** is the form a
-  project takes once installed from a distribution, as
-  `specified by PyPA <installedspec_>`__.
+    project source tree
+    source tree
+        The on-disk format of a :term:`Project` used for development,
+        containing its raw source code before being packaged
+        into a :term:`source distribution` or :term:`Built Distribution`.
 
-**Project Source Metadata** *(Sub: Project Table Metadata, Key, Subkey)*
-  Core metadata defined by the package author in the project source tree,
-  as top-level keys in the ``[project]`` table of a ``pyproject.toml`` file,
-  in the ``[metadata]`` table of ``setup.cfg``, or the equivalent for other
-  build tools.
+    source distribution
+    sdist
+        A :term:`distribution archive` format
+        (generated using, e.g., ``python -m build --sdist``)
+        that provides the :term:`Core Metadata` and essential source files
+        needed by a build backend (as defined in :pep:`517`)
+        to generate a :term:`Built Distribution`.
 
-  The **Project Table Metadata**, or ``pyproject.toml`` ``[project]`` metadata,
-  refers specifically to the former, as defined by the
-  `PyPA Declaring Project Metadata specification <pyprojecttoml_>`__
-  and originally specified in :pep:`621`.
-  A **Project Table Key**, or an unqualified *key* refers specifically to
-  a top-level ``[project]`` key
-  (notably, distinct from a core metadata *field*),
-  while a **subkey** refers to a second-level key in a table-valued
-  ``[project]`` key.
+    Wheel format
+    Wheel
+        The standard :term:`Built Distribution` format
+        originally introduced in :pep:`427`
+        and currently defined by
+        the PyPA spec :ref:`packaging:binary-distribution-format`.
+        Not to be confused with its reference implementation,
+        the :term:`Wheel project`.
 
-**Root License Directory** *(Short: License Directory)*
-  The directory under which license files are stored in a project/distribution
-  and the root directory that their paths, as recorded under the
-  ``License-File`` core metadata fields, are relative to.
-  Defined here to be the project root directory for source trees and source
-  distributions, and a subdirectory named ``licenses`` of the directory
-  containing the core metadata (i.e., the ``.dist-info/licenses``
-  directory) for built distributions and installed projects.
+    Wheel project
+        The PyPA reference implementation of the :term:`Wheel format`.
+        To avoid ambiguity with the latter,
+        Will be consistently referred to as such here.
 
-**Tool** *(Sub: Packaging Tool, Build Tool, Install Tool, Publishing Tool)*
-  A program, script or service executed by the user or automatically that
-  seeks to conform to the specification defined in this PEP.
 
-  A **packaging tool** refers to a tool used to build, publish,
-  install, or otherwise directly interact with Python packages.
+.. _639-terminology-metadata:
 
-  A **build tool** is a packaging tool used to generate a source or built
-  distribution from a project source tree or sdist, when directly invoked
-  as such (as opposed to by end-user-facing install tools).
-  Examples: Wheel project, :pep:`517` backends via ``build`` or other
-  package-developer-facing frontends, calling ``setup.py`` directly.
+Metadata terms
+--------------
 
-  An **install tool** is a packaging tool used to install a source or built
-  distribution in a target environment. Examples include the PyPA pip and
-  ``installer`` projects.
+The :doc:`PyPA PyPUG Glossary <packaging:glossary>` is
+(at the time of this PEP's writing)
+largely lacking in specific terminology to refer to packaging metadata.
+Therefore, we explicitly define the following metadata-related terms:
 
-  A **publishing tool** is a packaging tool used to upload distribution
-  archives to a package index, such as Twine for PyPI.
+.. glossary::
 
-**Wheel** *(Short: wheel, Rel: wheel format, Wheel project)*
-  Here, **wheel**, the standard built distribution format introduced in
-  :pep:`427` and `specified by the PyPA <wheelspec_>`__, will be referred to in
-  lowercase, while the `Wheel project <wheelproject_>`__, its reference
-  implementation, will be referred to as such with **Wheel** in Title Case.
+    built metadata
+        The concrete form :term:`Core Metadata` takes
+        when included inside an installed :term:`Project` (``METADATA`` file)
+        or a :term:`distribution archive`
+        (``PKG-INFO`` in a :term:`sdist` and ``METADATA`` in a :term:`Wheel`).
+
+    Core Metadata
+        The :ref:`PyPA specification <packaging:core-metadata>`
+        and the set of :term:`metadata field`\s it defines
+        that describe key static attributes of
+        a :term:`distribution package` or :term:`installed project`.
+
+    Core Metadata field
+    metadata field
+        A single key-value pair
+        (or sequence of such with the same name, for multiple-use fields)
+        defined in the :term:`Core Metadata` spec
+        and stored in the :term:`built metadata`.
+        Notably, distinct from a :term:`Pyproject Metadata key`.
+
+    project source metadata
+    source metadata
+        Metadata defined by the package author
+        in a :term:`Project`'s :term:`source tree`,
+        to be transformed into :term:`Core Metadata field`\s
+        in the :term:`built metadata`
+        by the project's build backend.
+        Can be written as :term:`Pyproject Metadata`,
+        or in a tool-specific format
+        (under the ``[tool]`` table in ``pyproject.toml``,
+        or in a tool's own configuration file).
+
+    Pyproject Metadata
+        The :term:`source metadata` format
+        defined by the PyPA spec :ref:`packaging:declaring-project-metadata`
+        and originally introduced in :pep:`621`,
+        stored as :term:`metadata key`\s
+        under the ``[project]`` table of a ``pyproject.toml`` file
+        Notably, *not* a tool-specific source metadata format
+        under the ``[tool]`` table in ``pyproject.toml``.
+
+    Pyproject Metadata key
+    metadata key
+        A top-level TOML key in the ``[project]`` table in ``pyproject.toml``;
+        part of the :term:`Pyproject Metadata`.
+        Notably, distinct from a :term:`Core Metadata field`.
+
+    Pyproject Metadata subkey
+    metadata subkey
+    table subkey
+        A second-level TOML key under a table-valued
+        :term:`Pyproject Metadata key`.
+
+
+.. _639-terminology-license:
+
+License terms
+-------------
+
+The license-related terminology draws heavily from the `SPDX Project <spdx_>`__,
+particularly :term:`license identifier` and :term:`license expression`.
+
+.. glossary::
+
+    license classifier
+        A `PyPI Trove classifier <classifiers_>`__
+        (as :ref:`described <packaging:core-metadata-classifier>`
+        in the :term:`Core Metadata` specification)
+        which begins with ``License ::``.
+
+    license expression
+    SPDX expression
+        A string with valid `SPDX license expression syntax <spdxpression_>`__
+        including one or more SPDX :term:`license identifier`\(s),
+        which describes a project's license(s) and how they inter-relate.
+        Examples:
+        ``GPL-3.0-or-later``,
+        ``MIT AND (Apache-2.0 OR BSD-2-clause)``
+
+    license identifier
+    SPDX identifier
+        A valid `SPDX short-form license identifier <spdxid_>`__,
+        as described in the
+        :ref:`639-spec-field-license-expression` section of this PEP.
+        This includes all valid SPDX identifiers and
+        the strings ``LicenseRef-Public-Domain`` and ``LicenseRef-Proprietary``.
+        Examples:
+        ``MIT``,
+        ``GPL-3.0-only``
+
+    root license directory
+    license directory
+        The directory under which license files are stored in a
+        :term:`project source tree`, :term:`distribution archive`
+        or :term:`installed project`.
+        Also, the root directory that their paths
+        recorded in the :ref:`License-File <639-spec-field-license-file>`
+        :term:`Core Metadata field` are relative to.
+        Defined to be the :term:`project root directory`
+        for a :term:`source tree` or :term:`source distribution`;
+        and a subdirectory named ``licenses`` of
+        the directory containing the :term:`built metadata`—
+        i.e., the ``.dist-info/licenses`` directory—
+        for a :term:`Built Distribution` or :term:`installed project`.
 
 
 .. _639-specification:

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -402,25 +402,22 @@ particularly :term:`license identifier` and :term:`license expression`.
 Specification
 =============
 
-The changes necessary to implement the improved license handling outlined in
-this PEP include both :ref:`those in <639-spec-core-metadata>`
-the :term:`build metadata` for :term:`Distribution Packages`,
-as defined in the :term:`Core Metadata` `specification <coremetadataspec_>`__,
-and :ref:`those in <639-spec-source-metadata>` :term:`project source metadata`,
-as defined in the
-:term:`Pyproject Metadata` `specification <pyprojecttoml_>`__
-(originally introduced in :pep:`621`).
+The changes necessary to implement this PEP include:
 
-Further, :ref:`minor additions <639-spec-project-formats>` to the
-:term:`source distribution` (:term:`sdist`),
-:term:`built distribution` (:term:`Wheel`)
-and :term:`installed project` specifications
-will help document and clarify the already-allowed,
-now formally standardized behavior in these respects.
-Finally, :ref:`guidance is established <639-spec-converting-metadata>`
-for tools handling and converting legacy license metadata
-to :term:`license expressions`,
-to ensure the results are consistent, correct and unambiguous.
+- additions to :ref:`Core Metadata <639-spec-core-metadata>`,
+  as defined in the `specification <coremetadataspec_>`__.
+
+- additions to the author-provided
+  :ref:`project source metadata <639-spec-source-metadata>`,
+  as defined in the `specification <pyprojecttoml_>`__.
+
+- :ref:`minor additions <639-spec-project-formats>` to the
+  source distribution (sdist), built distribution (wheel) and installed project
+  specifications.
+
+- :ref:`guide for tools <639-spec-converting-metadata>`
+  handling and converting legacy license metadata to license
+  expressions, to ensure the results are consistent and correct.
 
 Note that the guidance on errors and warnings is for tools' default behavior;
 they MAY operate more strictly if users explicitly configure them to do so,

--- a/peps/pep-0639/appendix-examples.rst
+++ b/peps/pep-0639/appendix-examples.rst
@@ -49,7 +49,7 @@ Or, in the ``[project]`` table of ``pyproject.toml``:
     [project]
     license = "MIT"
 
-The output core metadata for the distribution packages would then be:
+The output Core Metadata for the distribution packages would then be:
 
 .. code-block:: email
 
@@ -60,7 +60,7 @@ The ``LICENSE`` file would be stored at ``/setuptools-${VERSION}/LICENSE``
 in the sdist and ``/setuptools-${VERSION}.dist-info/licenses/LICENSE``
 in the wheel, and unpacked from there into the site directory (e.g.
 ``site-packages``) on installation; ``/`` is the root of the respective archive
-and ``${VERSION}`` the version of the Setuptools release in the core metadata.
+and ``${VERSION}`` the version of the Setuptools release in the Core Metadata.
 
 
 .. _639-example-advanced:
@@ -152,7 +152,7 @@ Or alternatively, matched via glob patterns, this could be:
         "setuptools/_vendor/LICENSE*",
     ]
 
-With either approach, the output core metadata in the distribution
+With either approach, the output Core Metadata in the distribution
 would be:
 
 .. code-block:: email
@@ -164,7 +164,7 @@ would be:
     License-File: setuptools/_vendor/packaging/LICENSE.BSD
 
 In the resulting sdist, with ``/`` as the root of the archive and ``${VERSION}``
-the version of the Setuptools release specified in the core metadata,
+the version of the Setuptools release specified in the Core Metadata,
 the license files would be located at the paths:
 
 .. code-block:: shell

--- a/peps/pep-0639/appendix-license-survey.rst
+++ b/peps/pep-0639/appendix-license-survey.rst
@@ -11,7 +11,7 @@ This document contains the results of a comprehensive survey of license
 documentation in Python and other languages.
 
 The key takeaways from the survey, which have guided the recommendations of
-PEP 639 are as follows:
+PEP 639, are as follows:
 
 - Most package formats use a single ``License`` field.
 

--- a/peps/pep-0639/appendix-license-survey.rst
+++ b/peps/pep-0639/appendix-license-survey.rst
@@ -18,14 +18,14 @@ License Documentation in Python
 
 .. _639-license-doc-core-metadata:
 
-Core metadata
+Core Metadata
 '''''''''''''
 
-There are two overlapping core metadata fields to document a license: the
+There are two overlapping Core Metadata fields to document a license: the
 license ``Classifier`` `strings <classifiers_>`__ prefixed with ``License ::``
 and the ``License`` `field <licensefield_>`__ as free text.
 
-The core metadata ``License`` field documentation is currently:
+The Core Metadata ``License`` field documentation is currently:
 
 .. code-block:: rst
 

--- a/peps/pep-0639/appendix-license-survey.rst
+++ b/peps/pep-0639/appendix-license-survey.rst
@@ -10,6 +10,23 @@ There are multiple ways used or recommended to document licenses.
 This document contains the results of a comprehensive survey of license
 documentation in Python and other languages.
 
+The key takeaways from the survey, which have guided the recommendations of
+PEP 639 are as follows:
+
+- Most package formats use a single ``License`` field.
+
+- Many modern package systems use some form of :term:`license expression`
+  to optionally combine more than one :term:`license identifier` together.
+  SPDX and SPDX-like syntaxes are the most popular in use.
+
+- SPDX license identifiers are becoming the de facto way to reference common
+  licenses everywhere, whether or not a full license expression syntax is used.
+
+- Several package formats support documenting both a license expression and the
+  paths of the corresponding files that contain the license text. Most Free and
+  Open Source Software licenses require package authors to include their full
+  text in a :term:`Distribution Package`.
+
 
 .. _639-license-doc-python:
 

--- a/peps/pep-0639/appendix-license-survey.rst
+++ b/peps/pep-0639/appendix-license-survey.rst
@@ -148,8 +148,8 @@ globally in a shared documentation directory (e.g. ``/usr/share/doc``).
   `License Texts <fedoratext_>`__ and use a
   `License field <fedoralicense_>`__ that must be filled
   with appropriate short license identifier(s) from an extensive list
-  of `"Good Licenses" <fedoralist_>`__. Fedora also defines its own
-  license expression syntax, similar to that of SPDX.
+  of `"Good Licenses" <fedoralist_>`__. Fedora uses SPDX
+  license expression syntax.
 
 - `OpenSUSE packages <opensuse_>`__ use SPDX license expressions with
   SPDX license IDs and a

--- a/peps/pep-0639/appendix-license-survey.rst
+++ b/peps/pep-0639/appendix-license-survey.rst
@@ -155,7 +155,7 @@ globally in a shared documentation directory (e.g. ``/usr/share/doc``).
   SPDX license IDs and a
   `list of additional license identifiers <opensuselist_>`__.
 
-- `Gentoo ebuild <pycode_>`__ uses a ``LICENSE`` variable.
+- `Gentoo ebuild <gentoo_>`__ uses a ``LICENSE`` variable.
   This field is specified in `GLEP-0023 <glep23_>`__ and in the
   `Gentoo development manual <gentoodev_>`__.
   Gentoo also defines a list of allowed licenses and a license expression

--- a/peps/pep-0639/appendix-rejected-ideas.rst
+++ b/peps/pep-0639/appendix-rejected-ideas.rst
@@ -12,11 +12,11 @@ This document contains a list of the alternative ideas to the ones proposed
 in PEP 639 with detailed explanations why they were rejected.
 
 
-Core metadata fields
+Core Metadata fields
 --------------------
 
 Potential alternatives to the structure, content and deprecation of the
-core metadata fields specified in :pep:`639`.
+Core Metadata fields specified in :pep:`639`.
 
 
 Re-use the ``License`` field
@@ -190,7 +190,7 @@ field was separate from the existing ``License``, which would make
 validation much more challenging and backwards-incompatible, breaking
 existing packages. With that change, there was a clear consensus that
 the new field should be validated from the start, guaranteeing that all
-distributions uploaded to PyPI that declare core metadata version 2.4
+distributions uploaded to PyPI that declare Core Metadata version 2.4
 or higher and have the ``License-Expression`` field will have a valid
 expression, such that PyPI and consumers of its packages and metadata
 can rely upon to follow the specification here.
@@ -226,12 +226,12 @@ Most saliently, this means two very different types of metadata are being
 specified under the same top-level key that require very different handling,
 and furthermore, unlike the previous arrangement, the subkeys were not mutually
 exclusive and can both be specified at once, and with some subkeys potentially
-being dynamic and others static, and mapping to different core metadata fields.
+being dynamic and others static, and mapping to different Core Metadata fields.
 
 Furthermore, this leads to a conflict with marking the key as ``dynamic``
 (assuming that is intended to specify the ``[project]`` table keys,
 as that PEP seems to imprecisely imply,
-rather than core metadata fields), as either or both would have
+rather than Core Metadata fields), as either or both would have
 to be treated as ``dynamic``.
 Grouping both license expressions and license files under the same key
 forces an "all or nothing" approach, and creates ambiguity as to user intent.
@@ -241,9 +241,9 @@ keep track of which fields are mutually exclusive with which of the others,
 greatly increasing cognitive and code complexity, and in turn the probability
 of errors. Conceptually, juxtaposing so many different fields under the
 same key is rather jarring, and leads to a much more complex mapping between
-``[project]`` keys and core metadata fields, not in keeping with :pep:`621`.
+``[project]`` keys and Core Metadata fields, not in keeping with :pep:`621`.
 This causes the ``[project]`` table naming and structure to diverge further
-from both the core metadata and native formats of the various popular packaging
+from both the Core Metadata and native formats of the various popular packaging
 tools that use it. Finally, this results in the spec being significantly more
 complex and convoluted to understand and implement than the alternatives.
 
@@ -255,7 +255,7 @@ and results in a much clearer and cleaner design overall.
 It allows ``license`` and ``license-files`` to be tagged
 ``dynamic`` independently, separates two independent types of metadata
 (syntactically and semantically), restores a closer to 1:1 mapping of
-``[project]`` table keys to core metadata fields,
+``[project]`` table keys to Core Metadata fields,
 and reduces nesting by a level for both.
 Other than adding one extra key to the file, there was no significant
 apparent downside to this latter approach, so it was adopted for PEP 639.
@@ -292,10 +292,10 @@ rather than using the reserved string value of the ``license`` key.
 This was seen as clearer and more explicit for readers and writers,
 in line with the goals of PEP 639.
 
-Additionally, while differences from existing tool formats (and core metadata
+Additionally, while differences from existing tool formats (and Core Metadata
 field names) have precedent in :pep:`621`,
 using a key with an identical name as in most/all current tools
-to mean something different (and map to a different core metadata field),
+to mean something different (and map to a different Core Metadata field),
 with distinct and incompatible syntax and semantics, does not,
 and could cause confusion and ambiguity for readers and authors.
 
@@ -327,7 +327,7 @@ without deprecating the key itself,
 and makes them inherently mutually exclusive without users having to remember
 and tools having to enforce it.
 
-Finally, consistency with other tool formats and the underlying core metadata
+Finally, consistency with other tool formats and the underlying Core Metadata
 was not considered a sufficient priority
 to override the advantages of using the existing key,
 and the ``dynamic`` concerns were mostly mitigated by
@@ -356,8 +356,8 @@ alternative way that SPDX license expressions could be implemented.
 
 However, all the same downsides as in the previous item apply here,
 including greater complexity, a more complex mapping between the project
-source metadata and core metadata and inconsistency between the presentation
-in tool config, project source metadata and core metadata,
+source metadata and Core Metadata and inconsistency between the presentation
+in tool config, project source metadata and Core Metadata,
 a much less clean deprecation, further bikeshedding over what to name it,
 and inability to mark one but not the other as dynamic, among others.
 
@@ -370,7 +370,7 @@ understand that what they are entering is unambiguously a license expression,
 with all the false positive and false negative issues as above.
 
 Therefore, for these as well as the same reasons this approach was rejected
-for the core metadata in favor of a distinct ``License-Expression`` field,
+for the Core Metadata in favor of a distinct ``License-Expression`` field,
 we similarly reject this here in favor of
 the reserved string value of the ``license`` key.
 
@@ -379,7 +379,7 @@ Must be marked dynamic to back-fill
 '''''''''''''''''''''''''''''''''''
 
 The ``license`` key in the ``pyproject.toml`` could be required to be
-explicitly set to dynamic in order for the ``License`` core metadata field
+explicitly set to dynamic in order for the ``License`` Core Metadata field
 to be automatically back-filled from
 the top-level string value of the ``license`` key.
 This would be more explicit that the filling will be done,
@@ -485,7 +485,7 @@ serious limitations for many workflows, if we must assume the items
 are glob patterns rather than literal paths.
 
 This allows tools to locate them and know the exact values of the
-``License-File`` core metadata fields without having to traverse the
+``License-File`` Core Metadata fields without having to traverse the
 source tree of the project and match globs, potentially allowing easier,
 more efficient and reliable programmatic inspection and processing.
 
@@ -604,7 +604,7 @@ However, this is merely declaring a static, strictly-specified default value
 for this particular key, required to be used exactly by all conforming tools
 (so long as it is not marked ``dynamic``, negating this argument entirely),
 and is no less static than any other set of glob patterns the user themself
-may specify. Furthermore, the resulting ``License-File`` core metadata values
+may specify. Furthermore, the resulting ``License-File`` Core Metadata values
 can still be determined with only a list of files in the source, without
 installing or executing any of the code, or even inspecting file contents.
 
@@ -705,7 +705,7 @@ likely conflicts with those of license-related files. Finally,
 putting licenses into their own specified subdirectory would allow
 humans and tools to quickly, easily and correctly list, copy and manipulate
 all of them at once (such as in distro packaging, legal checks, etc)
-without having to reference each of their paths from the core metadata.
+without having to reference each of their paths from the Core Metadata.
 
 Therefore, now is a prudent time to specify an alternate approach.
 The simplest and most obvious solution, as suggested by several on the Wheel
@@ -724,7 +724,7 @@ significant problems in practice. Given this will be much harder if not
 impossible to change later, once the status quo is standardized, tools are
 relying on the current behavior and there is much greater uptake of not
 only simply including license files but potentially accessing them as well
-using the core metadata, if we're going to change it, now would be the time
+using the Core Metadata, if we're going to change it, now would be the time
 (particularly since we're already introducing an edge-case change with how
 license files in subdirs are handled, along with other refinements).
 
@@ -735,7 +735,7 @@ Add new ``licenses`` category to wheel
 ''''''''''''''''''''''''''''''''''''''
 
 Instead of defining a root license directory (``licenses``) inside
-the core metadata directory (``.dist-info``) for wheels, we could instead
+the Core Metadata directory (``.dist-info``) for wheels, we could instead
 define a new category (and, presumably, a corresponding install scheme),
 similar to the others currently included under ``.data`` in the wheel archive,
 specifically for license files, called (e.g.) ``licenses``. This was mentioned
@@ -747,7 +747,7 @@ them there.
 However, at present, PEP 639 does not implement this idea, and it is
 deferred to a future one. It would add significant complexity and friction
 to PEP 639, being primarily concerned with standardizing existing practice
-and updating the core metadata specification. Furthermore, doing so would
+and updating the Core Metadata specification. Furthermore, doing so would
 likely require modifying ``sysconfig`` and the install schemes specified
 therein, alongside Wheel, Installer and other tools, which would be a
 non-trivial undertaking. While potentially slightly more complex for
@@ -777,7 +777,7 @@ Both ``licenses`` and ``license_files`` have been suggested as potential
 names for the root license directory inside ``.dist-info`` of wheels and
 installed projects. An initial draft of the PEP specified the former
 due to being slightly clearer and consistent with the
-name of the core metadata field (``License-File``)
+name of the Core Metadata field (``License-File``)
 and the ``[project]`` table key (``license-files``).
 However, the current version of the PEP adopts the ``license`` name,
 due to a general preference by the community for its shorter length,

--- a/peps/pep-0639/appendix-rejected-ideas.rst
+++ b/peps/pep-0639/appendix-rejected-ideas.rst
@@ -299,7 +299,7 @@ to mean something different (and map to a different core metadata field),
 with distinct and incompatible syntax and semantics, does not,
 and could cause confusion and ambiguity for readers and authors.
 
-Also, per the `project source metadata spec <pep621specdynamic_>`__,
+Also, per the `project source metadata spec <pyprojecttomldynamic_>`__,
 this would allow separately marking the ``[project]`` keys
 corresponding to the ``License`` and ``License-Expression`` metadata fields
 as ``dynamic``,
@@ -877,7 +877,7 @@ mechanism can be found.
 
 .. _choosealicense: https://choosealicense.com/
 .. _numpyissue: https://github.com/numpy/numpy/issues/8689
-.. _pep621specdynamic: https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#dynamic
+.. _pyprojecttomldynamic: https://packaging.python.org/en/latest/specifications/pyproject-toml/#dynamic
 .. _pytorch: https://pypi.org/project/torch/
 .. _reusediscussion: https://github.com/pombredanne/spdx-pypi-pep/issues/7
 .. _scipyissue: https://github.com/scipy/scipy/issues/7093

--- a/peps/pep-0639/appendix-rejected-ideas.rst
+++ b/peps/pep-0639/appendix-rejected-ideas.rst
@@ -25,68 +25,50 @@ Re-use the ``License`` field
 Following `initial discussion <reusediscussion_>`__, earlier versions of
 PEP 639 proposed re-using the existing ``License`` field, which tools would
 attempt to parse as a SPDX license expression with a fallback to free text.
-Initially, this would merely cause a warning (or even pass silently),
-but would eventually be treated as an error by modern tooling.
+Initially, this would cause a warning and eventually it would be treated as an
+error.
 
-This offered the potential benefit of greater backwards-compatibility,
-easing the community into using SPDX license expressions while taking advantage
-of packages that already have them (either intentionally or coincidentally),
+This would be more backwards-compatibile, allowed a smooth adoption
+of SPDX license expressions in the community,
 and avoided adding yet another license-related field.
 
-However, following substantial discussion, consensus was reached that a
-dedicated ``License-Expression`` field was the preferred overall approach.
-The presence of this field is an unambiguous signal that a package
-intends it to be interpreted as a valid SPDX identifier, without the need
-for complex and potentially erroneous heuristics, and allows tools to
-easily and unambiguously detect invalid content.
-
-This avoids both false positive (``License`` values that a package author
-didn't explicitly intend as an explicit SPDX identifier, but that happen
-to validate as one), and false negatives (expressions the author intended
-to be valid SPDX, but due to a typo or mistake are not), which are otherwise
-not clearly distinguishable from true positives and negatives, an ambiguity
-at odds with the goals of PEP 639.
+Eventually, consensus was reached that a
+dedicated ``License-Expression`` field was a better approach.
+The presence of this field unambiguously signals support for the SPDX
+identifiers, without the need for complex heuristics, and allows tools to
+easily detect invalid content.
 
 Furthermore, it allows both the existing ``License`` field and
-the license classifiers to be more easily deprecated,
-with tools able to cleanly distinguish between packages intending to
-affirmatively conform to the updated specification in PEP 639 or not,
-and adapt their behavior (warnings, errors, etc) accordingly.
-Otherwise, tools would either have to allow duplicative and potentially
-conflicting ``License`` fields and classifiers, or warn/error on the
-substantial number of existing packages that have SPDX identifiers as the
-value for the ``License`` field, intentionally or otherwise (e.g. ``MIT``).
+the license classifiers to be easily deprecated,
+with tools able to distinguish between packages conforming to PEP 639 or not,
+and adapt their behavior accordingly.
 
 Finally, it avoids changing the behavior of an existing metadata field,
 and avoids tools having to guess the ``Metadata-Version`` and field behavior
 based on its value rather than merely its presence.
 
-While this would mean the subset of existing distributions containing
-``License`` fields valid as SPDX license expressions wouldn't automatically be
-recognized as such, this only requires appending a few characters to the key
-name in the project's source metadata, and PEP 639 provides extensive
+Distributions which already contain valid SPDX license expressions in the
+``License`` fields will not automatically be recognized as such.
+The migration is simple though, and PEP 639 provides
 guidance on how this can be done automatically by tooling.
-
-Given all this, it was decided to proceed with defining a new,
-purpose-created field, ``License-Expression``.
 
 
 Re-Use the ``License`` field with a value prefix
 ''''''''''''''''''''''''''''''''''''''''''''''''
 
 As an alternative to the previous, prefixing SPDX license expressions with,
-e.g. ``spdx:`` was suggested to reduce the ambiguity inherent in re-using
+e.g. ``spdx:`` was suggested to reduce the ambiguity of re-using
 the ``License`` field. However, this effectively amounted to creating
-a field within a field, and doesn't address all the downsides of
+a field within a field, and doesn't address the downsides of
 keeping the ``License`` field. Namely, it still changes the behavior of an
 existing metadata field, requires tools to parse its value
 to determine how to handle its content, and makes the specification and
 deprecation process more complex and less clean.
 
-Yet, it still shares a same main potential downside as just creating a new
-field: projects currently using valid SPDX identifiers in the ``License``
-field, intentionally or not, won't be automatically recognized, and requires
-about the same amount of effort to fix, namely changing a line in the
+Projects currently using valid SPDX identifiers in the ``License``
+field won't be automatically recognized, and require
+about the same amount of effort to fix as in the case of introducing a new
+field, namely changing a line in the
 project's source metadata. Therefore, it was rejected in favor of a new field.
 
 
@@ -96,76 +78,36 @@ Don't make ``License-Expression`` mutually exclusive
 For backwards compatibility, the ``License`` field and/or the license
 classifiers could still be allowed together with the new
 ``License-Expression`` field, presumably with a warning. However, this
-could easily lead to inconsistent, and at the very least duplicative
+could easily lead to inconsistent
 license metadata in no less than *three* different fields, which is
-squarely contrary to the goals of PEP 639 of making the licensing story
-simpler and unambiguous. Therefore, and in concert with clear community
-consensus otherwise, this idea was soundly rejected.
+contrary to the goal of PEP 639 of making the licensing story
+unambiguous. Therefore, with the community
+consensus this idea was rejected.
 
 
 Don't deprecate existing ``License`` field and classifiers
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Several community members were initially concerned that deprecating the
+Several community members were concerned that deprecating the
 existing ``License`` field and classifiers would result in
-excessive churn for existing package authors and raise the barrier to
-entry for new ones, particularly everyday Python developers seeking to
-package and publish their personal projects without necessarily caring
-too much about the legal technicalities or being a "license lawyer".
-Indeed, every deprecation comes with some non-zero short-term cost,
-and should be carefully considered relative to the overall long-term
-net benefit. And at the minimum, this change shouldn't make it more
-difficult for the average Python developer to share their work under
+much churn for package authors and raise the barrier to
+entry for new ones, particularly developers seeking to
+package their personal projects without caring
+too much about the legal technicalities.
+Indeed, every deprecation should be carefully considered relative to the
+long-term
+net benefit. At the minimum, this change shouldn't make it more
+difficult for a Python developer to share their work under
 a license of their choice, and ideally improve the situation.
 
-Following many rounds of proposals, discussion and refinement,
-the general consensus was clearly in favor of deprecating the legacy
-means of specifying a license, in favor of "one obvious way to do it",
-to improve the currently complex and fragmented story around license
-documentation. Not doing so would leave three different un-deprecated ways of
-specifying a license for a package, two of them ambiguous, less than
-clear/obvious how to use, inconsistently documented and out of date.
-This is more complex for all tools in the ecosystem to support
-indefinitely (rather than simply installers supporting older packages
-implementing previous frozen metadata versions), resulting in a non-trivial
-and unbounded maintenance cost.
-
-Furthermore, it leads to a more complex and confusing landscape for users with
-three similar but distinct options to choose from, particularly with older
-documentation, answers and articles floating around suggesting different ones.
-Of the three, ``License-Expression`` is the simplest and clearest to use
-correctly; users just paste in their desired license identifier, or select it
-via a tool, and they're done; no need to learn about Trove classifiers and
-dig through the list to figure out which one(s) apply (and be confused
-by many ambiguous options), or figure out on their own what should go
-in the ``license`` key (anything from nothing, to the license text,
-to a free-form description, to the same SPDX identifier they would be
-entering in the ``license`` key anyway, assuming they can
-easily find documentation at all about it). In fact, this can be
-made even easier thanks to the new field. For example, GitHub's popular
-`ChooseALicense.com <choosealicense_>`__ links to how to add SPDX license
-identifiers to the project source metadata of various languages that support
-them right in the sidebar of every license page; the SPDX support in this
-PEP enables adding Python to that list.
-
-For current package maintainers who have specified a ``License`` or license
-classifiers, PEP 639 only recommends warnings and prohibits errors for
-all but publishing tools, which are allowed to error if their intended
-distribution platform(s) so requires. Once maintainers are ready to
-upgrade, for those already using SPDX license expressions (accidentally or not)
-this only requires appending a few characters to the key name in the
-project's source metadata, and for those with license classifiers that
-map to a single unambiguous license, or another defined case (public domain,
-proprietary), they merely need to drop the classifier and paste in the
-corresponding license identifier. PEP 639 provides extensive guidance and
-examples, as will other resources, as well as explicit instructions for
-automated tooling to take care of this with no human changes needed.
-More complex cases where license metadata is currently specified may
-need a bit of human intervention, but in most cases tools will be able
-to provide a list of options following the mappings in PEP 639, and
-these are typically the projects most likely to be constrained by the
-limitations of the existing license metadata, and thus most benefited
-by the new fields in PEP 639.
+Following many rounds of discussion,
+the general consensus was in favor of deprecating the legacy
+means of specifying a license and in favor of "one obvious way to do it".
+Not doing so would leave three different un-deprecated ways of
+specifying a license for a package, two of them ambiguous,
+inconsistently documented and out of date.
+This is more complex for tools to support
+indefinitely, resulting in a non-trivial maintenance cost.
 
 Finally, for unmaintained packages, those using tools supporting older
 metadata versions, or those who choose not to provide license metadata,
@@ -175,20 +117,18 @@ no changes are required regardless of the deprecation.
 Don't mandate validating new fields on PyPI
 '''''''''''''''''''''''''''''''''''''''''''
 
-Previously, while PEP 639 did include normative guidelines for packaging
-publishing tools (such as Twine), it did not provide specific guidance
+Previously, PEP 639 did not provide specific guidance
 for PyPI (or other package indices) as to whether and how they
 should validate the ``License-Expression`` or ``License-File`` fields,
 nor how they should handle using them in combination with the deprecated
 ``License`` field or license classifiers. This simplifies the specification
-and either defers implementation on PyPI to a later PEP, or gives
-discretion to PyPI to enforce the stated invariants, to minimize
+and defers implementation on PyPI to a later PEP to minimize
 disruption to package authors.
 
-However, this had been left unstated from before the ``License-Expression``
-field was separate from the existing ``License``, which would make
-validation much more challenging and backwards-incompatible, breaking
-existing packages. With that change, there was a clear consensus that
+This was in place for an earlier draft of PEP 639 which didn't separate
+``License-Expression`` from the ``License`` field. The validation would have
+been difficult and backwards-incompatible, breaking existing packages.
+With the current proposal, there was a clear consensus that
 the new field should be validated from the start, guaranteeing that all
 distributions uploaded to PyPI that declare Core Metadata version 2.4
 or higher and have the ``License-Expression`` field will have a valid
@@ -197,55 +137,43 @@ can rely upon to follow the specification here.
 
 The same can be extended to the new ``License-File`` field as well,
 to ensure that it is valid and the legally required license files are
-present, and thus it is lawful for PyPI, users and downstream consumers
-to distribute the package. (Of course, this makes no *guarantee* of such
-as it is ultimately reliant on authors to declare them, but it improves
-assurance of this and allows doing so in the future if the community so
-decides.) To be clear, this would not require that any uploaded distribution
-have such metadata, only that if they choose to declare it per the new
+present. To be clear, this would not require that any uploaded distribution
+have such metadata, only that if they choose to declare it per the
 specification in PEP 639, it is assured to be valid.
 
 
 Source metadata ``license`` key
 -------------------------------
 
-Alternate possibilities related to the ``license`` key in the
+Alternative possibilities related to the ``license`` key in the
 ``pyproject.toml`` project source metadata.
 
 
 Add ``expression`` and ``files`` subkeys to table
 '''''''''''''''''''''''''''''''''''''''''''''''''
 
-A previous working draft of PEP 639 added ``expression`` and ``files`` subkeys
+A previous draft of PEP 639 added ``expression`` and ``files`` subkeys
 to the existing ``license`` table in the project source metadata, to parallel
-the existing ``file`` and ``text`` subkeys. While this seemed perhaps the
-most obvious approach at first glance, it had several serious drawbacks
+the existing ``file`` and ``text`` subkeys. While this seemed the
+most obvious approach at first glance, it had serious drawbacks
 relative to that ultimately taken here.
 
-Most saliently, this means two very different types of metadata are being
+This means two very different types of metadata are being
 specified under the same top-level key that require very different handling,
-and furthermore, unlike the previous arrangement, the subkeys were not mutually
-exclusive and can both be specified at once, and with some subkeys potentially
+and unlike the previous arrangement, the subkeys were not mutually
+exclusive and could both be specified at once, with some subkeys potentially
 being dynamic and others static, and mapping to different Core Metadata fields.
-
-Furthermore, this leads to a conflict with marking the key as ``dynamic``
-(assuming that is intended to specify the ``[project]`` table keys,
-as that PEP seems to imprecisely imply,
-rather than Core Metadata fields), as either or both would have
-to be treated as ``dynamic``.
-Grouping both license expressions and license files under the same key
-forces an "all or nothing" approach, and creates ambiguity as to user intent.
 
 There are further downsides to this as well. Both users and tools would need to
 keep track of which fields are mutually exclusive with which of the others,
-greatly increasing cognitive and code complexity, and in turn the probability
-of errors. Conceptually, juxtaposing so many different fields under the
-same key is rather jarring, and leads to a much more complex mapping between
+greatly increasing complexity, and the probability
+of errors. Having so many different fields under the
+same key leads to a much more complex mapping between
 ``[project]`` keys and Core Metadata fields, not in keeping with :pep:`621`.
 This causes the ``[project]`` table naming and structure to diverge further
 from both the Core Metadata and native formats of the various popular packaging
 tools that use it. Finally, this results in the spec being significantly more
-complex and convoluted to understand and implement than the alternatives.
+complex to understand and implement than the alternatives.
 
 The approach PEP 639 now takes, using the reserved top-level string value
 of the ``license`` key, adding a new ``license-files`` key
@@ -265,20 +193,20 @@ Add an ``expression`` subkey instead of a string value
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 Adding just an ``expression`` subkey to the ``license`` table,
-instead of using the reserved top-level string value,
+instead of using the top-level string value,
 would be more explicit for readers and writers,
 in line with PEP 639's goals.
 However, it still has the downsides listed above
 that are not specific to the inclusion of the ``files`` key.
 
 Relative to a flat string value,
-it adds verbosity, complexity and an extra level of nesting,
+it adds complexity and an extra level of nesting,
 and requires users and tools to remember and handle
 the mutual exclusivity of the subkeys
-and remember which are deprecated and which are not,
+and remember which are deprecated,
 instead of cleanly deprecating the table subkeys as a whole.
 Furthermore, it is less clearly the "default" choice for modern use,
-given users tend to gravitate toward the simplest and most obvious option.
+given users tend to gravitate toward the most obvious option.
 Finally, it seems reasonable to follow the suggested guidance in :pep:`621`,
 given the top-level string value was specifically reserved for this purpose.
 
@@ -288,16 +216,15 @@ Define a new top-level ``license-expression`` key
 
 An earlier version of PEP 639 defined a new, top-level ``license-expression``
 under the ``[project]`` table,
-rather than using the reserved string value of the ``license`` key.
-This was seen as clearer and more explicit for readers and writers,
+rather than using the string value of the ``license`` key.
+This was seen as clearer for readers and writers,
 in line with the goals of PEP 639.
 
-Additionally, while differences from existing tool formats (and Core Metadata
-field names) have precedent in :pep:`621`,
-using a key with an identical name as in most/all current tools
-to mean something different (and map to a different Core Metadata field),
-with distinct and incompatible syntax and semantics, does not,
-and could cause confusion and ambiguity for readers and authors.
+While differences from existing tool formats (and Core Metadata
+field names) have precedent in :pep:`621`, repurposing an existing key to mean
+something different (and map to a different Core Metadata field),
+with distinct and incompatible syntax does not, 
+and could cause ambiguity for readers and authors.
 
 Also, per the `project source metadata spec <pyprojecttomldynamic_>`__,
 this would allow separately marking the ``[project]`` keys
@@ -317,18 +244,18 @@ as :pep:`reserved for this purpose by PEP 621 <621#license>`:
     (the same logic applies to any sort of "type" field specifying what
     license the file or text represents).
 
-This is shorter and simpler for users to remember and type,
+This is simpler for users to remember and type,
 avoids adding a new top-level key while taking advantage of an existing one,
 guides users toward using a license expression as the default,
 and follows what was envisioned in the original :pep:`621`.
 
 Additionally, this allows cleanly deprecating the table values
 without deprecating the key itself,
-and makes them inherently mutually exclusive without users having to remember
+and makes them mutually exclusive without users having to remember
 and tools having to enforce it.
 
 Finally, consistency with other tool formats and the underlying Core Metadata
-was not considered a sufficient priority
+was not a sufficient priority
 to override the advantages of using the existing key,
 and the ``dynamic`` concerns were mostly mitigated by
 not specifying legacy license to license expression conversion at build time,
@@ -348,30 +275,28 @@ of the ``license`` key in the ``[project]`` table,
 one could add a ``type`` subkey to the ``license`` table
 to control whether ``text`` (or a string value)
 is interpreted as free-text or a license expression. This could make
-backward compatibility a little more seamless, as older tools could ignore
+backward compatibility a bit easier, as older tools could ignore
 it and always treat ``text`` as ``license``, while newer tools would
 know to treat it as a license expression, if ``type`` was set appropriately.
 Indeed, :pep:`621` seems to suggest something of this sort as a possible
-alternative way that SPDX license expressions could be implemented.
+way that SPDX license expressions could be implemented.
 
-However, all the same downsides as in the previous item apply here,
+However, it has got all the same downsides as in the previous item,
 including greater complexity, a more complex mapping between the project
 source metadata and Core Metadata and inconsistency between the presentation
 in tool config, project source metadata and Core Metadata,
-a much less clean deprecation, further bikeshedding over what to name it,
+a harder deprecation, further bikeshedding over what to name it,
 and inability to mark one but not the other as dynamic, among others.
 
-In addition, while theoretically potentially a little easier in the short
+In addition, while theoretically a little easier in the short
 term, in the long term it would mean users would always have to remember
 to specify the correct ``type`` to ensure their license expression is
 interpreted correctly, which adds work and potential for error; we could
-never safety change the default while being confident that users
+never safely change the default while being confident that users
 understand that what they are entering is unambiguously a license expression,
 with all the false positive and false negative issues as above.
 
-Therefore, for these as well as the same reasons this approach was rejected
-for the Core Metadata in favor of a distinct ``License-Expression`` field,
-we similarly reject this here in favor of
+Therefore, for these reasons, we reject this here in favor of
 the reserved string value of the ``license`` key.
 
 
@@ -388,9 +313,9 @@ as strictly speaking the ``license`` key is not (and cannot be) specified in
 of the previous :pep:`621` specification that PEP 639 revises.
 
 However, this doesn't seem to be necessary, because it is simply using the
-static, verbatim literal value of the ``license`` key, as specified
-strictly in PEP 639. Therefore, any conforming tool can trivially,
-deterministically and unambiguously derive this using only the static data
+static, literal value of the ``license`` key, as specified
+strictly in PEP 639. Therefore, any conforming tool can
+deterministically derive this using only the static data
 in the ``pyproject.toml`` file itself.
 
 Furthermore, this actually adds significant ambiguity, as it means the value
@@ -401,9 +326,9 @@ why such is explicitly prohibited by PEP 639. Therefore, not marking it as
 requirements.
 
 Finally, users explicitly being told to mark it as ``dynamic``, or not, to
-control filling behavior seems to be a bit of a mis-use of the ``dynamic``
+control filling behavior seems to be a bit of a misuse of the ``dynamic``
 field as apparently intended, and prevents tools from adapting to best
-practices (fill, don't fill, etc) as they develop and evolve over time.
+practices (fill, don't fill, etc.) as they develop and evolve over time.
 
 
 Source metadata ``license-files`` key
@@ -420,47 +345,46 @@ Add a ``type`` subkey to ``license-files``
 Instead of defining mutually exclusive ``paths`` and ``globs`` subkeys
 of the ``license-files`` ``[project]`` table key, we could
 achieve the same effect with a ``files`` subkey for the list and
-a ``type`` subkey for how to interpret it. However, the latter offers no
-real advantage over the former, in exchange for requiring more keystrokes,
-verbosity and complexity, as well as less flexibility in allowing both,
+a ``type`` subkey for how to interpret it. However, it offers no
+real advantage in exchange for requiring more keystrokes,
+increased complexity, as well as less flexibility in allowing both,
 or another additional subkey in the future, as well as the need to bikeshed
-over the subkey name. Therefore, it was summarily rejected.
+over the subkey name. Therefore, it was rejected.
 
 
 Only accept verbatim paths
 ''''''''''''''''''''''''''
 
-Globs could be disallowed completely as values to the ``license-files``
-key in ``pyproject.toml`` and only verbatim literal paths allowed.
-This would ensure that all license files are explicitly specified, all
-specified license files are found and included, and the source metadata
+Globs could be disallowed as values to the ``license-files``
+key in ``pyproject.toml`` and only verbatim paths allowed.
+This would ensure that all license files are explicitly specified,
+found and included, and the source metadata
 is completely static in the strictest sense of the term, without tools
 having to inspect the rest of the project source files to determine exactly
 what license files will be included and what the ``License-File`` values
-will be. This would also modestly simplify the spec and tool implementation.
+will be. This would also simplify the spec and tool implementation.
 
-However, practicality once again beats purity here. Globs are supported and
-used by many existing tools for finding license files, and explicitly
+However, practicality beats purity here. Globs are already supported
+by many existing tools, and explicitly
 specifying the full path to every license file would be unnecessarily tedious
-for more complex projects with vendored code and dependencies. More
+for complex projects with vendored dependencies. More
 critically, it would make it much easier to accidentally miss a required
-legal file, silently rendering the package illegal to distribute.
+legal file, creating the package illegal to distribute.
 
-Tools can still statically and consistently determine the files to be included,
-based only on those glob patterns the user explicitly specified and the
+Tools can still determine the files to be included,
+based only on the glob patterns the user specified and the
 filenames in the package, without installing it, executing its code or even
-examining its files. Furthermore, tools are still explicitly allowed to warn
-if specified glob patterns (including full paths) don't match any files.
+examining its files. Furthermore, tools are explicitly allowed to warn
+if specified glob patterns don't match any files.
 And, of course, sdists, wheels and others will have the full static list
 of files specified in their distribution metadata.
 
-Perhaps most importantly, this would also preclude the currently specified
-default value, as widely used by the current most popular tools, and thus
-be a major break to backward compatibility, tool consistency, and safe
-and sane default functionality to avoid unintentional license violations.
-And of course, authors are welcome and encouraged to specify their license
+Perhaps most importantly, this would also exclude the currently specified
+default value widely used by the most popular tools, and thus
+be a major break to backward compatibility.
+And of course, authors are welcome to specify their license
 files explicitly via the ``paths`` table subkey, once they are aware of it and
-if it is suitable for their project and workflow.
+find it suitable for their project.
 
 
 Only accept glob patterns
@@ -480,14 +404,14 @@ Including an explicit ``paths`` value ensures that the resulting
 ``License-File`` metadata is correct, complete and purely static in the
 strictest sense of the term, with all license paths explicitly specified
 in the ``pyproject.toml`` file, guaranteed to be included and with an early
-error should any be missing. This is not practical to do, at least without
+error if any are missing. This is not practical to do, at least without
 serious limitations for many workflows, if we must assume the items
 are glob patterns rather than literal paths.
 
 This allows tools to locate them and know the exact values of the
 ``License-File`` Core Metadata fields without having to traverse the
-source tree of the project and match globs, potentially allowing easier,
-more efficient and reliable programmatic inspection and processing.
+source tree of the project and match globs, potentially allowing
+more reliable programmatic inspection and processing.
 
 Therefore, given the relatively small cost and the significant benefits,
 this approach was not adopted.
@@ -498,28 +422,26 @@ Infer whether paths or globs
 
 It was considered whether to simply allow specifying an array of strings
 directly for the ``license-files`` key, rather than making it a table with
-explicit ``paths`` and ``globs``. This would be somewhat simpler and avoid
+explicit ``paths`` and ``globs``. This would be simpler and avoid
 an extra level of nesting, and more closely match the configuration format
 of existing tools. However, it was ultimately rejected in favor of separate,
 mutually exclusive ``paths`` and ``globs`` table subkeys.
 
 In practice, it only saves six extra characters in the ``pyproject.toml``
 (``license-files = [...]`` vs ``license-files.globs = [...]``), but allows
-the user to more explicitly declare their intent, ensures they understand how
-the values are going to be interpreted, and serves as an unambiguous indicator
-for tools to parse them as globs rather than verbatim path literals.
+the user to explicitly declare their intent and serves as an unambiguous
+indicator for tools to parse them as globs rather than verbatim paths.
 
-This, in turn, allows for more appropriate, clearly specified tool
+This, in turn, allows for clearly specified tool
 behaviors for each case, many of which would be unreliable or impossible
-without it, to avoid common traps, provide more helpful feedback and
-behave more sensibly and intuitively overall. These include, with ``paths``,
-guaranteeing that each and every specified file is included and immediately
+without it and
+behave more intuitively overall. These include, with ``paths``,
+guaranteeing that each specified file is included and immediately
 raising an error if one is missing, and with ``globs``, checking glob syntax,
-excluding unwanted backup, temporary, or other such files (as current tools
-already do), and optionally warning if a glob doesn't match any files.
+excluding unwanted backup, temporary, or other such files,
+and optionally warning if a glob doesn't match any files.
 This also avoids edge cases (e.g. paths that contain glob characters) and
-reliance on heuristics to determine interpretation—the very thing PEP 639
-seeks to avoid.
+reliance on heuristics to determine interpretation.
 
 
 .. _639-license-files-allow-flat-array:
@@ -530,25 +452,23 @@ Also allow a flat array value
 Initially, after deciding to define ``license-files`` as a table of ``paths``
 and ``globs``, thought was given to making a top-level string array under the
 ``license-files`` key mean one or the other (probably ``globs``, to match most
-current tools). This is slightly shorter and simpler, would allow gently
-nudging users toward a preferred one, and allow a slightly cleaner handling of
-the empty case (which, at present, is treated identically for either).
+current tools). This is slightly shorter, indicates to
+the users which one is a preferred one, and allows a cleaner handling of
+the empty case.
 
-However, this again only saves six characters in the best case, and there
-isn't an obvious choice; whether from a perspective of preference (both had
-clear use cases and benefits), nor as to which one users would naturally
-assume.
+However, this only saves six characters in the best case, and there
+isn't an obvious choice.
 
 Flat may be better than nested, but in the face of ambiguity, users
 may not resist the temptation to guess. Requiring users to explicitly specify
 one or the other ensures they are aware of how their inputs will be handled,
-and is more readable for others, both human and machine alike. It also makes
+and is more readable for others. It also makes
 the spec and tool implementation slightly more complicated, and it can always
 be added in the future, but not removed without breaking backward
 compatibility. And finally, for the "preferred" option, it means there is
 more than one obvious way to do it.
 
-Therefore, per :pep:`20`, the Zen of Python, this approach is hereby rejected.
+Therefore, per :pep:`20`, the Zen of Python, this approach is rejected.
 
 
 Allow both ``paths`` and ``globs`` subkeys
@@ -556,73 +476,64 @@ Allow both ``paths`` and ``globs`` subkeys
 
 Allowing both ``paths`` and ``globs`` subkeys to be specified under the
 ``license-files`` table was considered, as it could potentially allow
-more flexible handling for particularly complex projects, and specify on a
-per-pattern rather than overall basis whether ``license-files`` entries
-should be treated as ``paths`` or ``globs``.
+more flexible handling for particularly complex projects.
 
 However, given the existing proposed approach already matches or exceeds the
-power and capabilities of those offered in tools' config files, there isn't
-clear demand for this and few likely cases that would benefit, it adds a large
-amount of complexity for relatively minimal gain, in terms of the
-specification, in tool implementations and in ``pyproject.toml`` itself.
+capabilities of those offered in tools' config files, there isn't
+clear demand for this, and it adds a large
+amount of complexity in tool implementations and ``pyproject.toml``
+for relatively minimal gain.
 
 There would be many more edge cases to deal with, such as how to handle files
-matched by both lists, and it conflicts in multiple places with the current
-specification for how tools should behave with one or the other, such as when
-no files match, guarantees of all files being included and of the file paths
-being explicitly, statically specified, and others.
+matched by both lists, and it conflicts with the current
+specification for how tools should behave, such as when
+no files match.
 
 Like the previous, if there is a clear need for it, it can be always allowed
-in the future in a backward-compatible manner (to the extent it is possible
-in the first place), while the same is not true of disallowing it.
+in the future in a backward-compatible manner,
+while the same is not true of disallowing it.
 Therefore, it was decided to require the two subkeys to be mutually exclusive.
 
 
 Rename ``paths`` subkey to ``files``
 ''''''''''''''''''''''''''''''''''''
 
-Initially, it was considered whether to name the ``paths`` subkey of the
-``license-files`` table ``files`` instead. However, ``paths`` was ultimately
-chosen, as calling the table subkey ``files`` resulted in duplication between
+Initially, the name ``files`` was considered instead of the ``paths`` for the
+subkey of ``license-files`` table. However, ``paths`` was ultimately
+chosen to avoid duplication between
 the table name (``license-files``) and the subkey name (``files``), i.e.
-``license-files.files = ["LICENSE.txt"]``, made it seem like the preferred/
-default subkey when it was not, and lacked the same parallelism with ``globs``
-in describing the format of the string entry rather than what was being
-pointed to.
+``license-files.files = ["LICENSE.txt"]``. It made it seem like
+the preferred subkey when it was not, and didn't describe the format of the
+string entry similarly to the existing ``globs``.
 
 
 Must be marked dynamic to use defaults
 ''''''''''''''''''''''''''''''''''''''
 
-It may seem outwardly sensible, at least with a particularly restrictive
-interpretation of :pep:`621`'s description of the ``dynamic`` list, to
-consider requiring the ``license-files`` key to be explicitly marked as
-``dynamic`` in order for the default glob patterns to be used, or alternatively
+With a restrictive
+interpretation of :pep:`621`'s description of the ``dynamic`` list it may
+seem sensible to require the ``license-files`` key to be marked as
+``dynamic`` for the default glob patterns to be used, or alternatively
 for license files to be matched and included at all.
 
-However, this is merely declaring a static, strictly-specified default value
-for this particular key, required to be used exactly by all conforming tools
-(so long as it is not marked ``dynamic``, negating this argument entirely),
-and is no less static than any other set of glob patterns the user themself
-may specify. Furthermore, the resulting ``License-File`` Core Metadata values
-can still be determined with only a list of files in the source, without
-installing or executing any of the code, or even inspecting file contents.
+However, this is just declaring a static, strictly-specified default value,
+required to be used exactly by all conforming tools, similarly to any other set
+of glob patterns the user themself may specify.
+The resulting ``License-File`` Core Metadata values
+can be determined through inspecting a list of files in the source, without
+executing code, or even inspecting file contents.
 
-Moreover, even if this were not so, practicality would trump purity, as this
-interpretation would be strictly backwards-incompatible with the existing
+Moreover, even if this were not so, this
+interpretation would be backwards-incompatible with the existing
 format, and be inconsistent with the behavior with the existing tools.
-Further, this would create a very serious and likely risk of a large number of
+Further, this would create a serious risk of a large number of
 projects unknowingly no longer including legally mandatory license files,
-making their distribution technically illegal, and is thus not a sane,
-much less sensible default.
+and is thus not a sane default.
 
-Finally, aside from adding an additional line of default-required boilerplate
-to the file, not defining the default as dynamic allows authors to clearly
-and unambiguously indicate when their build/packaging tools are going to be
-handling the inclusion of license files themselves rather than strictly
-conforming to the project source metadata portions of PEP 639;
-to do otherwise would defeat the primary purpose of the ``dynamic`` list
-as a marker and escape hatch.
+Finally, not defining the default as dynamic allows authors to unambiguously
+indicate when their build/packaging tools are going to be
+handling the inclusion of license files themselves;
+to do otherwise would defeat the purpose of the ``dynamic`` list.
 
 
 License file paths
@@ -635,36 +546,31 @@ and built distributions.
 Flatten license files in subdirectories
 '''''''''''''''''''''''''''''''''''''''
 
-Previous drafts of PEP 639 were silent on the issue of handling license files
-in subdirectories. Currently, the `Wheel <wheelfiles_>`__ and (following its
-example) `Setuptools <setuptoolsfiles_>`__ projects flatten all license files
+Previous drafts of PEP 639 didn't specify how to handle the license files
+in subdirectories. Currently, the `Wheel <wheelfiles_>`__ and
+`Setuptools <setuptoolsfiles_>`__ projects flatten all license files
 into the ``.dist-info`` directory without preserving the source subdirectory
 hierarchy.
 
-While this is the simplest approach and matches existing ad hoc practice,
-this can result in name conflicts and license files clobbering others,
-with no obvious defined behavior for how to resolve them, and leaving the
-package legally un-distributable without any clear indication to users that
-their specified license files have not been included.
+While this approach and matches existing ad hoc practice,
+it can result in name conflicts and license files clobbering others,
+with no defined behavior for how to resolve them, and leaving the
+package legally un-distributable without any clear indication that
+the specified license files have not been included.
 
 Furthermore, this leads to inconsistent relative file paths for non-root
 license files between the source, sdist and wheel, and prevents the paths
-given in the "static" ``[project]`` table metadata from being truly static,
-as they need to be flattened, and may potentially overwrite one another.
-Finally, the source directory structure often implies valuable information
-about what the licenses apply to, and where to find them in the source,
+given in the "static" ``[project]`` table metadata from being truly static.
+Finally, the source directory structure often holds valuable information
+about what the licenses apply to,
 which is lost when flattening them and far from trivial to reconstruct.
 
-To resolve this, the PEP now proposes, as did contributors on both of the
-above issues, reproducing the source directory structure of the original
-license files inside the ``.dist-info`` directory. This would fully resolve the
-concerns above, with the only downside being a more nested ``.dist-info``
-directory. There is still a risk of collision with edge-case custom
-filenames (e.g. ``RECORD``, ``METADATA``), but that is also the case
-with the previous approach, and in fact with fewer files flattened
-into the root, this would actually reduce the risk. Furthermore,
-the following proposal rooting the license files under a ``licenses``
-subdirectory eliminates both collisions and the clutter problem entirely.
+To resolve this, the PEP now proposes reproducing the source directory
+structure of the original
+license files inside the ``.dist-info`` directory. The only downside of this
+approach is having a more nested ``.dist-info``
+directory. The following proposal rooting the license files under a ``licenses``
+subdirectory eliminates both name collisions and the clutter problem entirely.
 
 
 Resolve name conflicts differently
@@ -677,58 +583,43 @@ to the license filename, traversing up the tree until the name was unique,
 to avoid excessively nested directories.
 
 However, this would not address the path consistency issues, would require
-much more discussion, coordination and bikeshedding, and further complicate
-the specification and the implementations. Therefore, it was rejected in
-favor of the simpler and more obvious solution of just preserving the
-source subdirectory layout, as many stakeholders have already advocated for.
+much more discussion and further complicate
+the specification. Therefore, it was rejected in
+favor of the more obvious solution of just preserving the
+source subdirectory layout, as many stakeholders have advocated for.
 
 
 Dump directly in ``.dist-info``
 '''''''''''''''''''''''''''''''
 
 Previously, the included license files were stored directly in the top-level
-``.dist-info`` directory of built wheels and installed projects. This followed
-existing ad hoc practice, ensured most existing wheels currently using this
-feature will match new ones, and kept the specification simpler, with the
-license files always being stored in the same location relative to the core
-metadata regardless of distribution type.
+``.dist-info`` directory of built wheels and installed projects.
 
-However, this leads to a more cluttered ``.dist-info`` directory, littered
-with arbitrary license files and subdirectories, as opposed to separating
-licenses into their own namespace (which per the Zen of Python, :pep:`20`, are
-"one honking great idea"). While currently small, there is still a
-risk of collision with specific custom license filenames
+However, this leads to a more cluttered ``.dist-info`` directory
+as opposed to separating
+licenses into their own namespace. There is still a
+risk of collision with custom license filenames
 (e.g. ``RECORD``, ``METADATA``) in the ``.dist-info`` directory, which
-would only increase if and when additional files were specified here, and
-would require carefully limiting the potential filenames used to avoid
-likely conflicts with those of license-related files. Finally,
+would require limiting the potential filenames used. Finally,
 putting licenses into their own specified subdirectory would allow
-humans and tools to quickly, easily and correctly list, copy and manipulate
-all of them at once (such as in distro packaging, legal checks, etc)
+humans and tools to correctly manipulate
+all of them at once (such as in distro packaging, legal checks, etc.)
 without having to reference each of their paths from the Core Metadata.
 
-Therefore, now is a prudent time to specify an alternate approach.
-The simplest and most obvious solution, as suggested by several on the Wheel
-and Setuptools implementation issues, is to simply root the license files
+Therefore, the simplest and most obvious solution, as suggested by several
+on the Wheel
+and Setuptools implementation issues, is to root the license files
 relative to a ``licenses`` subdirectory of ``.dist-info``. This is simple
-to implement and solves all the problems noted here, without clear significant
+to implement and solves all the problems noted here, without significant
 drawbacks relative to other more complex options.
 
-It does make the specification a bit more complex and less elegant, but
+It does make the specification a bit more complex, but
 implementation should remain equally simple. It does mean that wheels
 produced with following this change will have differently-located licenses
 than those prior, but as this was already true for those in subdirectories,
-and until PEP 639 there was no way of discovering these files or
-accessing them programmatically, this doesn't seem likely to pose
-significant problems in practice. Given this will be much harder if not
-impossible to change later, once the status quo is standardized, tools are
-relying on the current behavior and there is much greater uptake of not
-only simply including license files but potentially accessing them as well
-using the Core Metadata, if we're going to change it, now would be the time
-(particularly since we're already introducing an edge-case change with how
-license files in subdirs are handled, along with other refinements).
-
-Therefore, the latter has been incorporated into current drafts of PEP 639.
+and until PEP 639 there was no way of
+accessing these files programmatically, this should not pose
+significant problems in practice.
 
 
 Add new ``licenses`` category to wheel
@@ -741,31 +632,30 @@ similar to the others currently included under ``.data`` in the wheel archive,
 specifically for license files, called (e.g.) ``licenses``. This was mentioned
 by the wheel creator, and would allow installing licenses somewhere more
 platform-appropriate and flexible than just the ``.dist-info`` directory
-in the site path, and potentially be conceptually cleaner than including
-them there.
+in the site path.
 
 However, at present, PEP 639 does not implement this idea, and it is
 deferred to a future one. It would add significant complexity and friction
 to PEP 639, being primarily concerned with standardizing existing practice
-and updating the Core Metadata specification. Furthermore, doing so would
-likely require modifying ``sysconfig`` and the install schemes specified
+and updating the Core Metadata specification. Furthermore, doing so could
+require modifying ``sysconfig`` and the install schemes specified
 therein, alongside Wheel, Installer and other tools, which would be a
 non-trivial undertaking. While potentially slightly more complex for
-repackagers (such as those for Linux distributions), the current proposal still
-ensures all license files are included, and in a single dedicated directory
-(which can easily be copied or relocated downstream), and thus should still
-greatly improve the status quo in this regard without the attendant complexity.
+repackagers, the current proposal still
+ensures all license files are included in a single dedicated directory,
+and thus should still
+greatly improve the status quo in this regard.
 
 In addition, this approach is not fully backwards compatible (since it
 isn't transparent to tools that simply extract the wheel), is a greater
 departure from existing practice and would lead to more inconsistent
 license install locations from wheels of different versions. Finally,
-this would mean licenses would not be installed as proximately to their
+this would mean licenses would not be installed as close to their
 associated code, there would be more variability in the license root path
 across platforms and between built distributions and installed projects,
 accessing installed licenses programmatically would be more difficult, and a
-suitable install location and method would need to be created, discussed
-and decided that would avoid name clashes.
+suitable install location and method would need to be created that would avoid
+name clashes.
 
 Therefore, to keep PEP 639 in scope, the current approach was retained.
 
@@ -779,9 +669,9 @@ installed projects. An initial draft of the PEP specified the former
 due to being slightly clearer and consistent with the
 name of the Core Metadata field (``License-File``)
 and the ``[project]`` table key (``license-files``).
-However, the current version of the PEP adopts the ``license`` name,
-due to a general preference by the community for its shorter length,
-greater simplicity and the lack of a separator character (``_``, ``-``, etc.).
+However, the current version of the PEP adopts the ``licenses`` name,
+due to a general preference by the community for its shorter length
+and the lack of a separator character.
 
 
 Other ideas
@@ -794,9 +684,8 @@ ultimately not adopted.
 Map identifiers to license files
 ''''''''''''''''''''''''''''''''
 
-This would require using a mapping (as two parallel lists would be too prone to
-alignment errors), which would add extra complexity to how license
-are documented and add an additional nesting level.
+This would require using a mapping, which would add extra complexity to how
+license are documented and add an additional nesting level.
 
 A mapping would be needed, as it cannot be guaranteed that all expressions
 (keys) have a single license file associated with them (e.g.
@@ -805,15 +694,15 @@ does not have more than one. (e.g. an Apache license ``LICENSE`` and
 its ``NOTICE`` file, for instance, are two distinct files).
 For most common cases, a single license expression and one or more license
 files would be perfectly adequate. In the rarer and more complex cases where
-there are many licenses involved, authors can still safety use the fields
+there are many licenses involved, authors can still safely use the fields
 specified here, just with a slight loss of clarity by not specifying which
-text file(s) map to which license identifier (though this should be clear in
-practice given each license identifier has corresponding SPDX-registered
-full license text), while not forcing the more complex data model
-(a mapping) on the large majority of users who do not need or want it.
+text file(s) map to which license identifier (though each license identifier
+has corresponding SPDX-registered
+full license text), while not forcing the more complex mapping
+on the large majority of users who do not need or want it.
 
-We could of course have a data field with multiple possible value types (it's a
-string, it's a list, it's a mapping!) but this could be a source of confusion.
+We could of course have a data field with multiple possible value types
+but this could be a source of confusion.
 This is what has been done, for instance, in npm (historically) and in Rubygems
 (still today), and as result tools need to test the type of the metadata field
 before using it in code, while users are confused about when to use a list or a
@@ -833,8 +722,7 @@ Don't freeze compatibility with a specific SPDX version
 
 PEP 639 could omit specifying a specific SPDX specification version,
 or one for the list of valid license identifiers, which would allow
-more flexible updates as the specification evolves without another
-PEP or equivalent.
+more flexible updates as the specification evolves.
 
 However, serious concerns were expressed about a future SPDX update breaking
 compatibility with existing expressions and identifiers, leaving current
@@ -844,11 +732,10 @@ and a PEP or similar process to update it avoids this contingency,
 and follows the practice of other packaging ecosystems.
 
 Therefore, it was `decided <spdxversion_>`__ to specify a minimum version
-and requires tools to be compatible with it, while still allowing updates
+and require tools to be compatible with it, while still allowing updates
 so long as they don't break backward compatibility. This enables
 tools to immediate take advantage of improvements and accept new
-licenses, but also remain backwards compatible with the version
-specified here, balancing flexibility and compatibility.
+licenses balancing flexibility and compatibility.
 
 
 .. _639-rejected-ideas-difference-license-source-binary:
@@ -856,15 +743,13 @@ specified here, balancing flexibility and compatibility.
 Different licenses for source and binary distributions
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-As an additional use case, it was asked whether it was in scope for this
-PEP to handle cases where the license expression for a binary distribution
+As an additional use case, it was asked whether it was in scope for
+PEP 639 to handle cases where the license expression for a binary distribution
 (wheel) is different from that for a source distribution (sdist), such
 as in cases of non-pure-Python packages that compile and bundle binaries
 under different licenses than the project itself. An example cited was
 `PyTorch <pytorch_>`__, which contains CUDA from Nvidia, which is freely
-distributable but not open source. `NumPy <numpyissue_>`__ and
-`SciPy <scipyissue_>`__ also had similar issues, as reported by the
-original author of PEP 639 and now resolved for those cases.
+distributable but not open source.
 
 However, given the inherent complexity here and a lack of an obvious
 mechanism to do so, the fact that each wheel would need its own license
@@ -875,12 +760,9 @@ to resolve if sufficient need and interest exists and an appropriate
 mechanism can be found.
 
 
-.. _choosealicense: https://choosealicense.com/
-.. _numpyissue: https://github.com/numpy/numpy/issues/8689
 .. _pyprojecttomldynamic: https://packaging.python.org/en/latest/specifications/pyproject-toml/#dynamic
 .. _pytorch: https://pypi.org/project/torch/
 .. _reusediscussion: https://github.com/pombredanne/spdx-pypi-pep/issues/7
-.. _scipyissue: https://github.com/scipy/scipy/issues/7093
 .. _setuptoolsfiles: https://github.com/pypa/setuptools/issues/2739
 .. _spdxid: https://spdx.dev/ids/
 .. _spdxversion: https://github.com/pombredanne/spdx-pypi-pep/issues/6

--- a/peps/pep-0639/appendix-user-scenarios.rst
+++ b/peps/pep-0639/appendix-user-scenarios.rst
@@ -16,7 +16,7 @@ User Scenarios
 --------------
 
 The following covers the range of common use cases from a user perspective,
-providing straightforward guidance for each. Do note that the following
+providing guidance for each. Do note that the following
 should **not** be considered legal advice, and readers should consult a
 licensed legal practitioner in their jurisdiction if they are unsure about
 the specifics for their situation.
@@ -50,8 +50,7 @@ To apply it, just paste `the text <chooseamitlicense_>`__ into a file named
 ``LICENSE.txt`` at the root of your repo, and add the year and your name to
 the copyright line. Then, just add ``license = "MIT"`` under
 ``[project]`` in your ``pyproject.toml`` if your packaging tool supports it,
-or in its config file/section (e.g. Setuptools ``license_expression = MIT``
-under ``[metadata]`` in ``setup.cfg``). You're done!
+or in its config file/section. You're done!
 
 
 I want to distribute my project under a specific license
@@ -62,8 +61,7 @@ file at the root of your repo, if you don't have it in a file starting with
 ``LICENSE`` or ``COPYING`` already, and add
 ``license = "LICENSE-ID"`` under ``[project]`` in your
 ``pyproject.toml`` if your packaging tool supports it, or else in its
-config file (e.g. for Setuptools, ``license_expression = LICENSE-ID``
-under ``[metadata]`` in ``setup.cfg``). You can find the ``LICENSE-ID``
+config file. You can find the ``LICENSE-ID``
 and copyable license text on sites like
 `ChooseALicense <choosealicenselist_>`__ or `SPDX <spdxlist_>`__.
 
@@ -80,7 +78,6 @@ functionality.
 
 In your project config file, enter your license expression under
 ``license`` (``[project]`` table in ``pyproject.toml``),
-``license_expression`` (Setuptools ``setup.cfg`` / ``setup.py``),
 or the equivalent for your packaging tool,
 and make sure to remove any legacy ``license`` table subkeys or
 ``License ::`` classifiers. Your existing ``license`` value may already
@@ -88,16 +85,12 @@ be valid as one (e.g. ``MIT``, ``Apache-2.0 OR BSD-2-Clause``, etc);
 otherwise, check the `SPDX license list <spdxlist_>`__ for the identifier
 that matches the license used in your project.
 
-If your license files begin with ``LICENSE``, ``COPYING``, ``NOTICE`` or
-``AUTHORS``, or you've already configured your packaging tool to add them
-(e.g. ``license_files`` in ``setup.cfg``), you should already be good to go.
-If not, make sure to list them under ``license-files.paths``
+Make sure to list your license files under ``license-files.paths``
 or ``license-files.globs`` under ``[project]`` in ``pyproject.toml``
-(if your tool supports it), or else in your tool's configuration file
-(e.g. ``license_files`` in ``setup.cfg`` for Setuptools).
+or else in your tool's configuration file.
 
 See the :ref:`639-example-basic` for a simple but complete real-world demo
-of how this works in practice, including some additional technical details.
+of how this works in practiced.
 Packaging tools may support automatically converting legacy licensing
 metadata; check your tool's documentation for more information.
 
@@ -107,8 +100,8 @@ My package includes other code under different licenses
 
 If your project includes code from others covered by different licenses,
 such as vendored dependencies or files copied from other open source
-software, you can construct a license expression (or have a tool
-help you do so) to describe the licenses involved and the relationship
+software, you can construct a license expression
+to describe the licenses involved and the relationship
 between them.
 
 In short, ``License-1 AND License-2`` mean that *both* licenses apply
@@ -121,19 +114,15 @@ complex situations.
 
 In your project config file, enter your license expression under
 ``license`` (``[project]`` table of ``pyproject.toml``),
-``license_expression`` (Setuptools ``setup.cfg`` / ``setup.py``),
 or the equivalent for your packaging tool,
 and make sure to remove any legacy ``license`` table subkeys
 or ``License ::`` classifiers.
 
 Also, make sure you add the full license text of all the licenses as files
-somewhere in your project repository. If all of them are in the root directory
-and begin with ``LICENSE``, ``COPYING``, ``NOTICE`` or ``AUTHORS``,
-they will be included automatically. Otherwise, you'll need to list the
+somewhere in your project repository. List the
 relative path or glob patterns to each of them under ``license-files.paths``
 or ``license-files.globs`` under ``[project]`` in ``pyproject.toml``
-(if your tool supports it), or else in your tool's configuration file
-(e.g. ``license_files`` in ``setup.cfg`` for Setuptools).
+(if your tool supports it), or else in your tool's configuration file.
 
 As an example, if your project was licensed MIT but incorporated
 a vendored dependency (say, ``packaging``) that was licensed under
@@ -146,8 +135,8 @@ as glob patterns, or
 ``["LICENSE.txt", "_vendor/LICENSE-APACHE.txt", "_vendor/LICENSE-BSD.txt"]``
 as literal file paths.
 
-See a fully worked out :ref:`639-example-advanced` for a comprehensive end-to-end
-application of this to a real-world complex project, with copious technical
+See a fully worked out :ref:`639-example-advanced` for an end-to-end
+application of this to a real-world complex project, with many technical
 details, and consult a `tutorial <spdxtutorial_>`__ for more help and examples
 using SPDX identifiers and expressions.
 


### PR DESCRIPTION
To be rebased on #3727 once merged.
It's best to review section by section rather than by commits.