### PR TITLE
Infra: Skip Sphinx 7.3 to fix missing 404s

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 Pygments >= 2.9.0
 # Sphinx 6.1.0 broke copying images in parallel builds; fixed in 6.1.2
 # See https://github.com/sphinx-doc/sphinx/pull/11100
-Sphinx >= 5.1.1, != 6.1.0, != 6.1.1
+Sphinx >= 5.1.1, != 6.1.0, != 6.1.1, < 7.3
 docutils >= 0.19.0
 
 sphinx-autobuild


### PR DESCRIPTION
[Sphinx 7.3.0-7.3.5](https://www.sphinx-doc.org/en/master/changes.html) have just been released and for some reason a lot of PEPs are now 404, for example: https://peps.python.org/pep-0719/

Here are the missing directories at https://github.com/python/peps/tree/gh-pages:

<details>
<summary>Details</summary>

```
pep-0465
pep-0466
pep-0467
pep-0468
pep-0469
pep-0470
pep-0471
pep-0472
pep-0473
pep-0474
pep-0475
pep-0476
pep-0477
pep-0478
pep-0479
pep-0480
pep-0481
pep-0482
pep-0483
pep-0484
pep-0485
pep-0486
pep-0487
pep-0488
pep-0489
pep-0490
pep-0491
pep-0492
pep-0493
pep-0494
pep-0495
pep-0496
pep-0497
pep-0498
pep-0499
pep-0500
pep-0501
pep-0502
...
pep-0565
pep-0566
pep-0567
pep-0568
pep-0569
pep-0570
pep-0571
pep-0572
pep-0573
pep-0574
pep-0575
pep-0576
pep-0577
pep-0578
pep-0579
pep-0580
pep-0581
pep-0582
pep-0583
pep-0584
pep-0585
pep-0586
pep-0587
pep-0588
pep-0589
pep-0590
pep-0591
pep-0592
pep-0593
pep-0594
...
pep-0704
pep-0705
pep-0706
pep-0707
pep-0708
pep-0709
pep-0710
pep-0711
pep-0712
pep-0713
pep-0714
pep-0715
pep-0718
pep-0719
pep-0720
pep-0721
pep-0722
pep-0723
pep-0724
pep-0725
pep-0726
pep-0727
pep-0728
pep-0729
...
pep-0742
pep-0743
pep-0744
pep-0754
pep-0801
pep-3000
pep-3001
pep-3002
pep-3003
pep-3099
pep-3100
pep-3101
pep-3102
pep-3103
pep-3104
pep-3105
pep-3106
pep-3107
pep-3108
pep-3109
pep-3110
pep-3111
pep-3112
pep-3113
pep-3114
pep-3115
pep-3116
pep-3117
pep-3118
pep-3119
pep-3120
pep-3121
pep-3122
pep-3123
...
pep-3127
pep-3128
pep-3129
pep-3130
pep-3131
pep-3132
pep-3133
pep-3134
pep-3135
pep-3136
pep-3137
pep-3138
pep-3139
pep-3140
pep-3141
pep-3142
pep-3143
pep-3144
pep-3145
pep-3146
pep-3147
pep-3148
pep-3149
pep-3150
pep-3151
pep-3152
pep-3153
pep-3154
pep-3155
pep-3156
pep-3333
pep-8000
pep-8001
pep-8002
pep-8010
pep-8011
pep-8012
pep-8013
pep-8014
pep-8015
pep-8016
pep-8100
pep-8101
pep-8102
pep-8103
pep-8104
pep-8105
topic
```
</details>

Let's merge this now to restore them, and we can investigate and report to Sphinx.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3758.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->