### PR TITLE
PEP 639: Character ranges are treated locale-agnostic

### DIFF
--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -528,7 +528,8 @@ as specified below:
 
 - Special glob characters: ``*``, ``?``, ``**`` and character ranges: ``[]``
   containing only the verbatim matched characters MUST be supported.
-  Within ``[...]``, the hyphen indicates a range (e.g. ``a-z``).
+  Within ``[...]``, the hyphen indicates a locale-agnostic range (e.g. ``a-z``,
+  order based on Unicode code points).
   Hyphens at the start or end are matched literally.
 
 - Path delimiters MUST be the forward slash character (``/``).


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3914.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->