### PR TITLE
Various PEPs: Add acceptance dates

### DIFF
--- a/peps/pep-0649.rst
+++ b/peps/pep-0649.rst
@@ -20,7 +20,7 @@ Post-History: `11-Jan-2021 <https://mail.python.org/archives/list/python-dev@pyt
               `07-Feb-2023 <https://discuss.python.org/t/two-polls-on-how-to-revise-pep-649/23628>`__,
               `11-Apr-2023 <https://discuss.python.org/t/a-massive-pep-649-update-with-some-major-course-corrections/25672>`__,
 Replaces: 563
-Resolution: https://discuss.python.org/t/pep-649-deferred-evaluation-of-annotations-tentatively-accepted/21331/43
+Resolution: `08-May-2023 <https://discuss.python.org/t/pep-649-deferred-evaluation-of-annotations-tentatively-accepted/21331/43>`__
 
 ********
 Abstract

--- a/peps/pep-0688.rst
+++ b/peps/pep-0688.rst
@@ -11,7 +11,7 @@ Post-History: `23-Apr-2022 <https://mail.python.org/archives/list/typing-sig@pyt
               `25-Apr-2022 <https://discuss.python.org/t/15265>`__,
               `06-Oct-2022 <https://discuss.python.org/t/19756>`__,
               `26-Oct-2022 <https://mail.python.org/archives/list/typing-sig@python.org/thread/XH5ZK2MSZIQLL62PYZ6I5532SQKKVCBL/>`__
-Resolution: https://discuss.python.org/t/pep-688-making-the-buffer-protocol-accessible-in-python/15265/35
+Resolution: `07-Mar-2023 <https://discuss.python.org/t/pep-688-making-the-buffer-protocol-accessible-in-python/15265/35>`__
 
 .. canonical-doc:: :ref:`python:python-buffer-protocol`
 

--- a/peps/pep-0700.rst
+++ b/peps/pep-0700.rst
@@ -8,7 +8,7 @@ Type: Standards Track
 Topic: Packaging
 Created: 21-Oct-2022
 Post-History: `21-Oct-2022 <https://discuss.python.org/t/pep-700-additional-fields-for-the-simple-api-for-package-indexes/20177>`__
-Resolution: https://discuss.python.org/t/pep-700-additional-fields-for-the-simple-api-for-package-indexes/20177/42
+Resolution: `19-Dec-2022 <https://discuss.python.org/t/pep-700-additional-fields-for-the-simple-api-for-package-indexes/20177/42>`__
 
 .. canonical-pypa-spec:: :ref:`packaging:simple-repository-api`
 

--- a/peps/pep-0701.rst
+++ b/peps/pep-0701.rst
@@ -11,7 +11,7 @@ Content-Type: text/x-rst
 Created: 15-Nov-2022
 Python-Version: 3.12
 Post-History: `19-Dec-2022 <https://discuss.python.org/t/pep-701-syntactic-formalization-of-f-strings/22046>`__,
-Resolution: https://discuss.python.org/t/pep-701-syntactic-formalization-of-f-strings/22046/119
+Resolution: `14-Mar-2023 <https://discuss.python.org/t/pep-701-syntactic-formalization-of-f-strings/22046/119>`__
 
 
 Abstract

--- a/peps/pep-0703.rst
+++ b/peps/pep-0703.rst
@@ -10,7 +10,7 @@ Created: 09-Jan-2023
 Python-Version: 3.13
 Post-History: `09-Jan-2023 <https://discuss.python.org/t/22606>`__,
               `04-May-2023 <https://discuss.python.org/t/26503>`__
-Resolution: https://discuss.python.org/t/pep-703-making-the-global-interpreter-lock-optional-in-cpython-acceptance/37075
+Resolution: `24-Oct-2023 <https://discuss.python.org/t/pep-703-making-the-global-interpreter-lock-optional-in-cpython-acceptance/37075>`__
 
 .. note::
    The Steering Council accepts PEP 703, but with clear proviso: that

--- a/peps/pep-0705.rst
+++ b/peps/pep-0705.rst
@@ -13,7 +13,7 @@ Post-History: `30-Sep-2022 <https://mail.python.org/archives/list/typing-sig@pyt
               `14-Mar-2023 <https://discuss.python.org/t/pep-705-typedmapping/24827>`__,
               `17-Oct-2023 <https://discuss.python.org/t/pep-705-typeddict-read-only-and-other-keys/36457>`__,
               `04-Nov-2023 <https://discuss.python.org/t/pep-705-read-only-typeddict-items/37867>`__,
