### PR TITLE
PEP 639: Examples, always use ${VERSION}, not {version}

### DIFF
--- a/peps/pep-0639/appendix-examples.rst
+++ b/peps/pep-0639/appendix-examples.rst
@@ -175,7 +175,7 @@ the license files would be located at the paths:
     /setuptools-${VERSION}/setuptools/_vendor/packaging/LICENSE.BSD
 
 In the built wheel, with ``/`` being the root of the archive and
-``{version}`` as the previous, the license files would be stored at:
+``${VERSION}`` as the previous, the license files would be stored at:
 
 .. code-block:: shell
 
@@ -185,7 +185,7 @@ In the built wheel, with ``/`` being the root of the archive and
     /setuptools-${VERSION}.dist-info/licenses/setuptools/_vendor/packaging/LICENSE.BSD
 
 Finally, in the installed project, with ``site-packages`` being the site dir
-and ``{version}`` as the previous, the license files would be installed to:
+and ``${VERSION}`` as the previous, the license files would be installed to:
 
 .. code-block:: shell
 


### PR DESCRIPTION
The actual examples use ${VERSION}.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

cc @befeleme 