### PR TITLE
PEP 747: Rephrase rules for | operator. Remove ability to assign TypeExpr[X | Y | ...] to UnionType.

### DIFF
--- a/peps/pep-0747.rst
+++ b/peps/pep-0747.rst
@@ -444,19 +444,17 @@ so must be disambiguated based on its argument type:
 the value ``int1 | int2``, ``set1 | set2``, ``dict1 | dict2``, and more,
 so must be disambiguated based on its argument types:
 
--  As a value expression, ``x | y`` has type equal to the return type of ``type(x).__or__``
-   if ``type(x)`` overrides the ``__or__`` method.
+-  As a value expression, ``x | y`` was given type ``UnionType`` in certain situations
+   before this PEP existed. In those situations ``x | y`` is now given type
+   ``TypeExpr[x | y]``.
+   
+   -  For example the value expression ``int | str`` had type ``UnionType``
+      before this PEP but has type ``TypeExpr[int | str]`` after this PEP.
 
-   -  When ``x`` has type ``builtins.type``, ``types.GenericAlias``, or the
-      internal type of a typing special form, ``type(x).__or__`` has a return type
-      in the format ``TypeExpr[T1 | T2]``.
-
--  As a value expression, ``x | y`` has type equal to the return type of ``type(y).__ror__``
-   if ``type(y)`` overrides the ``__ror__`` method.
-
-   -  When ``y`` has type ``builtins.type``, ``types.GenericAlias``, or the
-      internal type of a typing special form, ``type(y).__ror__`` has a return type
-      in the format ``TypeExpr[T1 | T2]``.
+-  In all other situations, ``x | y`` continues to be given the same type as
+   before this PEP existed.
+   
+   -  For example the value expression ``2 | 5`` continues to have type ``int``.
 
 The **stringified type expression** ``"T"`` is ambiguous with both
 the stringified annotation expression ``"T"``

--- a/peps/pep-0747.rst
+++ b/peps/pep-0747.rst
@@ -760,10 +760,16 @@ spell simple **class objects** like ``int``, ``str``, ``list``, or ``MyClass``.
 including those with brackets (like ``list[int]``) or pipes (like ``int | None``),
 and including special types like ``Any``, ``LiteralString``, or ``Never``.
 
-A ``TypeExpr`` variable looks similar to a ``TypeAlias`` definition, but
-can only be used where a dynamic value is expected.
-``TypeAlias`` (and the ``type`` statement) by contrast define a name that can
-be used where a fixed type is expected:
+A ``TypeExpr`` variable (``maybe_float: TypeExpr``) looks similar to
+a ``TypeAlias`` definition (``MaybeFloat: TypeAlias``), but ``TypeExpr``
+can only be used where a dynamic value is expected:
+
+-  No:
+
+   ::
+
+      maybe_float: TypeExpr = float | None
+      def sqrt(n: float) -> maybe_float: ...  # ERROR: Can't use TypeExpr value in a type annotation
 
 -  Okay, but discouraged in Python 3.12+:
 
@@ -778,13 +784,6 @@ be used where a fixed type is expected:
 
       type MaybeFloat = float | None
       def sqrt(n: float) -> MaybeFloat: ...
-
--  No:
-
-   ::
-
-      maybe_float: TypeExpr = float | None
-      def sqrt(n: float) -> maybe_float: ...  # ERROR: Can't use TypeExpr value in a type annotation
 
 It is uncommon for a programmer to define their *own* function which accepts
 a ``TypeExpr`` parameter or returns a ``TypeExpr`` value. Instead it is more common

--- a/peps/pep-0747.rst
+++ b/peps/pep-0747.rst
@@ -458,12 +458,6 @@ so must be disambiguated based on its argument types:
       internal type of a typing special form, ``type(y).__ror__`` has a return type
       in the format ``TypeExpr[T1 | T2]``.
 
--  As a value expression, ``x | y`` has type ``UnionType``
-   in all other situations.
-
-   -  This rule is intended to be consistent with the preexisting fallback rule
-      used by static type checkers.
-
 The **stringified type expression** ``"T"`` is ambiguous with both
 the stringified annotation expression ``"T"``
 and the string literal ``"T"``,

