### PR TITLE
PEP 735: Add the acceptance post to Post-History

### DIFF
--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -8,7 +8,7 @@ Status: Accepted
 Type: Standards Track
 Topic: Packaging
 Created: 20-Nov-2023
-Post-History: `14-Nov-2023 <https://discuss.python.org/t/29684>`__, `20-Nov-2023 <https://discuss.python.org/t/39233>`__
+Post-History: `14-Nov-2023 <https://discuss.python.org/t/29684>`__, `20-Nov-2023 <https://discuss.python.org/t/39233>`__, `10-Oct-2024 <https://discuss.python.org/t/39233>`__
 Resolution: https://discuss.python.org/t/39233/312
 
 


### PR DESCRIPTION
* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

---

It's not clear that this is strictly *necessary*, but adding a final link to the post-history, to the acceptance post, makes the post and the date more discoverable.
This was raised in Discourse, and I thought it best to take some mild action to address it.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4053.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->