### PR TITLE
PEP 719: Python 3.13.0 final has been released

### DIFF
--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -50,10 +50,9 @@ Actual:
 - 3.13.0 candidate 1: Thursday, 2024-08-01
 - 3.13.0 candidate 2: Friday, 2024-09-06
 - 3.13.0 candidate 3: Tuesday, 2024-10-01
+- 3.13.0 final: Monday, 2024-10-07
 
 Expected:
-
-- 3.13.0 final: Monday, 2024-10-07
 
 Subsequent bugfix releases every two months.
 


### PR DESCRIPTION
https://discuss.python.org/t/python-3-13-0-final-has-been-released/66972

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4028.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->