### PR TITLE
PEP 745: Remove my email

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -1,6 +1,6 @@
 PEP: 745
 Title: Python 3.14 Release Schedule
-Author: Hugo van Kemenade <hugo@python.org>
+Author: Hugo van Kemenade
 Status: Active
 Type: Informational
 Topic: Release


### PR DESCRIPTION
I've had this email address for a year, and I think this is the only public place it's been posted. I only started getting spam to it a couple of weeks after publishing it here.

[PEP 1 says it's optional](https://peps.python.org/pep-0001/#pep-header-preamble), let's see if removing it makes any difference or if it's too late now!


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3820.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->