### PR TITLE
PEP 746: small clarification to specification.

### DIFF
--- a/peps/pep-0746.rst
+++ b/peps/pep-0746.rst
@@ -63,11 +63,10 @@ The protocol being introduced would be defined as follows if it were to be defin
 When a static type checker encounters a type expression of the form ``Annotated[T, M1, M2, ...]``,
 it should enforce that for each metadata element in ``M1, M2, ...``, one of the following is true:
 
-* The metadata element evaluates to a type that does not have a ``__supports_type__`` method; or
-* The metadata element evaluates to an object ``M`` that has a ``__supports_type__`` method, and
-  a call to ``M.__supports_type__(T)`` type checks without errors (i.e., ``T`` is assignable to the
-  parameter type of the ``__supports_type__`` method), and that call does not
-  evaluate to ``Literal[False]``.
+* The metadata element evaluates to an object that does not have a ``__supports_type__`` attribute; or
+* The metadata element evaluates to an object ``M`` that implements the ``SupportsType`` protocol;
+  and, with ``T`` instantiated to a value ``v``, a call to ``M.__supports_type__(v)`` type checks without errors;
+  and that call does not evaluate to ``Literal[False]``.
 
 The body of the ``__supports_type__`` method is not used to check the validity of the metadata
 and static type checkers can ignore it. However, tools that use the annotation at


### PR DESCRIPTION
Rewords part of the specification, to make it clearer what type checkers should be validating and what should happen when `__supports_type__` has the wrong type.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

cc @adriangb 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3828.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->