### PR TITLE
PEP 755: Add missing CODEOWNERS entry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -565,7 +565,6 @@ peps/pep-0681.rst  @jellezijlstra
 peps/pep-0682.rst
 peps/pep-0683.rst  @ericsnowcurrently
 peps/pep-0684.rst  @ericsnowcurrently
-# peps/pep-0684.rst
 peps/pep-0685.rst  @brettcannon
 peps/pep-0686.rst  @methane
 peps/pep-0687.rst  @encukou @erlend-aasland

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -636,11 +636,13 @@ peps/pep-0755.rst  @warsaw
 peps/pep-0756.rst  @vstinner
 peps/pep-0757.rst  @vstinner
 peps/pep-0758.rst  @pablogsal @brettcannon
+# ...
 peps/pep-0789.rst  @njsmith
 # ...
 peps/pep-0801.rst  @warsaw
 # ...
 peps/pep-2026.rst  @hugovk
+# ...
 peps/pep-3000.rst  @gvanrossum
 peps/pep-3001.rst  @birkenfeld
 # peps/pep-3002.rst

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -635,7 +635,7 @@ peps/pep-0752.rst  @warsaw
 peps/pep-0753.rst  @warsaw
 # ...
 # peps/pep-0754.rst
-# ...
+peps/pep-0755.rst  @warsaw
 peps/pep-0756.rst  @vstinner
 peps/pep-0757.rst  @vstinner
 peps/pep-0758.rst  @pablogsal @brettcannon

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -627,12 +627,10 @@ peps/pep-0746.rst  @JelleZijlstra
 peps/pep-0747.rst  @JelleZijlstra
 # ...
 peps/pep-0749.rst  @JelleZijlstra
-# ...
 peps/pep-0750.rst  @gvanrossum @lysnikolaou
 peps/pep-0751.rst  @brettcannon
 peps/pep-0752.rst  @warsaw
 peps/pep-0753.rst  @warsaw
-# ...
 # peps/pep-0754.rst
 peps/pep-0755.rst  @warsaw
 peps/pep-0756.rst  @vstinner


### PR DESCRIPTION
We forgot it in https://github.com/python/peps/pull/3947.

Plus a little tidy-up of the `CODEOWNERS` file.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4014.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->