--- a/peps/pep-0747.rst
+++ b/peps/pep-0747.rst
@@ -543,16 +543,6 @@ but not the other way around:
 -  ``type[Any]`` is assignable to ``TypeExpr[Any]``. (But not the
    other way around.)
 
-Relationship with UnionType
-'''''''''''''''''''''''''''
-
-``TypeExpr[U]`` is a subtype of ``UnionType`` iff ``U`` is
-the type expression ``X | Y | ...``:
-
--  ``TypeExpr[X | Y | ...]`` is a subtype of ``UnionType``.
-
-``UnionType`` is assignable to ``TypeExpr[Any]``.
-
 Relationship with object
 ''''''''''''''''''''''''
 
@@ -624,6 +614,16 @@ instances at runtime so that runtime ``isinstance`` checks like
 ``isinstance('42', int | str)`` and ``isinstance(int | str, UnionType)``
 continue to work.
 
+The following signatures accepting union type expressions introduce
+``TypeExpr`` where previously ``UnionType`` existed:
+
+-  ``builtins.isinstance``
+-  ``builtins.issubclass``
+-  ``typing.get_origin`` (used in an ``@overload``)
+
+Specifically, ``UnionType`` in the signature is replaced with
+``TypeExpr[T1, T2] | UnionType``, where ``T1`` and ``T2`` are type variables.
+
 
 Unchanged signatures
 ''''''''''''''''''''
@@ -658,13 +658,6 @@ not propose those changes now:
 
    -  Returns annotation expressions
 
-The following signatures accepting union type expressions continue
-to use ``UnionType``:
-
--  ``builtins.isinstance``
--  ``builtins.issubclass``
--  ``typing.get_origin`` (used in an ``@overload``)
-
 The following signatures transforming union type expressions continue
 to use ``UnionType`` because it is not possible to infer a more-precise
 ``TypeExpr`` type:
@@ -675,12 +668,46 @@ to use ``UnionType`` because it is not possible to infer a more-precise
 Backwards Compatibility
 =======================
 
+UnionType replaced with TypeExpr[X | Y]
+---------------------------------------
+
 As a value expression, ``X | Y`` previously had type ``UnionType`` (via :pep:`604`)
 but this PEP gives it the more-precise static type ``TypeExpr[X | Y]`` 
-(a subtype of ``UnionType``) while continuing to return a ``UnionType`` instance at runtime.
-Preserving compability with ``UnionType`` is important because ``UnionType``
-supports ``isinstance`` checks, unlike ``TypeExpr``, and existing code relies
-on being able to perform those checks.
+while continuing to return a ``UnionType`` instance at runtime.
+``TypeExpr[X | Y]`` is *not* a subtype of ``UnionType``, so signatures
+that previously included ``UnionType`` should be updated:
+
+-  In applications supporting only type checkers which understand PEP 747:
+
+   -  Change function parameters, variables, and return types annotated as ``UnionType``
+      to ``TypeExpr[T1 | T2]``, where ``T1`` and ``T2`` are type variables.
+
+-  In libraries supporting multiple type checkers which may or may not understand PEP 747:
+
+   -  Change function parameters, variables, and return types annotated as ``UnionType``
+      to ``NewUnionType``.
+   
+   -  Add the following compatibility code near the top of any file
+      which uses ``NewUnionType``:
+   
+      ::
+
+         try:
+             try:
+                 from typing import TypeExpr
+             except ImportError:
+                 from typing_extensions import TypeExpr
+         except ImportError:
+             from types import UnionType as NewUnionType
+         else:
+             from typing import TypeVar
+             T1 = TypeVar('T1')
+             T2 = TypeVar('T2')
+             NewUnionType = TypeExpr[T1 | T2]
+
+
+Recognizing type expression objects
+-----------------------------------
 
 The rules for recognizing other kinds of type expression objects
 in a value expression context were not previously defined, so static type checkers


### PR DESCRIPTION
Also:
* Streamline compare/contrast of TypeExpr vs. TypeAlias

---

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3876.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->