### PR TITLE
PEP 740: tweak JSON simple API prescriptions

### DIFF
--- a/peps/pep-0740.rst
+++ b/peps/pep-0740.rst
@@ -196,6 +196,8 @@ Index changes
 Simple Index
 ^^^^^^^^^^^^
 
+The following changes are made to the :pep:`503` Simple Index:
+
 * When an uploaded file has one or more attestations, the index **MAY**
   provide a ``.provenance`` file adjacent to the hosted distribution.
   The format of the ``.provenance`` file **SHALL** be a JSON-encoded
@@ -223,17 +225,18 @@ Simple Index
 JSON-based Simple API
 ^^^^^^^^^^^^^^^^^^^^^
 
+The following changes are made to the :pep:`691` JSON Simple API:
+
 * When an uploaded file has one or more attestations, the index **MAY**
-  include a ``provenance`` object in the ``file`` dictionary for that file.
-  The format of the ``provenance`` object **SHALL** be a JSON-encoded
-  :ref:`provenance object <provenance-object>`, which **SHALL** contain
-  the file's attestations.
+  include a ``provenance`` key in the ``file`` dictionary for that file.
 
-* The index **MAY** choose to modify the ``provenance`` object, under the same
-  conditions as the ``.provenance`` file specified above.
+  The value of the ``provenance`` key **SHALL** be a JSON string, which
+  **SHALL** be the SHA256 digest of the associated ``.provenance`` file,
+  as in the Simple Index.
 
-  See :ref:`changes-to-provenance-objects` for an additional discussion of
-  reasons why a file's provenance may change.
+  See :ref:`appendix-3` for an explanation of the technical decision to
+  embed the SHA256 digest in the JSON API, rather than the full
+  :ref:`provenance object <provenance-object>`.
 
 These changes require a version change to the JSON API:
 
@@ -667,6 +670,33 @@ of signed inclusion time, and can be verified either online or offline.
       """
       Cosigned checkpoints from zero or more log witnesses.
       """
+
+.. _appendix-3:
+
+Appendix 3: Simple JSON API size considerations
+===============================================
+
+A previous draft of this PEP required embedding each
+:ref:`provenance object <provenance-object>` directly into its appropriate part
+of the :pep:`691` JSON Simple API.
+
+The current version of this PEP embeds the SHA256 digest of the provenance
+object instead. This is done for size and network bandwidth consideration
+reasons:
+
+1. We estimate the typical size of an attestation object to be approximately
+   5.3KB of JSON.
+2. We conservatively estimate that indices eventually host around 3 attestations
+   per release file, or approximately 15.9KB of JSON per combined provenance
+   object.
+3. As of May 2024, the average project on PyPI has approximately 21 release
+   files. We conservatively expect this average to increase over time.
+4. Combined, these numbers imply that a typical project might expect to host
+   between 60 and 70 attestations, or approximately 339KB of additional JSON
+   in its :pep:`691` "project detail" endpoint.
+
+These numbers are significantly worse in "pathological" cases, where projects
+have hundreds or thousands of releases and/or dozens of files per release.
 
 Copyright
 =========


### PR DESCRIPTION
Per discussion with @dstufft: this removes the embedded provenance objects from the simple API and replaces them with digest references, much like the simple index. This has the virtuous effect of reducing the amount of mostly chaff JSON that client API consumers will need to download.

The added Appendix 3 has further details, including a rationale and concrete numbers. These have also been shared in the [discussion thread](https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498/18).