### PR TITLE
PEP 750: fix specifier mixup

### DIFF
--- a/peps/pep-0750.rst
+++ b/peps/pep-0750.rst
@@ -206,9 +206,9 @@ You can see each of the ``Interpolation`` parts getting extracted:
 
 - The lambda expression to call and get the value in the scope it was defined
 - The raw string of the interpolation (``name``)
-- The Python "conversion" field (``s``)
+- The Python "conversion" field (``r``)
 - Any `format specification <https://docs.python.org/3/library/string.html#format-specification-mini-language>`_
-  (``r``)
+  (``s``)
 
 Specification
 =============


### PR DESCRIPTION
In one of the examples, the explanation appears to name the conversion and format-spec specifiers incorrectly.

This proposal fixes the specifiers so they are consistent to what the example code says.

---

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3900.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->