### PR TITLE
PEP 705: Remove extra `self` parameter from example

### DIFF
--- a/peps/pep-0705.rst
+++ b/peps/pep-0705.rst
@@ -353,7 +353,7 @@ Keyword argument typing
     class Function(Protocol):
         def __call__(self, **kwargs: Unpack[Args]) -> None: ...
 
-    def impl(self, **kwargs: Unpack[ReadOnlyArgs]) -> None:
+    def impl(**kwargs: Unpack[ReadOnlyArgs]) -> None:
         kwargs["key1"] = 3  # Type check error: key1 is readonly
 
     fn: Function = impl  # Accepted by type checker: function signatures are identical


### PR DESCRIPTION
Seems to be a typo. `impl()` is not expected to have `self` parameter, I believe.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3934.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->