### PR TITLE
PEP 705: Mark as Final

### DIFF
--- a/peps/pep-0705.rst
+++ b/peps/pep-0705.rst
@@ -3,10 +3,9 @@ Title: TypedDict: Read-only items
 Author: Alice Purcell <alicederyn@gmail.com>
 Sponsor: Pablo Galindo <pablogsal@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-705-read-only-typeddict-items/37867
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 07-Nov-2022
 Python-Version: 3.13
 Post-History: `30-Sep-2022 <https://mail.python.org/archives/list/typing-sig@python.org/thread/6FR6RKNUZU4UY6B6RXC2H4IAHKBU3UKV/>`__,
@@ -16,6 +15,8 @@ Post-History: `30-Sep-2022 <https://mail.python.org/archives/list/typing-sig@pyt
               `04-Nov-2023 <https://discuss.python.org/t/pep-705-read-only-typeddict-items/37867>`__,
 Resolution: https://discuss.python.org/t/pep-705-read-only-typeddict-items/37867/39
 
+.. canonical-typing-spec:: :ref:`typing:readonly` and
+                           :external+py3.13:data:`typing.ReadOnly`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps https://github.com/python/peps/issues/3781, cc @alicederyn.

The spec link goes to:

https://typing.readthedocs.io/en/latest/spec/typeddict.html#typing-readonly-type-qualifier

Or do we want to link to the header just above it? We'll need to add an extra ref to the spec, if so.

https://typing.readthedocs.io/en/latest/spec/typeddict.html#read-only-items

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3938.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->