### PR TITLE
PEP 101: Remove outdated info and add new info

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,7 +50,7 @@ peps/pep-0020.rst  @tim-one
 peps/pep-0042.rst  @jeremyhylton
 # ...
 peps/pep-0100.rst  @malemburg
-peps/pep-0101.rst  @Yhg1s @pablogsal @ambv @ned-deily
+peps/pep-0101.rst  @hugovk @Yhg1s @pablogsal @ambv @ned-deily
 peps/pep-0102.rst  @warsaw @gvanrossum
 # peps/pep-0103.rst
 # ...

--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -385,8 +385,8 @@ to perform some manual editing steps.
   to your home directory on ``downloads.nyc1.psf.io``.
 
   While you're waiting for the files to finish uploading, you can continue
-  on with the remaining tasks.  You can also ask folks on #python-dev
-  and/or python-committers to download the files as they finish uploading
+  on with the remaining tasks.  You can also ask folks on Discord
+  and/or `discuss.python.org`_ to download the files as they finish uploading
   so that they can test them on their platforms as well.
 
 - Now you need to go to ``downloads.nyc1.psf.io`` and move all the files in place

--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -77,6 +77,9 @@ Here's a hopefully-complete list.
   account, or a redirecting alias + SMTP credentials to send email from
   this address that looks legit to major email providers.
 
+* Be added to the `Python Security Response Team
+  <https://www.python.org/dev/security/>`__.
+
 Types of Releases
 =================
 

--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -50,9 +50,6 @@ Here's a hopefully-complete list.
     `Misc/NEWS <https://github.com/python/cpython/tree/main/Misc/NEWS.d>`_
     management tool. You can pip install it.
 
-  * A fairly complete installation of a recent TeX distribution,
-    such as texlive.  You need that for building the PDF docs.
-
 * Access to servers where you will upload files:
 
   * ``downloads.nyc1.psf.io``, the server that hosts download files; and
@@ -624,8 +621,7 @@ Now it's time to twiddle the website.  Almost none of this is automated, sorry.
 
 To do these steps, you must have the permission to edit the website.  If you
 don't have that, ask someone on pydotorg@python.org for the proper
-permissions.  (Or ask Ewa, who coordinated the effort for the new website
-with RevSys.)
+permissions.
 
 - Log in to https://www.python.org/admin
 

--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -121,6 +121,7 @@ release.  The roles and their current experts are:
 
 * RM = Release Manager
 
+  - Hugo van Kemenade <hugo@python.org> (FI)
   - Thomas Wouters <thomas@python.org> (NL)
   - Pablo Galindo Salgado <pablogsal@python.org> (UK)
   - Łukasz Langa <lukasz@python.org> (PL)

--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -328,7 +328,7 @@ to perform some manual editing steps.
   If you're feeling lucky and have some time to kill, or if you are making
   a release candidate or **final** release, run the full test suite::
 
-    make testall
+    make buildbottest
 
   If the tests pass, then you can feel good that the tarball is
   fine.  If some of the tests fail, or anything else about the


### PR DESCRIPTION
* A Tex installation is no longer needed, the docs are built on CI: https://github.com/python/release-tools/actions/workflows/source-and-docs-release.yml
* Remove old note about asking Ewa for website access
* Note new RMs should be added to PSRT
* Add me to list of RMs
* The `make testall` command is now `make buildbottest`: https://github.com/python/cpython/pull/110122
* Replace MLs with Discord/Discourse