### PR TITLE
PEP 257: Remove outdated Unicode docstring advice

### DIFF
--- a/peps/pep-0257.rst
+++ b/peps/pep-0257.rst
@@ -1,13 +1,10 @@
 PEP: 257
 Title: Docstring Conventions
-Version: $Revision$
-Last-Modified: $Date$
 Author: David Goodger <goodger@python.org>,
         Guido van Rossum <guido@python.org>
 Discussions-To: doc-sig@python.org
 Status: Active
 Type: Informational
-Content-Type: text/x-rst
 Created: 29-May-2001
 Post-History: 13-Jun-2001
 
@@ -294,13 +291,3 @@ by Guido van Rossum.
 
 This document borrows ideas from the archives of the Python Doc-SIG_.
 Thanks to all members past and present.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   fill-column: 70
-   sentence-end-double-space: t
-   End:

--- a/peps/pep-0257.rst
+++ b/peps/pep-0257.rst
@@ -272,9 +272,9 @@ Once trimmed, these docstrings are equivalent::
 References and Footnotes
 ========================
 
-.. _Docutils: http://docutils.sourceforge.net/
+.. _Docutils: https://docutils.sourceforge.io/
 
-.. _Doc-SIG: http://www.python.org/sigs/doc-sig/
+.. _Doc-SIG: https://www.python.org/community/sigs/current/doc-sig/
 
 
 Copyright

--- a/peps/pep-0257.rst
+++ b/peps/pep-0257.rst
@@ -74,8 +74,7 @@ detailed description of attribute and additional docstrings.
 
 For consistency, always use ``"""triple double quotes"""`` around
 docstrings.  Use ``r"""raw triple double quotes"""`` if you use any
-backslashes in your docstrings.  For Unicode docstrings, use
-``u"""Unicode triple-quoted strings"""``.
+backslashes in your docstrings.
 
 There are two forms of docstrings: one-liners and multi-line
 docstrings.


### PR DESCRIPTION
We no longer need this Python 2 advice:

> For Unicode docstrings, use``u"""Unicode triple-quoted strings"""``.

Also:

* Update links
* Remove redundant headers and emacs footer

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3748.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->