### PR TITLE
PEP 101: Formatting, links, typos

### DIFF
--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -1,15 +1,13 @@
 PEP: 101
 Title: Doing Python Releases 101
-Version: $Revision$
-Last-Modified: $Date$
 Author: Barry Warsaw <barry@python.org>, Guido van Rossum <guido@python.org>
 Status: Active
 Type: Informational
-Content-Type: text/x-rst
 Created: 22-Aug-2001
 Post-History:
 Replaces: 102
 
+.. highlight:: shell
 
 Abstract
 ========
@@ -41,13 +39,14 @@ Here's a hopefully-complete list.
 
 * A bunch of software:
 
-  * A checkout of the `python/release-tools
-    <https://github.com/python/release-tools/>`_ repo.
-    It contains a ``requirements.txt`` file that you need to install
+  * A checkout of the `python/release-tools`_ repo.
+    It contains a `requirements.txt
+    <https://github.com/python/release-tools/blob/master/requirements.txt>`_
+    file that you need to install
     dependencies from first. Afterwards, you can fire up scripts in the
     repo, covered later in this PEP.
 
-  * ``blurb``, the
+  * `blurb <https://github.com/python/blurb>`__, the
     `Misc/NEWS <https://github.com/python/cpython/tree/main/Misc/NEWS.d>`_
     management tool. You can pip install it.
 
@@ -59,19 +58,19 @@ Here's a hopefully-complete list.
   * ``downloads.nyc1.psf.io``, the server that hosts download files; and
   * ``docs.nyc1.psf.io``, the server that hosts the documentation.
 
-* Administrator access to ``https://github.com/python/cpython``.
+* Administrator access to `python/cpython`_.
 
-* An administrator account on www.python.org, including an "API key".
+* An administrator account on `www.python.org`_, including an "API key".
 
-* Write access to the PEP repository.
+* Write access to the `python/peps`_ repository.
 
   If you're reading this, you probably already have this--the first
   task of any release manager is to draft the release schedule.  But
   in case you just signed up... sucker!  I mean, uh, congratulations!
 
-* Posting access to http://blog.python.org, a Blogger-hosted weblog.
+* Posting access to `blog.python.org`_, a Blogger-hosted weblog.
   The RSS feed from this blog is used for the 'Python News' section
-  on www.python.org.
+  on `www.python.org`_.
 
 * A subscription to the super secret release manager mailing list, which may
   or may not be called ``python-cabal``. Bug Barry about this.
@@ -100,7 +99,7 @@ There are several types of releases you will need to make.  These include:
 Some of these release types actually involve more than
 one release branch. In particular, a **new branch** is that point in the
 release cycle when a new feature release cycle begins.  Under the current
-organization of the cpython git repository, the *main* branch is always
+organization of the CPython Git repository, the *main* branch is always
 the target for new features.  At some point in the release cycle of the
 next feature release, a **new branch** release is made which creates a
 new separate branch for stabilization and later maintenance of the
@@ -125,28 +124,27 @@ release.  The roles and their current experts are:
 
 * RM = Release Manager
 
-    - Thomas Wouters <thomas@python.org> (NL)
-    - Pablo Galindo Salgado <pablogsal@python.org> (UK)
-    - Łukasz Langa <lukasz@python.org> (PL)
+  - Thomas Wouters <thomas@python.org> (NL)
+  - Pablo Galindo Salgado <pablogsal@python.org> (UK)
+  - Łukasz Langa <lukasz@python.org> (PL)
 
 * WE = Windows - Steve Dower <steve.dower@python.org>
 * ME = Mac - Ned Deily <nad@python.org> (US)
 * DE = Docs - Julien Palard <julien@python.org> (Central Europe)
 
-    .. note:: It is highly recommended that the RM contact the Experts the day
-       before the release.  Because the world is round and everyone lives
-       in different timezones, the RM must ensure that the release tag is
-       created in enough time for the Experts to cut binary releases.
+.. note:: It is highly recommended that the RM contact the Experts the day
+  before the release.  Because the world is round and everyone lives
+  in different timezones, the RM must ensure that the release tag is
+  created in enough time for the Experts to cut binary releases.
 
-       You should not make the release public (by updating the website and
-       sending announcements) before all experts have updated their bits.
-       In rare cases where the expert for Windows or Mac is MIA, you may add
-       a message "(Platform) binaries will be provided shortly" and proceed.
+  You should not make the release public (by updating the website and
+  sending announcements) before all experts have updated their bits.
+  In rare cases where the expert for Windows or Mac is MIA, you may add
+  a message "(Platform) binaries will be provided shortly" and proceed.
 
 As much as possible, the release steps are automated and guided by the
 release script, which is available in a separate repository:
