### PR TITLE
PEP 2026: Fix repeated word typos

### DIFF
--- a/peps/pep-2026.rst
+++ b/peps/pep-2026.rst
@@ -220,7 +220,7 @@ For example:
    removal in Python 3.15
 
 However, once aware of CalVer, it is immediately obvious from the warning how
-long you have to to take action:
+long you have to take action:
 
    DeprecationWarning: 'ctypes.SetPointerType' is deprecated and slated for
    removal in Python 3.26
@@ -494,7 +494,7 @@ commands. ``python`` can map to either ``python2`` or ``python3``.
 These would need revisiting if the major version changed, and started changing annually.
 
 Four years after Python 2.7's end-of-life, we could recommend ``python`` only
-maps to the the latest Python 3+ version.
+maps to the latest Python 3+ version.
 But what would ``python3`` map to when Python 26.0 is out?
 This would introduce additional complexity and cost.
 


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

---

Spotted two instances where a word is repeated twice:
* "how long you have **to to** take action"
* "maps to **the the** latest Python 3+ version."

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3957.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->