### PR TITLE
PEP 719: Update 3.13.0b3 release date

### DIFF
--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -45,10 +45,10 @@ Actual:
 - 3.13.0 beta 1: Wednesday, 2024-05-08
   (No new features beyond this point.)
 - 3.13.0 beta 2: Wednesday, 2024-06-05
+- 3.13.0 beta 3: Thursday, 2024-06-27
 
 Expected:
 
-- 3.13.0 beta 3: Tuesday, 2024-06-25
 - 3.13.0 beta 4: Tuesday, 2024-07-16
 - 3.13.0 candidate 1: Tuesday, 2024-07-30
 - 3.13.0 candidate 2: Tuesday, 2024-09-03


### PR DESCRIPTION
* https://discuss.python.org/t/python-3-13-0-beta-3-now-available/56847
* https://www.python.org/downloads/release/python-3130b3/

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3854.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->