-
-    https://github.com/python/release-tools
+`python/release-tools`_.
 
 We use the following conventions in the examples below.  Where a release
 number is given, it is of the form ``3.X.YaN``, e.g. 3.13.0a3 for Python 3.13.0
@@ -169,11 +167,11 @@ to perform some manual editing steps.
   Go to https://github.com/python/cpython/issues and look for any open
   bugs that can block this release.  You're looking at two relevant labels:
 
-  release-blocker
+  `release-blocker`_
       Stops the release dead in its tracks.  You may not
       make any release with any open release blocker bugs.
 
-  deferred-blocker
+  `deferred-blocker`_
       Doesn't block this release, but it will block a
       future release.  You may not make a final or
       candidate release with any open deferred blocker
@@ -198,11 +196,12 @@ to perform some manual editing steps.
 
 - Make a release clone.
 
-  On a fork of the cpython repository on GitHub, create a release branch
+  On a fork of the CPython repository on GitHub, create a release branch
   within it (called the "release clone" from now on).  You can use the same
-  GitHub fork you use for cpython development.  Using the standard setup
-  recommended in the Python Developer's Guide, your fork would be referred
-  to as ``origin`` and the standard cpython repo as ``upstream``.  You will
+  GitHub fork you use for CPython development.  Using the standard setup
+  recommended in the `Python Developer's Guide <https://devguide.python.org/>`__,
+  your fork would be referred
+  to as ``origin`` and the standard CPython repo as ``upstream``.  You will
   use the branch on your fork to do the release engineering work, including
   tagging the release, and you will use it to share with the other experts
   for making the binaries.
@@ -217,46 +216,48 @@ to perform some manual editing steps.
   since the previous rc, you can proceed as normal.
 
 - Make sure the current branch of your release clone is the branch you
-  want to release from.  (``git status``)
+  want to release from (``git status``).
 
 - Run ``blurb release <version>`` specifying the version number
   (e.g. ``blurb release 3.4.7rc1``).  This merges all the recent news
   blurbs into a single file marked with this release's version number.
 
-- Regenerate Lib/pydoc-topics.py.
+- Regenerate ``Lib/pydoc-topics.py``.
 
-  While still in the Doc directory, run ``make pydoc-topics``.  Then copy
-  ``build/pydoc-topics/topics.py`` to ``../Lib/pydoc_data/topics.py``.
+  While still in the ``Doc`` directory, run::
+
+    make pydoc-topics
+    cp build/pydoc-topics/topics.py ../Lib/pydoc_data/topics.py
 
 - Commit your changes to ``pydoc_topics.py``
   (and any fixes you made in the docs).
 
 - Consider running ``autoconf`` using the currently accepted standard version
-  in case ``configure`` or other autoconf-generated files were last
+  in case ``configure`` or other Autoconf-generated files were last
   committed with a newer or older version and may contain spurious or
-  harmful differences.  Currently, autoconf 2.71 is our de facto standard.
+  harmful differences.  Currently, Autoconf 2.71 is our de facto standard.
   if there are differences, commit them.
 
 - Make sure the ``SOURCE_URI`` in ``Doc/tools/extensions/pyspecific.py``
-  points to the right branch in the git repository (``main`` or ``3.X``).
-  For a **new branch** release, change the branch in the file from *main*
+  points to the right branch in the Git repository (``main`` or ``3.X``).
+  For a **new branch** release, change the branch in the file from ``main``
   to the new release branch you are about to create (``3.X``).
 
 - Bump version numbers via the release script::
 
-      $ .../release-tools/release.py --bump 3.X.YaN
+      .../release-tools/release.py --bump 3.X.YaN
 
-  Reminder: X, Y, and N should be integers.
-  a should be one of "a", "b", or "rc" (e.g. "3.4.3rc1").
-  For **final** releases omit the aN ("3.4.3").  For the first
-  release of a new version Y should be 0 ("3.6.0").
+  Reminder: ``X``, ``Y``, and ``N`` should be integers.
+  ``a`` should be one of ``a``, ``b``, or ``rc`` (e.g. ``3.4.3rc1``).
+  For **final** releases omit the ``aN`` (``3.4.3``).  For the first
+  release of a new version ``Y`` should be ``0`` (``3.6.0``).
 
   This automates updating various release numbers, but you will have to
-  modify a few files manually.  If your $EDITOR environment variable is
-  set up correctly, release.py will pop up editor windows with the files
+  modify a few files manually.  If your ``$EDITOR`` environment variable is
+  set up correctly, ``release.py`` will pop up editor windows with the files
   you need to edit.
 
