### PR TITLE
PEP 751: make `packages.multiple-entries` optional

### DIFF
--- a/peps/pep-0751.rst
+++ b/peps/pep-0751.rst
@@ -338,6 +338,7 @@ unless otherwise specified for the same reason.
 ``packages.multiple-entries``
 -----------------------------
 
+- Optional (defaults to ``false``)
 - Boolean
 - If package locking via ``[package-lock]``, then the multiple entries for the
   same package MUST be mutually exclusive via ``packages.marker`` (this is not


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3894.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->