### PR TITLE
PEP 0592: typo "awhile ago" → "a while ago"

### DIFF
--- a/peps/pep-0592.rst
+++ b/peps/pep-0592.rst
@@ -90,7 +90,7 @@ Installers
 The desirable experience for users is that once a file is yanked, when
 a human being is currently trying to directly install a yanked file, that
 it fails as if that file had been deleted. However, when a human did that
-awhile ago, and now a computer is just continuing to mechanically follow
+a while ago, and now a computer is just continuing to mechanically follow
 the original order to install the now yanked file, then it acts as if it
 had not been yanked.
 


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [ ] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3844.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->