### PR TITLE
PEP 753: suggested human labels

### DIFF
--- a/peps/pep-0753.rst
+++ b/peps/pep-0753.rst
@@ -209,15 +209,19 @@ as well as equivalent aliases.
 The following table lists these labels, in canonical form:
 
 .. csv-table::
-    :header: "Label", "Description", "Aliases"
-    :widths: 20, 50, 30
+    :header: "Label", "Description", "Aliases", "Human-readable equivalent"
+    :widths: 15, 50, 20, 15
 
-    "``homepage``", "The project's home page", "*(none)*"
-    "``download``", "A download URL for the current distribution, equivalent to ``Download-URL``", "*(none)*"
-    "``changelog``", "The project's changelog", "``changes``, ``releasenotes``, ``whatsnew``, ``history``"
-    "``documentation``", "The project's online documentation", "``docs``"
-    "``issues``", "The project's bug tracker", "``bugs``, ``issue``, ``bug``, ``tracker``, ``report``"
-    "``sponsor``", "Sponsoring information", "``funding``, ``donate``, ``donation``"
+    "``homepage``", "The project's home page", "*(none)*", "Homepage"
+    "``download``", "A download URL for the current distribution, equivalent to ``Download-URL``", "*(none)*", "Download"
+    "``changelog``", "The project's changelog", "``changes``, ``releasenotes``, ``whatsnew``, ``history``", "Changelog"
+    "``documentation``", "The project's online documentation", "``docs``", "Documentation"
+    "``issues``", "The project's bug tracker", "``bugs``, ``issue``, ``bug``, ``tracker``, ``report``", "Issue Tracker"
+    "``sponsor``", "Sponsoring information", "``funding``, ``donate``, ``donation``", "Sponsor"
+
+Indices **MAY** choose to use the human-readable equivalents suggested above
+in their UI elements, if appropriate. Alternatively, indices **MAY** choose
+their own appropriate human-readable equivalents for UI elements.
 
 Packagers and metadata producers **MAY** choose to use these well-known
 labels to communicate specific URL intents to package indices and downstreams.


### PR DESCRIPTION
From feedback in https://discuss.python.org/t/pep-753-uniform-project-urls-in-core-metadata/62792/4 -- this adds a list of suggested human-readable equivalents for use in UI elements, with additional language emphasizing that the index is not required to use these particular equivalents.