### PR TITLE
Pin Sphinx to <8.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 Pygments >= 2.9.0
 # Sphinx 6.1.0 broke copying images in parallel builds; fixed in 6.1.2
 # See https://github.com/sphinx-doc/sphinx/pull/11100
-Sphinx >= 5.1.1, != 6.1.0, != 6.1.1
+Sphinx >= 5.1.1, != 6.1.0, != 6.1.1, < 8.1.0
 docutils >= 0.19.0
 
 # For tests


### PR DESCRIPTION
The Sphinx 8.1 release added a new check for unreferenced footnotes, which causes CI to fail.

A

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4044.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->