### PR TITLE
PEP 708: update reference to match implementation

### DIFF
--- a/peps/pep-0708.rst
+++ b/peps/pep-0708.rst
@@ -282,7 +282,7 @@ HTML
 To enable a project to extend its namespace across multiple repositories, this
 PEP allows a project owner to declare a list of "alternate locations" for their
 project. This is exposed in JSON as the key ``alternate-locations`` and in HTML
-as a meta element named ``pypi-alternate-locations``, which may be used multiple
+as a meta element named ``pypi:alternate-locations``, which may be used multiple
 times.
 
 There are a few key properties that **MUST** be observed when using this


### PR DESCRIPTION
PyPI's existing meta elements follow a `pypi:` naming convention. Implementation in https://github.com/pypi/warehouse/pull/15716 will follow this convention.