### PR TITLE
PEP 581: Mark as Final

### DIFF
--- a/peps/pep-0581.rst
+++ b/peps/pep-0581.rst
@@ -1,13 +1,10 @@
 PEP: 581
 Title: Using GitHub Issues for CPython
-Version: $Revision$
-Last-Modified: $Date$
 Author: Mariatta <mariatta@python.org>
 BDFL-Delegate: Barry Warsaw <barry@python.org>
 Discussions-To: https://discuss.python.org/t/535
-Status: Accepted
+Status: Final
 Type: Process
-Content-Type: text/x-rst
 Created: 20-Jun-2018
 Post-History: 07-Mar-2019
 Resolution: https://mail.python.org/pipermail/python-dev/2019-May/157399.html
@@ -293,14 +290,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: rst
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [x] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [ ] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps https://github.com/python/peps/issues/2872, which says:

> [PEP-581](https://peps.python.org/581) _Using GitHub Issues for CPython_: Since the PEP's content is tightly focused on the rationale for choosing GitHub rather than the current, active process for using it and is thus now of historical rather than procedural value, it should be marked Final (rather than Active) like other transition-oriented Process PEPs have.

Also remove some redundant fields.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3807.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->