### PR TITLE
PEP 696: Mark as Final

### DIFF
--- a/peps/pep-0696.rst
+++ b/peps/pep-0696.rst
@@ -12,7 +12,8 @@ Post-History: `22-Mar-2022 <https://mail.python.org/archives/list/typing-sig@pyt
               `08-Jan-2023 <https://discuss.python.org/t/pep-696-type-defaults-for-typevarlikes/22569/>`__,
 Resolution: https://discuss.python.org/t/pep-696-type-defaults-for-typevarlikes/22569/34
 
-.. canonical-typing-spec:: :ref:`typing:type_parameter_defaults`
+.. canonical-typing-spec:: :ref:`typing:type_parameter_defaults` and
+                           :external+py3.13:ref:`type-params`
 
 Abstract
 --------

--- a/peps/pep-0696.rst
+++ b/peps/pep-0696.rst
@@ -3,15 +3,16 @@ Title: Type Defaults for Type Parameters
 Author: James Hilton-Balfe <gobot1234yt@gmail.com>
 Sponsor: Jelle Zijlstra <jelle.zijlstra@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-696-type-defaults-for-typevarlikes/22569
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
-Content-Type: text/x-rst
 Created: 14-Jul-2022
 Python-Version: 3.13
 Post-History: `22-Mar-2022 <https://mail.python.org/archives/list/typing-sig@python.org/thread/7VWBZWXTCX6RAJO6GG67BAXUPFZ24NTC/>`__,
               `08-Jan-2023 <https://discuss.python.org/t/pep-696-type-defaults-for-typevarlikes/22569/>`__,
 Resolution: https://discuss.python.org/t/pep-696-type-defaults-for-typevarlikes/22569/34
+
+.. canonical-typing-spec:: :ref:`typing:type_parameter_defaults`
 
 Abstract
 --------


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Helps https://github.com/python/peps/issues/3781, cc @Gobot1234.

This is documented in the typing spec at https://typing.readthedocs.io/en/latest/spec/generics.html#type-parameter-defaults.

Is it documented at https://docs.python.org/3.13/? Should it be?
