### PR TITLE
PEP 560: Add Typing label

### DIFF
--- a/peps/pep-0560.rst
+++ b/peps/pep-0560.rst
@@ -3,6 +3,7 @@ Title: Core support for typing module and generic types
 Author: Ivan Levkivskyi <levkivskyi@gmail.com>
 Status: Final
 Type: Standards Track
+Topic: Typing
 Created: 03-Sep-2017
 Python-Version: 3.7
 Post-History: 09-Sep-2017, 14-Nov-2017


### PR DESCRIPTION
I was looking for this PEP on 
https://peps.python.org/topic/typing/ but because
it's missing the label, the sphinx pep_zero_generator skipped this one.

<!--
This template is for an infra or meta change not belonging to another category.
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3753.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->