### PR TITLE
PEP 740: Mark as Provisional

### DIFF
--- a/peps/pep-0740.rst
+++ b/peps/pep-0740.rst
@@ -12,6 +12,7 @@ Topic: Packaging
 Created: 08-Jan-2024
 Post-History: `02-Jan-2024 <https://discuss.python.org/t/pre-pep-exposing-trusted-publisher-provenance-on-pypi/42337>`__,
               `29-Jan-2024 <https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498>`__
+Resolution: https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498/26
 
 Abstract
 ========

--- a/peps/pep-0740.rst
+++ b/peps/pep-0740.rst
@@ -14,6 +14,7 @@ Post-History: `02-Jan-2024 <https://discuss.python.org/t/pre-pep-exposing-truste
               `29-Jan-2024 <https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498>`__
 Resolution: https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498/26
 
+
 Abstract
 ========
 

--- a/peps/pep-0740.rst
+++ b/peps/pep-0740.rst
@@ -7,7 +7,7 @@ Sponsor: Donald Stufft <donald@stufft.io>
 PEP-Delegate: Donald Stufft <donald@stufft.io>
 Discussions-To: https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498
 Status: Provisional
-Type: Informational
+Type: Standards Track
 Topic: Packaging
 Created: 08-Jan-2024
 Post-History: `02-Jan-2024 <https://discuss.python.org/t/pre-pep-exposing-trusted-publisher-provenance-on-pypi/42337>`__,

--- a/peps/pep-0740.rst
+++ b/peps/pep-0740.rst
@@ -6,7 +6,7 @@ Author: William Woodruff <william@yossarian.net>,
 Sponsor: Donald Stufft <donald@stufft.io>
 PEP-Delegate: Donald Stufft <donald@stufft.io>
 Discussions-To: https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498
-Status: Draft
+Status: Provisional
 Type: Informational
 Topic: Packaging
 Created: 08-Jan-2024


### PR DESCRIPTION
~~Changing the status here to provisional, per the PyPA PEP policy: https://www.pypa.io/en/latest/specifications/#provisional-acceptance~~

I opened this prematurely last month, but reopening now that @dstufft has provisionally accepted: https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498/26

CC @dstufft 🙂 



<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3848.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->