### PR TITLE
PEP 639: Incorporate the latest discussion feedback

### DIFF
--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -451,21 +451,17 @@ in the ``Classifier`` :term:`Core Metadata field`
 (`described in the Core Metadata specification <coremetadataclassifiers_>`__)
 is deprecated and replaced by the more precise ``License-Expression`` field.
 
-If the ``License-Expression`` field is present, build tools SHOULD and
-publishing tools MUST raise an error if one or more license classifiers
+If the ``License-Expression`` field is present, build tools MAY raise an error
+if one or more license classifiers
 is included in a ``Classifier`` field, and MUST NOT add
 such classifiers themselves.
 
-Otherwise, if this field contains a license classifier, build tools MAY
-and publishing tools SHOULD issue a warning informing users such classifiers
+Otherwise, if this field contains a license classifier,
+tools MAY issue a warning informing users such classifiers
 are deprecated, and recommending ``License-Expression`` instead.
 For compatibility with existing publishing and installation processes,
 the presence of license classifiers SHOULD NOT raise an error unless
 ``License-Expression`` is also provided.
-
-For all newly-uploaded distributions that include a
-``License-Expression`` field, the `Python Package Index (PyPI) <pypi_>`__ MUST
-reject any that also specify any license classifiers.
 
 New license classifiers MUST NOT be `added to PyPI <classifiersrepo_>`__;
 users needing them SHOULD use the ``License-Expression`` field instead.

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -574,23 +574,6 @@ If the ``license-files`` key is present, and the ``paths`` or ``globs`` subkey
 is set to a value of an empty array, then tools MUST NOT include any
 license files and MUST NOT raise an error.
 
-.. _639-default-patterns:
-
-If the ``license-files`` key is not present and not explicitly marked as
-``dynamic``, tools MUST assume a default value of the following:
-
-.. code-block:: toml
-
-    license-files.globs = ["LICEN[CS]E*", "COPYING*", "NOTICE*", "AUTHORS*"]
-
-In this case, tools MAY issue a warning if no license files are matched,
-but MUST NOT raise an error.
-
-If the ``license-files`` key is marked as ``dynamic`` (and not present),
-to preserve consistent behavior with current tools and help ensure the packages
-they create are legally distributable, build tools SHOULD default to
-including at least the license files matching the above patterns, unless the
-user has explicitly specified their own.
 
 Examples of valid license files declaration:
 
@@ -662,11 +645,6 @@ in the core metadata, and MUST include the specified file
 as if it were specified in a ``license-file.paths`` field.
 If the file does not exist at the specified path,
 tools MUST raise an informative error as previously specified.
-However, tools MUST also still assume the
-:ref:`specified default value <639-default-patterns>`
-for the ``license-files`` key and also include,
-in addition to a license file specified under the ``license.file`` subkey,
-any license files that match the specified list of patterns.
 
 Table values for the ``license`` key MAY be removed
 from a new version of the specification in a future PEP.

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -520,87 +520,62 @@ paths in the project source tree relative to ``pyproject.toml`` to file(s)
 containing licenses and other legal notices to be distributed with the package.
 It corresponds to the ``License-File`` fields in the Core Metadata.
 
-Its value is a table, which if present MUST contain one of two optional,
-mutually exclusive subkeys, ``paths`` and ``globs``; if both are specified,
-tools MUST raise an error. Both are arrays of strings; the ``paths`` subkey
-contains verbatim file paths, and the ``globs`` subkey valid glob patterns,
-which MUST be parsable by the ``glob`` `module <globmodule_>`__ in the
-Python standard library.
-
+Its value is an array of strings which MUST contain valid glob patterns,
+as specified below.
+The glob patterns MAY contain special glob characters: ``*``, ``?``, ``**``
+and character ranges: ``[]``, and tools MUST support them.
 Path delimiters MUST be the forward slash character (``/``),
 and parent directory indicators (``..``) MUST NOT be used.
 Tools MUST assume that license file content is valid UTF-8 encoded text,
 and SHOULD validate this and raise an error if it is not.
 
-If the ``paths`` subkey is a non-empty array, build tools:
+Literal paths (e.g. ``LICENSE``) are treated as valid globs which means they
+can also be defined.
 
-- MUST treat each value as a verbatim, literal file path, and
-  MUST NOT treat them as glob patterns.
+To achieve better portability, the filenames to match should only contain
+the alphanumeric characters, underscores (``_``), hyphens (``-``)
+and dots (``.`` - for extensions).
 
