### PR TITLE
PEP 703: Fix typo 

### DIFF
--- a/peps/pep-0703.rst
+++ b/peps/pep-0703.rst
@@ -13,7 +13,7 @@ Post-History: `09-Jan-2023 <https://discuss.python.org/t/22606>`__,
 Resolution: https://discuss.python.org/t/pep-703-making-the-global-interpreter-lock-optional-in-cpython-acceptance/37075
 
 .. note::
-   The Steering Council accepts PEP 703, but with clear provisio: that
+   The Steering Council accepts PEP 703, but with clear provision: that
    the rollout be gradual and break as little as possible, and that we can roll
    back any changes that turn out to be too disruptive – which includes
    potentially rolling back all of PEP 703 entirely if necessary

--- a/peps/pep-0703.rst
+++ b/peps/pep-0703.rst
@@ -13,7 +13,7 @@ Post-History: `09-Jan-2023 <https://discuss.python.org/t/22606>`__,
 Resolution: https://discuss.python.org/t/pep-703-making-the-global-interpreter-lock-optional-in-cpython-acceptance/37075
 
 .. note::
-   The Steering Council accepts PEP 703, but with clear provision: that
+   The Steering Council accepts PEP 703, but with clear proviso: that
    the rollout be gradual and break as little as possible, and that we can roll
    back any changes that turn out to be too disruptive – which includes
    potentially rolling back all of PEP 703 entirely if necessary


### PR DESCRIPTION
Pretty self-explanatory, this PR updates a typo.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3956.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->