### PR TITLE
PEP 735: Add include-project to Deferred Ideas

### DIFF
--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -800,8 +800,8 @@ For example, testing a package involves installing testing dependencies and the
 package itself. Additionally, the compatibility of a dependency group with the
 main package is a valuable input to lockfile generators.
 
-In such cases, it is be desirable for a Dependency Group to declare that it
-depends upon the project itself. Example syntaxes from discussion included
+In such cases, it is desirable for a Dependency Group to declare that it
+depends upon the project itself. Example syntaxes from discussions included
 ``{include-project = true}`` and ``{include-group = ":project:"}``.
 
 However, if a specification is established to extend :pep:`508` with Path

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -790,6 +790,38 @@ Compared with changes to ``[project.dependencies]`` and
 Therefore, given that this PEP declines to make changes to the ``[project]``
 table, changing ``[build-system]`` is also deferred.
 
+
+Why not support a Dependency Group which includes the current project?
+----------------------------------------------------------------------
+
+Several usage scenarios for dependency groups revolve around installing a
+dependency group alongside a package defined in the ``[project]`` table.
+For example, testing a package involves installing testing dependencies and the
+package itself. Additionally, the compatibility of a dependency group with the
+main package is a valuable input to lockfile generators.
+
+In such cases, it is be desirable for a Dependency Group to declare that it
+depends upon the project itself. Example syntaxes from discussion included
+``{include-project = true}`` and ``{include-group = ":project:"}``.
+
+However, if a specification is established to extend :pep:`508` with Path
+Dependencies, this would result in Dependency Groups having two ways of
+specifying the main package. For example, if ``.`` becomes formally supported,
+and ``{include-project = true}`` is included in this PEP, then dependency
+groups may specify any of the following groups
+
+.. code-block:: toml
+
+    [dependency-groups]
+    case1 = [{include-project = true}]
+    case2 = ["."]
+    case3 = [{include-project = true}, "."]
+    case4 = [{include-project = false}, "."]
+
+In order to avoid a confusing future in which multiple different options
+specify the package defined in ``pyproject.toml``, any syntax for declaring
+this relationship is omitted from this PEP.
+
 .. _prior_art:
 
 Appendix A: Prior Art in Non-Python Languages


### PR DESCRIPTION
This is a fairly simple addition -- writing up an idea which surfaced
in the discourse thread as Deferred. The rationale given here, which
is the primary one for deferral, is that this would be obviated by
(and therefore create a confusing situation in combination with) Path
Dependencies.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [ ] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4012.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->