### PR TITLE
PEP 756: Fix buffer format

### DIFF
--- a/peps/pep-0756.rst
+++ b/peps/pep-0756.rst
@@ -171,8 +171,8 @@ export format:
 Export format               Buffer format       Item size
 ==========================  ==================  ============
 ``PyUnicode_FORMAT_UCS1``   ``"B"``             1 byte
-``PyUnicode_FORMAT_UCS2``   ``"H"``             2 bytes
-``PyUnicode_FORMAT_UCS4``   ``"I"`` or ``"L"``  4 bytes
+``PyUnicode_FORMAT_UCS2``   ``"=H"``            2 bytes
+``PyUnicode_FORMAT_UCS4``   ``"=I"``            4 bytes
 ``PyUnicode_FORMAT_UTF8``   ``"B"``             1 byte
 ``PyUnicode_FORMAT_ASCII``  ``"B"``             1 byte
 ==========================  ==================  ============


### PR DESCRIPTION
Use the native encoding. "=I" size is 4 bytes on all platforms.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3967.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->