### PR TITLE
PEP 667: Fix word duplication

### DIFF
--- a/peps/pep-0667.rst
+++ b/peps/pep-0667.rst
@@ -186,8 +186,7 @@ there will be some observable differences.
 For example, ``f.f_locals is f.f_locals`` may be ``False``.
 
 However ``f.f_locals == f.f_locals`` will be ``True``, and
-all changes to the underlying variables, by any means, will be
-always be visible.
+all changes to the underlying variables, by any means, will always be visible.
 
 Backwards Compatibility
 =======================


### PR DESCRIPTION
Fixed an editorial issue in the accepted PEP 667: redundancy in the phrase "will be always be visible.".

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3803.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->