### PR TITLE
PEP 719: Update 3.13.0rc1 release date

### DIFF
--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -47,10 +47,10 @@ Actual:
 - 3.13.0 beta 2: Wednesday, 2024-06-05
 - 3.13.0 beta 3: Thursday, 2024-06-27
 - 3.13.0 beta 4: Thursday, 2024-07-18
+- 3.13.0 candidate 1: Thursday, 2024-08-01
 
 Expected:
 
-- 3.13.0 candidate 1: Tuesday, 2024-07-30
 - 3.13.0 candidate 2: Tuesday, 2024-09-03
 - 3.13.0 final: Tuesday, 2024-10-01
 


### PR DESCRIPTION
- https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703
- https://www.python.org/downloads/release/python-3130rc1/
