### PR TITLE
PEP 757: use PyLong_Export

### DIFF
--- a/peps/pep-0757.rst
+++ b/peps/pep-0757.rst
@@ -100,12 +100,19 @@ Export a Python integer as a digits array::
 
         // Read-only array of unsigned digits.
         const void *digits;
+
+        // Member used internally, must not be used for other purpose.
+        Py_uintptr_t _reserved;
     } PyLong_DigitArray;
 
     PyAPI_FUNC(int) PyLong_Export(PyObject *obj, PyLong_DigitArray *array);
 
 On CPython 3.14, no memory copy is needed, it's just a thin wrapper to
 expose Python int internal digits array.
+
+``PyLong_DigitArray._reserved`` stores a strong reference to the Python
+:class:`int` object to make sure that that structure remains valid until
+``PyLong_FreeExport()`` is called.
 
 
 PyLong_Export()

--- a/peps/pep-0757.rst
+++ b/peps/pep-0757.rst
@@ -123,8 +123,8 @@ On error, set an exception and return -1.
 If ``array->digits`` set to ``NULL``, caller must use instead ``array->value``
 to get value of an :class:`int` object.
 
-This function always succeeds if *obj* is a Python :class:`int` object or a
-subclass.
+CPython implementation detail: This function always succeeds if *obj* is a
+Python :class:`int` object or a subclass.
 
 ``PyLong_FreeExport()`` must be called once done with using *array*.
 

--- a/peps/pep-0757.rst
+++ b/peps/pep-0757.rst
@@ -17,8 +17,7 @@ Abstract
 ========
 
 Add a new C API to import and export Python integers, :class:`int` objects:
-especially ``PyLongWriter_Create()`` and ``PyLong_AsDigitArray()``
-functions.
+especially ``PyLongWriter_Create()`` and ``PyLong_Export()`` functions.
 
 
 Rationale
@@ -90,8 +89,11 @@ Export API
 Export a Python integer as a digits array::
 
     typedef struct PyLong_DigitArray {
+        // use value, if digits set to NULL.
+        int64_t value;
+
         // 1 if the number is negative, 0 otherwise.
-        int negative;
+        int8_t negative;
 
         // Number of digits in the 'digits' array.
         Py_ssize_t ndigits;
@@ -103,37 +105,31 @@ Export a Python integer as a digits array::
         Py_uintptr_t _reserved;
     } PyLong_DigitArray;
 
-    PyAPI_FUNC(int) PyLong_AsDigitArray(
-        PyObject *obj,
-        PyLong_DigitArray *array);
-    PyAPI_FUNC(void) PyLong_FreeDigitArray(
-        PyLong_DigitArray *array);
+    PyAPI_FUNC(int) PyLong_Export(PyObject *obj, PyLong_DigitArray *array);
 
 On CPython 3.14, no memory copy is needed, it's just a thin wrapper to
 expose Python int internal digits array.
 
-``PyLong_DigitArray.obj`` stores a strong reference to the Python
-:class:`int` object to make sure that that structure remains valid until
-``PyLong_FreeDigitArray()`` is called.
 
-
-PyLong_AsDigitArray()
-^^^^^^^^^^^^^^^^^^^^^
+PyLong_Export()
+^^^^^^^^^^^^^^^
 
 API::
 
-    int PyLong_AsDigitArray(PyObject *obj, PyLong_DigitArray *array)
+    int PyLong_Export(PyObject *obj, PyLong_DigitArray *array)
 
 Export a Python :class:`int` object as a digits array.
 
 On success, set *\*array* and return 0.
 On error, set an exception and return -1.
 
+If ``array->digits`` set to ``NULL``, caller must use instead ``array->value``
+to get value of an :class:`int` object.
+
 This function always succeeds if *obj* is a Python :class:`int` object or a
 subclass.
 
-``PyLong_FreeDigitArray()`` must be called once done with using
-*array*.
+``PyLong_FreeExport()`` must be called once done with using *array*.
 
 
 PyLong_FreeDigitArray()
@@ -141,9 +137,9 @@ PyLong_FreeDigitArray()
 
 API::
 
-    void PyLong_FreeDigitArray(PyLong_DigitArray *array)
+    void PyLong_FreeExport(PyLong_DigitArray *array)
 
-Release the export *array* created by ``PyLong_AsDigitArray()``.
+Free the export *array* created by ``PyLong_Export()``.
 
 
 Import API
@@ -223,7 +219,7 @@ directly Python internals, the proposed API can have a significant
 performance overhead on small integers.
 
 For small integers of a few digits (for example, 1 or 2 digits), existing APIs
