### PR TITLE
PEP 639: consuming tools SHOULD reject invalid glob patterns

### DIFF
--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -540,7 +540,7 @@ as specified below:
 
 Any characters or character sequences not covered by this specification are
 invalid. Projects MUST NOT use such values.
-Tools consuming this field MAY reject invalid values with an error.
+Tools consuming this field SHOULD reject invalid values with an error.
 
 Tools MUST assume that license file content is valid UTF-8 encoded text,
 and SHOULD validate this and raise an error if it is not.


### PR DESCRIPTION
Inspired by https://github.com/python/peps/pull/3913/files#r1722968974 .

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3926.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->