### PR TITLE
PEP 101: Update Windows version bump step

### DIFF
--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -562,8 +562,8 @@ the main repo.
   - Make sure the ``SOURCE_URI`` in ``Doc/tools/extensions/pyspecific.py``
     points to ``main``.
 
-  - Update the version numbers for the Windows builds in ``PC/`` and
-    ``PCbuild/``, which have references to ``python38``::
+  - Update the version numbers for the Windows builds
+    which have references to ``python38``::
 
         ls PC/pyconfig.h.in PCbuild/rt.bat | xargs sed -i 's/python3\.\?[0-9]\+/python39/g'
 

--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -565,7 +565,7 @@ the main repo.
   - Update the version numbers for the Windows builds in ``PC/`` and
     ``PCbuild/``, which have references to ``python38``::
 
-        find PC/pyconfig.h.in PCbuild/rt.bat | xargs sed -i 's/python3\.?\d+/python39/g'
+        ls PC/pyconfig.h.in PCbuild/rt.bat | xargs sed -i 's/python3\.\?[0-9]\+/python39/g'
 
   - Commit these changes to the main branch::
 

--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -562,6 +562,11 @@ the main repo.
   - Make sure the ``SOURCE_URI`` in ``Doc/tools/extensions/pyspecific.py``
     points to ``main``.
 
+  - Update the version numbers for the Windows builds in ``PC/`` and
+    ``PCbuild/``, which have references to ``python38``::
+
+        find PC/pyconfig.h.in PCbuild/rt.bat | xargs sed -i 's/python3\.?\d+/python39/g'
+
   - Commit these changes to the main branch::
 
         $ git status

--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -565,7 +565,7 @@ the main repo.
   - Update the version numbers for the Windows builds
     which have references to ``python38``::
 
-        ls PC/pyconfig.h.in PCbuild/rt.bat | xargs sed -i 's/python3\.\?[0-9]\+/python39/g'
+        ls PC/pyconfig.h.in PCbuild/rt.bat | xargs sed -i 's/python3\(\.\?\)[0-9]\+/python3\19/g'
 
   - Commit these changes to the main branch::
 

--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -562,15 +562,6 @@ the main repo.
   - Make sure the ``SOURCE_URI`` in ``Doc/tools/extensions/pyspecific.py``
     points to ``main``.
 
-  - Update the version numbers for the Windows builds in PC/ and
-    PCbuild/, which have references to python38.
-    NOTE, check with Steve Dower about this step, it is probably obsolete.::
-
-        $ find PC/ PCbuild/ -type f | xargs sed -i 's/python38/python39/g'
-        $ git mv -f PC/os2emx/python38.def PC/os2emx/python39.def
-        $ git mv -f PC/python38stub.def PC/python39stub.def
-        $ git mv -f PC/python38gen.py PC/python39gen.py
-
   - Commit these changes to the main branch::
 
         $ git status


### PR DESCRIPTION
This step says:

> NOTE, check with Steve Dower about this step, it is probably obsolete.

It was added in https://github.com/python/peps/commit/f2ada91bbec53eeafeac171449e163964de6d13e.

@zooba Is it obsolete? Can it be removed, or does it need updating?

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3750.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->