### PR TITLE
PEP 635: Minor typo fix in code sample.

### DIFF
--- a/peps/pep-0635.rst
+++ b/peps/pep-0635.rst
@@ -1118,7 +1118,7 @@ be emulated by a user-defined class as follows::
 The proposal was to combine patterns with type annotations::
 
   match x:
-      case [a: int, b: str]: print(f"An int {a} and a string {b}:)
+      case [a: int, b: str]: print(f"An int {a} and a string {b}:")
       case [a: int, b: int, c: int]: print("Three ints", a, b, c)
       ...
 


### PR DESCRIPTION
Looks like an unclosed f-string.


* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3871.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->