-  Review the blurb-generated Misc/NEWS file and edit as necessary.
+  Review the blurb-generated ``Misc/NEWS`` file and edit as necessary.
 
 - Make sure all changes have been committed.  (``release.py --bump``
   doesn't check in its changes for you.)
@@ -265,32 +266,32 @@ to perform some manual editing steps.
   was some time last year, add the current year to the copyright
   notice in several places:
 
-  - README
-  - LICENSE (make sure to change on trunk and the branch)
-  - Python/getcopyright.c
-  - Doc/copyright.rst
-  - Doc/license.rst
-  - PC/python_ver_rc.h sets up the DLL version resource for Windows
+  - ``README``
+  - ``LICENSE`` (make sure to change on ``main`` and the branch)
+  - ``Python/getcopyright.c``
+  - ``Doc/copyright.rst``
+  - ``Doc/license.rst``
+  - ``PC/python_ver_rc.h`` sets up the DLL version resource for Windows
     (displayed when you right-click on the DLL and select
     Properties).  This isn't a C include file, it's a Windows
     "resource file" include file.
 
 - For a **final** major release, edit the first paragraph of
-  Doc/whatsnew/3.X.rst to include the actual release date; e.g. "Python
+  ``Doc/whatsnew/3.X.rst`` to include the actual release date; e.g. "Python
   2.5 was released on August 1, 2003."  There's no need to edit this for
   alpha or beta releases.
 
-- Do a "git status" in this directory.
+- Do a ``git status`` in this directory.
 
-  You should not see any files.  I.e. you better not have any uncommitted
+  You should not see any files, i.e., you better not have any uncommitted
   changes in your working directory.
 
-- Tag the release for 3.X.YaN::
+- Tag the release for ``3.X.YaN``::
 
-      $ .../release-tools/release.py --tag 3.X.YaN
+    .../release-tools/release.py --tag 3.X.YaN
 
   This executes a ``git tag`` command with the ``-s`` option so that the
-  release tag in the repo is signed with your gpg key.  When prompted
+  release tag in the repo is signed with your GPG key.  When prompted
   choose the private key you use for signing release tarballs etc.
 
 - For **begin security-only mode** and **end-of-life** releases, review the
@@ -298,15 +299,15 @@ to perform some manual editing steps.
 
 - Time to build the source tarball.  Use the release script to create
   the source gzip and xz tarballs,
-  documentation tar and zip files, and gpg signature files::
+  documentation tar and zip files, and GPG signature files::
 
-      $ .../release-tools/release.py --export 3.X.YaN
+    .../release-tools/release.py --export 3.X.YaN
 
   This can take a while for **final** releases, and it will leave all the
   tarballs and signatures in a subdirectory called ``3.X.YaN/src``, and the
   built docs in ``3.X.YaN/docs`` (for **final** releases).
 
-  Note that the script will sign your release with Sigstore. Please use
+  Note that the script will sign your release with Sigstore. Use
   your **@python.org** email address for this. See here for more information:
   https://www.python.org/download/sigstore/.
 
@@ -315,35 +316,35 @@ to perform some manual editing steps.
   virgin build passes the regression test.  Here are the best
   steps to take::
 
-    $ cd /tmp
-    $ tar xvf /path/to/your/release/clone/<version>//Python-3.2rc2.tgz
-    $ cd Python-3.2rc2
-    $ ls
-    (Do things look reasonable?)
-    $ ls Lib
-    (Are there stray .pyc files?)
-    $ ./configure
-    (Loads of configure output)
-    $ make test
-    (Do all the expected tests pass?)
+    cd /tmp
+    tar xvf /path/to/your/release/clone/<version>//Python-3.2rc2.tgz
+    cd Python-3.2rc2
+    ls
+    # (Do things look reasonable?)
+    ls Lib
+    # (Are there stray .pyc files?)
+    ./configure
+    # (Loads of configure output)
+    make test
+    # (Do all the expected tests pass?)
 
   If you're feeling lucky and have some time to kill, or if you are making
   a release candidate or **final** release, run the full test suite::
 
-      $ make testall
+    make testall
 
   If the tests pass, then you can feel good that the tarball is
   fine.  If some of the tests fail, or anything else about the
   freshly unpacked directory looks weird, you better stop now and
   figure out what the problem is.
 
-- Push your commits to the remote release branch in your GitHub fork.::
+- Push your commits to the remote release branch in your GitHub fork::
 
     # Do a dry run first.
-    $ git push --dry-run --tags origin
-    # Make sure you are pushing to your GitHub fork, *not* to the main
-    # python/cpython repo!
-    $ git push --tags origin
+    git push --dry-run --tags origin
+    # Make sure you are pushing to your GitHub fork,
+    # *not* to the main python/cpython repo!
+    git push --tags origin
 
 - Notify the experts that they can start building binaries.
 
@@ -363,14 +364,14 @@ to perform some manual editing steps.
   - Compile all variants of binaries (32-bit, 64-bit, debug/release),
     including running profile-guided optimization.
 
-  - Compile the HTML Help file containing the Python documentation
+  - Compile the HTML Help file containing the Python documentation.
 
-  - Codesign all the binaries with the PSF's certificate
+  - Codesign all the binaries with the PSF's certificate.
 
   - Create packages for python.org, nuget.org, the embeddable distro and
-    the Windows Store
+    the Windows Store.
 
-  - Perform basic verification of the installers
+  - Perform basic verification of the installers.
 
   - Upload packages to python.org and nuget.org, purge download caches and
     run a test download.
@@ -381,30 +382,30 @@ to perform some manual editing steps.
   WE.
 
 - The ME builds Mac installer packages and uploads them to
-  downloads.nyc1.psf.io together with gpg signature files.
+  downloads.nyc1.psf.io together with GPG signature files.
 
-- scp or rsync all the files built by ``release.py --export``
-  to your home directory on downloads.nyc1.psf.io.
+- ``scp`` or ``rsync`` all the files built by ``release.py --export``
+  to your home directory on ``downloads.nyc1.psf.io``.
 
   While you're waiting for the files to finish uploading, you can continue
   on with the remaining tasks.  You can also ask folks on #python-dev
   and/or python-committers to download the files as they finish uploading
   so that they can test them on their platforms as well.
 
-- Now you need to go to downloads.nyc1.psf.io and move all the files in place
+- Now you need to go to ``downloads.nyc1.psf.io`` and move all the files in place
   over there.  Our policy is that every Python version gets its own
   directory, but each directory contains all releases of that version.
 
-  - On downloads.nyc1.psf.io, ``cd /srv/www.python.org/ftp/python/3.X.Y``
-    creating it if necessary.  Make sure it is owned by group 'downloads'
+  - On ``downloads.nyc1.psf.io``, ``cd /srv/www.python.org/ftp/python/3.X.Y``
+    creating it if necessary.  Make sure it is owned by group ``downloads``
     and group-writable.
 
-  - Move the release .tgz, and .tar.xz files into place, as well as the
-    .asc GPG signature files.  The Win/Mac binaries are usually put there
+  - Move the release ``.tgz``, and ``.tar.xz`` files into place, as well as the
+    ``.asc`` GPG signature files.  The Win/Mac binaries are usually put there
     by the experts themselves.
 
     Make sure they are world readable.  They should also be group
-    writable, and group-owned by downloads.
+    writable, and group-owned by ``downloads``.
 
   - Use ``gpg --verify`` to make sure they got uploaded intact.
 
@@ -416,7 +417,7 @@ to perform some manual editing steps.
 
   - If this is a **final** or rc release (even a maintenance release), also
     unpack the HTML docs to ``/srv/docs.python.org/release/3.X.Y[rcA]`` on
-    docs.nyc1.psf.io. Make sure the files are in group ``docs`` and are
+    ``docs.nyc1.psf.io``. Make sure the files are in group ``docs`` and are
     group-writeable.
 
   - Let the DE check if the docs are built and work all right.
@@ -425,22 +426,22 @@ to perform some manual editing steps.
     you change archives after downloading them through the website, you'll
     need to purge the stale data in the CDN like this::
 
-        $ curl -X PURGE https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tar.xz
+      curl -X PURGE https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tar.xz
 
     You should always purge the cache of the directory listing as people
     use that to browse the release files::
 
-        $ curl -X PURGE https://www.python.org/ftp/python/3.12.0/
+      curl -X PURGE https://www.python.org/ftp/python/3.12.0/
 
 - For the extra paranoid, do a completely clean test of the release.
-  This includes downloading the tarball from www.python.org.
+  This includes downloading the tarball from `www.python.org`_.
 
   Make sure the md5 checksums match.  Then unpack the tarball,
-  and do a clean make test.::
+  and do a clean make test::
 
-    $ make distclean
-    $ ./configure
-    $ make test
+    make distclean
+    ./configure
+    make test
 
   To ensure that the regression test suite passes.  If not, you
   screwed up somewhere!
@@ -462,7 +463,7 @@ the main repo.
   disable branch protection for administrators.  Go to the
   ``Settings | Branches`` page:
 
-  https://github.com/python/cpython/settings/branches/
+  https://github.com/python/cpython/settings/branches
 
   "Edit" the settings for the branch you're releasing on.
   This will load the settings page for that branch.
@@ -472,39 +473,39 @@ the main repo.
 - Merge your release clone into the main development repo::
 
     # Pristine copy of the upstream repo branch
-    $ git clone git@github.com:python/cpython.git merge
-    $ cd merge
+    git clone git@github.com:python/cpython.git merge
+    cd merge
 
     # Checkout the correct branch:
     # 1. For feature pre-releases up to and including a
     #    **new branch** release, i.e. alphas and first beta
     #   do a checkout of the main branch
-    $ git checkout main
+    git checkout main
 
     # 2. Else, for all other releases, checkout the
     #       appropriate release branch.
-    $ git checkout 3.X
+    git checkout 3.X
 
     # Fetch the newly created and signed tag from your clone repo
-    $ git fetch --tags git@github.com:your-github-id/cpython.git v3.X.YaN
+    git fetch --tags git@github.com:your-github-id/cpython.git v3.X.YaN
     # Merge the temporary release engineering branch back into
-    $ git merge --no-squash v3.X.YaN
-    $ git commit -m 'Merge release engineering branch'
+    git merge --no-squash v3.X.YaN
+    git commit -m 'Merge release engineering branch'
 
 - If this is a **new branch** release, i.e. first beta,
   now create the new release branch::
 
-    $ git checkout -b 3.X
+    git checkout -b 3.X
 
   Do any steps needed to setup the new release branch, including:
 
-        * In README.rst, change all references from ``main`` to
-          the new branch, in particular, GitHub repo URLs.
+  * In ``README.rst``, change all references from ``main`` to
+    the new branch, in particular, GitHub repo URLs.
 
 - For *all* releases, do the guided post-release steps with the
-  release script.::
+  release script::
 
-    $ .../release-tools/release.py --done 3.X.YaN
+    .../release-tools/release.py --done 3.X.YaN
 
 - For a **final** or **release candidate 2+** release, you may need to
   do some post-merge cleanup.  Check the top-level ``README.rst``
@@ -513,34 +514,34 @@ the main repo.
   The patchlevel should be the release tag with a ``+``.
   Also, if you cherry-picked changes from the standard release
   branch into the release engineering branch for this release,
-  you will now need to manual remove each blurb entry from
+  you will now need to manually remove each blurb entry from
   the ``Misc/NEWS.d/next`` directory that was cherry-picked
   into the release you are working on since that blurb entry
-  is now captured in the merged x.y.z.rst file for the new
+  is now captured in the merged ``x.y.z.rst`` file for the new
   release.  Otherwise, the blurb entry will appear twice in
   the ``changelog.html`` file, once under ``Python next`` and again
   under ``x.y.z``.
 
 - Review and commit these changes::
 
-    $ git commit -m 'Post release updates'
+    git commit -m 'Post release updates'
 
 - If this is a **new branch** release (e.g. the first beta),
-  update the main branch to start development for the
+  update the ``main`` branch to start development for the
   following feature release.  When finished, the ``main``
   branch will now build Python ``X.Y+1``.
 
-  - First, set main up to be the next release, i.e.X.Y+1.a0::
+  - First, set ``main`` up to be the next release, i.e. X.Y+1.a0::
 
-      $ git checkout main
-      $ .../release-tools/release.py --bump 3.9.0a0
+      git checkout main
+      .../release-tools/release.py --bump 3.9.0a0
 
-  - Edit all version references in README.rst
+  - Edit all version references in ``README.rst``
 
   - Move any historical "what's new" entries from ``Misc/NEWS`` to
     ``Misc/HISTORY``.
 
-  - Edit ``Doc/tutorial/interpreter.rst`` (2 references to '[Pp]ython3x',
+  - Edit ``Doc/tutorial/interpreter.rst`` (two references to '[Pp]ython3x',
     one to 'Python 3.x', also make the date in the banner consistent).
 
   - Edit ``Doc/tutorial/stdlib.rst`` and ``Doc/tutorial/stdlib2.rst``, which
@@ -552,10 +553,12 @@ the main repo.
     the initial ``whatsnew/3.x.rst`` checkin from previous releases
     may be incorrect due to the initial midstream change to ``blurb``
     that propagates from release to release!  Help break the cycle: if
-    necessary make the following change::
+    necessary make the following change:
 
-        - For full details, see the :source:`Misc/NEWS` file.
-        + For full details, see the :ref:`changelog <changelog>`.
+    .. code-block:: diff
+
+        -For full details, see the :source:`Misc/NEWS` file.
+        +For full details, see the :ref:`changelog <changelog>`.
 
   - Update the version number in ``configure.ac`` and re-run ``autoconf``.
 
@@ -569,41 +572,41 @@ the main repo.
 
   - Commit these changes to the main branch::
 
-        $ git status
-        $ git add ...
-        $ git commit -m 'Bump to 3.9.0a0'
+        git status
+        git add ...
+        git commit -m 'Bump to 3.9.0a0'
 
 - Do another ``git status`` in this directory.
 
-  You should not see any files.  I.e. you better not have any uncommitted
+  You should not see any files, i.e., you better not have any uncommitted
   changes in your working directory.
 
-- Commit and push to the main repo.::
+- Commit and push to the main repo::
 
     # Do a dry run first.
 
     # For feature pre-releases prior to a **new branch** release,
     #   i.e. a feature alpha release:
-    $ git push --dry-run --tags  git@github.com:python/cpython.git main
+    git push --dry-run --tags  git@github.com:python/cpython.git main
     # If it looks OK, take the plunge.  There's no going back!
-    $ git push --tags  git@github.com:python/cpython.git main
+    git push --tags  git@github.com:python/cpython.git main
 
     # For a **new branch** release, i.e. first beta:
-    $ git push --dry-run --tags  git@github.com:python/cpython.git 3.X
-    $ git push --dry-run --tags  git@github.com:python/cpython.git main
+    git push --dry-run --tags  git@github.com:python/cpython.git 3.X
+    git push --dry-run --tags  git@github.com:python/cpython.git main
     # If it looks OK, take the plunge.  There's no going back!
-    $ git push --tags  git@github.com:python/cpython.git 3.X
-    $ git push --tags  git@github.com:python/cpython.git main
+    git push --tags  git@github.com:python/cpython.git 3.X
+    git push --tags  git@github.com:python/cpython.git main
 
     # For all other releases:
-    $ git push --dry-run --tags  git@github.com:python/cpython.git 3.X
+    git push --dry-run --tags  git@github.com:python/cpython.git 3.X
     # If it looks OK, take the plunge.  There's no going back!
-    $ git push --tags  git@github.com:python/cpython.git 3.X
+    git push --tags  git@github.com:python/cpython.git 3.X
 
 - If this is a **new branch** release, add a ``Branch protection rule``
   for the newly created branch (3.X).  Look at the values for the previous
   release branch (3.X-1) and use them as a template.
-  https://github.com/python/cpython/settings/branches/
+  https://github.com/python/cpython/settings/branches
 
   Also, add a ``needs backport to 3.X`` label to the GitHub repo.
   https://github.com/python/cpython/labels
@@ -611,20 +614,20 @@ the main repo.
 - You can now re-enable enforcement of branch settings against administrators
   on GitHub.  Go back to the ``Settings | Branch`` page:
 
-  https://github.com/python/cpython/settings/branches/
+  https://github.com/python/cpython/settings/branches
 
   "Edit" the settings for the branch you're releasing on.
   Re-check the "Include administrators" box and press the
   "Save changes" button at the bottom.
 
-Now it's time to twiddle the web site.  Almost none of this is automated, sorry.
+Now it's time to twiddle the website.  Almost none of this is automated, sorry.
 
 To do these steps, you must have the permission to edit the website.  If you
 don't have that, ask someone on pydotorg@python.org for the proper
 permissions.  (Or ask Ewa, who coordinated the effort for the new website
 with RevSys.)
 
-- Log in to https://www.python.org/admin .
+- Log in to https://www.python.org/admin
 
 - Create a new "release" for the release.  Currently "Releases" are
   sorted under "Downloads".
@@ -633,7 +636,7 @@ with RevSys.)
   Python release "page", editing as you go.
 
   You can use `Markdown <https://daringfireball.net/projects/markdown/syntax>`_ or
-  `ReStructured Text <http://docutils.sourceforge.net/docs/user/rst/quickref.html>`_
+  `reStructured Text <http://docutils.sourceforge.net/docs/user/rst/quickref.html>`_
   to describe your release.  The former is less verbose, while the latter has nifty
   integration for things like referencing PEPs.
 
@@ -644,14 +647,14 @@ with RevSys.)
 - Populate the release with the downloadable files.
 
   Your friend and mine, Georg Brandl, made a lovely tool
