### PR TITLE
Infra: Only install sphinx-autobuild for `make htmllive`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,15 @@ html: venv
 htmlview: html
 	$(PYTHON) -c "import os, webbrowser; webbrowser.open('file://' + os.path.realpath('build/index.html'))"
 
+.PHONY: ensure-sphinx-autobuild
+ensure-sphinx-autobuild: venv
+	$(VENVDIR)/bin/sphinx-autobuild --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install sphinx-autobuild
+
 ## htmllive       to rebuild and reload HTML files in your browser
 .PHONY: htmllive
 htmllive: SPHINXBUILD = $(VENVDIR)/bin/sphinx-autobuild
 htmllive: SPHINXERRORHANDLING = --re-ignore="/\.idea/|/venv/|/pep-0000.rst|/topic/" --open-browser --delay 0
-htmllive: html
+htmllive: ensure-sphinx-autobuild html
 
 ## dirhtml        to render PEPs to "index.html" files within "pep-NNNN" directories
 .PHONY: dirhtml

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,6 @@ Pygments >= 2.9.0
 Sphinx >= 5.1.1, != 6.1.0, != 6.1.1
 docutils >= 0.19.0
 
-sphinx-autobuild
-
 # For tests
 pytest
 pytest-cov


### PR DESCRIPTION
The 3.13-dev CI build has started failing: https://github.com/python/peps/actions/runs/9256853760/job/25463759359

The reason and fix is the same as https://github.com/python/cpython/pull/119607.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3796.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->