### PR TITLE
Infra: Fix Python 3.9 on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,13 @@ jobs:
         - "windows-latest"
         - "macos-latest"
         - "ubuntu-latest"
+        # Python 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
+        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
+        exclude:
+        - { python-version: "3.9", os: "macos-latest" }
+        include:
+        - { python-version: "3.9", os: "macos-13" }
+
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes https://github.com/python/peps/pull/3760#issuecomment-2071968850.

Re: https://github.com/actions/setup-python/issues/696#issuecomment-1637587760.

There's a couple of similar ways to do this, for this workflow the difference is mostly cosmetic.

Any preferences?

---

This PR: keep 3.9 in the matrix (it adds Windows, Ubuntu and `macos-latest`), then remove 3.9/`macos-latest` and include 3.9/`macos-13`:

<details>
<summary>diff</summary>

```diff
diff --git a/.github/workflows/test.yml b/.github/workflows/test.yml
index 70a62762..5fef7979 100644
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,13 @@ jobs:
         - "windows-latest"
         - "macos-latest"
         - "ubuntu-latest"
+        # Python 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
+        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
+        exclude:
+        - { python-version: "3.9", os: "macos-latest" }
+        include:
+        - { python-version: "3.9", os: "macos-13" }
+
 
     steps:
       - uses: actions/checkout@v4
```

</details>

It runs 3.9/`macos-13` last, the othe 3.9s stay at the top:

![image](https://github.com/python/peps/assets/1324225/d56ea2d7-a0da-483b-8ab2-0d7464d51f1f)

Benefit: only one moved to the end, still get to queue up the slowish 3.9/Windows sooner to give it a headstart.

---

Or remove 3.9 from the matrix, then add 3.9 and Windows, Ubuntu and `macos-latest`:


<details>
<summary>diff</summary>


```diff
diff --git a/.github/workflows/test.yml b/.github/workflows/test.yml
index 70a62762..87e2026e 100644
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.9"
         - "3.10"
         - "3.11"
         - "3.12"
@@ -39,6 +38,13 @@ jobs:
         - "windows-latest"
         - "macos-latest"
         - "ubuntu-latest"
+        # Python 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
+        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
+        include:
+        - { python-version: "3.9", os: "windows-latest" }
+        - { python-version: "3.9", os: "macos-13" }
+        - { python-version: "3.9", os: "ubuntu-latest" }
+
 
     steps:
       - uses: actions/checkout@v4
```
</details>

It runs all 3.9 jobs at the end:

![image](https://github.com/python/peps/assets/1324225/bc2bad50-26f3-4ae9-8051-a90637d98e95)

Benefit: all 3.9 jobs kept together.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3763.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->