### PR TITLE
PEP 291: Superseded by PEP 387

### DIFF
--- a/peps/pep-0291.rst
+++ b/peps/pep-0291.rst
@@ -3,10 +3,10 @@ Title: Backward Compatibility for the Python 2 Standard Library
 Author: Neal Norwitz <nnorwitz@gmail.com>
 Status: Final
 Type: Informational
-Content-Type: text/x-rst
 Created: 06-Jun-2002
 Python-Version: 2.3
 Post-History:
+Superseded-By: 387
 
 
 Abstract

--- a/peps/pep-0291.rst
+++ b/peps/pep-0291.rst
@@ -1,7 +1,7 @@
 PEP: 291
 Title: Backward Compatibility for the Python 2 Standard Library
 Author: Neal Norwitz <nnorwitz@gmail.com>
-Status: Final
+Status: Superseded
 Type: Informational
 Created: 06-Jun-2002
 Python-Version: 2.3

--- a/peps/pep-0387.rst
+++ b/peps/pep-0387.rst
@@ -9,6 +9,7 @@ Post-History: `19-Jun-2009 <https://mail.python.org/archives/list/python-dev@pyt
               `12-Jun-2020 <https://discuss.python.org/t/pep-387-backwards-compatibilty-policy/4421>`__,
               `19-Dec-2022 <https://discuss.python.org/t/22042>`__,
               `16-Jun-2023 <https://discuss.python.org/t/formalize-the-concept-of-soft-deprecation-dont-schedule-removal-in-pep-387-backwards-compatibility-policy/27957>`__
+Replaces: 291
 
 
 Abstract


### PR DESCRIPTION
Re: https://github.com/python/peps/issues/4030

PEP 291 is the Python 2 stdlib policy. 

It's been superseded by [PEP 387](https://peps.python.org/pep-0387/), 

cc @ncoghlan 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4032.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->