### PR TITLE
PEP 719: Add 3.13.0rc3, postpone 3.13.0 final

### DIFF
--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -52,7 +52,8 @@ Actual:
 
 Expected:
 
-- 3.13.0 final: Tuesday, 2024-10-01
+- 3.13.0 candidate 3: Monday, 2024-09-30
+- 3.13.0 final: Monday, 2024-10-07
 
 Subsequent bugfix releases every two months.
 


### PR DESCRIPTION
Re: https://discuss.python.org/t/incremental-gc-and-pushing-back-the-3-13-0-release/65285

* Release 3.13.0rc3 this Monday, September 30th.
* Release 3.13.0 final a week later, on Monday, October 7th (probably starting the release process on Sunday).


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4005.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->