### PR TITLE
PEP 101: Rename to `add_to_pydotorg.py`

### DIFF
--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -647,11 +647,11 @@ permissions.
 - Populate the release with the downloadable files.
 
   Your friend and mine, Georg Brandl, made a lovely tool
-  called ``add-to-pydotorg.py``.  You can find it in the
+  called ``add_to_pydotorg.py``.  You can find it in the
   `python/release-tools`_ repo (next to ``release.py``).  You run the
   tool on ``downloads.nyc1.psf.io``, like this::
 
-      AUTH_INFO=<username>:<python.org-api-key> python add-to-pydotorg.py <version>
+      AUTH_INFO=<username>:<python.org-api-key> python add_to_pydotorg.py <version>
 
   This walks the correct download directory for ``<version>``,
   looks for files marked with ``<version>``, and populates
@@ -664,8 +664,8 @@ permissions.
   keep it fresh.
 
   If new types of files are added to the release, someone will need to
-  update ``add-to-pydotorg.py`` so it recognizes these new files.
-  (It's best to update ``add-to-pydotorg.py`` when file types
+  update ``add_to_pydotorg.py`` so it recognizes these new files.
+  (It's best to update ``add_to_pydotorg.py`` when file types
   are removed, too.)
 
   The script will also sign any remaining files that were not


### PR DESCRIPTION
Follow up to https://github.com/python/release-tools/pull/146 which renamed this script with underscores to make it importable and testable.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3889.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->