### PR TITLE
Infra: add newlines so admonition text is shown

### DIFF
--- a/peps/pep-0003.rst
+++ b/peps/pep-0003.rst
@@ -7,6 +7,7 @@ Created: 25-Sep-2000
 Post-History:
 
 .. withdrawn::
+
    This PEP contained guidelines for handling bug reports in the Python
    bug tracker.  It has been replaced by the
    `Developer's Guide description of issue triaging

--- a/peps/pep-0009.rst
+++ b/peps/pep-0009.rst
@@ -8,6 +8,7 @@ Post-History:
 Resolution: https://mail.python.org/archives/list/python-dev@python.org/thread/2YMHVPRDWGQLA5A2FKXE2JMLM2HQEEGW/
 
 .. withdrawn::
+
    As of 05-Jan-2016, this PEP is officially deprecated and replaced
    by :pep:`12`.  All PEPs should now use the reStructuredText format
    described by :pep:`12`, and plaintext PEPs will no longer be

--- a/peps/pep-0042.rst
+++ b/peps/pep-0042.rst
@@ -7,7 +7,8 @@ Created: 12-Sep-2000
 Post-History:
 
 .. withdrawn::
-   This PEP has been `withdrawn as obsolete`_.
+
+   It is `obsolete`_.
    All new feature requests should  either go to the `Python bug tracker`_
    for very simple requests or the `Ideas Discourse category`_ for
    everything else.  The rest of this document is retained for historical
@@ -331,4 +332,4 @@ Building and Installing
 
 .. _`Python bug tracker`: https://github.com/python/cpython/issues
 .. _`Ideas Discourse category`: https://discuss.python.org/c/ideas/6
-.. _`withdrawn as obsolete`: https://github.com/python/peps/pull/108#issuecomment-249603204
+.. _`obsolete`: https://github.com/python/peps/pull/108#issuecomment-249603204

--- a/peps/pep-0103.rst
+++ b/peps/pep-0103.rst
@@ -7,7 +7,8 @@ Created: 01-Jun-2015
 Post-History: 12-Sep-2015
 
 .. withdrawn::
-   This PEP was withdrawn as it's too generic and doesn't really deals
+
+   It is too generic and doesn't really deal
    with Python development. It is no longer updated.
 
    The content was moved to `Python Wiki`_. Make further updates in the

--- a/peps/pep-0204.rst
+++ b/peps/pep-0204.rst
@@ -8,6 +8,7 @@ Python-Version: 2.0
 Post-History:
 
 .. rejected::
+
    After careful consideration, and a period of meditation, this
    proposal has been rejected. The open issues, as well as some
    confusion between ranges and slice syntax, raised enough questions

--- a/peps/pep-0211.rst
+++ b/peps/pep-0211.rst
@@ -9,6 +9,7 @@ Post-History:
 
 
 .. rejected::
+
    The approach in the later :pep:`465` was eventually accepted
    in lieu of this PEP. The :pep:`Rejected Ideas
    <465#rejected-alternatives-to-adding-a-new-operator>`

--- a/peps/pep-0216.rst
+++ b/peps/pep-0216.rst
@@ -9,7 +9,8 @@ Superseded-By: 287
 
 
 .. withdrawn::
-   This PEP is withdrawn by the author.  It has been superseded by :pep:`287`.
+
+   It has been superseded by :pep:`287`.
 
 
 Abstract

--- a/peps/pep-0224.rst
+++ b/peps/pep-0224.rst
@@ -8,7 +8,7 @@ Python-Version: 2.1
 Post-History:
 
 .. rejected::
-   This PEP has been rejected.
+
    See :ref:`224-rejection` for more information.
 
 Introduction

--- a/peps/pep-0225.rst
+++ b/peps/pep-0225.rst
@@ -10,6 +10,7 @@ Post-History:
 
 
 .. rejected::
+
    The approach in the later :pep:`465` was eventually accepted
    in lieu of this PEP. The :pep:`Rejected Ideas
    <465#rejected-alternatives-to-adding-a-new-operator>`

