### PR TITLE
PEP 684: Mark as Final

### DIFF
--- a/peps/pep-0684.rst
+++ b/peps/pep-0684.rst
@@ -2,9 +2,8 @@ PEP: 684
 Title: A Per-Interpreter GIL
 Author: Eric Snow <ericsnowcurrently@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-684-a-per-interpreter-gil/19583
-Status: Accepted
+Status: Final
 Type: Standards Track
-Content-Type: text/x-rst
 Requires: 683
 Created: 08-Mar-2022
 Python-Version: 3.12


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [ ] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)


Also remove redundant ``Content-Type`` field.
I guess this PEP doesn't need a ``canonical-doc`` directive


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3810.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->