### PR TITLE
PEP 730: Add canonical-doc link

### DIFF
--- a/peps/pep-0730.rst
+++ b/peps/pep-0730.rst
@@ -11,7 +11,6 @@ Python-Version: 3.13
 Resolution: https://discuss.python.org/t/pep-730-adding-ios-as-a-supported-platform/35854/66
 
 .. canonical-doc:: :ref:`python:using-ios`
-
 Abstract
 ========
 

--- a/peps/pep-0730.rst
+++ b/peps/pep-0730.rst
@@ -10,6 +10,8 @@ Created: 09-Oct-2023
 Python-Version: 3.13
 Resolution: https://discuss.python.org/t/pep-730-adding-ios-as-a-supported-platform/35854/66
 
+.. canonical-doc:: :ref:`python:using-ios`
+
 Abstract
 ========
 

--- a/peps/pep-0730.rst
+++ b/peps/pep-0730.rst
@@ -11,6 +11,8 @@ Python-Version: 3.13
 Resolution: https://discuss.python.org/t/pep-730-adding-ios-as-a-supported-platform/35854/66
 
 .. canonical-doc:: :ref:`python:using-ios`
+
+
 Abstract
 ========
 


### PR DESCRIPTION
Many people will follow the link from [today's release announcement](https://www.python.org/downloads/release/python-3130/) to this PEP, so we should forward them to [the live documentation](https://docs.python.org/3/using/ios.html#using-ios) for more actionable advice.

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4023.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->