### PR TITLE
PEP 710: state download_info structure used in pip

### DIFF
--- a/peps/pep-0710.rst
+++ b/peps/pep-0710.rst
@@ -170,9 +170,14 @@ limitations of these hash algorithms. Conversely, hash ``sha256`` SHOULD
 be included.
 
 Installers that cache distribution packages from an index SHOULD keep
-information related to the cached distribution artifact, so that
-the ``provenance_url.json`` file can be created even when installing distribution packages
-from the installer's cache.
+information related to the cached distribution artifact, so that the
+``provenance_url.json`` file can be created even when installing distribution
+packages from the installer's cache. In the case of pip, pip MAY use the
+``download_info`` structure to track the download information of the original
+artifact—either a source distribution used to build a wheel or the installed
+wheel directly. Information about the ``download_info`` structure is available
+in the `Installation Report documentation
+<https://pip.pypa.io/en/stable/reference/installation-report/>`__.
 
 Backwards Compatibility
 =======================


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3880.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->