### PR TITLE
PEP 7: Public C API should be compatible with C11

### DIFF
--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -31,7 +31,8 @@ C dialect
 
 * Python 3.11 and newer versions use C11 without `optional features
   <https://en.wikipedia.org/wiki/C11_%28C_standard_revision%29#Optional_features>`_.
-  The public C API should be compatible with C++.
+
+* The public C API should be compatible with C11 and with C++11.
 
 * Python 3.6 to 3.10 use C89 with several select C99 features:
 

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -32,7 +32,8 @@ C dialect
 * Python 3.11 and newer versions use C11 without `optional features
   <https://en.wikipedia.org/wiki/C11_%28C_standard_revision%29#Optional_features>`_.
 
-* The public C API should be compatible with C11 and with C++11.
+* The public C API should be compatible with C11 (with optional atomic
+  primitives and types) and with C++11.
 
 * Python 3.6 to 3.10 use C89 with several select C99 features:
 


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3896.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->