### PR TITLE
PEP 745: Python 3.14 release schedule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -623,6 +623,7 @@ peps/pep-0741.rst  @vstinner
 peps/pep-0742.rst  @JelleZijlstra
 peps/pep-0743.rst  @vstinner
 peps/pep-0744.rst  @brandtbucher
+peps/pep-0745.rst  @hugovk
 # ...
 # peps/pep-0754.rst
 # ...

--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -1,0 +1,72 @@
+PEP: 745
+Title: Python 3.14 Release Schedule
+Author: Hugo van Kemenade <hugo@python.org>
+Status: Active
+Type: Informational
+Topic: Release
+Created: 24-Apr-2024
+Python-Version: 3.14
+
+
+Abstract
+========
+
+This document describes the development and release schedule for
+Python 3.14.
+
+Release Manager and Crew
+========================
+
+- 3.14 Release Manager: Hugo van Kemenade
+- Windows installers: Steve Dower
+- Mac installers: Ned Deily
+- Documentation: Julien Palard
+
+
+Release Schedule
+================
+
+3.14.0 schedule
+---------------
+
+The dates below use a 17-month development period that results
+in a 12-month release cadence between feature versions, as defined by
+:pep:`602`.
+
+Expected:
+
+- 3.14 development begins: Tuesday, 2024-05-07
+- 3.14.0 alpha 1: Tuesday, 2024-10-15
+- 3.14.0 alpha 2: Tuesday, 2024-11-19
+- 3.14.0 alpha 3: Tuesday, 2024-12-17
+- 3.14.0 alpha 4: Tuesday, 2025-01-14
+- 3.14.0 alpha 5: Tuesday, 2025-02-11
+- 3.14.0 alpha 6: Friday, 2025-03-14
+- 3.14.0 alpha 7: Tuesday, 2025-04-08
+- 3.14.0 beta 1: Tuesday, 2025-05-06
+  (No new features beyond this point.)
+- 3.14.0 beta 2: Tuesday, 2025-05-27
+- 3.14.0 beta 3: Tuesday, 2025-06-17
+- 3.14.0 beta 4: Tuesday, 2025-07-08
+- 3.14.0 candidate 1: Tuesday, 2025-07-22
+- 3.14.0 candidate 2: Tuesday, 2025-08-26
+- 3.14.0 final: Wednesday, 2025-10-01
+
+Subsequent bugfix releases every two months.
+
+
+3.14 lifespan
+-------------
+
+Python 3.14 will receive bugfix updates approximately every two months for
+approximately 24 months. Around the time of the release of 3.16.0 final, the
+final 3.14 bugfix update will be released. After that, it is expected that
+security updates (source only) will be released until five years after the
+release of 3.14.0 final, so until approximately October 2030.
+
+
+Copyright
+=========
+
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.


### PR DESCRIPTION
<!--
You can use the following checklist when double-checking your PEP,
and you can help complete some of it yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about anything, just leave it blank and we'll take a look.

If your PEP is not Standards Track, remove the corresponding section.
-->

## Basic requirements (all PEP Types)

* [x] Read and followed [PEP 1](https://peps.python.org/1) & [PEP 12](https://peps.python.org/12)
* [x] File created from the [latest PEP template](https://github.com/python/peps/blob/main/peps/pep-0012/pep-NNNN.rst?plain=1)
* [x] PEP has next available number, & set in filename (``pep-NNNN.rst``), PR title (``PEP 123: <Title of PEP>``) and ``PEP`` header
* [x] Title clearly, accurately and concisely describes the content in 79 characters or less
* [x] Core dev/PEP editor listed as ``Author`` or ``Sponsor``, and formally confirmed their approval
* [x] ``Author``, ``Status`` (``Draft``), ``Type`` and ``Created`` headers filled out correctly
* [x] ``PEP-Delegate``, ``Topic``, ``Requires`` and ``Replaces`` headers completed if appropriate
* [x] Required sections included
    * [x] Abstract (first section)
    * [x] Copyright (last section; exact wording from template required)
* [x] Code is well-formatted (PEP 7/PEP 8) and is in [code blocks, with the right lexer names](https://peps.python.org/pep-0012/#literal-blocks) if non-Python
* [x] PEP builds with no warnings, pre-commit checks pass and content displays as intended in the rendered HTML
* [x] Authors/sponsor added to ``.github/CODEOWNERS`` for the PEP

Tentative schedule based on the initial 3.13 schedule ([PEP 719](https://peps.python.org/pep-0719/)).


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3764.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->