### PR TITLE
PEP 667: Change slots in FrameLocalsProxy

### DIFF
--- a/peps/pep-0667.rst
+++ b/peps/pep-0667.rst
@@ -282,7 +282,7 @@ They serve only to illustrate the proposed design.
     class FrameLocalsProxy:
         "Implements collections.MutableMapping."
 
-        __slots__ "_frame"
+        __slots__ = ("_frame", )
 
         def __init__(self, frame:FrameType):
             self._frame = frame


### PR DESCRIPTION
Changed __slots__ in FrameLocalsProxy

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3805.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->