### PR TITLE
PEP 735: Mark as Accepted

### DIFF
--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -9,7 +9,8 @@ Type: Standards Track
 Topic: Packaging
 Created: 20-Nov-2023
 Post-History: `14-Nov-2023 <https://discuss.python.org/t/29684>`__, `20-Nov-2023 <https://discuss.python.org/t/39233>`__
-Resolution: https://discuss.python.org/t/pep-735-dependency-groups-in-pyproject-toml/39233/312
+Resolution: https://discuss.python.org/t/39233/312
+
 
 Abstract
 ========

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -4,11 +4,12 @@ Author: Stephen Rosen <sirosen0@gmail.com>
 Sponsor: Brett Cannon <brett@python.org>
 PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/39233
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Topic: Packaging
 Created: 20-Nov-2023
 Post-History: `14-Nov-2023 <https://discuss.python.org/t/29684>`__, `20-Nov-2023 <https://discuss.python.org/t/39233>`__
+Resolution: https://discuss.python.org/t/pep-735-dependency-groups-in-pyproject-toml/39233/312
 
 Abstract
 ========


### PR DESCRIPTION
* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` link points directly to SC/PEP Delegate official acceptance/rejected post
* [ ] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4042.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->