### PR TITLE
PEP 744: Additional updates from discussion thread

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -622,7 +622,7 @@ peps/pep-0740.rst  @dstufft
 peps/pep-0741.rst  @vstinner
 peps/pep-0742.rst  @JelleZijlstra
 peps/pep-0743.rst  @vstinner
-peps/pep-0744.rst  @brandtbucher
+peps/pep-0744.rst  @brandtbucher @savannahostrowski
 peps/pep-0745.rst  @hugovk
 peps/pep-0746.rst  @JelleZijlstra
 peps/pep-0749.rst  @JelleZijlstra

--- a/peps/pep-0744.rst
+++ b/peps/pep-0744.rst
@@ -504,7 +504,9 @@ Currently, the JIT is `about as fast as the existing specializing interpreter
 <https://github.com/faster-cpython/benchmarking-public/blob/main/configs.png>`__
 on most platforms. Improving this is obviously a top priority at this point,
 since providing a significant performance gain is the entire motivation for
-having a JIT at all.
+having a JIT at all. A number of proposed improvements are already underway, and
+this ongoing work is being tracked in `GH-115802
+<https://github.com/python/cpython/issues/115802>`
 
 Memory
 ------

--- a/peps/pep-0744.rst
+++ b/peps/pep-0744.rst
@@ -517,7 +517,7 @@ level), optimizations, like removing type checks, propagating constants and
 inlining functions, are considered when it can be proven that it is safe to do 
 so. At this level, there is also opportunity for reasoning across micro-ops and 
 identifying opportunities for replacing micro-ops with more efficient equivalents. 
-Examples of this include smaller optimization like skipping reference counting 
+Examples of this include smaller optimizations like skipping reference counting 
 for known immortal values, as well as larger optimizations like replacing global 
 loads with constants if it can be proven that they have not been modified. At a 
 lower-level (i.e. machine code stage), it's possible to optimize across micro-ops

--- a/peps/pep-0744.rst
+++ b/peps/pep-0744.rst
@@ -1,6 +1,7 @@
 PEP: 744
 Title: JIT Compilation
-Author: Brandt Bucher <brandt@python.org>
+Author: Brandt Bucher <brandt@python.org>,
+        Savannah Ostrowski <savannahostrowski@gmail.com>,
 Discussions-To: https://discuss.python.org/t/pep-744-jit-compilation/50756
 Status: Draft
 Type: Informational
@@ -33,7 +34,8 @@ the following resources:
   JIT at the 2023 CPython Core Developer Sprint. It includes relevant
   background, a light technical introduction to the "copy-and-patch" technique
   used, and an open discussion of its design amongst the core developers
-  present.
+  present. Slides for this talk can be found on `GitHub 
+ <https://github.com/brandtbucher/brandtbucher/blob/master/2023/10/10/a_jit_compiler_for_cpython.pdf>`__.
 
 - The `open access paper <https://dl.acm.org/doi/10.1145/3485513>`__ originally
   describing copy-and-patch.
@@ -533,6 +535,12 @@ executable. These issues are no longer present in the current design.
 
 Dependencies
 ------------
+
+At the time of writing, the JIT has a build-time dependency on LLVM. LLVM
+is used to compile individual micro-op instructions into blobs of machine code,
+which are then linked together to form the JIT's templates. These templates are 
+used to build CPython itself. The JIT has no runtime dependency on LLVM and is 
+therefore not at all exposed as a dependency to end users.
 
 Building the JIT adds between 3 and 60 seconds to the build process, depending
 on platform. It is only rebuilt whenever the generated files become out-of-date,

--- a/peps/pep-0744.rst
+++ b/peps/pep-0744.rst
@@ -134,8 +134,8 @@ and has no runtime dependencies. It supports a wide range of platforms (see the
 `Support`_ section below), and has comparatively low maintenance burden. In all,
 the current implementation is made up of about 900 lines of build-time Python
 code and 500 lines of runtime C code. The current approach is optimized for 
-runtime compilation and would likely not work well for ahead-of-time compilation.
- This is not a direction currently being explored or pursued.
+runtime compilation and would likely not work well for ahead-of-time compilation. 
+This is not a direction currently being explored or pursued.
 
 Specification
 =============

--- a/peps/pep-0744.rst
+++ b/peps/pep-0744.rst
@@ -133,12 +133,20 @@ Like the rest of the interpreter, the JIT compiler is generated at build time,
 and has no runtime dependencies. It supports a wide range of platforms (see the
 `Support`_ section below), and has comparatively low maintenance burden. In all,
 the current implementation is made up of about 900 lines of build-time Python
