### PR TITLE
PEP 561: link to canonical typing-spec on distributing typed Python packages

### DIFF
--- a/peps/pep-0561.rst
+++ b/peps/pep-0561.rst
@@ -9,6 +9,7 @@ Created: 09-Sep-2017
 Python-Version: 3.7
 Post-History: 10-Sep-2017, 12-Sep-2017, 06-Oct-2017, 26-Oct-2017, 12-Apr-2018
 
+.. canonical-typing-spec:: :ref:`typing:distributing`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)