-can be used. Examples to import / export:
+can be used
 
 * :external+py3.14:c:func:`PyLong_FromUInt64()` / :external+py3.14:c:func:`PyLong_AsUInt64()`;
 * :c:func:`PyLong_FromLong()` / :c:func:`PyLong_AsLong()` or :c:func:`PyLong_AsInt()`;
@@ -248,8 +244,8 @@ Implementation
 Benchmarks
 ==========
 
-Export: PyLong_AsDigitArray() with gmpy2
-----------------------------------------
+Export: PyLong_Export() with gmpy2
+----------------------------------
 
 Code::
 
@@ -263,15 +259,25 @@ Code::
             const PyLongLayout* layout = PyLong_GetNativeLayout();
             static PyLong_DigitArray long_export;
 
-            PyLong_AsDigitArray(obj, &long_export);
-            mpz_import(z, long_export.ndigits, layout->endian,
-                       layout->digit_size, layout->digits_order,
-                       layout->digit_size*8 - layout->bits_per_digit,
-                       long_export.digits);
+            PyLong_Export(obj, &long_export);
+            if (long_export.digits) {
+                mpz_import(z, long_export.ndigits, layout->digits_order,
+                           layout->digit_size, layout->endian,
+                           layout->digit_size*8 - layout->bits_per_digit,
+                           long_export.digits);
+            }
+            else {
+                if (long_export.negative) {
+                    long_export.value = -long_export.value;
+                }
+                mpz_import(z, 1, -1, sizeof(int64_t), 0, 0,
+                           &long_export.value);
+            }
+            PyLong_FreeExport(&long_export);
+
             if (long_export.negative) {
                 mpz_neg(z, z);
             }
-            PyLong_FreeDigitArray(&long_export);
         }
         else {
             mpz_set_si(z, val);

--- a/peps/pep-0757.rst
+++ b/peps/pep-0757.rst
@@ -93,7 +93,7 @@ Export a Python integer as a digits array::
         int64_t value;
 
         // 1 if the number is negative, 0 otherwise.
-        int8_t negative;
+        uint8_t negative;
 
         // Number of digits in the 'digits' array.
         Py_ssize_t ndigits;
@@ -105,7 +105,7 @@ Export a Python integer as a digits array::
         Py_uintptr_t _reserved;
     } PyLong_DigitArray;
 
-    PyAPI_FUNC(int) PyLong_Export(PyObject *obj, PyLong_DigitArray *array);
+    int PyLong_Export(PyObject *obj, PyLong_DigitArray *array);
 
 On CPython 3.14, no memory copy is needed, it's just a thin wrapper to
 expose Python int internal digits array.

