### PR TITLE
PEP 8: Change PascalCase and CamelCase confusion

### DIFF
--- a/peps/pep-0008.rst
+++ b/peps/pep-0008.rst
@@ -923,15 +923,14 @@ The following naming styles are commonly distinguished:
 - ``lower_case_with_underscores``
 - ``UPPERCASE``
 - ``UPPER_CASE_WITH_UNDERSCORES``
-- ``CapitalizedWords`` (or CapWords, or CamelCase -- so named because
-  of the bumpy look of its letters [4]_).  This is also sometimes known
+- ``CapitalizedWords`` (or CapWords, or PascalCase [4]_).  This is also sometimes known
   as StudlyCaps.
 
   Note: When using acronyms in CapWords, capitalize all the
   letters of the acronym.  Thus HTTPServerError is better than
   HttpServerError.
-- ``mixedCase`` (differs from CapitalizedWords by initial lowercase
-  character!)
+- ``mixedCase`` (or CamelCase -- so named because
+  of the bumpy look of its letters [5]_)
 - ``Capitalized_Words_With_Underscores`` (ugly!)
 
 There's also the style of using a short unique prefix to group related
@@ -1570,7 +1569,7 @@ annotations have changed.
   :pep:`484` recommends the use of stub files: .pyi files that are read
   by the type checker in preference of the corresponding .py files.
   Stub files can be distributed with a library, or separately (with
-  the library author's permission) through the typeshed repo [5]_.
+  the library author's permission) through the typeshed repo [6]_.
 
 
 Variable Annotations
@@ -1631,9 +1630,12 @@ References
 
 .. [3] Donald Knuth's *The TeXBook*, pages 195 and 196.
 
-.. [4] http://www.wikipedia.com/wiki/CamelCase
+-- [4] What is Pascal Case
+       https://www.techopedia.com/definition/pascal-case
 
-.. [5] Typeshed repo
+.. [5] http://www.wikipedia.com/wiki/CamelCase
+
+.. [6] Typeshed repo
    https://github.com/python/typeshed
 
 


### PR DESCRIPTION
Change CamelCase to PascalCase in PEP 8, which is commonly swapped by people. CamelCase actually starts lowercase and PascalCase uppercase. Also move CamelCase to mixedCase

Sources:
- https://stackoverflow.com/questions/41768733/camel-case-and-pascal-case-mistake
- https://www.techopedia.com/definition/pascal-case
- https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names

* Change is either:
    * [ ] To a Draft PEP
    * [X] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3773.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->