### PR TITLE
PEP 664: 3.11.9 is the final regular bugfix release with binary installers

### DIFF
--- a/peps/pep-0664.rst
+++ b/peps/pep-0664.rst
@@ -71,7 +71,8 @@ Actual:
 - 3.11.6: Monday, 2023-10-02
 - 3.11.7: Monday, 2023-12-04
 - 3.11.8: Tuesday, 2024-02-06
-- 3.11.9: Tuesday, 2024-04-02
+- 3.11.9: Tuesday, 2024-04-02 (final regular bugfix release with binary
+  installers)
 
 3.11 Lifespan
 -------------
@@ -109,13 +110,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  sentence-end-double-space: t
-  fill-column: 72
-  coding: utf-8
-  End:


### PR DESCRIPTION
Similar to the others:

* https://peps.python.org/pep-0619/#bugfix-releases
* https://peps.python.org/pep-0596/#bugfix-releases

Sorry for missing in https://github.com/python/peps/pull/3745 :)

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3746.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->