### PR TITLE
PEP 723: Mark as final

### DIFF
--- a/peps/pep-0723.rst
+++ b/peps/pep-0723.rst
@@ -4,7 +4,7 @@ Author: Ofek Lev <ofekmeister@gmail.com>
 Sponsor: Adam Turner <python@quite.org.uk>
 PEP-Delegate: Brett Cannon <brett@python.org>
 Discussions-To: https://discuss.python.org/t/31151
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Packaging
 Content-Type: text/x-rst
@@ -15,12 +15,6 @@ Post-History: `04-Aug-2023 <https://discuss.python.org/t/30979>`__,
               `06-Dec-2023 <https://discuss.python.org/t/40418>`__,
 Replaces: 722
 Resolution: https://discuss.python.org/t/40418/82
-
-
-.. note::
-   This PEP will be declared final once it has been specified at
-   https://packaging.python.org and implemented in a couple of tools,
-   ideally including ``pip-run`` and ``pipx``.
 
 Abstract
 ========

--- a/peps/pep-0723.rst
+++ b/peps/pep-0723.rst
@@ -17,7 +17,6 @@ Resolution: https://discuss.python.org/t/40418/82
 
 .. canonical-pypa-spec:: :ref:`packaging:inline-script-metadata`
 
-
 Abstract
 ========
 

--- a/peps/pep-0723.rst
+++ b/peps/pep-0723.rst
@@ -7,7 +7,6 @@ Discussions-To: https://discuss.python.org/t/31151
 Status: Final
 Type: Standards Track
 Topic: Packaging
-Content-Type: text/x-rst
 Created: 04-Aug-2023
 Post-History: `04-Aug-2023 <https://discuss.python.org/t/30979>`__,
               `06-Aug-2023 <https://discuss.python.org/t/31151>`__,
@@ -15,6 +14,9 @@ Post-History: `04-Aug-2023 <https://discuss.python.org/t/30979>`__,
               `06-Dec-2023 <https://discuss.python.org/t/40418>`__,
 Replaces: 722
 Resolution: https://discuss.python.org/t/40418/82
+
+.. canonical-pypa-spec:: :ref:`packaging:inline-script-metadata`
+
 
 Abstract
 ========


### PR DESCRIPTION
- Documented: https://packaging.python.org/en/latest/specifications/inline-script-metadata/
- Implemented:
    - Hatch: https://hatch.pypa.io/latest/how-to/run/python-scripts/
    - pip-run: https://github.com/jaraco/pip-run/tree/v12.6.1#script-declared-dependencies

* [X] Final implementation has been merged (including tests and docs)
* [X] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [X] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [X] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [ ] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3772.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->