### PR TITLE
PEP 747: fix rst syntax

### DIFF
--- a/peps/pep-0747.rst
+++ b/peps/pep-0747.rst
@@ -223,7 +223,7 @@ For example, if a static type checker encounters the expression ``str | None``,
 it may normally evaluate its type as ``UnionType`` because it produces a
 runtime value that is an instance of ``types.UnionType``. However, because
 this expression is a valid type expression, it is also assignable to the
-type ``TypeForm[str | None]``:
+type ``TypeForm[str | None]``::
 
   v1_actual: UnionType = str | None  # OK
   v1_type_form: TypeForm[str | None] = str | None  # OK


### PR DESCRIPTION
This causes a mis-rendering on https://peps.python.org/pep-0747/


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4004.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->