### PR TITLE
Infra: Link RSS to website not feed

### DIFF
--- a/pep_sphinx_extensions/generate_rss.py
+++ b/pep_sphinx_extensions/generate_rss.py
@@ -109,7 +109,7 @@ def create_rss_feed(doctree_dir: Path, output_dir: Path):
 <rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
   <channel>
     <title>Newest Python PEPs</title>
-    <link>https://peps.python.org/peps.rss</link>
+    <link>https://peps.python.org/</link>
     <description>{RSS_DESCRIPTION}</description>
     <atom:link href="https://peps.python.org/peps.rss" rel="self"/>
     <docs>https://cyber.harvard.edu/rss/rss.html</docs>


### PR DESCRIPTION
The RSS feed https://peps.python.org/peps.rss starts:

```xml
<?xml version='1.0' encoding='UTF-8'?>
<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
  <channel>
    <title>Newest Python PEPs</title>
    <link>https://peps.python.org/peps.rss</link>
    <description>Newest Python Enhancement Proposals (PEPs): Information on new language features and some meta-information like release procedure and schedules.</description>
    <atom:link href="https://peps.python.org/peps.rss" rel="self"/>
    <docs>https://cyber.harvard.edu/rss/rss.html</docs>
    <language>en</language>
    <lastBuildDate>Wed, 18 Sep 2024 12:01:25 GMT</lastBuildDate>
    <item>
      <title>PEP 757: C API to import-export Python integers</title>
      <link>https://peps.python.org/pep-0757/</link>
      <description>Add a new C API to import and export Python integers, int objects: especially PyLongWriter_Create() and PyLong_Export() functions.</description>
      <author>Sergey B Kirpichev (skirpichev@gmail.com), Victor Stinner (vstinner@python.org)</author>
      <guid isPermaLink="true">https://peps.python.org/pep-0757/</guid>
      <pubDate>Fri, 13 Sep 2024 00:00:00 GMT</pubDate>
    </item>
```

The channel `<link>https://peps.python.org/peps.rss</link>` should be to the website, not the feed:



Element | Description | Example
-- | -- | --
title | The name of the channel. It's how people refer to your service. If you have an HTML website that contains the same information as your RSS file, the title of your channel should be the same as the title of your website. | GoUpstate.com News Headlines
link | The URL to the HTML website corresponding to the channel. | http://www.goupstate.com/
description | Phrase or sentence describing the channel. | The latest news from GoUpstate.com, a Spartanburg Herald-Journal Web site.




https://www.rssboard.org/rss-specification#requiredChannelElements

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3976.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->