### PR TITLE
PEP 639: Make the policy around globs tighter

### DIFF
--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -521,20 +521,31 @@ containing licenses and other legal notices to be distributed with the package.
 It corresponds to the ``License-File`` fields in the Core Metadata.
 
 Its value is an array of strings which MUST contain valid glob patterns,
-as specified below.
-The glob patterns MAY contain special glob characters: ``*``, ``?``, ``**``
-and character ranges: ``[]``, and tools MUST support them.
-Path delimiters MUST be the forward slash character (``/``),
-and parent directory indicators (``..``) MUST NOT be used.
+as specified below:
+
+- Alphanumeric characters, underscores (``_``), hyphens (``-``) and dots (``.``)
+  MUST be matched verbatim.
+
+- Special glob characters: ``*``, ``?``, ``**`` and character ranges: ``[]``
+  containing only the verbatim matched characters MUST be supported.
+  Within ``[...]``, the hyphen indicates a range (e.g. ``a-z``).
+  Hyphens at the start or end are matched literally.
+
+- Path delimiters MUST be the forward slash character (``/``).
+  Patterns are relative to the directory containing ``pyproject.toml``,
+  therefore the leading slash character MUST NOT be used.
+
+- Parent directory indicators (``..``) MUST NOT be used.
+
+Any characters or character sequences not covered by this specification are
+invalid. Projects MUST NOT use such values.
+Tools consuming this field MAY reject invalid values with an error.
+
 Tools MUST assume that license file content is valid UTF-8 encoded text,
 and SHOULD validate this and raise an error if it is not.
 
 Literal paths (e.g. ``LICENSE``) are treated as valid globs which means they
 can also be defined.
-
-To achieve better portability, the filenames to match should only contain
-the alphanumeric characters, underscores (``_``), hyphens (``-``)
-and dots (``.``).
 
 Build tools:
 


### PR DESCRIPTION
Changes made based on the recent development of https://discuss.python.org/t/pep-639-round-3-improving-license-clarity-with-better-package-metadata/53020


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3913.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->