### PR TITLE
PEP 683: Mark Final

### DIFF
--- a/peps/pep-0683.rst
+++ b/peps/pep-0683.rst
@@ -901,14 +901,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-
-..
-    Local Variables:
-    mode: indented-text
-    indent-tabs-mode: nil
-    sentence-end-double-space: t
-    fill-column: 70
-    coding: utf-8
-    End:

--- a/peps/pep-0683.rst
+++ b/peps/pep-0683.rst
@@ -2,7 +2,7 @@ PEP: 683
 Title: Immortal Objects, Using a Fixed Refcount
 Author: Eric Snow <ericsnowcurrently@gmail.com>, Eddie Elizondo <eduardo.elizondorueda@gmail.com>
 Discussions-To: https://discuss.python.org/t/18183
-Status: Accepted
+Status: Final
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 10-Feb-2022
@@ -13,20 +13,18 @@ Post-History: `16-Feb-2022 <https://mail.python.org/archives/list/python-dev@pyt
               `12-Aug-2022 <https://discuss.python.org/t/18183>`__,
 Resolution: https://discuss.python.org/t/18183/26
 
+.. canonical-doc: :term:`reference count`
 
 PEP Acceptance Conditions
 =========================
 
 The PEP was accepted with conditions:
 
-* we must apply the primary proposal
-  in `Solutions for Accidental De-Immortalization`_
-  (reset the immortal refcount in ``tp_dealloc()``)
-* types without this may not be immortalized (in CPython's code)
-* the PEP must be updated with final benchmark results once
-  the implementation is finalized
-* we will have one last round of discussion about those results at that point
-
+* the primary proposal in `Solutions for Accidental De-Immortalization`_
+  (reset the immortal refcount in ``tp_dealloc()``) was applied
+* types without this were not immortalized (in CPython's code)
+* the PEP was updated with final benchmark results once
+  the implementation is finalized (confirming the change is worthwhile)
 
 Abstract
 ========

--- a/peps/pep-0683.rst
+++ b/peps/pep-0683.rst
@@ -13,7 +13,7 @@ Post-History: `16-Feb-2022 <https://mail.python.org/archives/list/python-dev@pyt
               `12-Aug-2022 <https://discuss.python.org/t/18183>`__,
 Resolution: https://discuss.python.org/t/18183/26
 
-.. canonical-doc: :term:`reference count`
+.. canonical-doc:: :term:`reference count`
 
 PEP Acceptance Conditions
 =========================

--- a/peps/pep-0683.rst
+++ b/peps/pep-0683.rst
@@ -4,7 +4,6 @@ Author: Eric Snow <ericsnowcurrently@gmail.com>, Eddie Elizondo <eduardo.elizond
 Discussions-To: https://discuss.python.org/t/18183
 Status: Final
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 10-Feb-2022
 Python-Version: 3.12
 Post-History: `16-Feb-2022 <https://mail.python.org/archives/list/python-dev@python.org/thread/TPLEYDCXFQ4AMTW6F6OQFINSIFYBRFCR/>`__,


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [x] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps #3817


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3824.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->