### PR TITLE
PEP 755: Address feedback, round 1

### DIFF
--- a/peps/pep-0755.rst
+++ b/peps/pep-0755.rst
@@ -37,9 +37,8 @@ and even `account recovery <https://discuss.python.org/t/43422/122>`__.
 
 __ https://pyfound.blogspot.com/2024/07/announcing-our-new-pypi-support.html
 
-The `default policy <approval-criteria_>`_ of only allowing corporate
-organizations to reserve namespaces (except in specific scenarios) provides
-the following benefits:
+The `default policy <approval-criteria_>`_ of giving paid organizations more
+leniency when reserving namespaces provides the following benefits:
 
 * PyPI would have a constant source of funding for support specialists,
   infrastructure maintenance, bug fixes and new features.
@@ -50,14 +49,18 @@ the following benefits:
 Terminology
 ===========
 
-Corporate Organization
-    Corporate organizations are :pep:`organizations <752#organizations>` that
-    pay for special functionality on PyPI.
+Paid/Corporate Organization
+    `Corporate organizations`__ are :pep:`organizations <752#organizations>`
+    that pay for special functionality on PyPI. This PEP refers to them as
+    paid in most circumstances for brevity and to ease understanding for
+    non-native speakers.
 Root Grant
     A grant as defined by :pep:`PEP 752 terminology <752#terminology>`.
 Child Grant
     A grant created from a root grant with the associated namespace being a
     child namespace as defined by :pep:`PEP 752 terminology <752#terminology>`.
+
+__ https://docs.pypi.org/organization-accounts/pricing-and-payments/#corporate-organizations
 
 Implementation
 ==============
@@ -68,8 +71,13 @@ Grant Applications
 Submission
 ''''''''''
 
-Only organizations have access to the page for submitting grant applications.
-Reviews of corporate organizations' applications will be prioritized.
+Only organization (non-user) accounts have access to the grant application
+form.
+
+Applications for paid organizations receive priority in the reviewing queue.
+This is both to offer a meaningful benefit to paid organizations and to ensure
+that funding is available for PyPI's operational costs, including more
+reviewers.
 
 .. _approval-criteria:
 
@@ -83,8 +91,8 @@ Approval Criteria
 5. There should be evidence that *not* reserving the namespace may cause
    ambiguity, confusion, or other harm to the community.
 
-Organizations that are not corporate organizations will
-represent one of the following:
+Organizations that are not paid organizations will represent one of the
+following:
 
 * Large, popular open-source projects with many packages
 * Universities that actively publish packages
@@ -92,8 +100,8 @@ represent one of the following:
 * NPOs/NGOs that actively publish packages like
   `Our World in Data <https://github.com/owid>`__
 
-Generally speaking, reviewers should be more tolerant of corporate
-organizations that apply for grants for which they are not yet using.
+Generally speaking, reviewers should be more tolerant of paid organizations
+that apply for grants for which they are not yet using.
 
 For example, while it's reasonable to grant a namespace to a startup or an
 existing company with a new product line, it's not as reasonable to grant a
@@ -150,9 +158,9 @@ grant. The grants behave as if they were owned by the organization. The owner
 may revoke this permission at any time.
 
 The owner may transfer ownership to another organization at any time without
-approval from PyPI admins. If the organization is a corporate organization,
-the target for transfer must also be a corporate organization. Settings for
-permitted organizations are transferred as well.
+approval from PyPI admins. If the organization is a paid organization, the
+target for transfer must also be a paid organization. Settings for permitted
+organizations are transferred as well.
 
 .. _user-interface:
 
@@ -213,9 +221,6 @@ When a `child grant <child-grant_>`_ is created, its
 time. If a grant is open, it cannot be made restricted unless the owner of the
 grant is the owner of every project that matches the namespace.
 
-Root grants given to `community projects <approval-criteria_>`_ should only be
-open but is ultimately up to the reviewer of the application.
-
 Grant Removal
 -------------
 
@@ -237,6 +242,10 @@ How to Teach This
 
 For organizations, we will document how to reserve namespaces, what the
 benefits are and pricing.
+
+We will document :pep:`541` on the same pages so that organizations are aware
+of the main mechanism to report improper uses of existing packages matching
+their grants.
 
 Rejected Ideas
 ==============


### PR DESCRIPTION
1. Improved wording in the rationale to make it clear that community organizations can reserve namespaces.
2. Used "paid" organization over "corporate" organization to ease understanding for non-native speakers and reduce concern among those who consider the word corporate to have a negative connotation.
3. Removed expectation that grants for communities should be open.
4. Improved language around why reviews for paid organizations are prioritized.
5. Included PEP 541 in the expected teaching process.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3959.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->