### PR TITLE
PEP 735: Fix a minor mistake

### DIFF
--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -197,15 +197,13 @@ Dependency Groups are not Hidden Extras
 ---------------------------------------
 
 Dependency Groups are very similar to extras which go unpublished.
-However, there are three major features which distinguish them from extras
+However, there are two major features which distinguish them from extras
 further:
 
 * they support non-package projects
 
 * installation of a Dependency Group does not imply installation of a package's
   dependencies (or the package itself)
-
-* a package's requirements (and extras) may depend upon Dependency Groups
 
 Future Compatibility & Invalid Data
 -----------------------------------


### PR DESCRIPTION
This line of text was not removed when the relevant behaviors were
removed from the PEP. It is therefore inaccurate.

---

I am not sure what this change qualifies as, based on the list below:

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)

* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

It's an Accepted PEP, but this is definitely an oversight.
I assume, since it's a packaging PEP, that if we get Paul's approval as the PEP delegate, it becomes the middle case?


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4047.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->