### PR TITLE
PEP 719: 3.13.0rc2 was posponed to 2024-09-06

### DIFF
--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -51,7 +51,7 @@ Actual:
 
 Expected:
 
-- 3.13.0 candidate 2: Tuesday, 2024-09-03
+- 3.13.0 candidate 2: Friday, 2024-09-06
 - 3.13.0 final: Tuesday, 2024-10-01
 
 Subsequent bugfix releases every two months.


### PR DESCRIPTION
Source: https://discuss.python.org/t/python-3-13-0rc2-tomorrow-w-this-friday/62694/2

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

cc @Yhg1s 

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3939.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->