### PR TITLE
PEPs 8104, 8105: Mark as Final

### DIFF
--- a/peps/pep-8104.rst
+++ b/peps/pep-8104.rst
@@ -2,10 +2,9 @@ PEP: 8104
 Title: 2023 Term Steering Council election
 Author: Ee Durbin <ee@python.org>
 Sponsor: Brett Cannon <brett@python.org>
-Status: Active
+Status: Final
 Type: Informational
 Topic: Governance
-Content-Type: text/x-rst
 Created: 08-Nov-2022
 
 

--- a/peps/pep-8105.rst
+++ b/peps/pep-8105.rst
@@ -2,10 +2,9 @@ PEP: 8105
 Title: 2024 Term Steering Council election
 Author: Ee Durbin <ee@python.org>
 Sponsor: Thomas Wouters <thomas@python.org>
-Status: Active
+Status: Final
 Type: Informational
 Topic: Governance
-Content-Type: text/x-rst
 Created: 23-Oct-2023
 
 
@@ -73,7 +72,7 @@ Ballots were be distributed based on the the `Python Voter Roll
 for this election.
 
 While this file is not public as it contains private email addresses,
-the `Complete Voter Roll`_ is available with a list of all elgible voters by name.
+the `Complete Voter Roll`_ is available with a list of all eligible voters by name.
 
 Election Implementation
 =======================


### PR DESCRIPTION
The 2023 and 2024 SC elections are complete.

Also remove the redundant `Content-Type: text/x-rst` header and fix a typo.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3808.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->