### PR TITLE
Infra: Fix 404s

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -49,6 +49,8 @@ jobs:
         run: rm -r build/.doctrees/
 
       - name: Deploy to GitHub pages
+        # This allows CI to build branches for testing
+        if: (github.ref == 'refs/heads/main') && (matrix.python-version == '3.x')
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: build # Synchronise with Makefile -> BUILDDIR

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -49,8 +49,6 @@ jobs:
         run: rm -r build/.doctrees/
 
       - name: Deploy to GitHub pages
-        # This allows CI to build branches for testing
-        if: (github.ref == 'refs/heads/main') && (matrix.python-version == '3.x')
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: build # Synchronise with Makefile -> BUILDDIR

--- a/pep_sphinx_extensions/__init__.py
+++ b/pep_sphinx_extensions/__init__.py
@@ -20,10 +20,6 @@ if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 
-def _depart_maths():
-    pass  # No-op callable for the type checker
-
-
 def _update_config_for_builder(app: Sphinx) -> None:
     app.env.document_ids = {}  # For PEPReferenceRoleTitleText
     app.env.settings["builder"] = app.builder.name
@@ -84,8 +80,8 @@ def setup(app: Sphinx) -> dict[str, bool]:
     app.connect("env-before-read-docs", create_pep_zero)  # PEP 0 hook
 
     # Mathematics rendering
-    inline_maths = HTMLTranslator.visit_math, _depart_maths
-    block_maths = HTMLTranslator.visit_math_block, _depart_maths
+    inline_maths = HTMLTranslator.visit_math, None
+    block_maths = HTMLTranslator.visit_math_block, None
     app.add_html_math_renderer("maths_to_html", inline_maths, block_maths)  # Render maths to HTML
 
     # Parallel safety: https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 Pygments >= 2.9.0
 # Sphinx 6.1.0 broke copying images in parallel builds; fixed in 6.1.2
 # See https://github.com/sphinx-doc/sphinx/pull/11100
-Sphinx >= 5.1.1, != 6.1.0, != 6.1.1, < 7.3
+Sphinx >= 5.1.1, != 6.1.0, != 6.1.1
 docutils >= 0.19.0
 
 sphinx-autobuild


### PR DESCRIPTION
This seems to fix things -- see https://aa-turner.github.io/peps/pep-0465/

A

xref:

* #3759 
* #3758

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3760.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->