### PR TITLE
PEP 710: remove index_url and state why it was removed

### DIFF
--- a/peps/pep-0710.rst
+++ b/peps/pep-0710.rst
@@ -118,9 +118,9 @@ may be present in a given ``.dist-info`` directory; installers MUST NOT add both
 The ``provenance_url.json`` JSON file MUST be a dictionary, compliant with
 :rfc:`8259` and UTF-8 encoded.
 
-If present, it MUST contain exactly three keys. The first MUST be ``url``, with
+If present, it MUST contain exactly two keys. The first MUST be ``url``, with
 type ``string``.  The second key MUST be ``archive_info`` with a value defined
-below. The third key MUST be ``index_url`` with type ``string``.
+below.
 
 The value of the ``url`` key MUST be the URL from which the distribution package was downloaded. If a wheel is
 built from a source distribution, the ``url`` value MUST be the URL from which
@@ -139,11 +139,6 @@ variables, matching the following regular expression:
 Additionally, the user:password section of the URL MAY be a well-known,
 non-security sensitive string. A typical example is ``git`` in the case of an
 URL such as ``ssh://git@gitlab.com``.
-
-The value of the ``index_url`` key MUST be a base URL of a :term:`Package Index`
-used to download the given distribution package, such as
-``https://pypi.org/simple/``. The recorded URL SHOULD point to a repository
-compliant with :pep:`503`.
 
 The value of ``archive_info`` MUST be a dictionary with a single key
 ``hashes``.  The value of ``hashes`` is a dictionary mapping hash function names to a
@@ -269,7 +264,6 @@ A valid ``provenance_url.json`` list multiple hashes:
         "sha512": "6bad5536c30a0b2d5905318a1592948929fbac9baf3bcf2e7faeaf90f445f82bc2b656d0a89070d8a6a9395761f4793c83187bd640c64b2656a112b5be41f73d"
       }
     },
-    "index_url": "https://pypi.org/simple/",
     "url": "https://files.pythonhosted.org/packages/07/51/2c0959c5adf988c44d9e1e0d940f5b074516ecc87e96b1af25f59de9ba38/pip-23.0.1-py3-none-any.whl"
   }
 
@@ -283,7 +277,6 @@ A valid ``provenance_url.json`` listing a single hash entry:
         "sha256": "236bcb61156d76c4b8a05821b988c7b8c35bf0da28a4b614e8d6ab5212c25c6f"
       }
     },
-    "index_url": "https://pypi.org/simple/",
     "url": "https://files.pythonhosted.org/packages/07/51/2c0959c5adf988c44d9e1e0d940f5b074516ecc87e96b1af25f59de9ba38/pip-23.0.1-py3-none-any.whl"
   }
 
@@ -298,7 +291,6 @@ build and install a wheel:
         "sha256": "8bfe29f17c10e2f2e619de8033a07a224058d96b3bfe2ed61777596f7ffd7fa9"
       }
     },
-    "index_url": "https://pypi.org/simple/",
     "url": "https://files.pythonhosted.org/packages/1d/43/ad8ae671de795ec2eafd86515ef9842ab68455009d864c058d0c3dcf680d/micropipenv-0.0.1.tar.gz"
   }
 
@@ -321,7 +313,6 @@ values in sync.
         "sha256": "236bcb61156d76c4b8a05821b988c7b8c35bf0da28a4b614e8d6ab5212c25c6f"
       }
     },
-    "index_url": "https://pypi.org/simple/",
     "url": "https://files.pythonhosted.org/packages/07/51/2c0959c5adf988c44d9e1e0d940f5b074516ecc87e96b1af25f59de9ba38/pip-23.0.1-py3-none-any.whl"
   }
 
@@ -337,7 +328,6 @@ in the Python docs under :attr:`py3.11:hashlib.hash.name`.
         "SHA-256": "236bcb61156d76c4b8a05821b988c7b8c35bf0da28a4b614e8d6ab5212c25c6f"
       }
     },
-    "index_url": "https://pypi.org/simple/",
     "url": "https://files.pythonhosted.org/packages/07/51/2c0959c5adf988c44d9e1e0d940f5b074516ecc87e96b1af25f59de9ba38/pip-23.0.1-py3-none-any.whl"
   }
 
@@ -442,6 +432,17 @@ in the ``provenance_url.json`` file if that file is created; per this PEP:
 
 By doing so, consumers of ``provenance_url.json`` can check
 artifact digests when the ``provenance_url.json`` file is created by installers.
+
+Storing index URL
+-----------------
+
+A possibility was raised for storing the index URL as part of the file content.
+This index URL would represent the index configured in pip's configuration or
+specified using the ``--index-url`` or ``--extra-index-url`` options. Storing
+this information was considered confusing, especially when using other
+installation options like ``--find-links``. Since the actual index URL is not
+strictly bound to the location from which the wheel file was downloaded, we
+decided not to store the index URL in the ``provenance_url.json`` file.
 
 Open Issues
 ===========
@@ -629,6 +630,9 @@ Thanks to Seth Michael Larson for providing valuable suggestions and for
 the proposed pip-sbom prototype.
 
 Thanks to Stéphane Bidoul and Chris Jerdonek for :pep:`610`.
+
+Thanks to Frost Ming for raising possible concern around storing index URL in
+the ``provenance_url.json`` file.
 
 Last, but not least, thanks to Donald Stufft for sponsoring this PEP.
 


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3878.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->