### PR TITLE
Fix a small typo

### DIFF
--- a/peps/pep-0708.rst
+++ b/peps/pep-0708.rst
@@ -147,7 +147,7 @@ manually configure them to get the correct binaries for their platform, GPU,
 CPU, etc.
 
 This use case is similar to the first, but the important difference that makes
-it a distinct use case on it's own is who is providing the information and what
+it a distinct use case on its own is who is providing the information and what
 their level of trust is.
 
 When a user configures a specific repository (or relies on the default) there


### PR DESCRIPTION
Upon reading PEP 708 in detail, I found a small typo.  Here's a fix.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3907.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->