### PR TITLE
PEP 0: Use an absolute link to `peps.json`

### DIFF
--- a/pep_sphinx_extensions/pep_zero_generator/writer.py
+++ b/pep_sphinx_extensions/pep_zero_generator/writer.py
@@ -183,7 +183,7 @@ class PEPZeroWriter:
 
             self.emit_title("API")
             self.emit_text(
-                "The `PEPS API <api/peps.json>`__ is a JSON file of metadata about "
+                "The `PEPS API </api/peps.json>`__ is a JSON file of metadata about "
                 "all the published PEPs. :doc:`Read more here <api/index>`."
             )
             self.emit_newline()


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


missing initial slash broke the link

making this after discussion on a `pythondotorg` [issue](https://github.com/python/pythondotorg/issues/2643)

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4045.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->