-Resolution: https://discuss.python.org/t/pep-705-read-only-typeddict-items/37867/39
+Resolution: `29-Feb-2024 <https://discuss.python.org/t/pep-705-read-only-typeddict-items/37867/39>`__
 
 .. canonical-typing-spec:: :ref:`typing:readonly` and
                            :external+py3.13:data:`typing.ReadOnly`

--- a/peps/pep-0714.rst
+++ b/peps/pep-0714.rst
@@ -9,7 +9,7 @@ Topic: Packaging
 Content-Type: text/x-rst
 Created: 06-Jun-2023
 Post-History: `06-Jun-2023 <https://discuss.python.org/t/27471>`__
-Resolution: https://discuss.python.org/t/27471/19
+Resolution: `27-Jun-2023 <https://discuss.python.org/t/27471/19>`__
 
 
 Abstract

--- a/peps/pep-0715.rst
+++ b/peps/pep-0715.rst
@@ -10,7 +10,7 @@ Topic: Packaging
 Content-Type: text/x-rst
 Created: 06-Jun-2023
 Post-History: `09-Jun-2023 <https://discuss.python.org/t/27610>`__
-Resolution: https://discuss.python.org/t/pep-715-disabling-bdist-egg-distribution-uploads-on-pypi/27610/13
+Resolution: `24-Jun-2023 <https://discuss.python.org/t/pep-715-disabling-bdist-egg-distribution-uploads-on-pypi/27610/13>`__
 
 Abstract
 ========

--- a/peps/pep-0721.rst
+++ b/peps/pep-0721.rst
@@ -10,7 +10,7 @@ Requires: 706
 Created: 12-Jul-2023
 Python-Version: 3.12
 Post-History: `04-Jul-2023 <https://discuss.python.org/t/28928>`__,
-Resolution: https://discuss.python.org/t/28928/13
+Resolution: `02-Aug-2023 <https://discuss.python.org/t/28928/13>`__
 
 .. canonical-pypa-spec:: :ref:`packaging:sdist-archive-features`
 

--- a/peps/pep-0723.rst
+++ b/peps/pep-0723.rst
@@ -13,7 +13,7 @@ Post-History: `04-Aug-2023 <https://discuss.python.org/t/30979>`__,
               `23-Aug-2023 <https://discuss.python.org/t/32149>`__,
               `06-Dec-2023 <https://discuss.python.org/t/40418>`__,
 Replaces: 722
-Resolution: https://discuss.python.org/t/40418/82
+Resolution: `08-Jan-2024 <https://discuss.python.org/t/40418/82>`__
 
 .. canonical-pypa-spec:: :ref:`packaging:inline-script-metadata`
 

--- a/peps/pep-0729.rst
+++ b/peps/pep-0729.rst
@@ -8,7 +8,7 @@ Topic: Governance, Typing
 Created: 19-Sep-2023
 Post-History: `04-Oct-2023 <https://discuss.python.org/t/pep-729-typing-governance-process/35362>`__,
               `20-Sep-2023 <https://discuss.python.org/t/proposed-new-typing-governance-process/34244>`__
-Resolution: https://discuss.python.org/t/pep-729-typing-governance-process/35362/12
+Resolution: `20-Nov-2023 <https://discuss.python.org/t/pep-729-typing-governance-process/35362/12>`__
 
 Abstract
 ========

--- a/peps/pep-0742.rst
+++ b/peps/pep-0742.rst
@@ -9,7 +9,7 @@ Created: 07-Feb-2024
 Python-Version: 3.13
 Post-History: `11-Feb-2024 <https://discuss.python.org/t/pep-742-narrowing-types-with-typenarrower/45613>`__
 Replaces: 724
-Resolution: https://discuss.python.org/t/pep-742-narrowing-types-with-typeis/45613/35
+Resolution: `03-Apr-2024 <https://discuss.python.org/t/pep-742-narrowing-types-with-typeis/45613/35>`__
 
 .. canonical-typing-spec:: :ref:`typing:typeis` and
                            :external+py3.13:data:`typing.TypeIs`

--- a/peps/pep-0753.rst
+++ b/peps/pep-0753.rst
@@ -11,7 +11,7 @@ Topic: Packaging
 Created: 29-Aug-2024
 Post-History: `26-Aug-2024 <https://discuss.python.org/t/core-metadata-should-home-page-and-download-url-be-deprecated/62037>`__,
               `03-Sep-2024 <https://discuss.python.org/t/pep-753-uniform-urls-in-core-metadata/62792>`__
-Resolution: https://discuss.python.org/t/62792/30
+Resolution: `10-Oct-2024 <https://discuss.python.org/t/62792/30>`__
 
 
 Abstract


### PR DESCRIPTION
Continuing #4054. I added acceptance dates to all PEPs in the packaging
and typing topics with numbers over 700, and then to a few other recent PEPs
where it seemed useful.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4064.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->