### PR TITLE
Infra: Use PEP abstract/introduction as HTML and OG description

### DIFF
--- a/pep_sphinx_extensions/__init__.py
+++ b/pep_sphinx_extensions/__init__.py
@@ -2,17 +2,27 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import html
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from docutils.writers.html5_polyglot import HTMLTranslator
 from sphinx import environment
 
-from pep_sphinx_extensions.generate_rss import create_rss_feed
-from pep_sphinx_extensions.pep_processor.html import pep_html_builder
-from pep_sphinx_extensions.pep_processor.html import pep_html_translator
-from pep_sphinx_extensions.pep_processor.parsing import pep_banner_directive
-from pep_sphinx_extensions.pep_processor.parsing import pep_parser
-from pep_sphinx_extensions.pep_processor.parsing import pep_role
+from pep_sphinx_extensions.generate_rss import (
+    create_rss_feed,
+    get_from_doctree,
+    pep_abstract,
+)
+from pep_sphinx_extensions.pep_processor.html import (
+    pep_html_builder,
+    pep_html_translator,
+)
+from pep_sphinx_extensions.pep_processor.parsing import (
+    pep_banner_directive,
+    pep_parser,
+    pep_role,
+)
 from pep_sphinx_extensions.pep_processor.transforms import pep_references
 from pep_sphinx_extensions.pep_zero_generator.pep_index_generator import create_pep_zero
 
@@ -41,6 +51,22 @@ def _post_build(app: Sphinx, exception: Exception | None) -> None:
     if "internal_builder" not in app.tags:
         create_index_file(Path(app.outdir), app.builder.name)
     create_rss_feed(app.doctreedir, app.outdir)
+
+
+def set_description(
+    app: Sphinx, pagename: str, templatename: str, context: dict[str, Any], doctree
+) -> None:
+    if not pagename.startswith("pep-"):
+        return
+
+    full_path = Path(app.doctreedir) / f"{pagename}.doctree"
+    abstract = get_from_doctree(full_path, "Abstract")
+    if abstract:
+        if len(abstract) > 256:
+            abstract = abstract[:253] + "..."
+        context["description"] = html.escape(abstract)
+    else:
+        context["description"] = "Python Enhancement Proposals (PEPs)"
 
 
 def setup(app: Sphinx) -> dict[str, bool]:
@@ -78,6 +104,7 @@ def setup(app: Sphinx) -> dict[str, bool]:
     # Register event callbacks
     app.connect("builder-inited", _update_config_for_builder)  # Update configuration values for builder used
     app.connect("env-before-read-docs", create_pep_zero)  # PEP 0 hook
+    app.connect('html-page-context', set_description)
 
     # Mathematics rendering
     inline_maths = HTMLTranslator.visit_math, None

--- a/pep_sphinx_extensions/generate_rss.py
+++ b/pep_sphinx_extensions/generate_rss.py
@@ -50,14 +50,21 @@ def pep_creation(full_path: Path) -> dt.datetime:
 
 
 def pep_abstract(document: nodes.document) -> str:
-    """Return the first paragraph of the PEP abstract"""
+    """Return the first paragraph of the PEP abstract.
+    If not found, return the first paragraph of the introduction.
+    """
+    introduction = ""
     for node in document.findall(nodes.section):
         title_node = node.next_node(nodes.title)
         if title_node is None:
             continue
+
         if title_node.astext() == "Abstract":
             return node.next_node(nodes.paragraph).astext().strip().replace("\n", " ")
-    return ""
+        elif title_node.astext() == "Introduction":
+            introduction = node.next_node(nodes.paragraph).astext().strip().replace("\n", " ")
+
+    return introduction
 
 
 def _generate_items(doctree_dir: Path):

--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="{{ pathto('_static/pygments_dark.css', resource=True) }}" type="text/css" media="(prefers-color-scheme: dark)" id="pyg-dark">
     <link rel="alternate" type="application/rss+xml" title="Latest PEPs" href="https://peps.python.org/peps.rss">
     <meta property="og:title" content='{{ title + " | peps.python.org"|safe }}'>
+    <meta property="og:description" content="{{ description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://peps.python.org/{{ pagename }}/">
     <meta property="og:site_name" content="Python Enhancement Proposals (PEPs)">
@@ -21,7 +22,7 @@
     <meta property="og:image:alt" content="Python PEPs">
     <meta property="og:image:width" content="200">
     <meta property="og:image:height" content="200">
-    <meta name="description" content="Python Enhancement Proposals (PEPs)">
+    <meta name="description" content="{{ description }}">
     <meta name="theme-color" content="#3776ab">
 </head>
 <body>


### PR DESCRIPTION
Fixes https://github.com/python/peps/issues/2919.

Use the PEP abstract for `<meta property="og:description">` and `<meta name="description">`.

If the abstract is not found, use the introduction. If that's not found, use the current default of "Python Enhancement Proposals (PEPs)".

The abstract and intros cover 631 / 652 PEPs, which is good enough.

(The abstract alone covers 594 / 652, which might be enough to remove a few extra lines here?)

Trim the description to 256 characters, and escape things like double quotes.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3801.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->