### PR TITLE
PEP 484: Add missing `None` return types to `__init__`s

### DIFF
--- a/peps/pep-0484.rst
+++ b/peps/pep-0484.rst
@@ -871,14 +871,14 @@ of some of the methods.  For example, the following code (the start of
 a simple binary tree implementation) does not work::
 
   class Tree:
-      def __init__(self, left: Tree, right: Tree):
+      def __init__(self, left: Tree, right: Tree) -> None:
           self.left = left
           self.right = right
 
 To address this, we write::
 
   class Tree:
-      def __init__(self, left: 'Tree', right: 'Tree'):
+      def __init__(self, left: 'Tree', right: 'Tree') -> None:
           self.left = left
           self.right = right
 
@@ -2312,7 +2312,7 @@ example::
   class Node:
       """Binary tree node."""
 
-      def __init__(self, left: Node, right: Node):
+      def __init__(self, left: Node, right: Node) -> None:
           self.left = left
           self.right = right
 


### PR DESCRIPTION
...to be consistent with PEP 484, lines 121–128.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [ ] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3915.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->