-  called "add-to-pydotorg.py".  You can find it in the
-  "release" tree (next to "release.py").  You run the
-  tool on downloads.nyc1.psf.io, like this::
+  called ``add-to-pydotorg.py``.  You can find it in the
+  `python/release-tools`_ repo (next to ``release.py``).  You run the
+  tool on ``downloads.nyc1.psf.io``, like this::
 
-      $ AUTH_INFO=<username>:<python.org-api-key> python add-to-pydotorg.py <version>
+      AUTH_INFO=<username>:<python.org-api-key> python add-to-pydotorg.py <version>
 
-  This walks the correct download directory for <version>,
-  looks for files marked with <version>, and populates
+  This walks the correct download directory for ``<version>``,
+  looks for files marked with ``<version>``, and populates
   the "Release Files" for the correct "release" on the web
   site with these files.  Note that clears the "Release Files"
   for the relevant version each time it's run.  You may run
@@ -661,19 +664,19 @@ with RevSys.)
   keep it fresh.
 
   If new types of files are added to the release, someone will need to
-  update add-to-pydotorg.py so it recognizes these new files.
-  (It's best to update add-to-pydotorg.py when file types
+  update ``add-to-pydotorg.py`` so it recognizes these new files.
+  (It's best to update ``add-to-pydotorg.py`` when file types
   are removed, too.)
 
   The script will also sign any remaining files that were not
   signed with Sigstore until this point. Again, if this happens,
-  do use your @python.org address for this process. More info:
+  do use your ``@python.org`` address for this process. More info:
   https://www.python.org/download/sigstore/
 
 - In case the CDN already cached a version of the Downloads page
   without the files present, you can invalidate the cache using::
 
-      $ curl -X PURGE https://www.python.org/downloads/release/python-XXX/
+      curl -X PURGE https://www.python.org/downloads/release/python-XXX/
 
 - If this is a **final** release:
 
@@ -700,7 +703,7 @@ with RevSys.)
     There's a page that lists all the currently-in-testing versions
     of Python:
 
