### PR TITLE
PEP 751: Add Discussions-To and Post-History

### DIFF
--- a/peps/pep-0751.rst
+++ b/peps/pep-0751.rst
@@ -1,10 +1,12 @@
 PEP: 751
 Title: A file format to list Python dependencies for installation reproducibility
 Author: Brett Cannon <brett@python.org>
+Discussions-To: https://discuss.python.org/t/59173
 Status: Draft
 Type: Standards Track
 Topic: Packaging
 Created: 24-Jul-2024
+Post-History: `25-Jul-2024 <https://discuss.python.org/t/59173>`__
 Replaces: 665
 
 ========
@@ -92,8 +94,8 @@ Per-file Locking
 ================
 
 *Per-file locking* operates under the premise that one wants to install exactly
-the same files in any matching environment. As such, the lock file specifies the
-with the files to install. There can be multiple environments specified in a
+the same files in any matching environment. As such, the lock file specifies
+what files to install. There can be multiple environments specified in a
 single file, each with their own set of files to install. By specifying the
 exact files to install, installers avoid performing any resolution to decide what
 to install.


### PR DESCRIPTION
<!--
You can use the following checklist when double-checking your PEP,
and you can help complete some of it yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about anything, just leave it blank and we'll take a look.

If your PEP is not Standards Track, remove the corresponding section.
-->

## Basic requirements (all PEP Types)

* [x] Read and followed [PEP 1](https://peps.python.org/1) & [PEP 12](https://peps.python.org/12)
* [x] File created from the [latest PEP template](https://github.com/python/peps/blob/main/peps/pep-0012/pep-NNNN.rst?plain=1)
* [x] PEP has next available number, & set in filename (``pep-NNNN.rst``), PR title (``PEP 123: <Title of PEP>``) and ``PEP`` header
* [x] Title clearly, accurately and concisely describes the content in 79 characters or less
* [x] Core dev/PEP editor listed as ``Author`` or ``Sponsor``, and formally confirmed their approval
* [x] ``Author``, ``Status`` (``Draft``), ``Type`` and ``Created`` headers filled out correctly
* [x] ``PEP-Delegate``, ``Topic``, ``Requires`` and ``Replaces`` headers completed if appropriate
* [x] Required sections included
    * [x] Abstract (first section)
    * [x] Copyright (last section; exact wording from template required)
* [x] Code is well-formatted (PEP 7/PEP 8) and is in [code blocks, with the right lexer names](https://peps.python.org/pep-0012/#literal-blocks) if non-Python
* [x] PEP builds with no warnings, pre-commit checks pass and content displays as intended in the rendered HTML
* [x] Authors/sponsor added to ``.github/CODEOWNERS`` for the PEP


## Standards Track requirements

* [x] PEP topic [discussed in a suitable venue](https://peps.python.org/pep-0001/#start-with-an-idea-for-python) with general agreement that a PEP is appropriate
* [x] [Suggested sections](https://peps.python.org/pep-0012/#suggested-sections) included (unless not applicable)
    * [ ] Motivation
    * [ ] Rationale
    * [ ] Specification
    * [ ] Backwards Compatibility
    * [ ] Security Implications
    * [ ] How to Teach This
    * [ ] Reference Implementation
    * [ ] Rejected Ideas
    * [ ] Open Issues
* [x] ``Python-Version`` set to valid (pre-beta) future Python version, if relevant
* [x] Any project stated in the PEP as supporting/endorsing/benefiting from the PEP formally confirmed such
* [x] Right before or after initial merging, [PEP discussion thread](https://peps.python.org/pep-0001/#discussing-a-pep) created and linked to in ``Discussions-To`` and ``Post-History``


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3872.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->