### PR TITLE
PEP 741: Update options

### DIFF
--- a/peps/pep-0741.rst
+++ b/peps/pep-0741.rst
@@ -276,7 +276,7 @@ Following options can be get by ``PyConfig_Get()`` and set and
      - API: ``sys.base_exec_prefix``.
    * - ``base_executable``
      - ``str``
-     - API: ``sys.base_executable``.
+     - API: ``sys._base_executable``.
    * - ``base_prefix``
      - ``str``
      - API: ``sys.base_prefix``.
@@ -285,7 +285,7 @@ Following options can be get by ``PyConfig_Get()`` and set and
      - API: ``sys.flags.bytes_warning``.
    * - ``exec_prefix``
      - ``str``
-     - API: ``sys.base_prefix``.
+     - API: ``sys.exec_prefix``.
    * - ``executable``
      - ``str``
      - API: ``sys.executable``.
@@ -370,7 +370,7 @@ Following options can be get by ``PyConfig_Get()``, but cannot be set by
      -
    * - ``check_hash_pycs_mode``
      - ``str``
-     - API: ``imp.check_hash_pycs_mode``.
+     -
    * - ``code_debug_ranges``
      - ``bool``
      -
@@ -424,32 +424,26 @@ Following options can be get by ``PyConfig_Get()``, but cannot be set by
      - API: ``sys.flags.isolated`` (``int``).
    * - ``legacy_windows_fs_encoding``
      - ``bool``
-     -
+     - Windows only.
    * - ``legacy_windows_stdio``
      - ``bool``
      - Windows only.
    * - ``malloc_stats``
      - ``bool``
      -
-   * - ``module_search_paths_set``
-     - ``bool``
-     -
    * - ``orig_argv``
      - ``list[str]``
      - API: ``sys.orig_argv``.
-   * - ``pathconfig_warnings``
+   * - ``parse_argv``
      - ``bool``
      -
-   * - ``parse_argv``
+   * - ``pathconfig_warnings``
      - ``bool``
      -
    * - ``perf_profiling``
      - ``bool``
      - API: ``sys.is_stack_trampoline_active()``.
    * - ``program_name``
-     - ``str``
-     -
-   * - ``pythonpath_env``
      - ``str``
      -
    * - ``run_command``
@@ -484,9 +478,6 @@ Following options can be get by ``PyConfig_Get()``, but cannot be set by
      - ``str``
      - API: ``sys.stdin.errors``, ``sys.stdout.errors`` and
        ``sys.stderr.errors``.
-   * - ``sys_path_0``
-     - ``str``
-     -
    * - ``tracemalloc``
      - ``int``
      - API: ``tracemalloc.is_tracing()`` (``bool``).
@@ -496,22 +487,13 @@ Following options can be get by ``PyConfig_Get()``, but cannot be set by
    * - ``use_hash_seed``
      - ``bool``
      -
-   * - ``utf8_mode``
-     - ``bool``
-     -
    * - ``user_site_directory``
      - ``bool``
      - API: ``sys.flags.no_user_site`` (``int``).
+   * - ``utf8_mode``
+     - ``bool``
+     -
    * - ``warn_default_encoding``
-     - ``bool``
-     -
-   * - ``_install_importlib``
-     - ``bool``
-     -
-   * - ``_init_main``
-     - ``bool``
-     -
-   * - ``_is_python_build``
      - ``bool``
      -
    * - ``_pystats``


### PR DESCRIPTION
* Remove read-only options:

  * "module_search_paths_set": not useful, always true.
  * "pythonpath_env": get os.environ['PYTHONPATH'] directly.
  * "sys_path_0": only make sense during Python initialization.
  * "_install_importlib", "_init_main", "_is_python_build": private options which only make sense during Python initialization.

* Fix related sys API for base_executable and exec_prefix.
* legacy_windows_fs_encoding is Windows only.
* Fix sorting.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3927.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->