-        https://www.python.org/download/pre-releases/
+    * https://www.python.org/download/pre-releases/
 
     Every time you make a release, one way or another you'll
     have to update this page:
@@ -721,7 +724,7 @@ with RevSys.)
 
   - If appropriate, update the "Python Documentation by Version" page:
 
-      https://www.python.org/doc/versions/
+    * https://www.python.org/doc/versions/
 
     This lists all releases of Python by version number and links to their
     static (not built daily) online documentation.  There's a list at the
@@ -729,32 +732,32 @@ with RevSys.)
     should go.  And yes you should be able to click on the link above then
     press the shiny, exciting "Edit this page" button.
 
-- Write the announcement on https://discuss.python.org/.  This is the
+- Write the announcement on `discuss.python.org`_.  This is the
   fuzzy bit because not much can be automated.  You can use an earlier
   announcement as a template, but edit it for content!
 
 - Once the announcement is up on Discourse, send an equivalent to the
   following mailing lists:
 
-  python-list@python.org
-  python-announce@python.org
-  python-dev@python.org
+  * python-list@python.org
+  * python-announce@python.org
+  * python-dev@python.org
 
-- Also post the announcement to
-  `The Python Insider blog <http://blog.python.org>`_.
+- Also post the announcement to the
+  `Python Insider blog <http://blog.python.org>`_.
   To add a new entry, go to
