### PR TITLE
PEP 578: Mark as Final

### DIFF
--- a/peps/pep-0578.rst
+++ b/peps/pep-0578.rst
@@ -84,7 +84,7 @@ The aim of these changes is to enable both application developers and
 system administrators to integrate Python into their existing
 monitoring systems without dictating how those systems look or behave.
 
-We propose two API changes to enable this: an Audit Hook and Verified
+We propose two API changes to enable this: an Audit Hook and Verified
 Open Hook. Both are available from Python and native code, allowing
 applications and frameworks written in pure Python code to take
 advantage of the extra messages, while also allowing embedders or
@@ -283,7 +283,7 @@ API Availability
 
 While all the functions added here are considered public and stable API,
 the behavior of the functions is implementation specific. Most
-descriptions here refer to the CPython implementation, and while other
+descriptions here refer to the CPython implementation, and while other
 implementations should provide the functions, there is no requirement
 that they behave the same.
 

--- a/peps/pep-0578.rst
+++ b/peps/pep-0578.rst
@@ -505,7 +505,7 @@ The argument that this is "security by obscurity" is valid, but
 irrelevant. Security by obscurity is only an issue when there are no
 other protective mechanisms; obscurity as the first step in avoiding
 attack is strongly recommended (see `this article
-<https://danielmiessler.com/study/security-by-obscurity/>`_ for
+<https://danielmiessler.com/p/security-by-obscurity/>`_ for
 discussion).
 
 This idea is rejected because there are no appropriate reasons for an
@@ -556,7 +556,7 @@ a secure or audited environment.
 References
 ==========
 
-.. [1] Python Performance Benchmark Suite `<https://github.com/python/performance>`_
+.. [1] Python Performance Benchmark Suite `<https://github.com/python/pyperformance>`_
 
 .. [2] Python Security model - Sandbox `<https://python-security.readthedocs.io/security.html#sandbox>`_
 

--- a/peps/pep-0578.rst
+++ b/peps/pep-0578.rst
@@ -566,4 +566,4 @@ Copyright
 Copyright (c) 2019 by Microsoft Corporation. This material may be
 distributed only subject to the terms and conditions set forth in the
 Open Publication License, v1.0 or later (the latest version is presently
-available at http://www.opencontent.org/openpub/).
+available at https://spdx.org/licenses/OPUBL-1.0.html).

--- a/peps/pep-0578.rst
+++ b/peps/pep-0578.rst
@@ -1,15 +1,14 @@
 PEP: 578
 Title: Python Runtime Audit Hooks
-Version: $Revision$
-Last-Modified: $Date$
 Author: Steve Dower <steve.dower@python.org>
 BDFL-Delegate: Christian Heimes <christian@python.org>
-Status: Accepted
+Status: Final
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 16-Jun-2018
 Python-Version: 3.8
 Post-History: 28-Mar-2019, 07-May-2019
+
+.. canonical-doc:: :ref:`python:audit-events`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Fixes https://github.com/python/peps/issues/2872.

Also:

* Fix broken licence link. http://www.opencontent.org/openpub/ has a 500 internal server error. Looks like the whole site is down. https://web.archive.org/web/20190228180246/https://www.opencontent.org/openpub/ is an archive from around the time the PEP was published, and I've verified the body text matches https://spdx.org/licenses/OPUBL-1.0.html (other than whitespace) which I've used as a replacement.
* Update a couple of redirecting links.
* Replace some non-breaking spaces with real spaces.

This is the last unchecked PEP in https://github.com/python/peps/issues/2872. Let's close it now, and use new issues such as https://github.com/python/peps/issues/3579 and https://github.com/python/peps/issues/3781 for tracking the remainder.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3811.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->