### PR TITLE
PEP 742: Mark as Final

### DIFF
--- a/peps/pep-0742.rst
+++ b/peps/pep-0742.rst
@@ -2,7 +2,7 @@ PEP: 742
 Title: Narrowing types with TypeIs
 Author: Jelle Zijlstra <jelle.zijlstra@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-742-narrowing-types-with-typenarrower/45613
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
 Created: 07-Feb-2024
@@ -11,6 +11,8 @@ Post-History: `11-Feb-2024 <https://discuss.python.org/t/pep-742-narrowing-types
 Replaces: 724
 Resolution: https://discuss.python.org/t/pep-742-narrowing-types-with-typeis/45613/35
 
+.. canonical-typing-spec:: :ref:`typing:typeis` and
+                           :external+py3.13:data:`typing.TypeIs`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps https://github.com/python/peps/issues/3781.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3937.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->