### PR TITLE
PEP 7: Break lines before operators ("Knuth's style")

### DIFF
--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -140,36 +140,23 @@ Code lay-out
                   "cannot create '%.100s' instances",
                   type->tp_name);
 
-* In new code, when you break a long expression at a binary operator, the
-  operator goes at the beginning of the next line, and braces should be
-  formatted as shown.  For example:
+* When you break a long expression at a binary operator, braces
+  should be formatted as shown:
 
   .. code-block::
      :class: good
 
-     if (type->tp_dictoffset != 0 && base->tp_dictoffset == 0
+     if (type->tp_dictoffset != 0
+         && base->tp_dictoffset == 0
          && type->tp_dictoffset == b_size
          && (size_t)t_size == b_size + sizeof(PyObject *))
      {
          return 0; /* "Forgive" adding a __dict__ only */
      }
 
-  For decades, the recommended style was to break after binary operators
-  instead.  It's OK to use this older style to stay consistent
-  with surrounding code:
-
-  .. code-block::
-     :class: maybe
-
-     if (type->tp_dictoffset != 0 && base->tp_dictoffset == 0 &&
-         type->tp_dictoffset == b_size &&
-         (size_t)t_size == b_size + sizeof(PyObject *))
-     {
-         return 0; /* "Forgive" adding a __dict__ only */
-     }
-
-  See :ref:`“Should a Line Break Before or After a Binary Operator?” in PEP 8
-  <pep8-operator-linebreak>` for discussion.
+  It's OK to put operators at ends of lines, especially to be
+  consistent with surrounding code.
+  (See :ref:`PEP 8 <pep8-operator-linebreak>` for a longer discussion.)
 
 * Vertically align line continuation characters in multi-line macros.
 

--- a/peps/pep-0007.rst
+++ b/peps/pep-0007.rst
@@ -140,12 +140,26 @@ Code lay-out
                   "cannot create '%.100s' instances",
                   type->tp_name);
 
-* When you break a long expression at a binary operator, the
-  operator goes at the end of the previous line, and braces should be
-  formatted as shown.  E.g.:
+* In new code, when you break a long expression at a binary operator, the
+  operator goes at the beginning of the next line, and braces should be
+  formatted as shown.  For example:
 
   .. code-block::
      :class: good
+
+     if (type->tp_dictoffset != 0 && base->tp_dictoffset == 0
+         && type->tp_dictoffset == b_size
+         && (size_t)t_size == b_size + sizeof(PyObject *))
+     {
+         return 0; /* "Forgive" adding a __dict__ only */
+     }
+
+  For decades, the recommended style was to break after binary operators
+  instead.  It's OK to use this older style to stay consistent
+  with surrounding code:
+
+  .. code-block::
+     :class: maybe
 
      if (type->tp_dictoffset != 0 && base->tp_dictoffset == 0 &&
          type->tp_dictoffset == b_size &&
@@ -153,6 +167,9 @@ Code lay-out
      {
          return 0; /* "Forgive" adding a __dict__ only */
      }
+
+  See :ref:`“Should a Line Break Before or After a Binary Operator?” in PEP 8
+  <pep8-operator-linebreak>` for discussion.
 
 * Vertically align line continuation characters in multi-line macros.
 

--- a/peps/pep-0008.rst
+++ b/peps/pep-0008.rst
@@ -257,6 +257,9 @@ Another such case is with ``assert`` statements.
 
 Make sure to indent the continued line appropriately.
 
+
+.. _`pep8-operator-linebreak`:
+
 Should a Line Break Before or After a Binary Operator?
 ------------------------------------------------------
 


### PR DESCRIPTION
As discussed in: https://discuss.python.org/t/pep-7-break-lines-before-operators-like-pep-8/62402

It doesn't make much sense for C and Python to be different here, and the reasons for "Knuth's style" in PEP 8 apply to C code as well.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3931.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->