### PR TITLE
Meta: Allow PEP authors to use a name other than their real name

### DIFF
--- a/peps/pep-0001.rst
+++ b/peps/pep-0001.rst
@@ -606,9 +606,9 @@ optional and are described below.  All other headers are required.
 
     PEP: <pep number>
     Title: <pep title>
-    Author: <list of authors' real names and optionally, email addrs>
-  * Sponsor: <real name of sponsor>
-  * PEP-Delegate: <PEP delegate's real name>
+    Author: <list of authors' names and optionally, email addrs>
+  * Sponsor: <name of sponsor>
+  * PEP-Delegate: <PEP delegate's name>
     Discussions-To: <URL of current canonical discussion thread>
     Status: <Draft | Active | Accepted | Provisional | Deferred | Rejected |
              Withdrawn | Final | Superseded>
@@ -637,7 +637,9 @@ if the email address is included, and just:
 
     Random J. User
 
-if the address is not given.
+if the address is not given. Most PEP authors use their real name, but
+if you prefer a different name and use it consistently in discussions
+related to the PEP, feel free to use it here.
 
 If there are multiple authors, each should be on a separate line
 following :rfc:`2822` continuation line conventions.  Note that personal


### PR DESCRIPTION
Fixes #4052.