### PR TITLE
PEP 740: Update api-version

### DIFF
--- a/peps/pep-0740.rst
+++ b/peps/pep-0740.rst
@@ -255,7 +255,7 @@ The following changes are made to the
 
 These changes require a version change to the JSON API:
 
-* The ``api-version`` **SHALL** specify version 1.2 or later.
+* The ``api-version`` **SHALL** specify version 1.3 or later.
 
 .. _attestation-object:
 


### PR DESCRIPTION
Both PEP 740 and [PEP 708](https://peps.python.org/pep-0708/) stipulated API version 1.2 as the next JSON API version, but PEP 708 was finished first! So this just bumps to the next unused API version.

CC @di 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4001.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->