### PR TITLE
PEP 667: PyFrame_GetLocals is no longer new

### DIFF
--- a/peps/pep-0667.rst
+++ b/peps/pep-0667.rst
@@ -138,22 +138,22 @@ C-API
 Extensions to the API
 '''''''''''''''''''''
 
-Four new C-API functions will be added::
+Three new C-API functions will be added::
 
     PyObject *PyEval_GetFrameLocals(void)
     PyObject *PyEval_GetFrameGlobals(void)
     PyObject *PyEval_GetFrameBuiltins(void)
-    PyObject *PyFrame_GetLocals(PyFrameObject *f)
 
 ``PyEval_GetFrameLocals()`` is equivalent to: ``locals()``.
 ``PyEval_GetFrameGlobals()`` is equivalent to: ``globals()``.
-
-``PyFrame_GetLocals(f)`` is equivalent to: ``f.f_locals``.
 
 All these functions will return a new reference.
 
 Changes to existing APIs
 ''''''''''''''''''''''''
+
+``PyFrame_GetLocals(f)`` is equivalent to ``f.f_locals``, and hence its return value
+will change as described above for accessing ``f.f_locals``.
 
 The following C-API functions will be deprecated, as they return borrowed references::
 
@@ -170,7 +170,7 @@ The following functions should be used instead::
 which return new references.
 
 The semantics of ``PyEval_GetLocals()`` is changed as it now returns a
-view of the frame locals, not a dictionary.
+proxy for the frame locals in optimized frames, not a dictionary.
 
 The following three functions will become no-ops, and will be deprecated::
 
@@ -209,7 +209,7 @@ PyEval_GetLocals
 ''''''''''''''''
 
 Because ``PyEval_GetLocals()`` returns a borrowed reference, it requires
-the dictionary to be cached on the frame, extending its lifetime and
+the proxy mapping to be cached on the frame, extending its lifetime and
 creating a cycle. ``PyEval_GetFrameLocals()`` should be used instead.
 
 This code::


### PR DESCRIPTION
PyFrame_GetLocals was already added back in Python 3.11, so PEP 667 is changing it rather than adding it.

(Discrepancy picked up while writing the C API docs update)

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3793.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->