-- MUST include each listed file in all distribution archives.
-
-- MUST NOT match any additional license files beyond those explicitly
-  statically specified by the user under the ``paths`` subkey.
-
-- MUST list each file path under a ``License-File`` field in the Core Metadata.
-
-- MUST raise an error if one or more paths do not correspond to a valid file
-  in the project source that can be copied into the distribution archive.
-
-If the ``globs`` subkey is a non-empty array, build tools:
+Build tools:
 
 - MUST treat each value as a glob pattern, and MUST raise an error if the
   pattern contains invalid glob syntax.
 
-- MUST include all files matched by at least one listed pattern in all
+- MUST include all files matched by a listed pattern in all
   distribution archives.
-
-- MAY exclude files matched by glob patterns that can be unambiguously
-  determined to be backup, temporary, hidden, OS-generated or VCS-ignored.
 
 - MUST list each matched file path under a ``License-File`` field in the
   Core Metadata.
 
-- SHOULD issue a warning and MAY raise an error if no files are matched.
-
-- MAY issue a warning if any individual user-specified pattern
+- MUST raise an error if any individual user-specified pattern
   does not match at least one file.
 
-If the ``license-files`` key is present, and the ``paths`` or ``globs`` subkey
+If the ``license-files`` key is present and
 is set to a value of an empty array, then tools MUST NOT include any
 license files and MUST NOT raise an error.
-
 
 Examples of valid license files declaration:
 
 .. code-block:: toml
 
     [project]
-    license-files = { globs = ["LICEN[CS]E*", "AUTHORS*"] }
+    license-files = ["LICEN[CS]E*", "AUTHORS*"]
 
     [project]
-    license-files.paths = ["licenses/LICENSE.MIT", "licenses/LICENSE.CC0"]
+    license-files = ["licenses/LICENSE.MIT", "licenses/LICENSE.CC0"]
 
     [project]
-    license-files = { paths = [] }
+    license-files = ["LICENSE.txt", "licenses/*"]
 
     [project]
-    license-files.globs = []
+    license-files = []
 
 Examples of invalid license files declaration:
 
 .. code-block:: toml
 
     [project]
-    license-files.globs = ["LICEN[CS]E*", "AUTHORS*"]
-    license-files.paths = ["LICENSE.MIT"]
-
-Reason: license-files.paths and license-files.globs are mutually exclusive.
-
-.. code-block:: toml
-
-    [project]
-    license-files = { paths = ["..\LICENSE.MIT"] }
+    license-files = ["..\LICENSE.MIT"]
 
 Reason: ``..`` must not be used.
 ``\`` is an invalid path delimiter, ``/`` must be used.
@@ -609,7 +584,7 @@ Reason: ``..`` must not be used.
 .. code-block:: toml
 
     [project]
-    license-files = { globs = ["LICEN{CSE*"] }
+    license-files = ["LICEN{CSE*"]
 
 Reason: "LICEN{CSE*" is not a valid glob.
 
@@ -638,7 +613,7 @@ the ``license-files`` key instead.
 If the specified license ``file`` is present in the source tree,
 build tools SHOULD use it to fill the ``License-File`` field
 in the core metadata, and MUST include the specified file
-as if it were specified in a ``license-file.paths`` field.
+as if it were specified in a ``license-file`` field.
 If the file does not exist at the specified path,
 tools MUST raise an informative error as previously specified.
 
@@ -725,9 +700,9 @@ and license classifiers retain backwards compatibility. A removal is
 left to a future PEP and a new version of the Core Metadata specification.
 
 Specification of the new ``License-File`` Core Metadata field and adding the
-files in the distribution codifies the existing practices of many packaging
-tools. It is designed to be largely backwards-compatible with their existing
-use of that field. The new ``license-files`` key in the ``[project]`` table of
+files in the distribution is designed to be largely backwards-compatible with
+the existing use of that field in many packaging tools.
+The new ``license-files`` key in the ``[project]`` table of
 ``pyproject.toml`` will only have an effect once users and tools adopt it.
 
 This PEP specifies that license files should be placed in a dedicated
@@ -781,7 +756,8 @@ If an invalid ``License-Expression`` is used, the users will not be able
 to publish their package to PyPI and an error message will help them
 understand they need to use SPDX identifiers.
 It will be possible to generate a distribution with incorrect license metadata,
-but not to publish one on PyPI or any other index server that enforces ``License-Expression`` validity.
+but not to publish one on PyPI or any other index server that enforces
+``License-Expression`` validity.
 For authors using the now-deprecated ``License`` field or license classifiers,
 packaging tools may warn them and inform them of the replacement,
 ``License-Expression``.

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -534,7 +534,7 @@ can also be defined.
 
 To achieve better portability, the filenames to match should only contain
 the alphanumeric characters, underscores (``_``), hyphens (``-``)