-code and 500 lines of runtime C code.
+code and 500 lines of runtime C code. The current approach is optimized for 
+runtime compilation and would likely not work well for ahead-of-time compilation.
+ This is not a direction currently being explored or pursued.
 
 Specification
 =============
 
-The JIT will become non-experimental once all of the following conditions are
+Before discussing the requirements that need to be met before the JIT can be
+considered non-experimental, it is important to clarify that it will always be
+possible to build CPython without the JIT. The JIT is currently not part of the
+default build configuration, and it is likely to remain that way for the 
+forseeable future (though official binaries may include it).
+
+That said, the JIT will become non-experimental once all of the following conditions are
 met:
 
 #. It provides a meaningful performance improvement for at least one popular
@@ -501,9 +509,22 @@ Currently, the JIT is `about as fast as the existing specializing interpreter
 <https://github.com/faster-cpython/benchmarking-public/blob/main/configs.png>`__
 on most platforms. Improving this is obviously a top priority at this point,
 since providing a significant performance gain is the entire motivation for
-having a JIT at all. A number of proposed improvements are already underway, and
-this ongoing work is being tracked in `GH-115802
-<https://github.com/python/cpython/issues/115802>`__.
+having a JIT at all.
+
+Presently, there are a both higher-level and lower-level optimizations being 
+explored which may improve overall speed. At a higher-level (i.e. at the Python 
+level), optimizations, like removing type checks, propagating constants and 
+inlining functions, are considered when it can be proven that it is safe to do 
+so. At this level, there is also opportunity for reasoning across micro-ops and 
+identifying opportunities for replacing micro-ops with more efficient equivalents. 
+Examples of this include smaller optimization like skipping reference counting 
+for known immortal values, as well as larger optimizations like replacing global 
+loads with constants if it can be proven that they have not been modified. At a 
+lower-level (i.e. machine code stage), it's possible to optimize across micro-ops
+when LLVM is building JIT stencils by creating "superinstructions" from common 
+sequences from common pairs or triples of micro-op instructions.
+
+Ongoing work is being tracked in `GH-115802 <https://github.com/python/cpython/issues/115802>`__.
 
 Memory
 ------
@@ -525,7 +546,12 @@ likely to be a real concern.
 Not much effort has been put into optimizing the JIT's memory usage yet, so
 these numbers likely represent a maximum that will be reduced over time.
 Improving this is a medium priority, and is being tracked in `GH-116017
-<https://github.com/python/cpython/issues/116017>`__.
+<https://github.com/python/cpython/issues/116017>`__. However, we are currently
+exploring how garbage collection of cold traces (i.e. traces that are no longer
+executed) could be implemented, which could reduce the JIT's memory usage. We may 
+also consider exposing configurable parameters for limiting memory consumption in the
+future. No official APIs will be exposed until the JIT meets the requirements to be
+considering non-experimental.
 
 Earlier versions of the JIT had a more complicated memory allocation scheme
 which imposed a number of fragile limitations on the size and layout of the

--- a/peps/pep-0744.rst
+++ b/peps/pep-0744.rst
@@ -99,10 +99,11 @@ physical hardware registers).
 
 Since much of this data varies even between identical runs of a program and the
 existing optimization pipeline makes heavy use of runtime profiling information,
-it doesn't make much sense to compile these traces ahead of time. As has been
-demonstrated for many other dynamic languages (`and even Python itself
-<https://www.pypy.org>`__), the most promising approach is to compile the
-optimized micro-ops "just in time" for execution.
+it doesn't make much sense to compile these traces ahead of time and would be a 
+substantial redesign of the existing specification and micro-op tracing infrastructure 
+that has already been implemented. As has been demonstrated for many other dynamic 
+languages (`and even Python itself <https://www.pypy.org>`__), the most promising 
+approach is to compile the optimized micro-ops "just in time" for execution.
 
 Rationale
 =========
@@ -133,21 +134,15 @@ Like the rest of the interpreter, the JIT compiler is generated at build time,
 and has no runtime dependencies. It supports a wide range of platforms (see the
 `Support`_ section below), and has comparatively low maintenance burden. In all,
 the current implementation is made up of about 900 lines of build-time Python
-code and 500 lines of runtime C code. The current approach is optimized for 
-runtime compilation and would likely not work well for ahead-of-time compilation. 
-This is not a direction currently being explored or pursued.
+code and 500 lines of runtime C code.
 
 Specification
 =============
 
