### PR TITLE
PEP 749: Use __format__ instead of .format as param name

### DIFF
--- a/peps/pep-0749.rst
+++ b/peps/pep-0749.rst
@@ -715,9 +715,9 @@ identifier used by user code. We propose to use the name ``__format__``,
 as names with double underscores are reserved for the Python implementation.
 
 A previous version of this PEP proposed using the name ``.format`` with a
-leading dot. This has the advantage that it cannot collide with any
-identifier, reserved or not, but it also made it so ``inspect.signature``
-could not create a signature for annotate functions.
+leading dot. While ``.format`` has the advantage that it cannot collide with any
+identifier, reserved or not, it also prevents ``inspect.signature``
+from creating a signature for annotate functions.
 
 The documentation may still use the name ``format`` for simplicity.
 

--- a/peps/pep-0749.rst
+++ b/peps/pep-0749.rst
@@ -710,12 +710,14 @@ Signature of ``__annotate__`` functions
 
 However, using ``format`` as a parameter name could lead to collisions
 if an annotation uses a class named ``format``. The parameter should be
-positional-only and have a name that cannot be a legal identifier in order
-to avoid this problem.
+positional-only and have a name that does not coincide with an
+identifier used by user code. We propose to use the name ``__format__``,
+as names with double underscores are reserved for the Python implementation.
 
-The current implementation uses the name ``.format`` with a leading
-dot, but the exact name should be considered an implementation detail
-and cannot be relied upon.
+A previous version of this PEP proposed using the name ``.format`` with a
+leading dot. This has the advantage that it cannot collide with any
+identifier, reserved or not, but it also made it so ``inspect.signature``
+could not create a signature for annotate functions.
 
 The documentation may still use the name ``format`` for simplicity.
 


### PR DESCRIPTION
cc @larryhastings @carljm 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--3993.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->