### PR TITLE
PEP 753: updates

### DIFF
--- a/peps/pep-0753.rst
+++ b/peps/pep-0753.rst
@@ -145,6 +145,12 @@ These stipulations do not change the optionality of URL processing by indices.
 In other words, an index that does not process URLs within uploaded
 distributions may continue to ignore all URL fields entirely.
 
+Similarly, these stipulations do **not** imply that the index should
+persist any normalizations that it performs to a distribution's metadata.
+In other words, this PEP stipulates label normalization for the purpose
+of user presentation, not for the purpose of modifying an uploaded distribution
+or its "sidecar" :pep:`658` metadata file.
+
 .. _conventions-for-labels:
 
 Conventions for ``Project-URL`` labels


### PR DESCRIPTION
Qualifies the processing behavior in PEP 753 to emphasize that it's only for index presentation purposes, not that indices should persist their normalization changes to the metadata they host.

CC @ncoghlan 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4039.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->