### PR TITLE
PEP 594: Re-link removed batteries to last included version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ dirhtml: html
 
 ## linkcheck      to check validity of links within PEP sources
 .PHONY: linkcheck
-check-links: BUILDER = linkcheck
-check-links: html
+linkcheck: BUILDER = linkcheck
+linkcheck: html
 
 ## check-links    (deprecated: use 'make linkcheck' alias instead)
 .PHONY: pages

--- a/peps/conf.py
+++ b/peps/conf.py
@@ -20,6 +20,7 @@ master_doc = "contents"
 # Add any Sphinx extension module names here, as strings.
 extensions = [
     "pep_sphinx_extensions",
+    "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx.ext.githubpages",
 ]
@@ -58,6 +59,14 @@ intersphinx_mapping = {
     'py3.12': ('https://docs.python.org/3.12/', None),
 }
 intersphinx_disabled_reftypes = []
+
+# sphinx.ext.extlinks
+# This config is a dictionary of external sites,
+# mapping unique short aliases to a base URL and a prefix.
+# https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
+extlinks = {
+    "pypi": ("https://pypi.org/project/%s/", "%s"),
+}
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/peps/pep-0594.rst
+++ b/peps/pep-0594.rst
@@ -5,7 +5,6 @@ Author: Christian Heimes <christian@python.org>,
 Discussions-To: https://discuss.python.org/t/13508
 Status: Final
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 20-May-2019
 Python-Version: 3.11
 Post-History: 21-May-2019, 04-Feb-2022
@@ -192,7 +191,7 @@ Data encoding modules
 uu and the uu encoding
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The `uu <https://docs.python.org/3/library/uu.html>`_ module provides
+The :external+py3.12:mod:`uu` module provides
 uuencode format, an old binary encoding format for email from 1980. The uu
 format has been replaced by MIME. The uu codec is provided by the ``binascii``
 module.  There's also ``encodings/uu_codec.py`` which is a codec for the
@@ -202,7 +201,7 @@ same encoding; it should also be deprecated.
 xdrlib
 ~~~~~~
 
-The `xdrlib <https://docs.python.org/3/library/xdrlib.html>`_ module supports
+The :external+py3.12:mod:`xdrlib` module supports
 the Sun External Data Representation Standard. XDR is an old binary
 serialization format from 1987. These days it's rarely used outside
 specialized domains like NFS.
@@ -214,7 +213,7 @@ Multimedia modules
 aifc
 ~~~~
 
-The `aifc <https://docs.python.org/3/library/aifc.html>`_ module provides
+The :external+py3.12:mod:`aifc` module provides
 support for reading and writing AIFF and AIFF-C files. The Audio Interchange
 File Format is an old audio format from 1988 based on Amiga IFF. It was most
 commonly used on the Apple Macintosh. These days only few specialized
@@ -231,7 +230,7 @@ maintenance. The strategic benefits for Python may outmatch the burden.
 audioop
 ~~~~~~~
 
-The `audioop <https://docs.python.org/3/library/audioop.html>`_ module
+The :external+py3.12:mod:`audioop` module
 contains helper functions to manipulate raw audio data and adaptive
 differential pulse-code modulated audio data. The module is implemented in
 C without any additional dependencies. The `aifc`_, `sunau`_, and `wave`_
@@ -247,7 +246,7 @@ e.g. ``_audioop`` with ``byteswap``, ``alaw2lin``, ``ulaw2lin``, ``lin2alaw``,
 chunk
 ~~~~~
 
-The `chunk <https://docs.python.org/3/library/chunk.html>`_ module provides
+The :external+py3.12:mod:`chunk` module provides
 support for reading and writing Electronic Arts' Interchange File Format.
 IFF is an old audio file format originally introduced for Commodore and
 Amiga. The format is no longer relevant.
@@ -256,7 +255,7 @@ Amiga. The format is no longer relevant.
 imghdr
 ~~~~~~
 
-The `imghdr <https://docs.python.org/3/library/imghdr.html>`_ module is a
+The :external+py3.12:mod:`imghdr` module is a
 simple tool to guess the image file format from the first 32 bytes
 of a file or buffer. It supports only a limited number of formats and
 neither returns resolution nor color depth.
