### PR TITLE
PEP 668: Update link to official NixOS wiki

### DIFF
--- a/peps/pep-0668.rst
+++ b/peps/pep-0668.rst
@@ -462,7 +462,7 @@ In more detail, the use cases above are:
 
    .. _Nixpkgs: https://github.com/NixOS/nixpkgs
 
-   .. __: https://nixos.wiki/wiki/Python
+   .. __: https://wiki.nixos.org/wiki/Python
 
 8. When building distro Python packages for a distro Python (case 2),
    it may be useful to have ``pip install`` be usable as part of the


### PR DESCRIPTION
This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org

ref: NixOS/foundation#113

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3775.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->