### PR TITLE
Infra: Fix `make clean htmllive`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ htmlview: html
 
 .PHONY: ensure-sphinx-autobuild
 ensure-sphinx-autobuild: venv
-	$(VENVDIR)/bin/sphinx-autobuild --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install sphinx-autobuild
+	$(call ensure_package,sphinx-autobuild)
 
 ## htmllive       to rebuild and reload HTML files in your browser
 .PHONY: htmllive
@@ -82,17 +82,18 @@ venv:
 		echo "The venv has been created in the $(VENVDIR) directory"; \
 	fi
 
-.PHONY: ensure-pre-commit
-ensure-pre-commit: venv
+define ensure_package
 	if uv --version > /dev/null; then \
-		$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || VIRTUAL_ENV=$(VENVDIR) uv pip install pre-commit; \
+		$(VENVDIR)/bin/python3 -m $(1) --version > /dev/null || VIRTUAL_ENV=$(VENVDIR) uv pip install $(1); \
 	else \
-		$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit; \
-	fi;
+		$(VENVDIR)/bin/python3 -m $(1) --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install $(1); \
+	fi
+endef
 
 ## lint           to lint all the files
 .PHONY: lint
-lint: ensure-pre-commit
+lint: venv
+	$(call ensure_package,pre_commit)
 	$(VENVDIR)/bin/python3 -m pre_commit run --all-files
 
 ## test           to test the Sphinx extensions for PEPs
@@ -102,8 +103,8 @@ test: venv
 
 ## spellcheck     to check spelling
 .PHONY: spellcheck
-spellcheck: ensure-pre-commit
-	$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit
+spellcheck: venv
+	$(call ensure_package,pre_commit)
 	$(VENVDIR)/bin/python3 -m pre_commit run --all-files --hook-stage manual codespell
 
 .PHONY: help


### PR DESCRIPTION
Follow on from https://github.com/python/peps/pull/3791 and https://github.com/python/peps/pull/3796. 

Before:

```console
❯ make clean htmllive
rm -rf .venv
rm -rf build topic
Creating venv in .venv
Using Python 3.12.3 interpreter at: /Library/Frameworks/Python.framework/Versions/3.12/bin/python3
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate
Resolved 26 packages in 67ms
Installed 26 packages in 57ms
 + alabaster==0.7.16
 + babel==2.15.0
 + certifi==2024.6.2
 + charset-normalizer==3.3.2
 + coverage==7.5.3
 + docutils==0.21.2
 + idna==3.7
 + imagesize==1.4.1
 + iniconfig==2.0.0
 + jinja2==3.1.4
 + markupsafe==2.1.5
 + packaging==24.0
 + pluggy==1.5.0
 + pygments==2.18.0
 + pytest==8.2.1
 + pytest-cov==5.0.0
 + requests==2.32.3
 + snowballstemmer==2.2.0
 + sphinx==7.3.7
 + sphinxcontrib-applehelp==1.0.8
 + sphinxcontrib-devhelp==1.0.6
 + sphinxcontrib-htmlhelp==2.0.5
 + sphinxcontrib-jsmath==1.0.1
 + sphinxcontrib-qthelp==1.0.7
 + sphinxcontrib-serializinghtml==1.1.10
 + urllib3==2.2.1
The venv has been created in the .venv directory
.venv/bin/sphinx-autobuild --version > /dev/null || .venv/bin/python3 -m pip install sphinx-autobuild
/bin/sh: .venv/bin/sphinx-autobuild: No such file or directory
/Users/hugo/github/peps/.venv/bin/python3: No module named pip
make: *** [ensure-sphinx-autobuild] Error 1
```

After:

```console
❯ make clean htmllive
rm -rf .venv
rm -rf build topic
Creating venv in .venv
Using Python 3.12.3 interpreter at: /Library/Frameworks/Python.framework/Versions/3.12/bin/python3
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate
Resolved 26 packages in 5ms
Installed 26 packages in 44ms
 + alabaster==0.7.16
 + babel==2.15.0
 + certifi==2024.6.2
 + charset-normalizer==3.3.2
 + coverage==7.5.3
 + docutils==0.21.2
 + idna==3.7
 + imagesize==1.4.1
 + iniconfig==2.0.0
 + jinja2==3.1.4
 + markupsafe==2.1.5
 + packaging==24.0
 + pluggy==1.5.0
 + pygments==2.18.0
 + pytest==8.2.1
 + pytest-cov==5.0.0
 + requests==2.32.3
 + snowballstemmer==2.2.0
 + sphinx==7.3.7
 + sphinxcontrib-applehelp==1.0.8
 + sphinxcontrib-devhelp==1.0.6
 + sphinxcontrib-htmlhelp==2.0.5
 + sphinxcontrib-jsmath==1.0.1
 + sphinxcontrib-qthelp==1.0.7
 + sphinxcontrib-serializinghtml==1.1.10
 + urllib3==2.2.1
The venv has been created in the .venv directory
if uv --version > /dev/null; then .venv/bin/python3 -m sphinx-autobuild --version > /dev/null || VIRTUAL_ENV=.venv uv pip install sphinx-autobuild; else .venv/bin/python3 -m sphinx-autobuild --version > /dev/null || .venv/bin/python3 -m pip install sphinx-autobuild; fi
/Users/hugo/github/peps/.venv/bin/python3: No module named sphinx-autobuild
Resolved 31 packages in 170ms
Downloaded 1 package in 19ms
Installed 10 packages in 11ms
 + anyio==4.4.0
 + click==8.1.7
 + colorama==0.4.6
 + h11==0.14.0
 + sniffio==1.3.1
 + sphinx-autobuild==2024.4.16
 + starlette==0.37.2
 + uvicorn==0.30.1
 + watchfiles==0.22.0
 + websockets==12.0
.venv/bin/sphinx-autobuild --builder html --jobs auto  --re-ignore="/\.idea/|/venv/|/pep-0000.rst|/topic/" --open-browser --delay 0 --port 55302 peps build
[sphinx-autobuild] Starting initial build
[sphinx-autobuild] > sphinx-build --builder html --jobs auto peps build
Running Sphinx v7.3.7
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
loading intersphinx inventory from https://packaging.python.org/en/latest/objects.inv...
loading intersphinx inventory from https://typing.readthedocs.io/en/latest/objects.inv...
loading intersphinx inventory from https://devguide.python.org/objects.inv...
loading intersphinx inventory from https://docs.python.org/3.11/objects.inv...
loading intersphinx inventory from https://docs.python.org/3.12/objects.inv...
building [html]: targets for 652 source files that are out of date
updating environment: [new config] 652 added, 0 changed, 0 removed
reading sources... [100%] pep-8105 .. topic/typing
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [100%] pep-9999 .. topic/typing
generating indices... done
writing additional pages... done
copying images... [100%] pep-3147-1.png
dumping object inventory... done
build succeeded.

The HTML pages are in build.
[sphinx-autobuild] Serving on http://127.0.0.1:55302
[sphinx-autobuild] Waiting to detect changes...
```
