### PR TITLE
Infra: Remove GNU make-specific directive from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,9 @@ linkcheck: BUILDER = linkcheck
 linkcheck: html
 
 ## check-links    (deprecated: use 'make linkcheck' alias instead)
-.PHONY: pages
-check-links: linkcheck
-	@echo "\033[0;33mWarning:\033[0;31m 'make check-links' \033[0;33mis deprecated, use\033[0;32m 'make linkcheck' \033[0;33malias instead\033[0m"
+.PHONY: check-links
+check-links:
+	@echo "\033[0;33mError:\033[0;31m 'make check-links' \033[0;33mis deprecated, use\033[0;32m 'make linkcheck' \033[0;33malias instead\033[0m"
 
 ## clean          to remove the venv and build files
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ linkcheck: html
 .PHONY: check-links
 check-links:
 	@echo "\033[0;33mError:\033[0;31m 'make check-links' \033[0;33mis deprecated, use\033[0;32m 'make linkcheck' \033[0;33malias instead\033[0m"
+	@exit 1
 
 ## clean          to remove the venv and build files
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -50,12 +50,6 @@ dirhtml: html
 linkcheck: BUILDER = linkcheck
 linkcheck: html
 
-## check-links    (deprecated: use 'make linkcheck' alias instead)
-.PHONY: check-links
-check-links:
-	@echo "\033[0;33mError:\033[0;31m 'make check-links' \033[0;33mis deprecated, use\033[0;32m 'make linkcheck' \033[0;33malias instead\033[0m"
-	@exit 1
-
 ## clean          to remove the venv and build files
 .PHONY: clean
 clean: clean-venv


### PR DESCRIPTION
Like https://github.com/python/cpython/pull/122662.

This is mostly to keep the `Makefile`s similar in each repo to ease maintenance.

Also promote the `make check-links` deprecation warning (added in November 2023 in https://github.com/python/peps/pull/3514) to an error, although we could probably remove it already?

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3891.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->