-  `your Blogger home page, here. <https://www.blogger.com/home>`_
+  `your Blogger home page, here <https://www.blogger.com/home>`_.
 
 - Update any release PEPs (e.g. 719) with the release dates.
 
 - Update the labels on https://github.com/python/cpython/issues:
 
-  - Flip all the deferred-blocker issues back to release-blocker
+  - Flip all the `deferred-blocker`_ issues back to `release-blocker`_
     for the next release.
 
-  - Add version 3.X+1 as when version 3.X enters alpha.
+  - Add version ``3.X+1`` as when version ``3.X`` enters alpha.
 
-  - Change non-doc feature requests to version 3.X+1 when version 3.X
+  - Change non-doc feature requests to version ``3.X+1`` when version ``3.X``
     enters beta.
 
   - Update issues from versions that your release makes
@@ -769,40 +772,42 @@ with RevSys.)
   pieces of the development infrastructure are updated for the new branch.
   These include:
 
-  - Update the issue tracker for the new branch: add the new version to
-    the versions list.
+  - Update the `issue tracker`_ for the new branch:
+    add the new version to the versions list.
 
-  - Update the devguide to reflect the new branches and versions.
+  - Update the `devguide
+    <https://github.com/python/devguide/blob/main/include/release-cycle.json>`__
+    to reflect the new branches and versions.
 
   - Create a PR to update the supported releases table on the
