### PR TITLE
Add canonical refs to old package specs

### DIFF
--- a/peps/pep-0241.rst
+++ b/peps/pep-0241.rst
@@ -11,6 +11,7 @@ Superseded-By: 314
 
 .. canonical-pypa-spec:: :ref:`packaging:core-metadata`
 
+
 Introduction
 ============
 

--- a/peps/pep-0241.rst
+++ b/peps/pep-0241.rst
@@ -9,7 +9,10 @@ Created: 12-Mar-2001
 Post-History: `19-Mar-2001 <https://mail.python.org/archives/list/distutils-sig@python.org/thread/46XPDHQHI3XAAJHEZAMAMKZYAI6K7NB6/>`__
 Superseded-By: 314
 
+.. canonical-pypa-spec:: :ref:`packaging:core-metadata`
+
 .. superseded:: 314
+
 
 Introduction
 ============

--- a/peps/pep-0241.rst
+++ b/peps/pep-0241.rst
@@ -11,9 +11,6 @@ Superseded-By: 314
 
 .. canonical-pypa-spec:: :ref:`packaging:core-metadata`
 
-.. superseded:: 314
-
-
 Introduction
 ============
 

--- a/peps/pep-0314.rst
+++ b/peps/pep-0314.rst
@@ -14,8 +14,6 @@ Superseded-By: 345
 
 .. canonical-pypa-spec:: :ref:`packaging:core-metadata`
 
-.. superseded:: 345
-
 Introduction
 ============
 

--- a/peps/pep-0314.rst
+++ b/peps/pep-0314.rst
@@ -14,6 +14,7 @@ Superseded-By: 345
 
 .. canonical-pypa-spec:: :ref:`packaging:core-metadata`
 
+
 Introduction
 ============
 

--- a/peps/pep-0314.rst
+++ b/peps/pep-0314.rst
@@ -12,6 +12,9 @@ Post-History: 29-Apr-2003
 Replaces: 241
 Superseded-By: 345
 
+.. canonical-pypa-spec:: :ref:`packaging:core-metadata`
+
+.. superseded:: 345
 
 Introduction
 ============

--- a/peps/pep-0345.rst
+++ b/peps/pep-0345.rst
@@ -15,6 +15,7 @@ Resolution: https://mail.python.org/archives/list/python-dev@python.org/thread/M
 
 .. canonical-pypa-spec:: :ref:`packaging:core-metadata`
 
+
 Abstract
 ========
 

--- a/peps/pep-0345.rst
+++ b/peps/pep-0345.rst
@@ -13,6 +13,9 @@ Replaces: 314
 Superseded-By: 566
 Resolution: https://mail.python.org/archives/list/python-dev@python.org/thread/MKHXVV746H7ZDFN62Z72VNAX6KIRXNRO/
 
+.. canonical-pypa-spec:: :ref:`packaging:core-metadata`
+
+.. superseded:: 566
 
 Abstract
 ========

--- a/peps/pep-0345.rst
+++ b/peps/pep-0345.rst
@@ -15,8 +15,6 @@ Resolution: https://mail.python.org/archives/list/python-dev@python.org/thread/M
 
 .. canonical-pypa-spec:: :ref:`packaging:core-metadata`
 
-.. superseded:: 566
-
 Abstract
 ========
 

--- a/peps/pep-0426.rst
+++ b/peps/pep-0426.rst
@@ -18,8 +18,6 @@ Superseded-By: 566
 
 .. canonical-pypa-spec:: :ref:`packaging:core-metadata`
 
-.. superseded:: 566
-
 .. withdrawn::
 
    The ground-up metadata redesign proposed in this PEP has been withdrawn in

--- a/peps/pep-0426.rst
+++ b/peps/pep-0426.rst
@@ -14,6 +14,11 @@ Post-History: 14-Nov-2012, 05-Feb-2013, 07-Feb-2013, 09-Feb-2013,
               27-May-2013, 20-Jun-2013, 23-Jun-2013, 14-Jul-2013,
               21-Dec-2013
 Replaces: 345
+Superseded-By: 566
+
+.. canonical-pypa-spec:: :ref:`packaging:core-metadata`
+
+.. superseded:: 566
 
 .. withdrawn::
 


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4020.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->