### PR TITLE
Infra: Define port for htmllive to avoid collisions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ htmlview: html
 ## htmllive       to rebuild and reload HTML files in your browser
 .PHONY: htmllive
 htmllive: SPHINXBUILD = $(VENVDIR)/bin/sphinx-autobuild
-htmllive: SPHINXERRORHANDLING = --re-ignore="/\.idea/|/venv/|/pep-0000.rst|/topic/" --open-browser --delay 0
+htmllive: SPHINXERRORHANDLING = --re-ignore="/\.idea/|/venv/|/pep-0000.rst|/topic/" --open-browser --delay 0 --port 65121
 htmllive: html
 
 ## dirhtml        to render PEPs to "index.html" files within "pep-NNNN" directories

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ SPHINXBUILD  = PATH=$(VENVDIR)/bin:$$PATH sphinx-build
 BUILDER      = html
 JOBS         = auto
 SOURCES      =
-SPHINXERRORHANDLING = -W --keep-going -w sphinx-warnings.txt
+SPHINXERRORHANDLING = --fail-on-warning --keep-going --warning-file sphinx-warnings.txt
 
-ALLSPHINXOPTS = -b $(BUILDER) \
-                -j $(JOBS) \
+ALLSPHINXOPTS = --builder $(BUILDER) \
+                --jobs $(JOBS) \
                 $(SPHINXOPTS) $(SPHINXERRORHANDLING) \
                 peps $(BUILDDIR) $(SOURCES)
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,9 @@ htmlview: html
 ## htmllive       to rebuild and reload HTML files in your browser
 .PHONY: htmllive
 htmllive: SPHINXBUILD = $(VENVDIR)/bin/sphinx-autobuild
-htmllive: SPHINXERRORHANDLING = --re-ignore="/\.idea/|/venv/|/pep-0000.rst|/topic/" --open-browser --delay 0 --port 65121
+# Arbitrarily selected ephemeral port between 49152–65535
+# to avoid conflicts with other processes:
+htmllive: SPHINXERRORHANDLING = --re-ignore="/\.idea/|/venv/|/pep-0000.rst|/topic/" --open-browser --delay 0 --port 55302
 htmllive: html
 
 ## dirhtml        to render PEPs to "index.html" files within "pep-NNNN" directories


### PR DESCRIPTION
It's not unusual that I might run `make htmllive` for a pair of CPython docs, devguide and PEPs at the same time.

To avoid clashes, use a randomly-chosen ["ephemeral port"](https://en.wikipedia.org/wiki/Ephemeral_port) between 49152–65535 for the local server for each of devguide and PEPs.

```python
python -c "import random; print(random.randint(49152, 65535))"
```

Also use the more descriptive Sphinx long options (added in [7.3.0](https://www.sphinx-doc.org/en/master/changes.html#release-7-3-0-released-apr-16-2024)) for the Makefile. 

See also https://github.com/python/devguide/pull/1327.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3792.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->