--- a/peps/pep-0757.rst
+++ b/peps/pep-0757.rst
@@ -271,7 +271,7 @@ Code::
             PyLong_FreeExport(&long_export);
         }
         else {
-            if (LONG_MIN <= long_export.value <= LONG_MAX) {
+            if (LONG_MIN <= long_export.value && long_export.value <= LONG_MAX) {
                 mpz_set_si(z, long_export.value);
             }
             else {

--- a/peps/pep-0757.rst
+++ b/peps/pep-0757.rst
@@ -100,9 +100,6 @@ Export a Python integer as a digits array::
 
         // Read-only array of unsigned digits.
         const void *digits;
-
-        // Member used internally, must not be used for other purpose.
-        Py_uintptr_t _reserved;
     } PyLong_DigitArray;
 
     PyAPI_FUNC(int) PyLong_Export(PyObject *obj, PyLong_DigitArray *array);

--- a/peps/pep-0757.rst
+++ b/peps/pep-0757.rst
@@ -110,9 +110,9 @@ Export a Python integer as a digits array::
 On CPython 3.14, no memory copy is needed, it's just a thin wrapper to
 expose Python int internal digits array.
 
-``PyLong_DigitArray._reserved`` stores a strong reference to the Python
-:class:`int` object to make sure that that structure remains valid until
-``PyLong_FreeExport()`` is called.
+``PyLong_DigitArray._reserved``, if ``digits`` not ``NULL``, stores a strong
+reference to the Python :class:`int` object to make sure that that structure
+remains valid until ``PyLong_FreeExport()`` is called.
 
 
 PyLong_Export()
@@ -136,8 +136,8 @@ Python :class:`int` object or a subclass.
 ``PyLong_FreeExport()`` must be called once done with using *array*.
 
 
-PyLong_FreeDigitArray()
-^^^^^^^^^^^^^^^^^^^^^^^
+PyLong_FreeExport()
+^^^^^^^^^^^^^^^^^^^
 
 API::
 
@@ -256,35 +256,35 @@ Code::
     static void
     mpz_set_PyLong(mpz_t z, PyObject *obj)
     {
-        int overflow;
-        long val = PyLong_AsLongAndOverflow(obj, &overflow);
+        const PyLongLayout* layout = PyLong_GetNativeLayout();
+        static PyLong_DigitArray long_export;
 
-        if (overflow) {
-            const PyLongLayout* layout = PyLong_GetNativeLayout();
-            static PyLong_DigitArray long_export;
-
-            PyLong_Export(obj, &long_export);
-            if (long_export.digits) {
-                mpz_import(z, long_export.ndigits, layout->digits_order,
-                           layout->digit_size, layout->endian,
-                           layout->digit_size*8 - layout->bits_per_digit,
-                           long_export.digits);
-            }
-            else {
-                if (long_export.negative) {
-                    long_export.value = -long_export.value;
-                }
-                mpz_import(z, 1, -1, sizeof(int64_t), 0, 0,
-                           &long_export.value);
-            }
-            PyLong_FreeExport(&long_export);
-
+        PyLong_Export(obj, &long_export);
+        if (long_export.digits) {
+            mpz_import(z, long_export.ndigits, layout->digits_order,
+                       layout->digit_size, layout->endian,
+                       layout->digit_size*8 - layout->bits_per_digit,
+                       long_export.digits);
             if (long_export.negative) {
                 mpz_neg(z, z);
             }
+            PyLong_FreeExport(&long_export);
         }
         else {
-            mpz_set_si(z, val);
+            if (LONG_MIN <= long_export.value <= LONG_MAX) {
+                mpz_set_si(z, long_export.value);
+            }
+            else {
+                mpz_import(z, 1, -1, sizeof(int64_t), 0, 0,
+                           &long_export.value);
+                if (long_export.value < 0) {
+                    mpz_t tmp;
+                    mpz_init(tmp);
+                    mpz_ui_pow_ui(tmp, 2, 8*sizeof(size_t));
+                    mpz_sub(z, z, tmp);
+                    mpz_clear(tmp);
+                }
+            }
         }
     }
 

--- a/peps/pep-0757.rst
+++ b/peps/pep-0757.rst
@@ -88,7 +88,7 @@ Export API
 
 Export a Python integer as a digits array::
 
-    typedef struct PyLong_DigitArray {
+    typedef struct PyLongExport {
         // use value, if digits set to NULL.
         int64_t value;
 
@@ -103,14 +103,14 @@ Export a Python integer as a digits array::
 
         // Member used internally, must not be used for other purpose.
         Py_uintptr_t _reserved;
-    } PyLong_DigitArray;
+    } PyLongExport;
 
-    int PyLong_Export(PyObject *obj, PyLong_DigitArray *array);
+    int PyLong_Export(PyObject *obj, PyLongExport *array);
 
 On CPython 3.14, no memory copy is needed, it's just a thin wrapper to
 expose Python int internal digits array.
 
-``PyLong_DigitArray._reserved``, if ``digits`` not ``NULL``, stores a strong
+``PyLongExport._reserved``, if ``digits`` not ``NULL``, stores a strong
 reference to the Python :class:`int` object to make sure that that structure
 remains valid until ``PyLong_FreeExport()`` is called.
 
@@ -120,7 +120,7 @@ PyLong_Export()
 
 API::
 
-    int PyLong_Export(PyObject *obj, PyLong_DigitArray *array)
+    int PyLong_Export(PyObject *obj, PyLongExport *array)
 
 Export a Python :class:`int` object as a digits array.
 
@@ -141,7 +141,7 @@ PyLong_FreeExport()
 
 API::
 
-    void PyLong_FreeExport(PyLong_DigitArray *array)
+    void PyLong_FreeExport(PyLongExport *array)
 
 Free the export *array* created by ``PyLong_Export()``.
 
@@ -257,7 +257,7 @@ Code::
     mpz_set_PyLong(mpz_t z, PyObject *obj)
     {
         const PyLongLayout* layout = PyLong_GetNativeLayout();
-        static PyLong_DigitArray long_export;
+        static PyLongExport long_export;
 
         PyLong_Export(obj, &long_export);
         if (long_export.digits) {
@@ -413,7 +413,7 @@ Python integers.
 
 For example, it was proposed to add a *layout* parameter to
 ``PyLongWriter_Create()`` and a *layout* member to the
-``PyLong_DigitArray`` structure.
+``PyLongExport`` structure.
 
 The problem is that it's more complex to implement and not really
 needed. What's strictly needed is only an API to import-export using the


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

This change export API to Antoine Pitrou -like proposal.

* I'm unsure if we should use signed type for ``value`` or store here absolute value.
* Right now, we probably can put compact value to this field, but using PyLong_AsLongAndOverflow first seems to be faster.  So, we might just reserve ``value`` field for future use.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3970.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->