### PR TITLE
PEP 11: Add Android

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -121,6 +121,7 @@ Tier 3
 ================================ =========================== ========
 Target Triple                    Notes                       Contacts
 ================================ =========================== ========
+aarch64-linux-android                                        Russell Keith-Magee, Petr Viktorin
 aarch64-pc-windows-msvc                                      Steve Dower
 arm64-apple-ios                  iOS on device               Russell Keith-Magee, Ned Deily
 arm64-apple-ios-simulator        iOS on M1 macOS simulator   Russell Keith-Magee, Ned Deily
@@ -129,6 +130,7 @@ powerpc64le-unknown-linux-gnu    glibc, clang                Victor Stinner
 
                                  glibc, gcc                  Victor Stinner
 s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
+x86_64-linux-android                                         Russell Keith-Magee, Petr Viktorin
 x86_64-unknown-freebsd           BSD libc, clang             Victor Stinner
 ================================ =========================== ========
 


### PR DESCRIPTION
Split from #3982 so it can be merged separately.

Buildbot status:
* [aarch64](https://buildbot.python.org/#/workers/109): Passing on both 3.13 and main.
* [x86_64](https://buildbot.python.org/#/workers/110): Passing on 3.13, failing on main because of [cpython#124304](https://github.com/python/cpython/pull/124304).

@freakboy3742 [has agreed](https://github.com/python/peps/pull/3982#pullrequestreview-2318750985) to be added as a second core team sponsor for this platform.

* Change is either:
    * [ ] To a Draft PEP
    * [x] To an Accepted or Final PEP, with Steering Council approval
      * Implied by the approval of PEP 738.
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)
