### PR TITLE
PEP 747: Rename TypeExpr -> TypeForm (and related terminology)

### DIFF
--- a/peps/pep-0747.rst
+++ b/peps/pep-0747.rst
@@ -1,5 +1,5 @@
 PEP: 747
-Title: TypeExpr: Type Hint for a Type Expression
+Title: TypeForm: Type Hint for a Type Expression
 Author: David Foster <david at dafoster.net>
 Sponsor: Jelle Zijlstra <jelle.zijlstra at gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-747-typeexpr-type-hint-for-a-type-expression/55984
@@ -20,12 +20,12 @@ not allow ``type[C]`` to refer to arbitrary
 :ref:`type expression <typing:type-expression>` objects such
 as the runtime object ``str | None``, even if ``C`` is an unbounded
 ``TypeVar``. [#type_c]_ In cases where that restriction is unwanted, this
-PEP proposes a new notation ``TypeExpr[T]`` where ``T`` is a type, to
+PEP proposes a new notation ``TypeForm[T]`` where ``T`` is a type, to
 refer to a either a class object or some other type expression object
 that is a subtype of ``T``, allowing any kind of type to be referenced.
 
 This PEP makes no Python grammar changes. Correct usage of
-``TypeExpr[]`` is intended to be enforced only by static and runtime
+``TypeForm[]`` is intended to be enforced only by static and runtime
 type checkers and need not be enforced by Python itself at runtime.
 
 
@@ -34,7 +34,7 @@ type checkers and need not be enforced by Python itself at runtime.
 Motivation
 ==========
 
-The introduction of ``TypeExpr`` allows new kinds of metaprogramming
+The introduction of ``TypeForm`` allows new kinds of metaprogramming
 functions that operate on type expressions to be type-annotated and
 understood by type checkers.
 
@@ -44,9 +44,9 @@ original value:
 
 ::
 
-   def trycast[T](typx: TypeExpr[T], value: object) -> T | None: ...
+   def trycast[T](typx: TypeForm[T], value: object) -> T | None: ...
 
-The use of ``TypeExpr[]`` and the type variable ``T`` enables the return
+The use of ``TypeForm[]`` and the type variable ``T`` enables the return
 type of this function to be influenced by a ``typx`` value passed at
 runtime, which is quite powerful.
 
@@ -56,9 +56,9 @@ variable of a particular type, and if so returns ``True`` (as a special
 
 ::
 
-   def isassignable[T](value: object, typx: TypeExpr[T]) -> TypeIs[T]: ...
+   def isassignable[T](value: object, typx: TypeForm[T]) -> TypeIs[T]: ...
 
-The use of ``TypeExpr[]`` and ``TypeIs[]`` together enables type
+The use of ``TypeForm[]`` and ``TypeIs[]`` together enables type
 checkers to narrow the return type appropriately depending on what type
 expression is passed in:
 
@@ -74,7 +74,7 @@ conforms to a particular structure`_ of nested ``TypedDict``\ s,
 lists, unions, ``Literal``\ s, and other types. This kind
 of check was alluded to in :pep:`PEP 589 <589#using-typeddict-types>` but could
 not be implemented at the time without a notation similar to
-``TypeExpr[]``.
+``TypeForm[]``.
 
 .. _checking whether a value decoded from JSON conforms to a particular structure: https://mail.python.org/archives/list/typing-sig@python.org/thread/I5ZOQICTJCENTCDPHLZR7NT42QJ43GP4/
 
@@ -84,13 +84,13 @@ Why can’t ``type[]`` be used?
 
 One might think you could define the example functions above to take a
 ``type[C]`` - which is syntax that already exists - rather than a
-``TypeExpr[T]``. However if you were to do that then certain type
+``TypeForm[T]``. However if you were to do that then certain type
 expressions like ``str | None`` - which are not class objects and
 therefore not ``type``\ s at runtime - would be rejected:
 
 ::
 
-   # NOTE: Uses a type[C] parameter rather than a TypeExpr[T]
+   # NOTE: Uses a type[C] parameter rather than a TypeForm[T]
    def trycast_type[C](typ: type[C], value: object) -> T | None: ...
 
    trycast_type(str, 'hi')  # ok; str is a type
@@ -99,10 +99,10 @@ therefore not ``type``\ s at runtime - would be rejected:
    trycast_type(MyTypedDict, dict(value='hi'))  # questionable; accepted by mypy 1.9.0
 
 To solve that problem, ``type[]`` could be widened to include the
-additional values allowed by ``TypeExpr``. However doing so would lose
+additional values allowed by ``TypeForm``. However doing so would lose
 ``type[]``\ ’s current ability to spell a class object which always
 supports instantiation and ``isinstance`` checks, unlike arbitrary type
-expression objects. Therefore ``TypeExpr`` is proposed as new notation
+expression objects. Therefore ``TypeForm`` is proposed as new notation
 instead.
 
 For a longer explanation of why we don’t just widen ``type[T]`` to
@@ -112,11 +112,11 @@ accept all type expressions, see
 
 .. _runtime_type_checkers_using_typeexpr:
 
-Common kinds of functions that would benefit from TypeExpr
+Common kinds of functions that would benefit from TypeForm
 ----------------------------------------------------------
 
 `A survey of various Python libraries`_ revealed a few kinds of commonly
-defined functions which would benefit from ``TypeExpr[]``:
+defined functions which would benefit from ``TypeForm[]``:
 
 .. _A survey of various Python libraries: https://github.com/python/mypy/issues/9773#issuecomment-2017998886
 
@@ -126,9 +126,9 @@ defined functions which would benefit from ``TypeExpr[]``:
       then also narrows the type of the value to match the type
       expression.
    -  Pattern 1:
-      ``def isassignable[T](value: object, typx: TypeExpr[T]) -> TypeIs[T]``
+      ``def isassignable[T](value: object, typx: TypeForm[T]) -> TypeIs[T]``
    -  Pattern 2:
-      ``def ismatch[T](value: object, typx: TypeExpr[T]) -> TypeGuard[T]``
+      ``def ismatch[T](value: object, typx: TypeForm[T]) -> TypeGuard[T]``
    -  Examples: beartype.\ `is_bearable`_, trycast.\ `isassignable`_,
       typeguard.\ `check_type`_, xdsl.\ `isa`_
 
@@ -143,7 +143,7 @@ defined functions which would benefit from ``TypeExpr[]``:
       a *converter* returns the value narrowed to (or coerced to) that type
       expression. Otherwise, it raises an exception.
    -  Pattern 1:
-      ``def convert[T](value: object, typx: TypeExpr[T]) -> T``
+      ``def convert[T](value: object, typx: TypeForm[T]) -> T``
 
       -  Examples: cattrs.BaseConverter.\ `structure`_, trycast.\ `checkcast`_,
          typedload.\ `load`_
@@ -153,7 +153,7 @@ defined functions which would benefit from ``TypeExpr[]``:
       ::
 
         class Converter[T]:
-            def __init__(self, typx: TypeExpr[T]) -> None: ...
+            def __init__(self, typx: TypeForm[T]) -> None: ...
             def convert(self, value: object) -> T: ...
 
       -  Examples: pydantic.\ `TypeAdapter(T).validate_python`_,
@@ -172,7 +172,7 @@ defined functions which would benefit from ``TypeExpr[]``:
       ::
 
         class Field[T]:
-            value_type: TypeExpr[T]
+            value_type: TypeForm[T]
 
    -  Examples: attrs.\ `make_class`_,
       dataclasses.\ `make_dataclass`_ [#DataclassInitVar]_, `openapify`_
@@ -183,7 +183,7 @@ defined functions which would benefit from ``TypeExpr[]``:
 
 The survey also identified some introspection functions that take
 annotation expressions as input using plain ``object``\ s which would
-*not* gain functionality by marking those inputs as ``TypeExpr[]``:
+*not* gain functionality by marking those inputs as ``TypeForm[]``:
 
 -  General introspection operations:
 
@@ -210,7 +210,7 @@ different kinds of type annotations:
    | | | +---------------------+ |  | | 
    | | | | Class object        | |  | | = type[C]        
    | | | +---------------------+ |  | | 
-   | | | Type expression object  |  | | = TypeExpr[T]  <-- new!
+   | | | Type expression object  |  | | = TypeForm[T]  <-- new!
    | | +-------------------------+  | | 
    | | Annotation expression object | | 
    | +------------------------------+ | 
@@ -234,52 +234,52 @@ different kinds of type annotations:
    -  Examples: ``Final[int]``, ``Required[str]``, ``ClassVar[str]``,
       any type expression
 
-``TypeExpr`` aligns with an existing definition from the above list -
+``TypeForm`` aligns with an existing definition from the above list -
 *type expression* - to avoid introducing yet another subset of type annotations
 that users of Python typing need to think about.
 
-``TypeExpr`` aligns with *type expression* specifically
+``TypeForm`` aligns with *type expression* specifically
 because a type expression is already used to parameterize type variables,
 which are used in combination with ``TypeIs`` and ``TypeGuard`` to enable
 the compelling examples mentioned in :ref:`Motivation <motivation>`.
 
-``TypeExpr`` does not align with *annotation expression* for reasons given in
+``TypeForm`` does not align with *annotation expression* for reasons given in
 :ref:`Rejected Ideas » Accept arbitrary annotation expressions <accept_arbitrary_annotation_expressions>`.
 
 
 Specification
 =============
 
-A ``TypeExpr`` value represents a :ref:`type expression <typing:type-expression>`
+A ``TypeForm`` value represents a :ref:`type expression <typing:type-expression>`
 such as ``str | None``, ``dict[str, int]``, or ``MyTypedDict``.
-A ``TypeExpr`` type is written as
-``TypeExpr[T]`` where ``T`` is a type or a type variable. It can also be
-written without brackets as just ``TypeExpr``, which is treated the same as
-to ``TypeExpr[Any]``.
+A ``TypeForm`` type is written as
+``TypeForm[T]`` where ``T`` is a type or a type variable. It can also be
+written without brackets as just ``TypeForm``, which is treated the same as
+to ``TypeForm[Any]``.
 
 
-Using TypeExprs
+Using TypeForms
 ---------------
 
-A ``TypeExpr`` is a new kind of type expression, usable in any context where a
+A ``TypeForm`` is a new kind of type expression, usable in any context where a
 type expression is valid, as a function parameter type, a return type, 
 or a variable type:
 
 ::
 
-   def is_union_type(typx: TypeExpr) -> bool: ...  # parameter type
+   def is_union_type(typx: TypeForm) -> bool: ...  # parameter type
 
 ::
 
-   def union_of[S, T](s: TypeExpr[S], t: TypeExpr[T]) \
-       -> TypeExpr[S | T]: ...  # return type
+   def union_of[S, T](s: TypeForm[S], t: TypeForm[T]) \
+       -> TypeForm[S | T]: ...  # return type
 
 ::
 
-   STR_TYPE: TypeExpr = str  # variable type
+   STR_TYPE: TypeForm = str  # variable type
 
 Note however that an *unannotated* variable assigned a type expression literal
-will not be inferred to be of ``TypeExpr`` type by type checkers because PEP
+will not be inferred to be of ``TypeForm`` type by type checkers because PEP
 484 :pep:`reserves that syntax for defining type aliases <484#type-aliases>`:
 
 -  No:
@@ -290,71 +290,71 @@ will not be inferred to be of ``TypeExpr`` type by type checkers because PEP
 
 If you want a type checker to recognize a type expression literal in a bare
 assignment you’ll need to explicitly declare the assignment-target as
-having ``TypeExpr`` type:
+having ``TypeForm`` type:
 
 -  Yes:
 
    ::
 
-      STR_TYPE: TypeExpr = str
+      STR_TYPE: TypeForm = str
 
 -  Yes:
 
    ::
 
-      STR_TYPE: TypeExpr
+      STR_TYPE: TypeForm
       STR_TYPE = str
 
 -  Okay, but discouraged:
 
    ::
 
-      STR_TYPE = str  # type: TypeExpr  # the type comment is significant
+      STR_TYPE = str  # type: TypeForm  # the type comment is significant
 
-``TypeExpr`` values can be passed around and assigned just like normal
+``TypeForm`` values can be passed around and assigned just like normal
 values:
 
 ::
 
-   def swap1[S, T](t1: TypeExpr[S], t2: TypeExpr[T]) -> tuple[TypeExpr[T], TypeExpr[S]]:
-       t1_new: TypeExpr[T] = t2  # assigns a TypeExpr value to a new annotated variable
-       t2_new: TypeExpr[S] = t1
+   def swap1[S, T](t1: TypeForm[S], t2: TypeForm[T]) -> tuple[TypeForm[T], TypeForm[S]]:
+       t1_new: TypeForm[T] = t2  # assigns a TypeForm value to a new annotated variable
+       t2_new: TypeForm[S] = t1
        return (t1_new, t2_new)
 
-   def swap2[S, T](t1: TypeExpr[S], t2: TypeExpr[T]) -> tuple[TypeExpr[T], TypeExpr[S]]:
-       t1_new = t2  # assigns a TypeExpr value to a new unannotated variable
+   def swap2[S, T](t1: TypeForm[S], t2: TypeForm[T]) -> tuple[TypeForm[T], TypeForm[S]]:
+       t1_new = t2  # assigns a TypeForm value to a new unannotated variable
        t2_new = t1
-       assert_type(t1_new, TypeExpr[T])
-       assert_type(t2_new, TypeExpr[S])
+       assert_type(t1_new, TypeForm[T])
+       assert_type(t2_new, TypeForm[S])
        return (t1_new, t2_new)
 
    # NOTE: A more straightforward implementation would use isinstance()
    def ensure_int(value: object) -> None:
-       value_type: TypeExpr = type(value)  # assigns a type (a subtype of TypeExpr)
+       value_type: TypeForm = type(value)  # assigns a type (a subtype of TypeForm)
        assert value_type == int
 
 
-TypeExpr Values
+TypeForm Values
 ---------------
 
-A variable of type ``TypeExpr[T]`` where ``T`` is a type, can hold any
+A variable of type ``TypeForm[T]`` where ``T`` is a type, can hold any
 **type expression object** - the result of evaluating a 
 :ref:`type expression <typing:type-expression>`
 at runtime - which is a subtype of ``T``.
 
 Incomplete expressions like a bare ``Optional`` or ``Union`` which do
-not spell a type are not ``TypeExpr`` values.
+not spell a type are not ``TypeForm`` values.
 
-``TypeExpr[...]`` is itself a ``TypeExpr`` value:
+``TypeForm[...]`` is itself a ``TypeForm`` value:
 
 ::
 
-   OPTIONAL_INT_TYPE: TypeExpr = TypeExpr[int | None]  # OK
+   OPTIONAL_INT_TYPE: TypeForm = TypeForm[int | None]  # OK
    assert isassignable(int | None, OPTIONAL_INT_TYPE)
 
 .. _non_universal_typeexpr:
 
-``TypeExpr[]`` values include *all* type expressions including some
+``TypeForm[]`` values include *all* type expressions including some
 **non-universal type expressions** which are not valid in all annotation contexts.
 In particular:
 
@@ -363,24 +363,24 @@ In particular:
 -  ``TypeIs[...]`` (valid only in some contexts)
 
 
-Explicit TypeExpr Values
+Explicit TypeForm Values
 ''''''''''''''''''''''''
 
-The syntax ``TypeExpr(T)`` (with parentheses) can be used to
-spell a ``TypeExpr[T]`` value explicitly:
+The syntax ``TypeForm(T)`` (with parentheses) can be used to
+spell a ``TypeForm[T]`` value explicitly:
 
 ::
 
-   NONE = TypeExpr(None)
-   INT1 = TypeExpr('int')  # stringified type expression
-   INT2 = TypeExpr(int)
+   NONE = TypeForm(None)
+   INT1 = TypeForm('int')  # stringified type expression
+   INT2 = TypeForm(int)
 
-At runtime the ``TypeExpr(...)`` callable returns its single argument unchanged.
+At runtime the ``TypeForm(...)`` callable returns its single argument unchanged.
 
 
 .. _implicit_typeexpr_values:
 
-Implicit TypeExpr Values
+Implicit TypeForm Values
 ''''''''''''''''''''''''
 
 Historically static type checkers have only needed to recognize
@@ -399,7 +399,7 @@ Static type checkers already recognize **class objects** (``type[C]``):
 
 The following **unparameterized type expressions** can be recognized unambiguously:
 
--  As a value expression, ``X`` has type ``TypeExpr[X]``,
+-  As a value expression, ``X`` has type ``TypeForm[X]``,
    for each of the following values of X:
 
    -  ``<Any>``
@@ -409,14 +409,14 @@ The following **unparameterized type expressions** can be recognized unambiguous
    -  ``<Never>``
 
 **None**: The type expression ``None`` (``NoneType``) is ambiguous with the value ``None``,
-so must use the explicit ``TypeExpr(...)`` syntax:
+so must use the explicit ``TypeForm(...)`` syntax:
 
--  As a value expression, ``TypeExpr(None)`` has type ``TypeExpr[None]``.
+-  As a value expression, ``TypeForm(None)`` has type ``TypeForm[None]``.
 -  As a value expression, ``None`` continues to have type ``None``.
 
 The following **parameterized type expressions** can be recognized unambiguously:
 
--  As a value expression, ``X`` has type ``TypeExpr[X]``,
+-  As a value expression, ``X`` has type ``TypeForm[X]``,
    for each of the following values of X:
 
    -  ``<Literal> '[' ... ']'``
@@ -435,20 +435,20 @@ so must be disambiguated based on its argument type:
 
 -  As a value expression, ``Annotated[x, ...]`` has type ``type[C]``
    if ``x`` has type ``type[C]``.
--  As a value expression, ``Annotated[x, ...]`` has type ``TypeExpr[T]``
-   if ``x`` has type ``TypeExpr[T]``.
+-  As a value expression, ``Annotated[x, ...]`` has type ``TypeForm[T]``
+   if ``x`` has type ``TypeForm[T]``.
 -  As a value expression, ``Annotated[x, ...]`` has type ``object``
-   if ``x`` has a type that is not ``type[C]`` or ``TypeExpr[T]``.
+   if ``x`` has a type that is not ``type[C]`` or ``TypeForm[T]``.
 
 **Union**: The type expression ``T1 | T2`` is ambiguous with 
 the value ``int1 | int2``, ``set1 | set2``, ``dict1 | dict2``, and more,
-so must use the explicit ``TypeExpr(...)`` syntax:
+so must use the explicit ``TypeForm(...)`` syntax:
 
 -  Yes:
 
    ::
 
-      if isassignable(value, TypeExpr(int | str)): ...
+      if isassignable(value, TypeForm(int | str)): ...
 
 -  No:
 
@@ -457,15 +457,15 @@ so must use the explicit ``TypeExpr(...)`` syntax:
       if isassignable(value, int | str): ...
 
 Future PEPs may make it possible to recognize the value expression ``T1 | T2`` directly as an
-implicit TypeExpr value and avoid the need to use the explicit ``TypeExpr(...)`` syntax,
+implicit TypeForm value and avoid the need to use the explicit ``TypeForm(...)`` syntax,
 but that work is :ref:`deferred for now <recognize_uniontype_as_implicit_typeexpr_value>`.
 
 The **stringified type expression** ``"T"`` is ambiguous with both
 the stringified annotation expression ``"T"``
 and the string literal ``"T"``,
-so must use the explicit ``TypeExpr(...)`` syntax:
+so must use the explicit ``TypeForm(...)`` syntax:
 
--  As a value expression, ``TypeExpr("T")`` has type ``TypeExpr[T]``,
+-  As a value expression, ``TypeForm("T")`` has type ``TypeForm[T]``,
    where ``T`` is a valid type expression
 -  As a value expression, ``"T"`` continues to have type ``Literal["T"]``.
 
@@ -475,29 +475,29 @@ New kinds of type expressions that are introduced should define how they
 will be recognized in a value expression context.
 
 
-Literal[] TypeExprs
+Literal[] TypeForms
 '''''''''''''''''''
 
 A value of ``Literal[...]`` type is *not* considered assignable to
-a ``TypeExpr`` variable even if all of its members spell valid types because
+a ``TypeForm`` variable even if all of its members spell valid types because
 dynamic values are not allowed in type expressions:
 
 ::
 
    STRS_TYPE_NAME: Literal['str', 'list[str]'] = 'str'
-   STRS_TYPE: TypeExpr = STRS_TYPE_NAME  # ERROR: Literal[] value is not a TypeExpr
+   STRS_TYPE: TypeForm = STRS_TYPE_NAME  # ERROR: Literal[] value is not a TypeForm
 
-However ``Literal[...]`` itself is still a ``TypeExpr``:
+However ``Literal[...]`` itself is still a ``TypeForm``:
 
 ::
 
-   DIRECTION_TYPE: TypeExpr[Literal['left', 'right']] = Literal['left', 'right']  # OK
+   DIRECTION_TYPE: TypeForm[Literal['left', 'right']] = Literal['left', 'right']  # OK
 
 
-Static vs. Runtime Representations of TypeExprs
+Static vs. Runtime Representations of TypeForms
 '''''''''''''''''''''''''''''''''''''''''''''''
 
-A ``TypeExpr`` value appearing statically in a source file may be normalized
+A ``TypeForm`` value appearing statically in a source file may be normalized
 to a different representation at runtime. For example string-based 
 forward references are normalized at runtime to be ``ForwardRef`` instances
 in some contexts: [#forward_ref_normalization]_
@@ -508,80 +508,80 @@ in some contexts: [#forward_ref_normalization]_
    >>> IntTree
    list[typing.Union[int, ForwardRef('IntTree')]]
 
-The runtime representations of ``TypeExpr``\ s are considered implementation
+The runtime representations of ``TypeForm``\ s are considered implementation
 details that may change over time and therefore static type checkers are
 not required to recognize them:
 
 ::
 
-   INT_TREE: TypeExpr = ForwardRef('IntTree')  # ERROR: Runtime-only form
+   INT_TREE: TypeForm = ForwardRef('IntTree')  # ERROR: Runtime-only form
 
 Runtime type checkers that wish to assign a runtime-only representation
-of a type expression to a ``TypeExpr[]`` variable must use ``cast()`` to
+of a type expression to a ``TypeForm[]`` variable must use ``cast()`` to
 avoid errors from static type checkers:
 
 ::
 
-   INT_TREE = cast(TypeExpr, ForwardRef('IntTree'))  # OK
+   INT_TREE = cast(TypeForm, ForwardRef('IntTree'))  # OK
 
 
 Subtyping
 ---------
 
-Whether a ``TypeExpr`` value can be assigned from one variable to another is
+Whether a ``TypeForm`` value can be assigned from one variable to another is
 determined by the following rules:
 
 Relationship with type
 ''''''''''''''''''''''
 
-``TypeExpr[]`` is covariant in its argument type, just like ``type[]``:
+``TypeForm[]`` is covariant in its argument type, just like ``type[]``:
 
--  ``TypeExpr[T1]`` is a subtype of ``TypeExpr[T2]`` iff ``T1`` is a
+-  ``TypeForm[T1]`` is a subtype of ``TypeForm[T2]`` iff ``T1`` is a
    subtype of ``T2``.
--  ``type[C1]`` is a subtype of ``TypeExpr[C2]`` iff ``C1`` is a subtype
+-  ``type[C1]`` is a subtype of ``TypeForm[C2]`` iff ``C1`` is a subtype
    of ``C2``.
 
-An unparameterized ``type`` can be assigned to an unparameterized ``TypeExpr``
+An unparameterized ``type`` can be assigned to an unparameterized ``TypeForm``
 but not the other way around:
 
--  ``type[Any]`` is assignable to ``TypeExpr[Any]``. (But not the
+-  ``type[Any]`` is assignable to ``TypeForm[Any]``. (But not the
    other way around.)
 
 Relationship with object
 ''''''''''''''''''''''''
 
-``TypeExpr[]`` is a kind of ``object``, just like ``type[]``:
+``TypeForm[]`` is a kind of ``object``, just like ``type[]``:
 
--  ``TypeExpr[T]`` for any ``T`` is a subtype of ``object``.
+-  ``TypeForm[T]`` for any ``T`` is a subtype of ``object``.
 
-``TypeExpr[T]``, where ``T`` is a type variable, is assumed to have all
+``TypeForm[T]``, where ``T`` is a type variable, is assumed to have all
 the attributes and methods of ``object`` and is not callable.
 
 
 Interactions with isinstance() and issubclass()
 -----------------------------------------------
 
-The ``TypeExpr`` special form cannot be used as the ``type`` argument to
+The ``TypeForm`` special form cannot be used as the ``type`` argument to
 ``isinstance``:
 
 ::
 
-   >>> isinstance(str, TypeExpr)
-   TypeError: typing.TypeExpr cannot be used with isinstance()
+   >>> isinstance(str, TypeForm)
+   TypeError: typing.TypeForm cannot be used with isinstance()
 
-   >>> isinstance(str, TypeExpr[str])
+   >>> isinstance(str, TypeForm[str])
    TypeError: isinstance() argument 2 cannot be a parameterized generic
 
-The ``TypeExpr`` special form cannot be used as any argument to
+The ``TypeForm`` special form cannot be used as any argument to
 ``issubclass``:
 
 ::
 
-   >>> issubclass(TypeExpr, object)
+   >>> issubclass(TypeForm, object)
    TypeError: issubclass() arg 1 must be a class
 
-   >>> issubclass(object, TypeExpr)
-   TypeError: typing.TypeExpr cannot be used with issubclass()
+   >>> issubclass(object, TypeForm)
+   TypeError: typing.TypeForm cannot be used with issubclass()
 
 
 Affected signatures in the standard library
@@ -591,7 +591,7 @@ Changed signatures
 ''''''''''''''''''
 
 The following signatures related to type expressions introduce
-``TypeExpr`` where previously ``object`` or ``Any`` existed:
+``TypeForm`` where previously ``object`` or ``Any`` existed:
 
 -  ``typing.cast``
 -  ``typing.assert_type``
@@ -670,30 +670,30 @@ assigned to variables and manipulated like any other data in a program:
     a variable                    a type
     |                             |
     v                             v
-   MAYBE_INT_TYPE: TypeExpr = int | None
+   MAYBE_INT_TYPE: TypeForm = int | None
                     ^ 
                     | 
                     the type of a type
 
-``TypeExpr[]`` is how you spell the type of a variable containing a
+``TypeForm[]`` is how you spell the type of a variable containing a
 type annotation object describing a type.
 
-``TypeExpr[]`` is similar to ``type[]``, but ``type[]`` can only
+``TypeForm[]`` is similar to ``type[]``, but ``type[]`` can only
 spell simple **class objects** like ``int``, ``str``, ``list``, or ``MyClass``.
-``TypeExpr[]`` by contrast can additionally spell more complex types, 
+``TypeForm[]`` by contrast can additionally spell more complex types, 
 including those with brackets (like ``list[int]``) or pipes (like ``int | None``),
 and including special types like ``Any``, ``LiteralString``, or ``Never``.
 
-A ``TypeExpr`` variable (``maybe_float: TypeExpr``) looks similar to
-a ``TypeAlias`` definition (``MaybeFloat: TypeAlias``), but ``TypeExpr``
+A ``TypeForm`` variable (``maybe_float: TypeForm``) looks similar to
+a ``TypeAlias`` definition (``MaybeFloat: TypeAlias``), but ``TypeForm``
 can only be used where a dynamic value is expected:
 
 -  No:
 
    ::
 
-      maybe_float: TypeExpr = float | None
-      def sqrt(n: float) -> maybe_float: ...  # ERROR: Can't use TypeExpr value in a type annotation
+      maybe_float: TypeForm = float | None
+      def sqrt(n: float) -> maybe_float: ...  # ERROR: Can't use TypeForm value in a type annotation
 
 -  Okay, but discouraged in Python 3.12+:
 
@@ -710,16 +710,16 @@ can only be used where a dynamic value is expected:
       def sqrt(n: float) -> MaybeFloat: ...
 
 It is uncommon for a programmer to define their *own* function which accepts
-a ``TypeExpr`` parameter or returns a ``TypeExpr`` value. Instead it is more common
+a ``TypeForm`` parameter or returns a ``TypeForm`` value. Instead it is more common
 for a programmer to pass a literal type expression to an *existing* function
-accepting a ``TypeExpr`` input which was imported from a runtime type checker
+accepting a ``TypeForm`` input which was imported from a runtime type checker
 library.
 
 For example the ``isassignable`` function from the ``trycast`` library
 can be used like Python's built-in ``isinstance`` function to check whether
 a value matches the shape of a particular type.
 ``isassignable`` will accept *any* kind of type as an input because its input
-is a ``TypeExpr``. By contrast ``isinstance`` only accepts a simple class object
+is a ``TypeForm``. By contrast ``isinstance`` only accepts a simple class object
 (a ``type[]``) as input:
 
 -  Yes:
@@ -728,7 +728,7 @@ is a ``TypeExpr``. By contrast ``isinstance`` only accepts a simple class object
 
       from trycast import isassignable
       
-      if isassignable(some_object, MyTypedDict):  # OK: MyTypedDict is a TypeExpr[]
+      if isassignable(some_object, MyTypedDict):  # OK: MyTypedDict is a TypeForm[]
           ...
 
 -  No:
@@ -739,7 +739,7 @@ is a ``TypeExpr``. By contrast ``isinstance`` only accepts a simple class object
           ...
 
 There are :ref:`many other runtime type checkers <runtime_type_checkers_using_typeexpr>`
-providing useful functions that accept a ``TypeExpr``.
+providing useful functions that accept a ``TypeForm``.
 
 
 .. _advanced_examples:
@@ -750,13 +750,13 @@ Advanced Examples
 If you want to write your own runtime type checker or some other
 kind of function that manipulates types as values at runtime,
 this section gives examples of how you might implement such a function
-using ``TypeExpr``.
+using ``TypeForm``.
 
 
-Introspecting TypeExpr Values
+Introspecting TypeForm Values
 -----------------------------
 
-A ``TypeExpr`` is very similar to an ``object`` at runtime, with no additional
+A ``TypeForm`` is very similar to an ``object`` at runtime, with no additional
 attributes or methods defined.
 
 You can use existing introspection functions like ``typing.get_origin`` and
@@ -767,9 +767,9 @@ like ``Origin[Arg1, Arg2, ..., ArgN]``:
 
    import typing
 
-   def strip_annotated_metadata(typx: TypeExpr[T]) -> TypeExpr[T]:
+   def strip_annotated_metadata(typx: TypeForm[T]) -> TypeForm[T]:
        if typing.get_origin(typx) is typing.Annotated:
-           typx = cast(TypeExpr[T], typing.get_args(typx)[0])
+           typx = cast(TypeForm[T], typing.get_args(typx)[0])
        return typx
 
 You can also use ``isinstance`` and ``is`` to distinguish one kind of
@@ -780,11 +780,11 @@ type expression from another:
    import types
    import typing
 
-   def split_union(typx: TypeExpr) -> tuple[TypeExpr, ...]:
+   def split_union(typx: TypeForm) -> tuple[TypeForm, ...]:
        if isinstance(typx, types.UnionType):  # X | Y
-           return cast(tuple[TypeExpr, ...], typing.get_args(typx))
+           return cast(tuple[TypeForm, ...], typing.get_args(typx))
        if typing.get_origin(typx) is typing.Union:  # Union[X, Y]
-           return cast(tuple[TypeExpr, ...], typing.get_args(typx))
+           return cast(tuple[TypeForm, ...], typing.get_args(typx))
        if typx in (typing.Never, typing.NoReturn,):
            return ()
        return (typx,)
@@ -793,36 +793,36 @@ type expression from another:
 Combining with a type variable
 ------------------------------
 
-``TypeExpr[]`` can be parameterized by a type variable that is used elsewhere within
+``TypeForm[]`` can be parameterized by a type variable that is used elsewhere within
 the same function definition:
 
 ::
 
-   def as_instance[T](typx: TypeExpr[T]) -> T | None:
+   def as_instance[T](typx: TypeForm[T]) -> T | None:
        return typx() if isinstance(typx, type) else None
 
 
 Combining with type[]
 ---------------------
 
-Both ``TypeExpr[]`` and ``type[]`` can be parameterized by the same type
+Both ``TypeForm[]`` and ``type[]`` can be parameterized by the same type
 variable within the same function definition:
 
 ::
 
-   def as_type[T](typx: TypeExpr[T]) -> type[T] | None:
+   def as_type[T](typx: TypeForm[T]) -> type[T] | None:
        return typx if isinstance(typx, type) else None
 
 
 Combining with TypeIs[] and TypeGuard[]
 ---------------------------------------
 
-A type variable parameterizing a ``TypeExpr[]`` can also be used by a ``TypeIs[]``
+A type variable parameterizing a ``TypeForm[]`` can also be used by a ``TypeIs[]``
 within the same function definition:
 
 ::
 
-   def isassignable[T](value: object, typx: TypeExpr[T]) -> TypeIs[T]: ...
+   def isassignable[T](value: object, typx: TypeForm[T]) -> TypeIs[T]: ...
 
    count: int | str = ...
    if isassignable(count, int):
@@ -834,7 +834,7 @@ or by a ``TypeGuard[]`` within the same function definition:
 
 ::
 
-   def isdefault[T](value: object, typx: TypeExpr[T]) -> TypeGuard[T]:
+   def isdefault[T](value: object, typx: TypeForm[T]) -> TypeGuard[T]:
        return (value == typx()) if isinstance(typx, type) else False
 
    value: int | str = ''
@@ -848,10 +848,10 @@ or by a ``TypeGuard[]`` within the same function definition:
        assert_type(value, int | str)
 
 
-Challenges When Accepting All TypeExprs
+Challenges When Accepting All TypeForms
 ---------------------------------------
 
-A function that takes an *arbitrary* ``TypeExpr`` as
+A function that takes an *arbitrary* ``TypeForm`` as
 input must support a large variety of possible type expressions and is
 not easy to write. Some challenges faced by such a function include:
 
@@ -882,7 +882,7 @@ Reference Implementation
 The following will be true when
 `mypy#9773 <https://github.com/python/mypy/issues/9773>`__ is implemented:
 
-    The mypy type checker supports ``TypeExpr`` types.
+    The mypy type checker supports ``TypeForm`` types.
 
 A reference implementation of the runtime component is provided in the
 ``typing_extensions`` module.
@@ -900,12 +900,12 @@ Widen type[C] to support all type expressions
 class object can always be used as the second argument of ``isinstance()``
 and can usually be instantiated by calling it.
 
-``TypeExpr`` on the other hand is typically introspected by the user in
+``TypeForm`` on the other hand is typically introspected by the user in
 some way, is not necessarily directly instantiable, and is not
 necessarily directly usable in a regular ``isinstance()`` check.
 
 It would be possible to widen ``type`` to include the additional values
-allowed by ``TypeExpr`` but it would reduce clarity about the user’s
+allowed by ``TypeForm`` but it would reduce clarity about the user’s
 intentions when working with a ``type``. Different concepts and usage
 patterns; different spellings.
 
@@ -931,27 +931,27 @@ parameter type or a return type:
 
    def nonsense() -> Final[object]: ...  # ERROR: Final[] not meaningful here
 
-``TypeExpr[T]`` does not allow matching such annotation expressions
+``TypeForm[T]`` does not allow matching such annotation expressions
 because it is not clear what it would mean for such an expression
 to parameterized by a type variable in position ``T``:
 
 ::
 
-   def ismatch[T](value: object, typx: TypeExpr[T]) -> TypeGuard[T]: ...
+   def ismatch[T](value: object, typx: TypeForm[T]) -> TypeGuard[T]: ...
 
    def foo(some_arg):
-       if ismatch(some_arg, Final[int]):  # ERROR: Final[int] is not a TypeExpr
+       if ismatch(some_arg, Final[int]):  # ERROR: Final[int] is not a TypeForm
            reveal_type(some_arg)  # ? NOT Final[int], because invalid for a parameter
 
 Functions that wish to operate on *all* kinds of annotation expressions,
-including those that are not ``TypeExpr``\ s, can continue to accept such
+including those that are not ``TypeForm``\ s, can continue to accept such
 inputs as ``object`` parameters, as they must do so today.
 
 
 Accept only universal type expressions
 --------------------------------------
 
-Earlier drafts of this PEP only allowed ``TypeExpr[]`` to match the subset
+Earlier drafts of this PEP only allowed ``TypeForm[]`` to match the subset
 of type expressions which are valid in *all* contexts, excluding
 :ref:`non-universal type expressions <non_universal_typeexpr>`.
 However doing that would effectively
@@ -960,7 +960,7 @@ would have to understand, on top of all the existing distinctions between
 “class objects”, “type expressions”, and “annotation expressions”.
 
 To avoid introducing yet another concept that everyone has to learn,
-this proposal just rounds ``TypeExpr[]`` to exactly match the existing
+this proposal just rounds ``TypeForm[]`` to exactly match the existing
 definition of a “type expression”.
 
 
@@ -977,14 +977,14 @@ Consider the following possible pattern matching syntax:
 ::
 
    @overload
-   def checkcast(typx: TypeExpr[AT=Annotated[T, *Anns]], value: str) -> T: ...
+   def checkcast(typx: TypeForm[AT=Annotated[T, *Anns]], value: str) -> T: ...
    @overload
-   def checkcast(typx: TypeExpr[UT=Union[*Ts]], value: str) -> Union[*Ts]: ...
+   def checkcast(typx: TypeForm[UT=Union[*Ts]], value: str) -> Union[*Ts]: ...
    @overload
    def checkcast(typx: type[C], value: str) -> C: ...
    # ... (more)
 
-All functions observed in the wild that conceptually take a ``TypeExpr[]``
+All functions observed in the wild that conceptually take a ``TypeForm[]``
 generally try to support *all* kinds of type expressions, so it doesn’t
 seem valuable to enumerate a particular subset.
 
@@ -1001,7 +1001,7 @@ interior type argument and strip away the metadata:
 ::
 
    def checkcast(
-       typx: TypeExpr[T] | TypeExpr[AT=Annotated[T, *Anns]],
+       typx: TypeForm[T] | TypeForm[AT=Annotated[T, *Anns]],
        value: object
    ) -> T:
 
@@ -1011,17 +1011,17 @@ The example above could be more-straightforwardly written as the equivalent:
 
 ::
 
-   def checkcast(typx: TypeExpr[T], value: object) -> T:
+   def checkcast(typx: TypeForm[T], value: object) -> T:
 
 
 .. _recognize_uniontype_as_implicit_typeexpr_value:
 
-Recognize (T1 | T2) as an implicit TypeExpr value
+Recognize (T1 | T2) as an implicit TypeForm value
 -------------------------------------------------
 
 It would be nice if a value expression like ``int | str`` could be recognized
-as an implicit ``TypeExpr`` value and be used directly in a context where a
-``TypeExpr`` was expected. However making that possible would require making
+as an implicit ``TypeForm`` value and be used directly in a context where a
+``TypeForm`` was expected. However making that possible would require making
 changes to the rules that type checkers use for the ``|`` operator. These rules
 are currently underspecified and would need to be make explicit first,
 before making changes to them. The PEP author is not sufficently motivated to
@@ -1041,7 +1041,7 @@ Footnotes
    ``dataclass.make_dataclass`` accepts ``InitVar[...]`` as a special case
    in addition to type expressions. Therefore it may unfortunately be necessary
    to continue annotating its ``type`` parameter as ``object`` rather
-   than ``TypeExpr``.
+   than ``TypeForm``.
 
 .. [#forward_ref_normalization]
    Special forms normalize string arguments to ``ForwardRef`` instances


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3908.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->