@@ -265,7 +264,7 @@ neither returns resolution nor color depth.
 ossaudiodev
 ~~~~~~~~~~~
 
-The `ossaudiodev <https://docs.python.org/3/library/ossaudiodev.html>`_
+The :external+py3.12:mod:`ossaudiodev`
 module provides support for Open Sound System, an interface to sound
 playback and capture devices. OSS was initially free software, but later
 support for newer sound devices and improvements were proprietary. Linux
@@ -287,7 +286,7 @@ were removed in 2007 as part of the :pep:`3108` stdlib re-organization.
 sndhdr
 ~~~~~~
 
-The `sndhdr <https://docs.python.org/3/library/sndhdr.html>`_ module is
+The :external+py3.12:mod:`sndhdr` module is
 similar to the `imghdr`_ module but for audio formats. It guesses file
 format, channels, frame rate, and sample widths from the first 512 bytes of
 a file or buffer. The module only supports AU, AIFF, HCOM, VOC, WAV, and
@@ -297,7 +296,7 @@ other ancient formats.
 sunau
 ~~~~~
 
-The `sunau <https://docs.python.org/3/library/sunau.html>`_ module provides
+The :external+py3.12:mod:`sunau` module provides
 support for Sun AU sound format. It's yet another old, obsolete file format.
 
 
@@ -307,14 +306,14 @@ Networking modules
 asynchat
 ~~~~~~~~
 
-The `asynchat <https://docs.python.org/3/library/asynchat.html>`_ module
-is built on top of `asyncore`_ and has been deprecated since Python 3.6.
+The :external+py3.11:mod:`asynchat` module is built on top of
+:external+py3.11:mod:`asyncore` and has been deprecated since Python 3.6.
 
 
 asyncore
 ~~~~~~~~
 
-The `asyncore <https://docs.python.org/3/library/asyncore.html>`_ module was
+The :external+py3.11:mod:`asyncore` module was
 the first module for asynchronous socket service clients and servers. It
 has been replaced by asyncio and is deprecated since Python 3.6.
 
@@ -327,7 +326,7 @@ threading.
 cgi
 ~~~
 
-The `cgi <https://docs.python.org/3/library/cgi.html>`_ module is a support
+The :external+py3.12:mod:`cgi` module is a support
 module for Common Gateway Interface (CGI) scripts. CGI is deemed as
 inefficient because every incoming request is handled in a new process.
 :pep:`206` considers the module as:
@@ -367,7 +366,7 @@ As an explicit example of how close ``parse_header`` and
 cgitb
 ~~~~~
 
