### PR TITLE
PEP 646: Mark Final

### DIFF
--- a/peps/pep-0646.rst
+++ b/peps/pep-0646.rst
@@ -5,7 +5,7 @@ Author: Mark Mendoza <mendoza.mark.a@gmail.com>,
         Pradeep Kumar Srinivasan <gohanpra@gmail.com>,
         Vincent Siles <vsiles@fb.com>
 Sponsor: Guido van Rossum <guido@python.org>
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
 Content-Type: text/x-rst
@@ -13,6 +13,8 @@ Created: 16-Sep-2020
 Python-Version: 3.11
 Post-History: 07-Oct-2020, 23-Dec-2020, 29-Dec-2020
 Resolution: https://mail.python.org/archives/list/python-dev@python.org/message/OR5RKV7GAVSGLVH3JAGQ6OXFAXIP5XDX/
+
+.. canonical-doc:: :mod:`typing:typevartuple`
 
 Abstract
 ========

--- a/peps/pep-0646.rst
+++ b/peps/pep-0646.rst
@@ -14,7 +14,7 @@ Python-Version: 3.11
 Post-History: 07-Oct-2020, 23-Dec-2020, 29-Dec-2020
 Resolution: https://mail.python.org/archives/list/python-dev@python.org/message/OR5RKV7GAVSGLVH3JAGQ6OXFAXIP5XDX/
 
-.. canonical-doc:: :mod:`typing:typevartuple`
+.. canonical-doc:: :ref:`typing:typevartuple`
 
 Abstract
 ========

--- a/peps/pep-0646.rst
+++ b/peps/pep-0646.rst
@@ -14,7 +14,7 @@ Python-Version: 3.11
 Post-History: 07-Oct-2020, 23-Dec-2020, 29-Dec-2020
 Resolution: https://mail.python.org/archives/list/python-dev@python.org/message/OR5RKV7GAVSGLVH3JAGQ6OXFAXIP5XDX/
 
-.. canonical-doc:: :ref:`typing:typevartuple`
+.. canonical-doc:: :ref:`typing:typevartuple` and :py:class:`typing.TypeVarTuple`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [X] Final implementation has been merged (including tests and docs)
* [X] PEP matches the final implementation
* [X] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [X] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [X] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [X] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Fixes python/cpython#115528.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3832.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->