-and dots (``.`` - for extensions).
+and dots (``.``).
 
 Build tools:
 

--- a/peps/pep-0639/appendix-examples.rst
+++ b/peps/pep-0639/appendix-examples.rst
@@ -127,29 +127,30 @@ Putting it all together, our ``setup.cfg`` would be:
         setuptools/_vendor/packaging/LICENSE.APACHE
         setuptools/_vendor/packaging/LICENSE.BSD
 
-In the ``[project]`` table of ``pyproject.toml``, with license files
-specified explicitly via the ``paths`` subkey, this would look like:
+In the ``[project]`` table of ``pyproject.toml``, license files
+can be specified via glob patterns:
 
 .. code-block:: toml
 
     [project]
     license = "MIT AND (Apache-2.0 OR BSD-2-Clause)"
-    license-files.paths = [
+    license-files = [
+        "LICENSE*",
+        "setuptools/_vendor/LICENSE*",
+    ]
+
+Or alternatively, they can be specified explicitly (paths will be interpreted
+as glob patterns):
+
+.. code-block:: toml
+
+    [project]
+    license = "MIT AND (Apache-2.0 OR BSD-2-Clause)"
+    license-files = [
         "LICENSE",
         "setuptools/_vendor/LICENSE",
         "setuptools/_vendor/LICENSE.APACHE",
         "setuptools/_vendor/LICENSE.BSD",
-    ]
-
-Or alternatively, matched via glob patterns, this could be:
-
-.. code-block:: toml
-
-    [project]
-    license = "MIT AND (Apache-2.0 OR BSD-2-Clause)"
-    license-files.globs = [
-        "LICENSE*",
-        "setuptools/_vendor/LICENSE*",
     ]
 
 With either approach, the output Core Metadata in the distribution
@@ -211,6 +212,7 @@ Some additional examples of valid ``License-Expression`` values:
     License-Expression: GPL-3.0-only WITH Classpath-Exception-2.0 OR BSD-3-Clause
     License-Expression: LicenseRef-Public-Domain OR CC0-1.0 OR Unlicense
     License-Expression: LicenseRef-Proprietary
+    License-Expression: LicenseRef-Custom-License
 
 
 .. _packaginglicense: https://github.com/pypa/packaging/blob/21.2/LICENSE

--- a/peps/pep-0639/appendix-rejected-ideas.rst
+++ b/peps/pep-0639/appendix-rejected-ideas.rst
@@ -149,66 +149,23 @@ Alternative possibilities related to the ``license`` key in the
 ``pyproject.toml`` project source metadata.
 
 
-Add ``expression`` and ``files`` subkeys to table
-'''''''''''''''''''''''''''''''''''''''''''''''''
+Add new subkeys to table
+''''''''''''''''''''''''
 
-A previous draft of PEP 639 added ``expression`` and ``files`` subkeys
-to the existing ``license`` table in the project source metadata, to parallel
-the existing ``file`` and ``text`` subkeys. While this seemed the
-most obvious approach at first glance, it had serious drawbacks
-relative to that ultimately taken here.
+There were proposals to add various subkeys to the table.
+Combining different types of metadata which require different handling,
+adding new guidance regarding the subkeys mutual exclusivity and
+the possibility to define some of them as dynamic would make the
+transition harder and create more confusion rather than clarity for the users.
+This approach has been rejected in favour of more flat ``pyproject.toml``
+design, clear mapping between ``pyproject.toml`` keys and Core Metadata fields,
+and increased readability of the separate keys.
 
-This means two very different types of metadata are being
-specified under the same top-level key that require very different handling,
-and unlike the previous arrangement, the subkeys were not mutually
-exclusive and could both be specified at once, with some subkeys potentially
-being dynamic and others static, and mapping to different Core Metadata fields.
+Rejected proposals:
 
-There are further downsides to this as well. Both users and tools would need to
-keep track of which fields are mutually exclusive with which of the others,
-greatly increasing complexity, and the probability
-of errors. Having so many different fields under the
-same key leads to a much more complex mapping between
-``[project]`` keys and Core Metadata fields, not in keeping with :pep:`621`.
-This causes the ``[project]`` table naming and structure to diverge further
-from both the Core Metadata and native formats of the various popular packaging
-tools that use it. Finally, this results in the spec being significantly more
-complex to understand and implement than the alternatives.
-
-The approach PEP 639 now takes, using the reserved top-level string value
-of the ``license`` key, adding a new ``license-files`` key
-and deprecating the ``license`` table subkeys (``text`` and ``file``),
-avoids most of the issues identified above,
-and results in a much clearer and cleaner design overall.
-It allows ``license`` and ``license-files`` to be tagged
-``dynamic`` independently, separates two independent types of metadata
-(syntactically and semantically), restores a closer to 1:1 mapping of
-``[project]`` table keys to Core Metadata fields,
-and reduces nesting by a level for both.
-Other than adding one extra key to the file, there was no significant
-apparent downside to this latter approach, so it was adopted for PEP 639.
-
-
-Add an ``expression`` subkey instead of a string value
-''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Adding just an ``expression`` subkey to the ``license`` table,
-instead of using the top-level string value,
-would be more explicit for readers and writers,
-in line with PEP 639's goals.
-However, it still has the downsides listed above
-that are not specific to the inclusion of the ``files`` key.
-
-Relative to a flat string value,
-it adds complexity and an extra level of nesting,
-and requires users and tools to remember and handle
-the mutual exclusivity of the subkeys
-and remember which are deprecated,
-instead of cleanly deprecating the table subkeys as a whole.
-Furthermore, it is less clearly the "default" choice for modern use,
-given users tend to gravitate toward the most obvious option.
-Finally, it seems reasonable to follow the suggested guidance in :pep:`621`,
-given the top-level string value was specifically reserved for this purpose.
+- add ``expression`` and ``files`` subkeys to table
+- add an ``expression`` subkey instead of a string value
+- add a ``type`` key to treat ``text`` as expression
 
 
 Define a new top-level ``license-expression`` key
@@ -265,39 +222,6 @@ so there is little practical need to distinguish which is dynamic.
 
 Therefore, a top-level string value for ``license`` was adopted for PEP 639,
 as an earlier working draft had temporarily specified.
-
-
-Add a ``type`` key to treat ``text`` as expression
-''''''''''''''''''''''''''''''''''''''''''''''''''
-
-Instead of using the reserved top-level string value
-of the ``license`` key in the ``[project]`` table,
-one could add a ``type`` subkey to the ``license`` table
-to control whether ``text`` (or a string value)
-is interpreted as free-text or a license expression. This could make
-backward compatibility a bit easier, as older tools could ignore
-it and always treat ``text`` as ``license``, while newer tools would
-know to treat it as a license expression, if ``type`` was set appropriately.
-Indeed, :pep:`621` seems to suggest something of this sort as a possible
-way that SPDX license expressions could be implemented.
-
-However, it has got all the same downsides as in the previous item,
-including greater complexity, a more complex mapping between the project
-source metadata and Core Metadata and inconsistency between the presentation
-in tool config, project source metadata and Core Metadata,
-a harder deprecation, further bikeshedding over what to name it,
-and inability to mark one but not the other as dynamic, among others.
-
-In addition, while theoretically a little easier in the short
-term, in the long term it would mean users would always have to remember
-to specify the correct ``type`` to ensure their license expression is
-interpreted correctly, which adds work and potential for error; we could
-never safely change the default while being confident that users
-understand that what they are entering is unambiguously a license expression,
-with all the false positive and false negative issues as above.
-
-Therefore, for these reasons, we reject this here in favor of
-the reserved string value of the ``license`` key.
 
 
 Source metadata ``license-files`` key

--- a/peps/pep-0639/appendix-rejected-ideas.rst
+++ b/peps/pep-0639/appendix-rejected-ideas.rst
@@ -476,6 +476,22 @@ the preferred subkey when it was not, and didn't describe the format of the
 string entry similarly to the existing ``globs``.
 
 
+Use a default value for ``license-files`` if not specified
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+A previous draft of the PEP proposed a default value for detecting
+license files in case the users have not declared any and not marked the key
+as dynamic.
+That value was defined as an array of globs:
+``["LICEN[CS]E*", "COPYING*", "NOTICE*", "AUTHORS*"]``
+
+However, this would create an exception among the existing metadata,
+as no other key has got implicit defaults defined. Implicit values in
+pyproject.toml keys are delegated to the ``dynamic`` field,
+which is specified as being calculated. Also, the values were chosen
+arbitrarily, without a strong justification why they should pose a standard.
+
+
 Must be marked dynamic to use defaults
 ''''''''''''''''''''''''''''''''''''''
 


### PR DESCRIPTION
Included changes:
- remove the default glob values expected from build tools to match license-files (build backends can still define them if they wish, the standard just doesn't make any recommendation about them)
- change the error policy around deprecated license classifiers - tools MAY -- not MUST -- raise an error if they encounter them
- flatten the value of `license-files` key - expect glob patterns, specify the glob characters supported
- rework Rejected ideas to reflect the above changes, ideally reducing them in size during the process

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3866.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->