--- a/peps/pep-0239.rst
+++ b/peps/pep-0239.rst
@@ -8,7 +8,8 @@ Python-Version: 2.2
 Post-History: 16-Mar-2001
 
 .. rejected::
-   This PEP is rejected.  The needs outlined in the rationale section
+
+   The needs outlined in the rationale section
    have been addressed to some extent by the acceptance of :pep:`327`
    for decimal arithmetic.  Guido also noted, "Rational arithmetic
    was the default 'exact' arithmetic in ABC and it did not work out as

--- a/peps/pep-0242.rst
+++ b/peps/pep-0242.rst
@@ -8,6 +8,7 @@ Python-Version: 2.2
 Post-History: 17-Apr-2001
 
 .. withdrawn::
+
    This PEP has been closed by the author.  The kinds module will not
    be added to the standard library.
 

--- a/peps/pep-0242.rst
+++ b/peps/pep-0242.rst
@@ -9,8 +9,7 @@ Post-History: 17-Apr-2001
 
 .. withdrawn::
 
-   This PEP has been closed by the author.  The kinds module will not
-   be added to the standard library.
+   The kinds module will not be added to the standard library.
 
    There was no opposition to the proposal but only mild interest in
    using it, not enough to justify adding the module to the standard

--- a/peps/pep-0363.rst
+++ b/peps/pep-0363.rst
@@ -7,7 +7,7 @@ Created: 29-Jan-2007
 Post-History: 12-Feb-2007
 
 .. rejected::
-   This PEP has been rejected.
+
    See :ref:`363-rejection` for more information.
 
 Abstract

--- a/peps/pep-0426.rst
+++ b/peps/pep-0426.rst
@@ -16,11 +16,12 @@ Post-History: 14-Nov-2012, 05-Feb-2013, 07-Feb-2013, 09-Feb-2013,
 Replaces: 345
 
 .. withdrawn::
+
    The ground-up metadata redesign proposed in this PEP has been withdrawn in
    favour of the more modest proposal in :pep:`566`, which retains the basic
    Key:Value format of previous metadata versions, but also defines a standardised
    mechanism for translating that format to nested JSON-compatible data structures.
-   
+
    Some of the ideas in this PEP (or the related :pep:`459`) may still be considered
    as part of later proposals, but they will be handled in a more incremental
    fashion, rather than as a single large proposed change with no feasible


### PR DESCRIPTION
Follow on from https://github.com/python/peps/pull/3682.

Re: https://github.com/python/peps/pull/3682#issuecomment-2054071526

And remove text duplicating that inserted by the template.

Previews:


* https://pep-previews--3756.org.readthedocs.build/pep-0003/
* https://pep-previews--3756.org.readthedocs.build/pep-0009/
* https://pep-previews--3756.org.readthedocs.build/pep-0042/
* https://pep-previews--3756.org.readthedocs.build/pep-0103/
* https://pep-previews--3756.org.readthedocs.build/pep-0204/
* https://pep-previews--3756.org.readthedocs.build/pep-0206/
* https://pep-previews--3756.org.readthedocs.build/pep-0209/
* https://pep-previews--3756.org.readthedocs.build/pep-0210/
* https://pep-previews--3756.org.readthedocs.build/pep-0211/
* https://pep-previews--3756.org.readthedocs.build/pep-0215/
* https://pep-previews--3756.org.readthedocs.build/pep-0216/
* https://pep-previews--3756.org.readthedocs.build/pep-0220/
* https://pep-previews--3756.org.readthedocs.build/pep-0224/
* https://pep-previews--3756.org.readthedocs.build/pep-0225/
* https://pep-previews--3756.org.readthedocs.build/pep-0239/
* https://pep-previews--3756.org.readthedocs.build/pep-0241/
* https://pep-previews--3756.org.readthedocs.build/pep-0242/
* https://pep-previews--3756.org.readthedocs.build/pep-0363/
* https://pep-previews--3756.org.readthedocs.build/pep-0426/



<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3756.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->