### PR TITLE
PEP 749: use `annotationlib` as the proposed module name throughout

### DIFF
--- a/peps/pep-0749.rst
+++ b/peps/pep-0749.rst
@@ -680,9 +680,9 @@ But users could use ``annotationlib.call_evaluate_function`` to get the type in 
 
 .. code:: pycon
 
-  >>> annotations.call_evaluate_function(field.evaluate_type, annotations.Format.SOURCE)
+  >>> annotationlib.call_evaluate_function(field.evaluate_type, annotations.Format.SOURCE)
   'undefined'
-  >>> annotations.call_evaluate_function(field.evaluate_type, annotations.Format.FORWARDREF)
+  >>> annotationlib.call_evaluate_function(field.evaluate_type, annotations.Format.FORWARDREF)
   ForwardRef('undefined')
 
 Other variations are possible. For example, we could leave the ``type`` attribute unchanged,

--- a/peps/pep-0749.rst
+++ b/peps/pep-0749.rst
@@ -498,7 +498,7 @@ These attributes are read-only.
 Usually, users would use these attributes in combinations with
 ``annotationlib.call_evaluate_function``. For example, to get a ``TypeVar``'s bound
 in SOURCE format, one could write
-``annotationlib.call_evaluate_function(T.evaluate_bound, annotations.Format.SOURCE)``.
+``annotationlib.call_evaluate_function(T.evaluate_bound, annotationlib.Format.SOURCE)``.
 
 Miscellaneous implementation details
 ====================================
@@ -670,7 +670,7 @@ Accessing ``.type`` might throw an error:
     File "<python-input-4>", line 1, in <module>
       field.type
     File ".../dataclasses.py", line 308, in type
-      annos = self._annotate(annotations.Format.VALUE)
+      annos = self._annotate(annotationlib.Format.VALUE)
     File "<python-input-2>", line 3, in __annotate__
       x: undefined
         ^^^^^^^^^
@@ -680,9 +680,9 @@ But users could use ``annotationlib.call_evaluate_function`` to get the type in 
 
 .. code:: pycon
 
-  >>> annotationlib.call_evaluate_function(field.evaluate_type, annotations.Format.SOURCE)
+  >>> annotationlib.call_evaluate_function(field.evaluate_type, annotationlib.Format.SOURCE)
   'undefined'
-  >>> annotationlib.call_evaluate_function(field.evaluate_type, annotations.Format.FORWARDREF)
+  >>> annotationlib.call_evaluate_function(field.evaluate_type, annotationlib.Format.FORWARDREF)
   ForwardRef('undefined')
 
 Other variations are possible. For example, we could leave the ``type`` attribute unchanged,
@@ -723,7 +723,7 @@ code execution even with no access to any globals or builtins. For example:
 
   >>> def f(x: (1).__class__.__base__.__subclasses__()[-1].__init__.__builtins__["print"]("Hello world")): pass
   ... 
-  >>> annotations.get_annotations(f, format=annotations.Format.SOURCE)
+  >>> annotationlib.get_annotations(f, format=annotationlib.Format.SOURCE)
   Hello world
   {'x': 'None'}
 


### PR DESCRIPTION
The name `annotationlib` is mentioned through, but the examples use `annotations` instead. This commit fixes that.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3833.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->