### PR TITLE
PEP 744: fix broken links to benchmarking-public images

### DIFF
--- a/peps/pep-0744.rst
+++ b/peps/pep-0744.rst
@@ -501,7 +501,7 @@ Speed
 -----
 
 Currently, the JIT is `about as fast as the existing specializing interpreter 
-<https://github.com/faster-cpython/benchmarking-public/blob/main/configs.png>`__
+<https://github.com/faster-cpython/benchmarking-public/blob/main/configs.svg>`__
 on most platforms. Improving this is obviously a top priority at this point,
 since providing a significant performance gain is the entire motivation for
 having a JIT at all. A number of proposed improvements are already underway, and
@@ -515,7 +515,7 @@ Because it allocates additional memory for executable machine code, the JIT does
 use more memory than the existing interpreter at runtime. According to the
 official benchmarks, the JIT currently uses about `10-20% more memory than the
 base interpreter
-<https://github.com/faster-cpython/benchmarking-public/blob/main/memory_configs.png>`__.
+<https://github.com/faster-cpython/benchmarking-public/blob/main/memory_configs.svg>`__.
 The upper end of this range is due to ``aarch64-apple-darwin``, which has larger
 page sizes (and thus, a larger minimum allocation granularity).
 


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3953.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->