-Before discussing the requirements that need to be met before the JIT can be
-considered non-experimental, it is important to clarify that it will always be
-possible to build CPython without the JIT. The JIT is currently not part of the
-default build configuration, and it is likely to remain that way for the 
-foreseeable future (though official binaries may include it).
-
-That said, the JIT will become non-experimental once all of the following conditions are
-met:
+The JIT is currently not part of the default build configuration, and it is 
+likely to remain that way for the foreseeable future (though official binaries 
+may include it). That said, the JIT will become non-experimental once all of 
+the following conditions are met:
 
 #. It provides a meaningful performance improvement for at least one popular
    platform (realistically, on the order of 5%).
@@ -511,21 +506,6 @@ on most platforms. Improving this is obviously a top priority at this point,
 since providing a significant performance gain is the entire motivation for
 having a JIT at all.
 
-Presently, there are a both higher-level and lower-level optimizations being 
-explored which may improve overall speed. At a higher-level (i.e. at the Python 
-level), optimizations, like removing type checks, propagating constants and 
-inlining functions, are considered when it can be proven that it is safe to do 
-so. At this level, there is also opportunity for reasoning across micro-ops and 
-identifying opportunities for replacing micro-ops with more efficient equivalents. 
-Examples of this include smaller optimizations like skipping reference counting 
-for known immortal values, as well as larger optimizations like replacing global 
-loads with constants if it can be proven that they have not been modified. At a 
-lower-level (i.e. machine code stage), it's possible to optimize across micro-ops
-when LLVM is building JIT stencils by creating "superinstructions" from common 
-sequences from common pairs or triples of micro-op instructions.
-
-Ongoing work is being tracked in `GH-115802 <https://github.com/python/cpython/issues/115802>`__.
-
 Memory
 ------
 
@@ -546,12 +526,10 @@ likely to be a real concern.
 Not much effort has been put into optimizing the JIT's memory usage yet, so
 these numbers likely represent a maximum that will be reduced over time.
 Improving this is a medium priority, and is being tracked in `GH-116017
-<https://github.com/python/cpython/issues/116017>`__. However, we are currently
-exploring how garbage collection of cold traces (i.e. traces that are no longer
-executed) could be implemented, which could reduce the JIT's memory usage. We may 
-also consider exposing configurable parameters for limiting memory consumption in the
-future. No official APIs will be exposed until the JIT meets the requirements to be
-considering non-experimental.
+<https://github.com/python/cpython/issues/116017>`__. We may consider 
+exposing configurable parameters for limiting memory consumption in the
+future, but no official APIs will be exposed until the JIT meets the 
+requirements to be considered non-experimental.
 
 Earlier versions of the JIT had a more complicated memory allocation scheme
 which imposed a number of fragile limitations on the size and layout of the

--- a/peps/pep-0744.rst
+++ b/peps/pep-0744.rst
@@ -34,8 +34,7 @@ the following resources:
   JIT at the 2023 CPython Core Developer Sprint. It includes relevant
   background, a light technical introduction to the "copy-and-patch" technique
   used, and an open discussion of its design amongst the core developers
-  present. Slides for this talk can be found on `GitHub 
- <https://github.com/brandtbucher/brandtbucher/blob/master/2023/10/10/a_jit_compiler_for_cpython.pdf>`__.
+  present. Slides for this talk can be found on `GitHub <https://github.com/brandtbucher/brandtbucher/blob/master/2023/10/10/a_jit_compiler_for_cpython.pdf>`__.
 
 - The `open access paper <https://dl.acm.org/doi/10.1145/3485513>`__ originally
   describing copy-and-patch.

--- a/peps/pep-0744.rst
+++ b/peps/pep-0744.rst
@@ -506,7 +506,7 @@ on most platforms. Improving this is obviously a top priority at this point,
 since providing a significant performance gain is the entire motivation for
 having a JIT at all. A number of proposed improvements are already underway, and
 this ongoing work is being tracked in `GH-115802
-<https://github.com/python/cpython/issues/115802>`
+<https://github.com/python/cpython/issues/115802>`__.
 
 Memory
 ------

--- a/peps/pep-0744.rst
+++ b/peps/pep-0744.rst
@@ -144,7 +144,7 @@ Before discussing the requirements that need to be met before the JIT can be
 considered non-experimental, it is important to clarify that it will always be
 possible to build CPython without the JIT. The JIT is currently not part of the
 default build configuration, and it is likely to remain that way for the 
-forseeable future (though official binaries may include it).
+foreseeable future (though official binaries may include it).
 
 That said, the JIT will become non-experimental once all of the following conditions are
 met:


### PR DESCRIPTION
This PR addresses some additional comments from https://github.com/python/peps/pull/3850#pullrequestreview-2157965764. I've chosen to address the comment around the JIT environment variable in the JIT's README (see https://github.com/python/cpython/pull/121635) since I think that's maybe valuable to contributors and that file is linked from the PEP.

I've also added myself to CODEOWNERS for this file.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3861.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->