-The `cgitb <https://docs.python.org/3/library/cgitb.html>`_ module is a
+The :external+py3.12:mod:`cgitb` module is a
 helper for the ``cgi`` module for configurable tracebacks.
 
 The ``cgitb`` module is not used by any major Python web framework (Django,
@@ -378,7 +377,7 @@ optional debugging middleware.
 smtpd
 ~~~~~
 
-The `smtpd <https://docs.python.org/3/library/smtpd.html>`_ module provides
+The :external+py3.11:mod:`smtpd` module provides
 a simple implementation of a SMTP mail server. The module documentation
 marks the module as deprecated and recommends ``aiosmtpd`` instead. The
 deprecation message was added in releases 3.4.7, 3.5.4, and 3.6.1.
@@ -387,7 +386,7 @@ deprecation message was added in releases 3.4.7, 3.5.4, and 3.6.1.
 nntplib
 ~~~~~~~
 
-The `nntplib <https://docs.python.org/3/library/nntplib.html>`_ module
+The :external+py3.12:mod:`nntplib` module
 implements the client side of the Network News Transfer Protocol (nntp). News
 groups used to be a dominant platform for online discussions. Over the last
 two decades, news has been slowly but steadily replaced with mailing lists
@@ -407,7 +406,7 @@ buildbots.
 telnetlib
 ~~~~~~~~~
 
-The `telnetlib <https://docs.python.org/3/library/telnetlib.html>`_ module
+The :external+py3.12:mod:`telnetlib` module
 provides a Telnet class that implements the Telnet protocol.
 
 
@@ -417,7 +416,7 @@ Operating system interface
 crypt
 ~~~~~
 
-The `crypt <https://docs.python.org/3/library/crypt.html>`_ module implements
+The :external+py3.12:mod:`crypt` module implements
 password hashing based on the ``crypt(3)`` function from ``libcrypt`` or
 ``libxcrypt`` on Unix-like platforms. The algorithms are mostly old, of poor
 quality and insecure. Users are discouraged from using them.
@@ -441,7 +440,7 @@ quality and insecure. Users are discouraged from using them.
 nis
 ~~~
 
-The `nis <https://docs.python.org/3/library/nis.html>`_ module provides
+The :external+py3.12:mod:`nis` module provides
 NIS/YP support. Network Information Service / Yellow Pages is an old and
 deprecated directory service protocol developed by Sun Microsystems. Its
 designed successor NIS+ from 1992 never took off. For a long time, libc's
@@ -452,7 +451,7 @@ and more secure replacement for NIS.
 spwd
 ~~~~
 
-The `spwd <https://docs.python.org/3/library/spwd.html>`_ module provides
+The :external+py3.12:mod:`spwd` module provides
 direct access to Unix shadow password database using non-standard APIs.
 
 In general, it's a bad idea to use ``spwd``. It circumvents system
@@ -474,7 +473,7 @@ Misc modules
 mailcap
 ~~~~~~~
 
-The `mailcap <https://docs.python.org/3/library/mailcap.html>`__ package
+The :external+py3.12:mod:`mailcap` package
 reads *mail capability* files to assist in handling a file attachment in
 an email. In most modern operating systems the email client itself handles reacting to
 file attachments. Operating systems also have their own way to register
@@ -486,7 +485,7 @@ against it while having no maintainer to help fix it.
 msilib
 ~~~~~~
 
-The `msilib <https://docs.python.org/3/library/msilib.html>`_ package is a
+The :external+py3.12:mod:`msilib` package is a
 Windows-only package. It supports the creation of Microsoft Installers (MSI).
 The package also exposes additional APIs to create cabinet files (CAB). The
 module is used to facilitate distutils to create MSI installers with the
@@ -500,7 +499,7 @@ as a new deployment model [3]_.
 pipes
 ~~~~~
 
-The `pipes <https://docs.python.org/3/library/pipes.html>`_ module provides
+The :external+py3.12:mod:`pipes` module provides
 helpers to pipe the input of one command into the output of another command.
 The module is built on top of ``os.popen``. Users are encouraged to use
 the ``subprocess`` module instead.
@@ -525,7 +524,7 @@ listed as such in this PEP.
 colorsys
 --------
 
-The `colorsys <https://docs.python.org/3/library/colorsys.html>`_ module
+The :external+py3.12:mod:`colorsys` module
 defines color conversion functions between RGB, YIQ, HSL, and HSV coordinate
 systems.
 
@@ -542,7 +541,7 @@ between color systems.
 fileinput
 ---------
 
-The `fileinput <https://docs.python.org/3/library/fileinput.html>`_ module
+The :external+py3.12:mod:`fileinput` module
 implements helpers to iterate over a list of files from ``sys.argv``. The
 module predates the ``optparse`` and ``argparse`` modules. The same functionality
 can be implemented with the ``argparse`` module.
@@ -554,7 +553,7 @@ standard library, as it is handy for quick scripts.
 getopt
 ------
 
-The `getopt <https://docs.python.org/3/library/getopt.html>`_ module mimics
+The :external+py3.12:mod:`getopt` module mimics
 C's ``getopt()`` option parser.
 
 Although users are encouraged to use ``argparse`` instead, the ``getopt`` module is
@@ -565,7 +564,7 @@ to write simple Python scripts.
 optparse
 --------
 
-The `optparse <https://docs.python.org/3/library/optparse.html>`_ module is
+The :external+py3.12:mod:`optparse` module is
 the predecessor of the ``argparse`` module.
 
 Although it has been deprecated for many years, it's still too widely used
@@ -575,7 +574,7 @@ to remove it.
 wave
 ----
 
-The `wave <https://docs.python.org/3/library/wave.html>`_ module provides
+The :external+py3.12:mod:`wave` module provides
 support for the WAV sound format.
 
 The module is not deprecated, because the WAV format is still relevant these
@@ -687,14 +686,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/peps/pep-0594.rst
+++ b/peps/pep-0594.rst
@@ -136,46 +136,27 @@ audio processing.
    :widths: 2, 1, 1, 1, 1, 2
 
     aifc,3.11 (3.0\*),3.13,1993,**yes (inactive)**,\-
-    asynchat,**3.6** (3.0\*),3.12,1999,**yes**,asyncio_
-    asyncore,**3.6** (3.0\*),3.12,1999,**yes**,asyncio_
+    asynchat,**3.6** (3.0\*),3.12,1999,**yes**,:mod:`asyncio`
+    asyncore,**3.6** (3.0\*),3.12,1999,**yes**,:mod:`asyncio`
     audioop,3.11 (3.0\*),3.13,1992,**yes**,\-
     cgi,3.11 (2.0\*\*),3.13,1995,no,\-
     cgitb,3.11 (2.0\*\*),3.13,1995,no,\-
     chunk,3.11,3.13,1999,no,\-
-    crypt,3.11,3.13,1994,**yes (inactive)**,"legacycrypt_, bcrypt_, argon2-cffi_, hashlib_, passlib_"
-    imghdr,3.11,3.13,1992,no,"filetype_, puremagic_, python-magic_"
+    crypt,3.11,3.13,1994,**yes (inactive)**,":pypi:`legacycrypt`, :pypi:`bcrypt`, :pypi:`argon2-cffi`, :mod:`hashlib`, :pypi:`passlib`"
+    imghdr,3.11,3.13,1992,no,":pypi:`filetype`, :pypi:`puremagic`, :pypi:`python-magic`"
     mailcap,3.11,3.13,1995,no,\-
     msilib,3.11,3.13,2006,no,\-
     nntplib,3.11,3.13,1992,no,\-
     nis,3.11 (3.0\*),3.13,1992,no,\-
     ossaudiodev,3.11,3.13,2002,no,\-
-    pipes,3.11,3.13,1992,no,"subprocess_"
-    smtpd,"**3.4.7**, **3.5.4**",3.12,2001,**yes**,"aiosmtpd_"
-    sndhdr,3.11,3.13,1994,no,"filetype_, puremagic_, python-magic_"
-    spwd,3.11,3.13,2005,no,"python-pam_"
+    pipes,3.11,3.13,1992,no,:mod:`subprocess`
+    smtpd,"**3.4.7**, **3.5.4**",3.12,2001,**yes**,:pypi:`aiosmtpd`
+    sndhdr,3.11,3.13,1994,no,":pypi:`filetype`, :pypi:`puremagic`, :pypi:`python-magic`"
+    spwd,3.11,3.13,2005,no,:pypi:`python-pam`
     sunau,3.11 (3.0\*),3.13,1993,no,\-
-    telnetlib,3.11 (3.0\*),3.13,1997,no,"telnetlib3_, Exscript_"
+    telnetlib,3.11 (3.0\*),3.13,1997,no,":pypi:`telnetlib3`, :pypi:`Exscript`"
     uu,3.11,3.13,1994,no,\-
     xdrlib,3.11,3.13,1992/1996,no,\-
-
-.. _aiosmtpd: https://pypi.org/project/aiosmtpd/
-.. _argon2-cffi: https://pypi.org/project/argon2-cffi/
-.. _ast: https://docs.python.org/3/library/ast.html
-.. _astroid: https://pypi.org/project/astroid/
-.. _asyncio: https://docs.python.org/3/library/asyncio.html
-.. _bcrypt: https://pypi.org/project/bcrypt/
-.. _Exscript: https://pypi.org/project/Exscript/
-.. _filetype: https://pypi.org/project/filetype/
-.. _hashlib: https://docs.python.org/3/library/hashlib.html
-.. _importlib: https://docs.python.org/3/library/importlib.html
-.. _legacycrypt: https://pypi.org/project/legacycrypt/
-.. _passlib: https://pypi.org/project/passlib/
-.. _puremagic: https://pypi.org/project/puremagic/
-.. _python-magic: https://pypi.org/project/python-magic/
-.. _python-pam: https://pypi.org/project/python-pam/
-.. _simplepam: https://pypi.org/project/simplepam/
-.. _subprocess: https://docs.python.org/3/library/subprocess.html
-.. _telnetlib3: https://pypi.org/project/telnetlib3/
 
 Some module deprecations proposed by :pep:`3108` for 3.0 and :pep:`206` for
 2.0. The *added in* column illustrates, when a module was originally designed
@@ -340,8 +321,7 @@ related to executing code are:
 - ``parse_header`` with ``email.message.Message`` (see example below)
 - ``parse_multipart`` with ``email.message.Message`` (same MIME RFCs)
 - ``FieldStorage``/``MiniFieldStorage`` has no direct replacement, but can
-  typically be replaced by using `multipart
-  <https://pypi.org/project/multipart/>`_ (for ``POST`` and ``PUT``
+  typically be replaced by using :pypi:`multipart` (for ``POST`` and ``PUT``
   requests) or ``urllib.parse.parse_qsl`` (for ``GET`` and ``HEAD``
   requests)
 - ``valid_boundary`` (undocumented) with ``re.compile("^[ -~]{0,200}[!-~]$")``
@@ -502,7 +482,7 @@ pipes
 The :external+py3.12:mod:`pipes` module provides
 helpers to pipe the input of one command into the output of another command.
 The module is built on top of ``os.popen``. Users are encouraged to use
-the ``subprocess`` module instead.
+the :mod:`subprocess` module instead.
 
 
 Modules to keep

--- a/peps/pep-0594.rst
+++ b/peps/pep-0594.rst
@@ -371,7 +371,7 @@ implements the client side of the Network News Transfer Protocol (nntp). News
 groups used to be a dominant platform for online discussions. Over the last
 two decades, news has been slowly but steadily replaced with mailing lists
 and web-based discussion platforms. Twisted is also
-`planning <https://twistedmatrix.com/trac/ticket/9405>`_ to deprecate NNTP
+`planning <https://github.com/twisted/twisted/issues/9405>`_ to deprecate NNTP
 support and `pynntp <https://github.com/greenbender/pynntp>`_ hasn't seen any
 activity since 2014. This is a good indicator that the public interest in
 NNTP support is declining.
@@ -441,7 +441,7 @@ module for access control must be considered a *security bug*, as it bypasses
 PAM's access control.
 
 Furthermore, the ``spwd`` module uses the
-`shadow(3) <http://man7.org/linux/man-pages/man3/shadow.3.html>`_ APIs.
+`shadow(3) <https://man7.org/linux/man-pages/man3/shadow.3.html>`_ APIs.
 Functions like ``getspnam(3)`` access the ``/etc/shadow`` file directly. This
 is dangerous and even forbidden for confined services on systems with a
 security engine like SELinux or AppArmor.
@@ -653,11 +653,11 @@ Update 4
 References
 ==========
 
-.. [1] https://en.wikipedia.org/wiki/Open_Sound_System#Free,_proprietary,_free
+.. [1] https://en.wikipedia.org/wiki/Open_Sound_System#History
 .. [2] https://man.openbsd.org/ossaudio
-.. [3] https://blogs.msmvps.com/installsite/blog/2015/05/03/the-future-of-windows-installer-msi-in-the-light-of-windows-10-and-the-universal-windows-platform/
+.. [3] https://web.archive.org/web/20221206204209/https://blogs.msmvps.com/installsite/blog/2015/05/03/the-future-of-windows-installer-msi-in-the-light-of-windows-10-and-the-universal-windows-platform/
 .. [4] https://twitter.com/ChristianHeimes/status/1130257799475335169
-.. [5] https://twitter.com/dabeaz/status/1130278844479545351
+.. [5] https://web.archive.org/web/20220420154535/https://twitter.com/dabeaz/status/1130278844479545351
 .. [6] https://mail.python.org/pipermail/python-dev/2019-May/157634.html
 
 


### PR DESCRIPTION
When Python 3.13 is released in October, the links to the removed batteries in the main docs will be broken.

Let's link to the last version they were included, 3.11 or 3.12.

Also:

* Add `pypi` extlink role
* Use roles for linking to modules and PyPI packages
* Fix make linkcheck target
* Fix some broken links
* Remove redundant PEP fields

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3778.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->