### PR TITLE
PEP 738: Mark as Final

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -121,6 +121,7 @@ Tier 3
 ================================ =========================== ========
 Target Triple                    Notes                       Contacts
 ================================ =========================== ========
+aarch64-linux-android                                        Russell Keith-Magee, Petr Viktorin
 aarch64-pc-windows-msvc                                      Steve Dower
 arm64-apple-ios                  iOS on device               Russell Keith-Magee, Ned Deily
 arm64-apple-ios-simulator        iOS on M1 macOS simulator   Russell Keith-Magee, Ned Deily
@@ -129,6 +130,7 @@ powerpc64le-unknown-linux-gnu    glibc, clang                Victor Stinner
 
                                  glibc, gcc                  Victor Stinner
 s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
+x86_64-linux-android                                         Russell Keith-Magee, Petr Viktorin
 x86_64-unknown-freebsd           BSD libc, clang             Victor Stinner
 ================================ =========================== ========
 

--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -121,7 +121,6 @@ Tier 3
 ================================ =========================== ========
 Target Triple                    Notes                       Contacts
 ================================ =========================== ========
-aarch64-linux-android                                        Russell Keith-Magee, Petr Viktorin
 aarch64-pc-windows-msvc                                      Steve Dower
 arm64-apple-ios                  iOS on device               Russell Keith-Magee, Ned Deily
 arm64-apple-ios-simulator        iOS on M1 macOS simulator   Russell Keith-Magee, Ned Deily
@@ -130,7 +129,6 @@ powerpc64le-unknown-linux-gnu    glibc, clang                Victor Stinner
 
                                  glibc, gcc                  Victor Stinner
 s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
-x86_64-linux-android                                         Russell Keith-Magee, Petr Viktorin
 x86_64-unknown-freebsd           BSD libc, clang             Victor Stinner
 ================================ =========================== ========
 

--- a/peps/pep-0738.rst
+++ b/peps/pep-0738.rst
@@ -9,7 +9,7 @@ Created: 12-Dec-2023
 Python-Version: 3.13
 Resolution: https://discuss.python.org/t/pep-738-adding-android-as-a-supported-platform/40975/23
 
-.. canonical-doc:: :ref:`py3.14:using-android`
+.. canonical-doc:: :ref:`python:using-android`
 
 
 Abstract

--- a/peps/pep-0738.rst
+++ b/peps/pep-0738.rst
@@ -9,7 +9,7 @@ Created: 12-Dec-2023
 Python-Version: 3.13
 Resolution: https://discuss.python.org/t/pep-738-adding-android-as-a-supported-platform/40975/23
 
-.. canonical-doc:: :ref:`py3.13:using-android`
+.. canonical-doc:: :ref:`py3.14:using-android`
 
 
 Abstract

--- a/peps/pep-0738.rst
+++ b/peps/pep-0738.rst
@@ -3,11 +3,13 @@ Title: Adding Android as a supported platform
 Author: Malcolm Smith <smith@chaquo.com>
 Sponsor: Petr Viktorin <encukou@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-738-adding-android-as-a-supported-platform/40975
-Status: Accepted
+Status: Final
 Type: Standards Track
 Created: 12-Dec-2023
 Python-Version: 3.13
 Resolution: https://discuss.python.org/t/pep-738-adding-android-as-a-supported-platform/40975/23
+
+.. canonical-doc:: :ref:`py3.13:using-android`
 
 
 Abstract
@@ -289,8 +291,6 @@ namedtuple containing the following:
 * ``release`` - Android version of the device, as a string (e.g. ``"14"``)
 * ``api_level`` - :ref:`API level <738-os-versions>` of the device, as an
   integer (e.g. ``34``)
-* ``min_api_level`` - Minimum API level this build of Python can run on, as
-  an integer (e.g. ``23``). This is the same as ``sys.getandroidapilevel``.
 * ``manufacturer`` - `manufacturer
   <https://developer.android.com/reference/android/os/Build#MANUFACTURER>`__ of
   the device, as a string (e.g. ``"Google"``)
@@ -300,6 +300,8 @@ namedtuple containing the following:
 * ``device`` - `device name
   <https://developer.android.com/reference/android/os/Build#DEVICE>`__ of the
   device, as a string (e.g. ``"panther"``)
+* ``is_simulator`` - ``True`` if the device is an emulator; ``False`` if it’s a
+  physical device.
 
 Which one of ``model`` and ``device`` is more likely to be unique, and which one
 is more likely to resemble the marketing name, varies between different

--- a/peps/pep-0738.rst
+++ b/peps/pep-0738.rst
@@ -300,7 +300,7 @@ namedtuple containing the following:
 * ``device`` - `device name
   <https://developer.android.com/reference/android/os/Build#DEVICE>`__ of the
   device, as a string (e.g. ``"panther"``)
-* ``is_simulator`` - ``True`` if the device is an emulator; ``False`` if it’s a
+* ``is_emulator`` - ``True`` if the device is an emulator; ``False`` if it’s a
   physical device.
 
 Which one of ``model`` and ``device`` is more likely to be unique, and which one
@@ -437,6 +437,20 @@ implementation of code to execute test suites on Android devices and emulators.
 The `Toga Testbed <https://github.com/beeware/toga/tree/main/testbed>`__ is an
 example of a test suite that is executed on the Android emulator using GitHub
 Actions.
+
+
+Rejected Ideas
+==============
+
+The following changes were made to the original specification of
+``platform.android_ver()``:
+
+* The ``min_api_level`` field was removed, because unlike all the other fields,
+  it isn't a property of the current device. This information is still available
+  from the pre-existing function ``sys.getandroidapilevel()``.
+
+* The ``is_emulator`` field was added, since experience during testing showed
+  that some issues were emulator-specific.
 
 
 Copyright


### PR DESCRIPTION
~~The Android x86_64 buildbot is not yet up and running, so this is not quite ready to be merged.~~ The aarch64 and x86_64 buildbots are both now stable.

@freakboy3742: I assume you're OK with being added as a second core team contact for Android?

* [x] Final implementation has been merged (including tests and docs)
   * https://github.com/python/cpython/pull/124259
   * https://github.com/python/cpython/pull/124304
* [X] PEP matches the final implementation
* [X] Any substantial changes since the accepted version approved by the SC/PEP delegate
  * There were no substantial changes, only minor adjustments to the `android_ver` function, as discussed [here](https://github.com/python/cpython/pull/116674).
* [X] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [X] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [X] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)
* Closes https://github.com/python/cpython/issues/116622


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3982.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->