### PR TITLE
Infra: Move numerical index to own page

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -284,8 +284,8 @@ table.pep-zero-table tr td:nth-child(5) {
 /* Numerical index */
 article:has(> section#numerical-index) {
     float: unset !important;
-    width: 100% !important;
-    max-width: 100% !important;
+    width: 90% !important;
+    max-width: 90% !important;
 }
 
 /* Breadcrumbs rules */

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -281,6 +281,13 @@ table.pep-zero-table tr td:nth-child(5) {
     width: 50%;
 }
 
+/* Numerical index */
+article:has(> section#numerical-index) {
+    float: unset !important;
+    width: 100% !important;
+    max-width: 100% !important;
+}
+
 /* Breadcrumbs rules */
 section#pep-page-section > header {
     border-bottom: 1px solid var(--colour-rule-light);

--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -53,7 +53,7 @@
             <h2>Contents</h2>
             {{ toc }}
             <br>
-            {%- if not pagename.startswith(("pep-0000", "topic")) %}
+            {%- if not pagename.startswith(("numerical", "pep-0000", "topic")) %}
             <a id="source" href="https://github.com/python/peps/blob/main/peps/{{pagename}}.rst">Page Source (GitHub)</a>
             {%- endif %}
         </nav>

--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -49,6 +49,7 @@
         <article>
             {{ body }}
         </article>
+        {%- if not pagename == "numerical" %}
         <nav id="pep-sidebar">
             <h2>Contents</h2>
             {{ toc }}
@@ -57,6 +58,7 @@
             <a id="source" href="https://github.com/python/peps/blob/main/peps/{{pagename}}.rst">Page Source (GitHub)</a>
             {%- endif %}
         </nav>
+        {%- endif %}
     </section>
     <script src="{{ pathto('_static/colour_scheme.js', resource=True) }}"></script>
     <script src="{{ pathto('_static/wrap_tables.js', resource=True) }}"></script>

--- a/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
+++ b/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
@@ -63,6 +63,9 @@ def write_peps_json(peps: list[parser.PEP], path: Path) -> None:
 def create_pep_zero(app: Sphinx, env: BuildEnvironment, docnames: list[str]) -> None:
     peps = _parse_peps(Path(app.srcdir))
 
+    numerical_index_text = writer.PEPZeroWriter().write_numerical_index(peps)
+    subindices.update_sphinx("numerical", numerical_index_text, docnames, env)
+
     pep0_text = writer.PEPZeroWriter().write_pep0(peps, builder=env.settings["builder"])
     pep0_path = subindices.update_sphinx("pep-0000", pep0_text, docnames, env)
     peps.append(parser.PEP(pep0_path))

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -193,7 +193,7 @@ class PEPZeroWriter:
             self.emit_title("Numerical Index")
             self.emit_text(
                 "The :doc:`numerical index </numerical>` contains "
-                "a table of all PEPs :ref:`sorted by number <numerical-index>`."
+                "a table of all PEPs, ordered by number."
             )
             self.emit_newline()
 

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -133,6 +133,7 @@ class PEPZeroWriter:
         self.emit_newline()
 
     def write_numerical_index(self, peps: list[PEP]) -> str:
+        """Write PEPs by number."""
         self.emit_text(".. _numerical-index:")
         self.emit_newline()
 
@@ -190,7 +191,10 @@ class PEPZeroWriter:
         # PEPs by number
         if is_pep0:
             self.emit_title("Numerical Index")
-            self.emit_text("All PEPs :ref:`sorted by number <numerical-index>`.")
+            self.emit_text(
+                "The :doc:`numerical index </numerical>` contains "
+                "a table of all PEPs :ref:`sorted by number <numerical-index>`."
+            )
             self.emit_newline()
 
         # PEPs by category

--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -132,6 +132,17 @@ class PEPZeroWriter:
             self.emit_text("     -")
         self.emit_newline()
 
+    def write_numerical_index(self, peps: list[PEP]) -> str:
+        self.emit_text(".. _numerical-index:")
+        self.emit_newline()
+
+        self.emit_title("Numerical Index")
+        self.emit_table(peps)
+        self.emit_newline()
+
+        numerical_index_string = "\n".join(self.output)
+        return numerical_index_string
+
     def write_pep0(
         self,
         peps: list[PEP],
@@ -139,7 +150,7 @@ class PEPZeroWriter:
         intro: str = INTRO,
         is_pep0: bool = True,
         builder: str = None,
-    ):
+    ) -> str:
         if len(peps) == 0:
             return ""
 
@@ -176,6 +187,12 @@ class PEPZeroWriter:
             )
             self.emit_newline()
 
+        # PEPs by number
+        if is_pep0:
+            self.emit_title("Numerical Index")
+            self.emit_text("All PEPs :ref:`sorted by number <numerical-index>`.")
+            self.emit_newline()
+
         # PEPs by category
         self.emit_title("Index by Category")
         meta, info, provisional, accepted, open_, finished, historical, deferred, dead = _classify_peps(peps)
@@ -200,12 +217,6 @@ class PEPZeroWriter:
                 self.emit_subtitle(category)
                 self.emit_text("None.")
                 self.emit_newline()
-
-        self.emit_newline()
-
-        # PEPs by number
-        self.emit_title("Numerical Index")
-        self.emit_table(peps)
 
         self.emit_newline()
 
@@ -264,7 +275,7 @@ class PEPZeroWriter:
             self.emit_newline()
             self.emit_newline()
 
-        pep0_string = "\n".join(map(str, self.output))
+        pep0_string = "\n".join(self.output)
         return pep0_string
 
 

--- a/peps/contents.rst
+++ b/peps/contents.rst
@@ -14,6 +14,7 @@ This is an internal Sphinx page; please go to the :doc:`PEP Index <pep-0000>`.
    :glob:
    :caption: PEP Table of Contents (needed for Sphinx):
 
-   pep-*
    api/*
+   numerical
+   pep-*
    topic/*

--- a/peps/contents.rst
+++ b/peps/contents.rst
@@ -15,6 +15,6 @@ This is an internal Sphinx page; please go to the :doc:`PEP Index <pep-0000>`.
    :caption: PEP Table of Contents (needed for Sphinx):
 
    api/*
+   topic/*
    numerical
    pep-*
-   topic/*


### PR DESCRIPTION
Fixes https://github.com/python/peps/issues/2044.

Re: https://github.com/python/peps/issues/2044#issuecomment-1074914852

The frontpage index (PEP 0) is very long, and starts the PEPs grouped by category, followed by a big table sorted by number.

This duplicates the PEP list (there's 655 right now), and can make searching in the page a bit confusing.

This PR creates a new `numerical.html` page with the numerical index.

I've kept the "Numerical Index" header on the frontpage and added a link to the new page. I moved the header up, before the remaining groups, but don't have a strong opinion on where this should be.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3992.org.readthedocs.build/numerical/

<!-- readthedocs-preview pep-previews end -->