### PR TITLE
Infra: makefile/RTD: Use uv if installed

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,9 @@ build:
     python: "3"
 
   commands:
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
     - make dirhtml JOBS=$(nproc) BUILDDIR=_readthedocs/html
 
 sphinx:


### PR DESCRIPTION
Like https://github.com/python/devguide/pull/1320.

Using uv to install dependencies is quicker than pip.

On Read the Docs, it adds 1 second to install uv, and then cuts the docs build time from 134s -> 115s, overall reduces the time from 146s -> 129s.

pip: https://beta.readthedocs.org/projects/hugovk-peps/builds/24491058/
uv: https://beta.readthedocs.org/projects/hugovk-peps/builds/24491059/

Locally, running `make clean; time make venv` with a warm cache goes from 8.6s -> 0.5s:

* pip: `make venv  4.49s user 0.94s system 63% cpu 8.586 total`
* uv: `make venv  0.04s user 0.12s system 34% cpu 0.461 total`

`make html` is the same for both.

Overall, `make clean html` goes from 1m26s -> 1m09s.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3791.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->