### PR TITLE
PEP 744: Add link to slides and clarification about LLVM dependency

### DIFF
--- a/peps/pep-0744.rst
+++ b/peps/pep-0744.rst
@@ -1,6 +1,7 @@
 PEP: 744
 Title: JIT Compilation
-Author: Brandt Bucher <brandt@python.org>
+Author: Brandt Bucher <brandt@python.org>,
+        Savannah Ostrowski <savannahostrowski@gmail.com>,
 Discussions-To: https://discuss.python.org/t/pep-744-jit-compilation/50756
 Status: Draft
 Type: Informational
@@ -33,7 +34,8 @@ the following resources:
   JIT at the 2023 CPython Core Developer Sprint. It includes relevant
   background, a light technical introduction to the "copy-and-patch" technique
   used, and an open discussion of its design amongst the core developers
-  present.
+  present. Slides for this talk can be found on `GitHub 
+ <https://github.com/brandtbucher/brandtbucher/blob/master/2023/10/10/a_jit_compiler_for_cpython.pdf>`__.
 
 - The `open access paper <https://dl.acm.org/doi/10.1145/3485513>`__ originally
   describing copy-and-patch.
@@ -533,6 +535,12 @@ executable. These issues are no longer present in the current design.
 
 Dependencies
 ------------
+
+At the time of writing, the JIT has a build-time dependency on LLVM. LLVM
+is used to compile individual micro-op instructions into blobs of machine code,
+which are then linked together to form the JIT's templates. These templates are 
+used to build CPython itself. The JIT has no runtime dependency on LLVM and is 
+therefore not at all exposed as a dependency to end users.
 
 Building the JIT adds between 3 and 60 seconds to the build process, depending
 on platform. It is only rebuilt whenever the generated files become out-of-date,

--- a/peps/pep-0744.rst
+++ b/peps/pep-0744.rst
@@ -34,8 +34,7 @@ the following resources:
   JIT at the 2023 CPython Core Developer Sprint. It includes relevant
   background, a light technical introduction to the "copy-and-patch" technique
   used, and an open discussion of its design amongst the core developers
-  present. Slides for this talk can be found on `GitHub 
- <https://github.com/brandtbucher/brandtbucher/blob/master/2023/10/10/a_jit_compiler_for_cpython.pdf>`__.
+  present. Slides for this talk can be found on `GitHub <https://github.com/brandtbucher/brandtbucher/blob/master/2023/10/10/a_jit_compiler_for_cpython.pdf>`__.
 
 - The `open access paper <https://dl.acm.org/doi/10.1145/3485513>`__ originally
   describing copy-and-patch.


### PR DESCRIPTION
After going through the themes in the [discussion thread](https://discuss.python.org/t/pep-744-jit-compilation/50756), the biggest warranted update was to clarify the LLVM build time dependency. Some topics discussed go beyond the scope of the informational PEP (e.g., going more into how the inner workings of the JIT, details about tier 1 and 2 interpreters, existing/expired patents, comparison with PyPy) or are, in my opinion, sufficiently covered (e.g., copy-and-patch compilation) by linked content. 

I've also added a link to the slides for the first talk covering the JIT for easier reading. I found a few different versions on your GitHub @brandtbucher but chose to link the slides from when the talk was originally given. Let me know if you'd like to update the links to reflect the most recent talk and/or want to host the slides somewhere else.

I will keep this in draft to give folks a couple more days to reply to the thread in case there are other points they'd like to see clarified.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3850.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->