-    `downloads page <https://www.python.org/downloads/>`_.
-    (See https://github.com/python/pythondotorg/issues/1302)
+    `downloads page <https://www.python.org/downloads/>`__ (see
+    `python/pythondotorg#1302 <https://github.com/python/pythondotorg/issues/1302>`__).
 
   - Ensure buildbots are defined for the new branch (contact Łukasz
     or Zach Ware).
 
   - Ensure the various GitHub bots are updated, as needed, for the
     new branch, in particular, make sure backporting to the new
-    branch works (contact core-workflow team)
-    https://github.com/python/core-workflow/issues
+    branch works (contact the `core-workflow team
+    <https://github.com/python/core-workflow/issues>`__).
 
-  - Review the most recent commit history for the main and new release
+  - Review the most recent commit history for the ``main`` and new release
     branches to identify and backport any merges that might have been made
-    to the main branch during the release engineering phase and that
+    to the ``main`` branch during the release engineering phase and that
     should be in the release branch.
 
-  - Verify that CI is working for new PRs for the main and new release
+  - Verify that CI is working for new PRs for the ``main`` and new release
     branches and that the release branch is properly protected (no direct
     pushes, etc).
 
-  - Verify that the on-line docs are building properly (this may take up to
-    24 hours for a complete build on the web site).
+  - Verify that the `on-line docs <https://docs.python.org/>`__ are building
+    properly (this may take up to 24 hours for a complete build on the website).
 
 
 What Next?
 ==========
 
-* Verify!  Pretend you're a user: download the files from python.org, and
+* Verify!  Pretend you're a user: download the files from `www.python.org`_, and
   make Python from it. This step is too easy to overlook, and on several
   occasions we've had useless release files.  Once a general server problem
   caused mysterious corruption of all files; once the source tarball got
@@ -819,8 +824,9 @@ Moving to End-of-life
 =====================
 
 Under current policy, a release branch normally reaches end-of-life status
-5 years after its initial release.  The policy is discussed in more detail
-in `the Python Developer's Guide <https://devguide.python.org/devcycle/>`_.
+five years after its initial release.  The policy is discussed in more detail
+in the `Python Developer's Guide
+<https://devguide.python.org/developer-workflow/development-cycle/index.html>`_.
 When end-of-life is reached, there are a number of tasks that need to be
 performed either directly by you as release manager or by ensuring someone
 else does them.  Some of those tasks include:
@@ -829,7 +835,7 @@ else does them.  Some of those tasks include:
   changes.
 
 - Freeze the state of the release branch by creating a tag of its current HEAD
-  and then deleting the branch from the cpython repo.  The current HEAD should
+  and then deleting the branch from the CPython repo.  The current HEAD should
   be at or beyond the final security release for the branch::
 
         git fetch upstream
@@ -842,37 +848,39 @@ else does them.  Some of those tasks include:
         git push upstream --delete 3.3  # or perform from GitHub Settings page
 
 - Remove the release from the list of "Active Python Releases" on the Downloads
-  page.  To do this, log in to the admin page for python.org, navigate to Boxes,
-  and edit the ``downloads-active-releases`` entry.  Simply strip out the relevant
+  page.  To do this, `log in to the admin page <https://www.python.org/admin>`__
+  for python.org, navigate to Boxes,
+  and edit the ``downloads-active-releases`` entry.  Strip out the relevant
   paragraph of HTML for your release.  (You'll probably have to do the ``curl -X PURGE``
   trick to purge the cache if you want to confirm you made the change correctly.)
 
-- Add retired notice to each release page on python.org for the retired branch.
+- Add a retired notice to each release page on python.org for the retired branch.
   For example:
 
-      https://www.python.org/downloads/release/python-337/
+  * https://www.python.org/downloads/release/python-337/
 
-      https://www.python.org/downloads/release/python-336/
+  * https://www.python.org/downloads/release/python-336/
 
-- In the developer's guide, add the branch to the recent end-of-life branches
-  list (https://devguide.python.org/devcycle/#end-of-life-branches) and update
-  or remove references to the branch elsewhere in the devguide.
+- In the `developer's guide
+  <https://github.com/python/devguide/blob/main/include/release-cycle.json>`__,
+  set the branch status to end-of-life
+  and update or remove references to the branch elsewhere in the devguide.
 
-- Retire the release from the issue tracker. Tasks include:
+- Retire the release from the `issue tracker`_. Tasks include:
 
-    * remove version label from list of versions
+  * remove version label from list of versions
 
-    * remove the "needs backport to" label for the retired version
+  * remove the ``needs backport to`` label for the retired version
 
-    * review and dispose of open issues marked for this branch
+  * review and dispose of open issues marked for this branch
 
 - Announce the branch retirement in the usual places:
 
-    * discuss.python.org
+  * `discuss.python.org`_
 
-    * mailing lists (python-dev, python-list, python-announcements)
+  * mailing lists (python-dev, python-list, python-announcements)
 
-    * Python Dev blog
+  * Python Dev blog
 
 - Enjoy your retirement and bask in the glow of a job well done!
 
@@ -917,9 +925,12 @@ Copyright
 
 This document has been placed in the public domain.
 
-
-..
-  Local Variables:
-  mode: indented-text
-  indent-tabs-mode: nil
-  End:
+.. _blog.python.org: https://blog.python.org
+.. _deferred-blocker: https://github.com/python/cpython/labels/deferred-blocker
+.. _discuss.python.org: https://discuss.python.org
+.. _issue tracker: https://github.com/python/cpython/issues
+.. _python/cpython: https://github.com/python/cpython
+.. _python/peps: https://github.com/python/peps
+.. _python/release-tools: https://github.com/python/release-tools
+.. _release-blocker: https://github.com/python/cpython/labels/release-blocker
+.. _www.python.org: https://www.python.org


### PR DESCRIPTION
Changes mainly in presentation, not in substance.

* Remove redundant PEP headers and emacs metadata
* Default to `shell` highlight, the blocks are mainly commands to run
* Remove `$` from code blocks to make commands easier to copy/paste and run
* A lot of formatting fixes, such as reducing indents to make stuff no longer blockquoted
* Add/update links
* Some typos, minor wording

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3755.org.readthedocs.build/pep-0101/

<!-- readthedocs-preview pep-previews end -->