### PR TITLE
PEP 702: Mark as Final

### DIFF
--- a/peps/pep-0702.rst
+++ b/peps/pep-0702.rst
@@ -2,16 +2,17 @@ PEP: 702
 Title: Marking deprecations using the type system
 Author: Jelle Zijlstra <jelle.zijlstra@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-702-marking-deprecations-using-the-type-system/23036
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 30-Dec-2022
 Python-Version: 3.13
 Post-History: `01-Jan-2023 <https://mail.python.org/archives/list/typing-sig@python.org/thread/AKTFUYW3WDT7R7PGRIJQZMYHMDJNE4QH/>`__,
               `22-Jan-2023 <https://discuss.python.org/t/pep-702-marking-deprecations-using-the-type-system/23036>`__
 Resolution: https://discuss.python.org/t/pep-702-marking-deprecations-using-the-type-system/23036/61
 
+.. canonical-typing-spec:: :ref:`typing:deprecated` and
+                           :external+py3.13:func:`@warnings.deprecated<warnings.deprecated>`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps https://github.com/python/peps/issues/3781.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3940.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->