### PR TITLE
PEP 735: Fix a few typos and improve readability

### DIFF
--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -310,7 +310,8 @@ define four Dependency Groups: ``test``, ``docs``, ``typing``, and
 Note that none of these Dependency Group declarations implicitly install the
 current package, its dependencies, or any optional dependencies.
 Use of a Dependency Group like ``test`` to test a package requires that the
-user's configuration or toolchain also installs the current package (``.``). For example,
+user's configuration or toolchain also installs the current package (``.``).
+For example,
 
 .. code-block:: shell
 

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -310,7 +310,7 @@ define four Dependency Groups: ``test``, ``docs``, ``typing``, and
 Note that none of these Dependency Group declarations implicitly install the
 current package, its dependencies, or any optional dependencies.
 Use of a Dependency Group like ``test`` to test a package requires that the
-user's configuration or toolchain also installs ``.`` package. For example,
+user's configuration or toolchain also installs the current package (``.``). For example,
 
 .. code-block:: shell
 

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -58,7 +58,7 @@ Several motivating use cases are defined in detail in the :ref:`Use Cases Append
 Limitations of ``requirements.txt`` files
 -----------------------------------------
 
-Many projects may define one or more ``requirements.txt`` iles,
+Many projects may define one or more ``requirements.txt`` files,
 and may arrange them either at the project root (e.g. ``requirements.txt`` and
 ``test-requirements.txt``) or else in a directory (e.g.
 ``requirements/base.txt`` and ``requirements/test.txt``). However, there are
@@ -575,7 +575,7 @@ with Dependency Groups.
 Interfaces for Use of Dependency Groups
 ---------------------------------------
 
-This specificaion provides no universal interface for interacting with
+This specification provides no universal interface for interacting with
 Dependency Groups, other than inclusion in a built package via the ``project``
 table. This has implications both for tool authors and for users.
 

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -310,7 +310,7 @@ define four Dependency Groups: ``test``, ``docs``, ``typing``, and
 Note that none of these Dependency Group declarations implicitly install the
 current package, its dependencies, or any optional dependencies.
 Use of a Dependency Group like ``test`` to test a package requires that the
-user's configuration or toolchain also installs ``.``. For example,
+user's configuration or toolchain also installs ``.`` package. For example,
 
 .. code-block:: shell
 


### PR DESCRIPTION
Found 2 minor typos while reading the PEP.

Second commit is not about a typo, but I find that having `.`. is a bit hard to read:
<img width="289" alt="Screenshot 2024-10-12 at 11 38 43" src="https://github.com/user-attachments/assets/e2c9f8e4-eacb-4d32-bd44-a8a0c80b308b">

For comparison:
<img width="345" alt="Screenshot 2024-10-12 at 11 46 48" src="https://github.com/user-attachments/assets/f018d079-9665-4c48-9d78-fba81fc7ce57">


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4049.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->