### PR TITLE
Fix one small typo in PEP 694

### DIFF
--- a/peps/pep-0694.rst
+++ b/peps/pep-0694.rst
@@ -512,7 +512,7 @@ may have happened on this request.
 
 The ``errors`` key is an array of specific errors, each of which contains
 a ``source`` key, which is a string that indicates what the source of the
-error is, and a ``messasge`` key for that specific error.
+error is, and a ``message`` key for that specific error.
 
 The ``message`` and ``source`` strings do not have any specific meaning, and
 are intended for human interpretation to figure out what the underlying issue


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3859.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->