### PR TITLE
PEP 7: Public C API should be compatible with C99

### DIFF
--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -31,7 +31,8 @@ C dialect
 
 * Python 3.11 and newer versions use C11 without `optional features
   <https://en.wikipedia.org/wiki/C11_%28C_standard_revision%29#Optional_features>`_.
-  The public C API should be compatible with C++.
+
+* The public C API should be compatible with C99 and with C++03.
 
 * Python 3.6 to 3.10 use C89 with several select C99 features:
 

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -34,6 +34,10 @@ C dialect
 
 * The public C API should be compatible with C99 and with C++03.
 
+  The existing API does use a few C11 features which are
+  commonly available as compiler extensions to C99.
+  New API should not use these features.
+
 * Python 3.6 to 3.10 use C89 with several select C99 features:
 
   - Standard integer types in ``<stdint.h>`` and ``<inttypes.h>``. We


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3862.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->