### PR TITLE
PEP 740: clarify that provenance is nullable

### DIFF
--- a/peps/pep-0740.rst
+++ b/peps/pep-0740.rst
@@ -235,9 +235,9 @@ The following changes are made to the
 * When an uploaded file has one or more attestations, the index **MAY**
   include a ``provenance`` key in the ``file`` dictionary for that file.
 
-  The value of the ``provenance`` key **SHALL** be a JSON string, which
-  **SHALL** be the SHA-256 digest of the associated ``.provenance`` file,
-  as in the Simple Index.
+  The value of the ``provenance`` key **SHALL** be either a JSON string
+  or ``null``. If ``provenance`` is not ``null``, it **SHALL** be the SHA-256
+  digest of the associated ``.provenance`` file, as in the Simple Index.
 
   See :ref:`appendix-3` for an explanation of the technical decision to
   embed the SHA-256 digest in the JSON API, rather than the full


### PR DESCRIPTION
This tweaks PEP 740 a bit to clear up an ambiguity: like in the simple HTML index, the JSON Simple Index may choose to emit `provenance: null` when a distribution file has no provenance, rather than omitting the key entirely.

CC @di @darkamaul

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3906.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->