### PR TITLE
PEP 728: Revise proposal to spec the 'extra_items=T' idea

### DIFF
--- a/peps/pep-0728.rst
+++ b/peps/pep-0728.rst
@@ -17,7 +17,7 @@ Abstract
 
 This PEP adds two class parameters, ``closed`` and ``extra_items``
 to type the extra items on a :class:`~typing.TypedDict`. This addresses the
-need to define closed TypedDict type or to type a subset of keys that might
+need to define closed TypedDict types or to type a subset of keys that might
 appear in a ``dict`` while permitting additional items of a specified type.
 
 Motivation

--- a/peps/pep-0728.rst
+++ b/peps/pep-0728.rst
@@ -24,11 +24,11 @@ Motivation
 ==========
 
 A :py:class:`typing.TypedDict` type can annotate the value type of each known
-item in a dictionary. However, due to :term:`structural`
+item in a dictionary. However, due to :term:`typing:structural`
 :term:`assignability <typing:assignable>`, a TypedDict can have extra items
 that are not visible through its type. There is currently no way to restrict
 the types of items that might be present in the TypedDict type's
-:term:`consistent subtypes <consistent subtype>`.
+:term:`consistent subtypes <typing:consistent subtype>`.
 
 Disallowing Extra Items Explicitly
 ----------------------------------
@@ -59,7 +59,7 @@ Another possible use case for this is a sound way to
 
 Nothing prevents a ``dict`` that is assignable with ``Movie`` to have the
 ``author`` key, and under the current specification it would be incorrect for
-the type checker to :term:`narrow` its type.
+the type checker to :term:`typing:narrow` its type.
 
 Allowing Extra Items of a Certain Type
 --------------------------------------
@@ -83,8 +83,9 @@ from doing this::
     foo({"name": "Blade Runner", "year": 1982})  # Not OK
 
 While the restriction is enforced when constructing a TypedDict, due to
-:term:`structural` :term:`assignability <typing:assignable>`, the TypedDict
-may have extra items that are not visible through its type. For example::
+:term:`typing:structural` :term:`assignability <typing:assignable>`, the
+TypedDict may have extra items that are not visible through its type.
+For example::
 
     class Movie(MovieBase):
         year: int
@@ -94,7 +95,7 @@ may have extra items that are not visible through its type. For example::
 
 It is not possible to acknowledge the existence of the extra items through
 ``in`` checks and access them without breaking type safety, even though they
-might exist from some :term:`consistent subtypes <consistent subtype>` of
+might exist from some :term:`consistent subtypes <typing:consistent subtype>` of
 ``MovieBase``::
 
     def bar(movie: MovieBase) -> None:
@@ -145,7 +146,7 @@ intersection of types or syntax changes, offering a natural extension to the
 existing assignability rules.
 
 We propose to add a class parameter ``extra_items`` to TypedDict.
-It accepts a :term:`type expression` as the argument; when it is present,
+It accepts a :term:`typing:type expression` as the argument; when it is present,
 extra items are allowed, and their value types must be assignable to the
 type expression value.
 
@@ -167,7 +168,7 @@ There are some advantages to this approach:
   extra items.
 
 - We can precisely type the extra items without requiring the value types of the
-  known items to be :term:`assignable` to ``extra_items``.
+  known items to be :term:`typing:assignable` to ``extra_items``.
 
 - We do not lose backwards compatibility as both ``extra_items`` and ``closed``
   are opt-in only features.
@@ -324,7 +325,7 @@ Interaction with Read-only Items
 --------------------------------
 
 When the ``extra_items`` argument is annotated with the ``ReadOnly[]``
-:term:`type qualifier`, the extra items on the TypedDict have the
+:term:`typing:type qualifier`, the extra items on the TypedDict have the
 properties of read-only items. This interacts with inheritance rules specified
 in :ref:`Read-only Items <typing:readonly>`.
 
@@ -369,13 +370,13 @@ added in a subclass, all of the following conditions should apply:
 
   - The item can be either required or non-required
 
-  - The item's value type is :term:`assignable` to ``T``
+  - The item's value type is :term:`typing:assignable` to ``T``
 
 - If ``extra_items`` is not read-only
 
   - The item is non-required
 
-  - The item's value type is :term:`consistent` with ``T``
+  - The item's value type is :term:`typing:consistent` with ``T``
 
 - If ``extra_items`` is not overriden, the subclass inherits it as-is.
 
@@ -426,7 +427,7 @@ have an infinite set of items that all satisfy the following conditions.
 
 - If ``extra_items`` is read-only:
 
-  - The key's value type is :term:`assignable` to ``T``.
+  - The key's value type is :term:`typing:assignable` to ``T``.
 
   - The key is not in ``S``.
 
@@ -434,7 +435,7 @@ have an infinite set of items that all satisfy the following conditions.
 
   - The key is non-required.
 
-  - The key's value type is :term:`consistent` with ``T``.
+  - The key's value type is :term:`typing:consistent` with ``T``.
 
   - The key is not in ``S``.
 
@@ -443,9 +444,9 @@ when checking for assignability according to rules defined in the
 :ref:`Read-only Items <typing:readonly>` section, with a new rule added in bold
 text as follows:
 
-    A TypedDict type ``B`` is :term:`assignable` to a TypedDict type ``A`` if ``B``
-    is :term:`structurally <structural>` assignable to ``A``. This is true if and
-    only if all of the following are satisfied:
+    A TypedDict type ``B`` is :term:`typing:assignable` to a TypedDict type
+    ``A`` if ``B`` is :term:`structurally <typing:structural>` assignable to
+    ``A``. This is true if and only if all of the following are satisfied:
 
     * **[If no key with the same name can be found in ``B``, the 'extra_items'
       argument is considered the value type of the corresponding key.]**
@@ -496,7 +497,7 @@ corresponding key. ``'year'`` being required violates this rule:
     * For each required key in ``A``, the corresponding key is required in ``B``.
 
 When ``extra_items`` is specified to be read-only on a TypedDict type, it is
-possible for an item to have a :term:`narrower <narrow>` type than the
+possible for an item to have a :term:`narrower <typing:narrow>` type than the
 ``extra_items`` argument::
 
     class Movie(TypedDict, extra_items=ReadOnly[str | int]):
@@ -579,14 +580,15 @@ Interaction with Mapping[KT, VT]
 
 A TypedDict type can be assignable to ``Mapping[KT, VT]`` types other than
 ``Mapping[str, object]`` as long as all value types of the items on the
-TypedDict type is :term:`assignable` to ``VT``. This is an extension of this
+TypedDict type is :term:`typing:assignable` to ``VT``. This is an extension of this
 assignability rule from the `typing spec
 <https://typing.readthedocs.io/en/latest/spec/typeddict.html#assignability>`__:
 
-    * A TypedDict with all ``int`` values is not :term:`assignable` to
-      ``Mapping[str, int]``, since there may be additional non-``int`` values not
-      visible through the type, due to :term:`structural` assignability. These can
-      be accessed using the ``values()`` and ``items()`` methods in ``Mapping``,
+    * A TypedDict with all ``int`` values is not :term:`typing:assignable` to
+      ``Mapping[str, int]``, since there may be additional non-``int`` values
+      not visible through the type, due to :term:`typing:structural`
+      assignability. These can be accessed using the ``values()`` and
+      ``items()`` methods in ``Mapping``,
 
 For example::
 
@@ -610,14 +612,14 @@ Interaction with dict[KT, VT]
 -----------------------------
 
 Note that because the presence of ``extra_items`` on a closed TypedDict type
-prohibits additional required keys in its :term:`structural` :term:`subtypes
-<subtype>`, we can determine if the TypedDict type and its structural subtypes
-will ever have any required key during static analysis.
+prohibits additional required keys in its :term:`typing:structural`
+:term:`typing:subtypes <subtype>`, we can determine if the TypedDict type and
+its structural subtypes will ever have any required key during static analysis.
 
-The TypedDict type is :term:`assignable` to ``dict[str, VT]`` if all items on
-the TypedDict type satisfy the following conditions:
+The TypedDict type is :term:`typing:assignable` to ``dict[str, VT]`` if all
+items on the TypedDict type satisfy the following conditions:
 
-- The value type of the item is :term:`consistent` with ``VT``.
+- The value type of the item is :term:`typing:consistent` with ``VT``.
 
 - The item is not read-only.
 
@@ -738,9 +740,9 @@ extra items regardless of the type, like how ``total=True`` works::
 Because it did not offer a way to specify the type of the extra items, the type
 checkers will need to assume that the type of the extra items is ``Any``, which
 compromises type safety. Furthermore, the current behavior of TypedDict already
-allows untyped extra items to be present in runtime, due to :term:`structural`
-:term:`assignability <typing:assignable>`. ``closed=True`` plays a similar role
-in the current proposal.
+allows untyped extra items to be present in runtime, due to
+:term:`typing:structural` :term:`assignability <typing:assignable>`.
+``closed=True`` plays a similar role in the current proposal.
 
 Support Extra Items with Intersection
 -------------------------------------

--- a/peps/pep-0728.rst
+++ b/peps/pep-0728.rst
@@ -150,9 +150,9 @@ extra items are allowed, and their value types must be assignable to the
 type expression value.
 
 An application of this is to disallow extra items. We propose to add a
-``closed`` class parameter, which only accepts ``True`` as the argument.
-It should be a runtime error when ``closed=True`` and ``extra_items`` are used
-at the same time.
+``closed`` class parameter, which only accepts a literal ``True`` or ``False``
+as the argument. It should be a runtime error when ``closed`` and
+``extra_items`` are used at the same time.
 
 Different from index signatures, the types of the known items do not need to be
 assignable to the ``extra_items`` argument.
@@ -240,16 +240,27 @@ When ``closed=True`` is set, no extra items are allowed. This is a shorthand for
 ``extra_items=Never``, because there can't be a value type that is assignable to
 :class:`~typing.Never`.
 
-Different from ``total``, only a literal ``True`` is supported as the value of
-the ``closed`` argument; ``closed`` is unset by default.
+Similar to ``total``, only a literal ``True`` or ``False`` is supported as the
+value of the ``closed`` argument; ``closed`` is ``False`` by default, which
+preserves the previous TypedDict behavior.
 
 The value of ``closed`` is not inherited through subclassing, but the
-implicitly set ``extra_items=Never`` is.
+implicitly set ``extra_items=Never`` is. It should be an error to use the
+default ``closed=False`` when subclassing a closed TypedDict type::
 
-Setting both ``closed=True`` and ``extra_items`` when defining a TypedDict type
+    class BaseMovie(TypedDict, closed=True):
+        name: str
+
+    class MovieA(BaseMovie):  # Not OK. An explicit 'closed=True' is required
+        pass
+
+    class MovieB(BaseMovie, closed=True):  # OK
+        pass
+
+Setting both ``closed`` and ``extra_items`` when defining a TypedDict type
 should always be a runtime error::
 
-    class Person(TypedDict, closed=True, extra_items=bool):  # Not OK. 'closed=True' and 'extra_items' are incompatible
+    class Person(TypedDict, closed=False, extra_items=bool):  # Not OK. 'closed' and 'extra_items' are incompatible
         name: str
 
 As a consequence of ``closed=True`` being equivalent to ``extra_items=Never``.
@@ -263,17 +274,16 @@ The same rules that apply to ``extra_items=Never`` should also apply to
     class MovieClosed(Movie, closed=True):  # OK
         pass
 
-    class MovieNever(Movie, extra_items=Never):  # OK
+    class MovieNever(Movie, extra_items=Never):  # Not OK. 'closed=True' is preferred
         pass
 
 This will be further discussed in
 :ref:`a later section <pep728-inheritance-read-only>`.
 
 When neither ``extra_items`` nor ``closed=True`` is specified, the TypedDict
-type is considered non-closed. For such non-closed TypedDict types,
-it is assumed that they allow non-required extra items of value type
-``ReadOnly[object]`` during inheritance or assignability checks.
-This preserves the existing behavior of TypedDict.
+is assumed to allow non-required extra items of value type ``ReadOnly[object]``
+during inheritance or assignability checks. This preserves the existing behavior
+of TypedDict.
 
 Interaction with Totality
 -------------------------

--- a/peps/pep-0728.rst
+++ b/peps/pep-0728.rst
@@ -144,16 +144,15 @@ This proposal aims to support a similar feature without introducing general
 intersection of types or syntax changes, offering a natural extension to the
 existing assignability rules.
 
-We propose that we add a class parameter ``extra_items`` to TypedDict.
+We propose to add a class parameter ``extra_items`` to TypedDict.
 It accepts a :term:`type expression` as the argument; when it is present,
 extra items are allowed, and their value types must be assignable to the
 type expression value.
 
-An application of this is to disallow extra items with ``extra_items=Never``.
-Alternatively, the ``closed`` class parameter, which only accepts ``True``,
-is supported. When there is ``closed=True``, the TypedDict is treated as if
-it specifies ``extra_items=Never``. It should be a runtime error when
-``closed=True`` and ``extra_items`` are used at the same time.
+An application of this is to disallow extra items. We propose to add a
+``closed`` class parameter, which only accepts ``True`` as the argument.
+It should be a runtime error when ``closed=True`` and ``extra_items`` are used
+at the same time.
 
 Different from index signatures, the types of the known items do not need to be
 assignable to the ``extra_items`` argument.
@@ -179,8 +178,8 @@ Specification
 This specification is structured to parallel :pep:`589` to highlight changes to
 the original TypedDict specification.
 
-If ``extra_items`` is specified, extra items are treated as `non-required
-<https://typing.readthedocs.io/en/latest/spec/typeddict.html#required-and-notrequired>`__
+If ``extra_items`` is specified, extra items are treated as :ref:`non-required
+<typing:required-notrequired>`
 items matching the ``extra_items`` argument, whose keys are allowed when
 determining `supported and unsupported operations
 <https://typing.readthedocs.io/en/latest/spec/typeddict.html#supported-and-unsupported-operations>`__.
@@ -268,7 +267,7 @@ The same rules that apply to ``extra_items=Never`` should also apply to
         pass
 
 This will be further discussed in
-:ref:`a later section <inheritance-read-only>`.
+:ref:`a later section <pep728-inheritance-read-only>`.
 
 When neither ``extra_items`` nor ``closed=True`` is specified, the TypedDict
 type is considered non-closed. For such non-closed TypedDict types,
@@ -317,8 +316,7 @@ Interaction with Read-only Items
 When the ``extra_items`` argument is annotated with the ``ReadOnly[]``
 :term:`type qualifier`, the extra items on the TypedDict have the
 properties of read-only items. This interacts with inheritance rules specified
-in `Read-only Items
-<https://typing.readthedocs.io/en/latest/spec/typeddict.html#id3>`__.
+in :ref:`Read-only Items <typing:readonly>`.
 
 Notably, if the TypedDict type specifies ``extra_items`` to be read-only,
 subclasses of the TypedDict type may redeclare ``extra_items``.
@@ -335,8 +333,7 @@ Inheritance
 ``extra_items`` is inherited in a similar way as a regular ``key: value_type``
 item. As with the other keys, the `inheritance rules
 <https://typing.readthedocs.io/en/latest/spec/typeddict.html#inheritance>`__
-and `read-only items inheritance rules
-<https://typing.readthedocs.io/en/latest/spec/typeddict.html#id3>`__ apply.
+and :ref:`Read-only Items <typing:readonly>` inheritance rules apply.
 
 We need to reinterpret these rules to define how ``extra_items`` interacts with
 them.
@@ -356,7 +353,7 @@ items accepted to the TypedDict and marks them as non-required. Thus, the above
 restriction applies to any additional items defined in a subclass. For each item
 added in a subclass, all of the following conditions should apply:
 
-.. _inheritance-read-only:
+.. _pep728-inheritance-read-only:
 
 - If ``extra_items`` is read-only
 
@@ -432,9 +429,9 @@ have an infinite set of items that all satisfy the following conditions.
   - The key is not in ``S``.
 
 For type checking purposes, let ``extra_items`` be a non-required pseudo-item
-when checking for `assignability
-<https://typing.readthedocs.io/en/latest/spec/typeddict.html#id4>`__, and we
-add a new rule in bold text as follows:
+when checking for assignability according to rules defined in the
+:ref:`Read-only Items <typing:readonly>` section, with a new rule added in bold
+text as follows:
 
     A TypedDict type ``B`` is :term:`assignable` to a TypedDict type ``A`` if ``B``
     is :term:`structurally <structural>` assignable to ``A``. This is true if and
@@ -537,7 +534,7 @@ and a closed TypedDict type is allowed::
 Interaction with Constructors
 -----------------------------
 
-TypedDicts that allow extra items of type ``T`` also allows arbitrary keyword
+TypedDicts that allow extra items of type ``T`` also allow arbitrary keyword
 arguments of this type when constructed by calling the class object::
 
     class NonClosedMovie(TypedDict):
@@ -665,8 +662,8 @@ due to this change.
 
 Note that ``closed`` and ``extra_items`` as keyword arguments do not collide
 with othere keys when using something like
-``TD = TypedDict("TD", foo=str, bar=int)``, because this syntax is already
-scheduled to be removed in Python 3.13.
+``TD = TypedDict("TD", foo=str, bar=int)``, because this syntax has already
+been removed in Python 3.13.
 
 Because this is a type-checking feature, it can be made available to older
 versions as long as the type checker supports it.

--- a/peps/pep-0728.rst
+++ b/peps/pep-0728.rst
@@ -8,33 +8,33 @@ Type: Standards Track
 Topic: Typing
 Content-Type: text/x-rst
 Created: 12-Sep-2023
-Python-Version: 3.13
+Python-Version: 3.14
 Post-History: `09-Feb-2024 <https://discuss.python.org/t/pep-728-typeddict-with-typed-extra-items/45443>`__,
 
 
 Abstract
 ========
 
-This PEP proposes a way to limit extra items for :class:`~typing.TypedDict`
-using a ``closed`` argument and to type them with the special ``__extra_items__``
-key. This addresses the need to define closed TypedDict type or to type a subset
-of keys that might appear in a ``dict`` while permitting additional items of a
-specified type.
+This PEP adds two class parameters, ``closed`` and ``extra_items``
+to type the extra items on a :class:`~typing.TypedDict`. This addresses the
+need to define closed TypedDict type or to type a subset of keys that might
+appear in a ``dict`` while permitting additional items of a specified type.
 
 Motivation
 ==========
 
 A :py:class:`typing.TypedDict` type can annotate the value type of each known
-item in a dictionary. However, due to structural subtyping, a TypedDict can have
-extra items that are not visible through its type. There is currently no way to
-restrict the types of items that might be present in the TypedDict type's
-structural subtypes.
+item in a dictionary. However, due to :term:`structural`
+:term:`assignability <typing:assignable>`, a TypedDict can have extra items
+that are not visible through its type. There is currently no way to restrict
+the types of items that might be present in the TypedDict type's
+:term:`consistent subtypes <consistent subtype>`.
 
-Defining a Closed TypedDict Type
---------------------------------
+Disallowing Extra Items Explicitly
+----------------------------------
 
-The current behavior of TypedDict prevents users from defining a closed
-TypedDict type when it is expected that the type contains no additional items.
+The current behavior of TypedDict prevents users from defining a
+TypedDict type when it is expected that the type contains no extra items.
 
 Due to the possible presence of extra items, type checkers cannot infer more
 precise return types for ``.items()`` and ``.values()`` on a TypedDict. This can
@@ -55,58 +55,59 @@ Another possible use case for this is a sound way to
 
     def fun(entry: Movie | Book) -> None:
         if "author" in entry:
-            reveal_type(entry)  # Revealed type is 'Movie | Book'
+            reveal_type(entry)  # Revealed type is still 'Movie | Book'
 
-Nothing prevents a ``dict`` that is structurally compatible with ``Movie`` to
-have the ``author`` key, and under the current specification it would be
-incorrect for the type checker to narrow its type.
+Nothing prevents a ``dict`` that is assignable with ``Movie`` to have the
+``author`` key, and under the current specification it would be incorrect for
+the type checker to :term:`narrow` its type.
 
 Allowing Extra Items of a Certain Type
 --------------------------------------
 
 For supporting API interfaces or legacy codebase where only a subset of possible
-keys are known, it would be useful to explicitly expect additional keys of
-certain value types.
+keys are known, it would be useful to explicitly specify extra items of certain
+value types.
 
-However, the typing spec is more restrictive on type checking the construction of a
+However, the typing spec is more restrictive when checking the construction of a
 TypedDict, `preventing users <https://github.com/python/mypy/issues/4617>`__
 from doing this::
 
     class MovieBase(TypedDict):
         name: str
 
-    def fun(movie: MovieBase) -> None:
+    def foo(movie: MovieBase) -> None:
         # movie can have extra items that are not visible through MovieBase
         ...
 
     movie: MovieBase = {"name": "Blade Runner", "year": 1982}  # Not OK
-    fun({"name": "Blade Runner", "year": 1982})  # Not OK
+    foo({"name": "Blade Runner", "year": 1982})  # Not OK
 
 While the restriction is enforced when constructing a TypedDict, due to
-structural subtyping, the TypedDict may have extra items that are not visible
-through its type. For example::
+:term:`structural` :term:`assignability <typing:assignable>`, the TypedDict
+may have extra items that are not visible through its type. For example::
 
     class Movie(MovieBase):
         year: int
 
     movie: Movie = {"name": "Blade Runner", "year": 1982}
-    fun(movie)  # OK
+    foo(movie)  # OK
 
 It is not possible to acknowledge the existence of the extra items through
 ``in`` checks and access them without breaking type safety, even though they
-might exist from arbitrary structural subtypes of ``MovieBase``::
+might exist from some :term:`consistent subtypes <consistent subtype>` of
+``MovieBase``::
 
-    def g(movie: MovieBase) -> None:
+    def bar(movie: MovieBase) -> None:
         if "year" in movie:
             reveal_type(movie["year"])  # Error: TypedDict 'MovieBase' has no key 'year'
 
-Some workarounds have already been implemented in response to the need to allow
-extra keys, but none of them is ideal. For mypy,
+Some workarounds have already been implemented to allow
+extra items, but none of them is ideal. For mypy,
 ``--disable-error-code=typeddict-unknown-key``
 `suppresses type checking error <https://github.com/python/mypy/pull/14225>`__
 specifically for unknown keys on TypedDict. This sacrifices type safety over
 flexibility, and it does not offer a way to specify that the TypedDict type
-expects additional keys compatible with a certain type.
+expects additional keys whose value types are assignable with a certain type.
 
 Support Additional Keys for ``Unpack``
 --------------------------------------
@@ -114,14 +115,13 @@ Support Additional Keys for ``Unpack``
 :pep:`692` adds a way to precisely annotate the types of individual keyword
 arguments represented by ``**kwargs`` using TypedDict with ``Unpack``. However,
 because TypedDict cannot be defined to accept arbitrary extra items, it is not
-possible to
-`allow additional keyword arguments <https://discuss.python.org/t/pep-692-using-typeddict-for-more-precise-kwargs-typing/17314/87>`__
+possible to `allow additional keyword arguments
+<https://discuss.python.org/t/pep-692-using-typeddict-for-more-precise-kwargs-typing/17314/87>`__
 that are not known at the time the TypedDict is defined.
 
 Given the usage of pre-:pep:`692` type annotation for ``**kwargs`` in existing
 codebases, it will be valuable to accept and type extra items on TypedDict so
-that the old typing behavior can be supported in combination with the new
-``Unpack`` construct.
+that the old typing behavior can be supported in combination with ``Unpack``.
 
 Rationale
 =========
@@ -129,7 +129,8 @@ Rationale
 A type that allows extra items of type ``str`` on a TypedDict can be loosely
 described as the intersection between the TypedDict and ``Mapping[str, str]``.
 
-`Index Signatures <https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures>`__
+`Index Signatures
+<https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures>`__
 in TypeScript achieve this:
 
 .. code-block:: typescript
@@ -141,41 +142,36 @@ in TypeScript achieve this:
 
 This proposal aims to support a similar feature without introducing general
 intersection of types or syntax changes, offering a natural extension to the
-existing type consistency rules.
+existing assignability rules.
 
-We propose that we add an argument ``closed`` to TypedDict. Similar to
-``total``, only a literal ``True`` or ``False`` value is allowed. When
-``closed=True`` is used in the TypedDict type definition, we give the dunder
-attribute ``__extra_items__`` a special meaning: extra items are allowed, and
-their types should be compatible with the value type of ``__extra_items__``.
+We propose that we add a class parameter ``extra_items`` to TypedDict.
+It accepts a :term:`type expression` as the argument; when it is present,
+extra items are allowed, and their value types must be assignable to the
+type expression value.
 
-If ``closed=True`` is set, but there is no ``__extra_items__`` key, the
-TypedDict is treated as if it contained an item ``__extra_items__: Never``.
-
-Note that ``__extra_items__`` on the same TypedDict type definition will remain
-as a regular item if ``closed=True`` is not used.
+An application of this is to disallow extra items with ``extra_items=Never``.
+Alternatively, the ``closed`` class parameter, which only accepts ``True``,
+is supported. When there is ``closed=True``, the TypedDict is treated as if
+it specifies ``extra_items=Never``. It should be a runtime error when
+``closed=True`` and ``extra_items`` are used at the same time.
 
 Different from index signatures, the types of the known items do not need to be
-consistent with the value type of ``__extra_items__``.
+assignable to the ``extra_items`` argument.
 
 There are some advantages to this approach:
 
-- Inheritance works naturally. ``__extra_items__`` defined on a TypedDict will
-  also be available to its subclasses.
-
-- We can build on top of the `type consistency rules defined in the typing spec
-  <https://typing.readthedocs.io/en/latest/spec/typeddict.html#type-consistency>`__.
-  ``__extra_items__`` can be treated as a pseudo-item in terms of type
-  consistency.
+- We can build on top of the `assignability rules defined in the typing spec
+  <https://typing.readthedocs.io/en/latest/spec/typeddict.html#assignability>`__,
+  where ``extra_items`` can be treated as a pseudo-item.
 
 - There is no need to introduce a grammar change to specify the type of the
   extra items.
 
-- We can precisely type the extra items without making ``__extra_items__`` the
-  union of known items.
+- We can precisely type the extra items without requiring the value types of the
+  known items to be :term:`assignable` to ``extra_items``.
 
-- We do not lose backwards compatibility as ``__extra_items__`` still can be
-  used as a regular key.
+- We do not lose backwards compatibility as both ``extra_items`` and ``closed``
+  are opt-in only features.
 
 Specification
 =============
@@ -183,382 +179,385 @@ Specification
 This specification is structured to parallel :pep:`589` to highlight changes to
 the original TypedDict specification.
 
-If ``closed=True`` is specified, extra items are treated as non-required items
-having the same type of ``__extra_items__`` whose keys are allowed when
-determining
-`supported and unsupported operations
+If ``extra_items`` is specified, extra items are treated as `non-required
+<https://typing.readthedocs.io/en/latest/spec/typeddict.html#required-and-notrequired>`__
+items matching the ``extra_items`` argument, whose keys are allowed when
+determining `supported and unsupported operations
 <https://typing.readthedocs.io/en/latest/spec/typeddict.html#supported-and-unsupported-operations>`__.
 
-Using TypedDict Types
----------------------
+The ``extra_items`` Class Parameter
+-----------------------------------
 
-Assuming that ``closed=True`` is used in the TypedDict type definition.
+For a TypedDict type that specifies ``extra_items``, during construction, the
+value type of each unknown item is expected to be non-required and assignable
+to the ``extra_items`` argument. For example::
 
-For a TypedDict type that has the special ``__extra_items__`` key, during
-construction, the value type of each unknown item is expected to be non-required
-and compatible with the value type of ``__extra_items__``. For example::
-
-    class Movie(TypedDict, closed=True):
+    class Movie(TypedDict, extra_items=bool):
         name: str
-        __extra_items__: bool
     
     a: Movie = {"name": "Blade Runner", "novel_adaptation": True}  # OK
     b: Movie = {
         "name": "Blade Runner",
-        "year": 1982,  # Not OK. 'int' is incompatible with 'bool'
+        "year": 1982,  # Not OK. 'int' is not assignable to 'bool'
     }  
 
-In this example, ``__extra_items__: bool`` does not mean that ``Movie`` has a
-required string key ``"__extra_items__"`` whose value type is ``bool``. Instead,
-it specifies that keys other than "name" have a value type of ``bool`` and are
-non-required.
+Here, ``extra_items=bool`` specifies that items other than ``'name'``
+have a value type of ``bool`` and are non-required.
 
 The alternative inline syntax is also supported::
 
-    Movie = TypedDict("Movie", {"name": str, "__extra_items__": bool}, closed=True)
+    Movie = TypedDict("Movie", {"name": str}, extra_items=bool)
 
-Accessing extra keys is allowed. Type checkers must infer its value type from
-the value type of ``__extra_items__``::
+Accessing extra items is allowed. Type checkers must infer their value type from
+the ``extra_items`` argument::
 
     def f(movie: Movie) -> None:
         reveal_type(movie["name"])              # Revealed type is 'str'
         reveal_type(movie["novel_adaptation"])  # Revealed type is 'bool'
-
-When a TypedDict type defines ``__extra_items__`` without ``closed=True``,
-``closed`` defaults to ``False`` and the key is assumed to be a regular key::
-
-    class Movie(TypedDict):
-        name: str
-        __extra_items__: bool
     
-    a: Movie = {"name": "Blade Runner", "novel_adaptation": True}  # Not OK. Unexpected key 'novel_adaptation'
-    b: Movie = {
-        "name": "Blade Runner",
-        "__extra_items__": True,  # OK
-    }
+``extra_items`` is inherited through subclassing::
 
-For such non-closed TypedDict types, it is assumed that they allow non-required
-extra items of value type ``ReadOnly[object]`` during inheritance or type
-consistency checks. However, extra keys found during construction should still
-be rejected by the type checker.
-
-``closed`` is not inherited through subclassing::
-
-    class MovieBase(TypedDict, closed=True):
+    class MovieBase(TypedDict, extra_items=int | None):
         name: str
-        __extra_items__: ReadOnly[str | None]
     
     class Movie(MovieBase):
-        __extra_items__: str  # A regular key
-    
-    a: Movie = {"name": "Blade Runner", "__extra_items__": None}  # Not OK. 'None' is incompatible with 'str'
+        year: int
+
+    a: Movie = {"name": "Blade Runner", "year": None}  # Not OK. 'None' is incompatible with 'int'
     b: Movie = {
         "name": "Blade Runner",
-        "__extra_items__": "A required regular key",
+        "year": 1982,
         "other_extra_key": None,
     }  # OK
 
-Here, ``"__extra_items__"`` in ``a`` is a regular key defined on ``Movie`` where
-its value type is narrowed from ``ReadOnly[str | None]`` to ``str``,
-``"other_extra_key"`` in ``b`` is an extra key whose value type must be
-consistent with the value type of ``"__extra_items__"`` defined on
-``MovieBase``.
+Here, ``'year'`` in ``a`` is an extra key defined on ``Movie`` whose value type
+is ``int``. ``'other_extra_key'`` in ``b`` is another extra key whose value type
+must be assignable to the value of ``extra_items`` defined on ``MovieBase``.
+
+The ``closed`` Class Parameter
+------------------------------
+
+When ``closed=True`` is set, no extra items are allowed. This is a shorthand for
+``extra_items=Never``, because there can't be a value type that is assignable to
+:class:`~typing.Never`.
+
+Different from ``total``, only a literal ``True`` is supported as the value of
+the ``closed`` argument; ``closed`` is unset by default.
+
+The value of ``closed`` is not inherited through subclassing, but the
+implicitly set ``extra_items=Never`` is.
+
+Setting both ``closed=True`` and ``extra_items`` when defining a TypedDict type
+should always be a runtime error::
+
+    class Person(TypedDict, closed=True, extra_items=bool):  # Not OK. 'closed=True' and 'extra_items' are incompatible
+        name: str
+
+As a consequence of ``closed=True`` being equivalent to ``extra_items=Never``.
+The same rules that apply to ``extra_items=Never`` should also apply to
+``closed=True``. It is possible to use ``closed=True`` when subclassing if the
+``extra_items`` argument is a read-only type::
+
+    class Movie(TypedDict, extra_items=ReadOnly[str]):
+        pass
+
+    class MovieClosed(Movie, closed=True):  # OK
+        pass
+
+    class MovieNever(Movie, extra_items=Never):  # OK
+        pass
+
+This will be further discussed in
+:ref:`a later section <inheritance-read-only>`.
+
+When neither ``extra_items`` nor ``closed=True`` is specified, the TypedDict
+type is considered non-closed. For such non-closed TypedDict types,
+it is assumed that they allow non-required extra items of value type
+``ReadOnly[object]`` during inheritance or assignability checks.
+This preserves the existing behavior of TypedDict.
 
 Interaction with Totality
 -------------------------
 
-It is an error to use ``Required[]`` or ``NotRequired[]`` with the special
-``__extra_items__`` item. ``total=False`` and ``total=True`` have no effect on
-``__extra_items__`` itself.
+It is an error to use ``Required[]`` or ``NotRequired[]`` with ``extra_items``.
+``total=False`` and ``total=True`` have no effect on ``extra_items`` itself.
 
-The extra items are non-required, regardless of the totality of the TypedDict.
-Operations that are available to ``NotRequired`` items should also be available
-to the extra items::
+The extra items are non-required, regardless of the `totality
+<https://typing.readthedocs.io/en/latest/spec/typeddict.html#totality>`__ of the
+TypedDict. `Operations
+<https://typing.readthedocs.io/en/latest/spec/typeddict.html#supported-and-unsupported-operations>`__
+that are available to ``NotRequired`` items should also be available to the
+extra items::
 
-    class Movie(TypedDict, closed=True):
+    class Movie(TypedDict, extra_items=int):
         name: str
-        __extra_items__: int
 
     def f(movie: Movie) -> None:
-        del movie["name"]  # Not OK
-        del movie["year"]  # OK
+        del movie["name"]  # Not OK. The value type of 'name' is 'Required[int]'
+        del movie["year"]  # OK. The value type of 'year' is 'NotRequired[int]'
 
 Interaction with ``Unpack``
 ---------------------------
 
-For type checking purposes, ``Unpack[TypedDict]`` with extra items should be
+For type checking purposes, ``Unpack[SomeTypedDict]`` with extra items should be
 treated as its equivalent in regular parameters, and the existing rules for
 function parameters still apply::
 
-    class Movie(TypedDict, closed=True):
+    class Movie(TypedDict, extra_items=int):
         name: str
-        __extra_items__: int
     
     def f(**kwargs: Unpack[Movie]) -> None: ...
 
-    # Should be equivalent to
+    # Should be equivalent to:
     def f(*, name: str, **kwargs: int) -> None: ...
 
-Interaction with PEP 705
-------------------------
+Interaction with Read-only Items
+--------------------------------
 
-When the special ``__extra_items__`` item is annotated with ``ReadOnly[]``, the
-extra items on the TypedDict have the properties of read-only items. This
-interacts with inheritance rules specified in :pep:`PEP 705 <705#Inheritance>`.
+When the ``extra_items`` argument is annotated with the ``ReadOnly[]``
+:term:`type qualifier`, the extra items on the TypedDict have the
+properties of read-only items. This interacts with inheritance rules specified
+in `Read-only Items
+<https://typing.readthedocs.io/en/latest/spec/typeddict.html#id3>`__.
 
-Notably, if the TypedDict type declares ``__extra_items__`` to be read-only, a
-subclass of the TypedDict type may redeclare ``__extra_items__``'s value type or
-additional non-extra items' value type.
+Notably, if the TypedDict type specifies ``extra_items`` to be read-only,
+subclasses of the TypedDict type may redeclare ``extra_items``.
 
 Because a non-closed TypedDict type implicitly allows non-required extra items
-of value type ``ReadOnly[object]``, its subclass can override the special
-``__extra_items__`` with more specific types.
+of value type ``ReadOnly[object]``, its subclass can override the
+``extra_items`` argument with more specific types.
 
 More details are discussed in the later sections.
 
 Inheritance
 -----------
 
-When the TypedDict type is defined as ``closed=False`` (the default),
-``__extra_items__`` should behave and be inherited the same way a regular key
-would. A regular ``__extra_items__`` key can coexist with the special
-``__extra_items__`` and both should be inherited when subclassing.
+``extra_items`` is inherited in a similar way as a regular ``key: value_type``
+item. As with the other keys, the `inheritance rules
+<https://typing.readthedocs.io/en/latest/spec/typeddict.html#inheritance>`__
+and `read-only items inheritance rules
+<https://typing.readthedocs.io/en/latest/spec/typeddict.html#id3>`__ apply.
 
-We assume that ``closed=True`` whenever ``__extra_items__`` is mentioned for the
-rest of this section.
-
-``__extra_items__`` is inherited the same way as a regular ``key: value_type``
-item. As with the other keys, the same rules from
-`the typing spec <https://typing.readthedocs.io/en/latest/spec/typeddict.html#inheritance>`__
-and :pep:`PEP 705 <705#inheritance>` apply. We interpret the existing rules in the
-context of ``__extra_items__``.
-
-We need to reinterpret the following rule to define how ``__extra_items__``
-interacts with it:
+We need to reinterpret these rules to define how ``extra_items`` interacts with
+them.
 
     * Changing a field type of a parent TypedDict class in a subclass is not allowed.
 
-First, it is not allowed to change the value type of ``__extra_items__`` in a subclass
+First, it is not allowed to change the value of ``extra_items`` in a subclass
 unless it is declared to be ``ReadOnly`` in the superclass::
 
-    class Parent(TypedDict, closed=True):
-        __extra_items__: int | None
+    class Parent(TypedDict, extra_items=int | None):
+        pass
     
-    class Child(Parent, closed=True):
-        __extra_items__: int  # Not OK. Like any other TypedDict item, __extra_items__'s type cannot be changed
+    class Child(Parent, extra_items=int): # Not OK. Like any other TypedDict item, extra_items's type cannot be changed
 
-Second, ``__extra_items__: T`` effectively defines the value type of any unnamed
+Second, ``extra_items=T`` effectively defines the value type of any unnamed
 items accepted to the TypedDict and marks them as non-required. Thus, the above
 restriction applies to any additional items defined in a subclass. For each item
 added in a subclass, all of the following conditions should apply:
 
-- If ``__extra_items__`` is read-only
+.. _inheritance-read-only:
+
+- If ``extra_items`` is read-only
 
   - The item can be either required or non-required
 
-  - The item's value type is consistent with ``T``
+  - The item's value type is :term:`assignable` to ``T``
 
-- If ``__extra_items__`` is not read-only
+- If ``extra_items`` is not read-only
 
   - The item is non-required
 
-  - The item's value type is consistent with ``T``
+  - The item's value type is :term:`consistent` with ``T``
 
-  - ``T`` is consistent with the item's value type
-
-- If ``__extra_items__`` is not redeclared, the subclass inherits it as-is.
+- If ``extra_items`` is not overriden, the subclass inherits it as-is.
 
 For example::
 
-    class MovieBase(TypedDict, closed=True):
+    class MovieBase(TypedDict, extra_items=int | None):
         name: str
-        __extra_items__: int | None
     
-    class AdaptedMovie(MovieBase):  # Not OK. 'bool' is not consistent with 'int | None'
+    class AdaptedMovie(MovieBase):  # Not OK. 'bool' is not assignable to 'int | None'
         adapted_from_novel: bool
  
     class MovieRequiredYear(MovieBase):  # Not OK. Required key 'year' is not known to 'Parent'
         year: int | None
 
-    class MovieNotRequiredYear(MovieBase):  # Not OK. 'int | None' is not consistent with 'int'
+    class MovieNotRequiredYear(MovieBase):  # Not OK. 'int | None' is not assignable to 'int'
         year: NotRequired[int]
 
     class MovieWithYear(MovieBase):  # OK
         year: NotRequired[int | None]
 
-Due to this nature, an important side effect allows us to define a TypedDict
-type that disallows additional items::
+    class BookBase(TypedDict, extra_items=ReadOnly[int | str]):
+        title: str
 
-    class MovieFinal(TypedDict, closed=True):
+    class Book(BookBase, extra_items=str):  # OK
+        year: int  # OK
+
+An important side effect of the inheritance rules is that we can define a
+TypedDict type that disallows additional items::
+
+    class MovieClosed(TypedDict, extra_items=Never):
         name: str
-        __extra_items__: Never
 
-Here, annotating ``__extra_items__`` with :class:`typing.Never` specifies that
+Here, passing the value :class:`~typing.Never` to ``extra_items`` specifies that
 there can be no other keys in ``MovieFinal`` other than the known ones.
-Because of its potential common use, this is equivalent to::
+Because of its potential common use, there is a preferred alternative::
 
-    class MovieFinal(TypedDict, closed=True):
+    class MovieClosed(TypedDict, closed=True):
         name: str
 
-where we implicitly assume the ``__extra_items__: Never`` field by default
-if only ``closed=True`` is specified.
+where we implicitly assume that ``extra_items=Never``.
 
-Type Consistency
-----------------
+Assignability
+-------------
 
-In addition to the set ``S`` of keys of the explicitly defined items, a
-TypedDict type that has the item ``__extra_items__: T`` is considered to have an
-infinite set of items that all satisfy the following conditions:
+Let ``S`` be the set of keys of the explicitly defined items on a TypedDict
+type. If it specifies ``extra_items=T``, the TypedDict type is considered to
+have an infinite set of items that all satisfy the following conditions.
 
-- If ``__extra_items__`` is read-only
+- If ``extra_items`` is read-only:
 
-  - The key's value type is consistent with ``T``
-
-  - The key is not in ``S``.
-
-- If ``__extra_items__`` is not read-only
-
-  - The key is non-required
-
-  - The key's value type is consistent with ``T``
-
-  - ``T`` is consistent with the key's value type
+  - The key's value type is :term:`assignable` to ``T``.
 
   - The key is not in ``S``.
 
-For type checking purposes, let ``__extra_items__`` be a non-required pseudo-item to
-be included whenever "for each ... item/key" is stated in
-:pep:`the existing type consistency rules from PEP 705 <705#type-consistency>`,
-and we modify it as follows:
+- If ``extra_items`` is not read-only:
 
-    A TypedDict type ``A`` is consistent with TypedDict ``B`` if ``A`` is
-    structurally compatible with ``B``. This is true if and only if all of the
-    following are satisfied:
+  - The key is non-required.
 
-    * For each item in ``B``, ``A`` has the corresponding key, unless the item
-      in ``B`` is read-only, not required, and of top value type
-      (``ReadOnly[NotRequired[object]]``). **[Edit: Otherwise, if the
-      corresponding key with the same name cannot be found in ``A``,
-      "__extra_items__" is considered the corresponding key.]**
+  - The key's value type is :term:`consistent` with ``T``.
 
-    * For each item in ``B``, if ``A`` has the corresponding key **[Edit: or
-      "__extra_items__"]**, the corresponding value type in ``A`` is consistent
-      with the value type in ``B``.
+  - The key is not in ``S``.
 
-    * For each non-read-only item in ``B``, its value type is consistent with
-      the corresponding value type in ``A``. **[Edit: if the corresponding key
-      with the same name cannot be found in ``A``, "__extra_items__" is
-      considered the corresponding key.]**
+For type checking purposes, let ``extra_items`` be a non-required pseudo-item
+when checking for `assignability
+<https://typing.readthedocs.io/en/latest/spec/typeddict.html#id4>`__, and we
+add a new rule in bold text as follows:
 
-    * For each required key in ``B``, the corresponding key is required in ``A``.
-      For each non-required key in ``B``, if the item is not read-only in ``B``,
-      the corresponding key is not required in ``A``.
-      **[Edit: if the corresponding key with the same name cannot be found in
-      ``A``, "__extra_items__" is considered to be non-required as the
-      corresponding key.]**
+    A TypedDict type ``B`` is :term:`assignable` to a TypedDict type ``A`` if ``B``
+    is :term:`structurally <structural>` assignable to ``A``. This is true if and
+    only if all of the following are satisfied:
+
+    * **[If no key with the same name can be found in ``B``, the 'extra_items'
+      argument is considered the value type of the corresponding key.]**
+
+    * For each item in ``A``, ``B`` has the corresponding key, unless the item in
+      ``A`` is read-only, not required, and of top value type
+      (``ReadOnly[NotRequired[object]]``).
+
+    * For each item in ``A``, if ``B`` has the corresponding key, the corresponding
+      value type in ``B`` is assignable to the value type in ``A``.
+
+    * For each non-read-only item in ``A``, its value type is assignable to the
+      corresponding value type in ``B``, and the corresponding key is not read-only
+      in ``B``.
+
+    * For each required key in ``A``, the corresponding key is required in ``B``.
+
+    * For each non-required key in ``A``, if the item is not read-only in ``A``,
+      the corresponding key is not required in ``B``.
 
 The following examples illustrate these checks in action.
 
-``__extra_items__`` puts various restrictions on additional items for type
-consistency checks::
+``extra_items`` puts various restrictions on additional items for assignability
+checks::
 
-    class Movie(TypedDict, closed=True):
+    class Movie(TypedDict, extra_items=int | None):
         name: str
-        __extra_items__: int | None
 
-    class MovieDetails(TypedDict, closed=True):
+    class MovieDetails(TypedDict, extra_items=int | None):
         name: str
         year: NotRequired[int]
-        __extra_items__: int | None
     
     details: MovieDetails = {"name": "Kill Bill Vol. 1", "year": 2003}
-    movie: Movie = details  # Not OK. While 'int' is consistent with 'int | None',
-                            # 'int | None' is not consistent with 'int'
+    movie: Movie = details  # Not OK. While 'int' is assignable to 'int | None',
+                            # 'int | None' is not assignable to 'int'
 
-    class MovieWithYear(TypedDict, closed=True):
+    class MovieWithYear(TypedDict, extra_items=int | None):
         name: str
         year: int | None
-        __extra_items__: int | None
 
     details: MovieWithYear = {"name": "Kill Bill Vol. 1", "year": 2003}
     movie: Movie = details  # Not OK. 'year' is not required in 'Movie',
                             # so it shouldn't be required in 'MovieWithYear' either
 
-Because "year" is absent in ``Movie``, ``__extra_items__`` is considered the
-corresponding key. ``"year"`` being required violates the rule "For each
-required key in ``B``, the corresponding key is required in ``A``".
+Because ``'year'`` is absent in ``Movie``, ``extra_items`` is considered the
+corresponding key. ``'year'`` being required violates this rule:
 
-When ``__extra_items__`` is defined to be read-only in a TypedDict type, it is possible 
-for an item to have a narrower type than ``__extra_items__``'s value type::
+    * For each required key in ``A``, the corresponding key is required in ``B``.
 
-    class Movie(TypedDict, closed=True):
+When ``extra_items`` is specified to be read-only on a TypedDict type, it is
+possible for an item to have a :term:`narrower <narrow>` type than the
+``extra_items`` argument::
+
+    class Movie(TypedDict, extra_items=ReadOnly[str | int]):
         name: str
-        __extra_items__: ReadOnly[str | int]
     
-    class MovieDetails(TypedDict, closed=True):
+    class MovieDetails(TypedDict, extra_items=int):
         name: str
         year: NotRequired[int]
-        __extra_items__: int
 
     details: MovieDetails = {"name": "Kill Bill Vol. 2", "year": 2004}
-    movie: Movie = details  # OK. 'int' is consistent with 'str | int'.
+    movie: Movie = details  # OK. 'int' is assignable to 'str | int'.
 
-This behaves the same way as :pep:`705` specified if ``year: ReadOnly[str | int]``
-is an item defined in ``Movie``.
+This behaves the same way as if ``year: ReadOnly[str | int]`` is an item
+explicitly defined in ``Movie``.
 
-``__extra_items__`` as a pseudo-item follows the same rules that other items have, so
-when both TypedDicts contain ``__extra_items__``, this check is naturally enforced::
+``extra_items`` as a pseudo-item follows the same rules that other items have,
+so when both TypedDicts types specify ``extra_items``, this check is naturally
+enforced::
 
-    class MovieExtraInt(TypedDict, closed=True):
+    class MovieExtraInt(TypedDict, extra_items=int):
         name: str
-        __extra_items__: int
 
-    class MovieExtraStr(TypedDict, closed=True):
+    class MovieExtraStr(TypedDict, extra_items=str):
         name: str
-        __extra_items__: str
     
     extra_int: MovieExtraInt = {"name": "No Country for Old Men", "year": 2007}
     extra_str: MovieExtraStr = {"name": "No Country for Old Men", "description": ""}
-    extra_int = extra_str  # Not OK. 'str' is inconsistent with 'int' for item '__extra_items__'
-    extra_str = extra_int  # Not OK. 'int' is inconsistent with 'str' for item '__extra_items__'
+    extra_int = extra_str  # Not OK. 'str' is not assignable to extra items type 'int'
+    extra_str = extra_int  # Not OK. 'int' is not assignable to extra items type 'str'
     
 A non-closed TypedDict type implicitly allows non-required extra keys of value
-type ``ReadOnly[object]``. This allows to apply the type consistency rules
-between this type and a closed TypedDict type::
+type ``ReadOnly[object]``. Applying the assignability rules between this type
+and a closed TypedDict type is allowed::
 
     class MovieNotClosed(TypedDict):
         name: str
     
     extra_int: MovieExtraInt = {"name": "No Country for Old Men", "year": 2007}
     not_closed: MovieNotClosed = {"name": "No Country for Old Men"}
-    extra_int = not_closed  # Not OK. 'ReadOnly[object]' implicitly on 'MovieNotClosed' is not consistent with 'int' for item '__extra_items__'
+    extra_int = not_closed  # Not OK.
+                            # 'extra_items=ReadOnly[object]' implicitly on 'MovieNotClosed'
+                            # is not assignable to with 'extra_items=int'
     not_closed = extra_int  # OK
 
 Interaction with Constructors
 -----------------------------
 
-TypedDicts that allow extra items of type ``T`` also allow arbitrary keyword
+TypedDicts that allow extra items of type ``T`` also allows arbitrary keyword
 arguments of this type when constructed by calling the class object::
 
-    class OpenMovie(TypedDict):
+    class NonClosedMovie(TypedDict):
         name: str
 
-    OpenMovie(name="No Country for Old Men")  # OK
-    OpenMovie(name="No Country for Old Men", year=2007)  # Not OK. Unrecognized key
+    NonClosedMovie(name="No Country for Old Men")  # OK
+    NonClosedMovie(name="No Country for Old Men", year=2007)  # Not OK. Unrecognized item
 
-    class ExtraMovie(TypedDict, closed=True):
+    class ExtraMovie(TypedDict, extra_items=int):
         name: str
-        __extra_items__: int
 
     ExtraMovie(name="No Country for Old Men")  # OK
     ExtraMovie(name="No Country for Old Men", year=2007)  # OK
     ExtraMovie(
         name="No Country for Old Men",
         language="English",
-    )  # Not OK. Wrong type for extra key
+    )  # Not OK. Wrong type for extra item 'language'
 
-    # This implies '__extra_items__: Never',
-    # so extra keyword arguments produce an error
+    # This implies 'extra_items=Never',
+    # so extra keyword arguments would produce an error
     class ClosedMovie(TypedDict, closed=True):
         name: str
 
@@ -571,31 +570,30 @@ arguments of this type when constructed by calling the class object::
 Interaction with Mapping[KT, VT]
 --------------------------------
 
-A TypedDict type can be consistent with ``Mapping[KT, VT]`` types other than
-``Mapping[str, object]`` as long as the union of value types on the TypedDict
-type is consistent with ``VT``. It is an extension of this rule from the typing
-spec:
+A TypedDict type can be assignable to ``Mapping[KT, VT]`` types other than
+``Mapping[str, object]`` as long as all value types of the items on the
+TypedDict type is :term:`assignable` to ``VT``. This is an extension of this
+assignability rule from the `typing spec
+<https://typing.readthedocs.io/en/latest/spec/typeddict.html#assignability>`__:
 
-    * A TypedDict with all ``int`` values is not consistent with
-      ``Mapping[str, int]``, since there may be additional non-``int``
-      values not visible through the type, due to structural subtyping.
-      These can be accessed using the ``values()`` and ``items()``
-      methods in ``Mapping``
+    * A TypedDict with all ``int`` values is not :term:`assignable` to
+      ``Mapping[str, int]``, since there may be additional non-``int`` values not
+      visible through the type, due to :term:`structural` assignability. These can
+      be accessed using the ``values()`` and ``items()`` methods in ``Mapping``,
 
 For example::
 
-    class MovieExtraStr(TypedDict, closed=True):
+    class MovieExtraStr(TypedDict, extra_items=str):
         name: str
-        __extra_items__: str
 
     extra_str: MovieExtraStr = {"name": "Blade Runner", "summary": ""}
     str_mapping: Mapping[str, str] = extra_str  # OK
 
-    int_mapping: Mapping[str, int] = extra_int  # Not OK. 'int | str' is not consistent with 'int'
+    int_mapping: Mapping[str, int] = extra_int  # Not OK. 'int | str' is not assignable with 'int'
     int_str_mapping: Mapping[str, int | str] = extra_int  # OK
 
-Furthermore, type checkers should be able to infer the precise return types of
-``values()`` and ``items()`` on such TypedDict types::
+Type checkers should be able to infer the precise return types of ``values()``
+and ``items()`` on such TypedDict types::
 
     def fun(movie: MovieExtraStr) -> None:
         reveal_type(movie.items())  # Revealed type is 'dict_items[str, str]'
@@ -604,17 +602,15 @@ Furthermore, type checkers should be able to infer the precise return types of
 Interaction with dict[KT, VT]
 -----------------------------
 
-Note that because the presence of ``__extra_items__`` on a closed TypedDict type
-prohibits additional required keys in its structural subtypes, we can determine
-if the TypedDict type and its structural subtypes will ever have any required
-key during static analysis.
+Note that because the presence of ``extra_items`` on a closed TypedDict type
+prohibits additional required keys in its :term:`structural` :term:`subtypes
+<subtype>`, we can determine if the TypedDict type and its structural subtypes
+will ever have any required key during static analysis.
 
-The TypedDict type is consistent with ``dict[str, VT]`` if all items on the
-TypedDict type satisfy the following conditions:
+The TypedDict type is :term:`assignable` to ``dict[str, VT]`` if all items on
+the TypedDict type satisfy the following conditions:
 
-- ``VT`` is consistent with the value type of the item
-
-- The value type of the item is consistent with ``VT`` 
+- The value type of the item is :term:`consistent` with ``VT``.
 
 - The item is not read-only.
 
@@ -622,8 +618,8 @@ TypedDict type satisfy the following conditions:
 
 For example::
 
-    class IntDict(TypedDict, closed=True):
-        __extra_items__: int
+    class IntDict(TypedDict, extra_items=int):
+        pass
 
     class IntDictWithNum(IntDict):
         num: NotRequired[int]
@@ -632,9 +628,9 @@ For example::
         v: dict[str, int] = x  # OK
         v.clear()  # OK
     
-    not_required_num: IntDictWithNum = {"num": 1, "bar": 2} 
-    regular_dict: dict[str, int] = not_required_num  # OK
-    f(not_required_num)  # OK
+    not_required_num_dict: IntDictWithNum = {"num": 1, "bar": 2} 
+    regular_dict: dict[str, int] = not_required_num_dict  # OK
+    f(not_required_num_dict)  # OK
 
 In this case, methods that are previously unavailable on a TypedDict are allowed::
 
@@ -642,11 +638,11 @@ In this case, methods that are previously unavailable on a TypedDict are allowed
 
     reveal_type(not_required_num.popitem())  # OK. Revealed type is tuple[str, int]
 
-However, ``dict[str, VT]`` is not necessarily consistent with a TypedDict type,
+However, ``dict[str, VT]`` is not necessarily assignable to a TypedDict type,
 because such dict can be a subtype of dict::
 
     class CustomDict(dict[str, int]):
-        ...
+        pass
     
     not_a_regular_dict: CustomDict = {"num": 1}
     int_dict: IntDict = not_a_regular_dict  # Not OK
@@ -654,9 +650,9 @@ because such dict can be a subtype of dict::
 How to Teach This
 =================
 
-The choice of the spelling ``"__extra_items__"`` is intended to make this
+The choice of the spelling ``"extra_items"`` is intended to make this
 feature more understandable to new users compared to shorter alternatives like
-``"__extra__"``.
+``"extra"``.
 
 Details of this should be documented in both the typing spec and the
 :mod:`typing` documentation.
@@ -664,21 +660,61 @@ Details of this should be documented in both the typing spec and the
 Backwards Compatibility
 =======================
 
-Because ``__extra_items__`` remains as a regular key if ``closed=True`` is not
-specified, no existing codebase will break due to this change.
+Because ``extra_items`` is an opt-in feature, no existing codebase will break
+due to this change.
 
-If the proposal is accepted, none of ``__required_keys__``,
-``__optional_keys__``, ``__readonly_keys__`` and ``__mutable_keys__`` should
-include ``"__extra_items__"`` defined on the same TypedDict type when
-``closed=True`` is specified.
-
-Note that ``closed`` as a keyword argument does not collide with the keyword
-arguments alternative to define keys with the functional syntax that allows
-things like ``TD = TypedDict("TD", foo=str, bar=int)``, because it is scheduled
-to be removed in Python 3.13.
+Note that ``closed`` and ``extra_items`` as keyword arguments do not collide
+with othere keys when using something like
+``TD = TypedDict("TD", foo=str, bar=int)``, because this syntax is already
+scheduled to be removed in Python 3.13.
 
 Because this is a type-checking feature, it can be made available to older
 versions as long as the type checker supports it.
+
+Open Issues
+===========
+
+Use a Special ``__extra_items__`` Key with the ``closed`` Class Parameter
+-------------------------------------------------------------------------
+
+In an earlier revision of this proposal, we discussed an approach that would
+utilize ``__extra_items__``'s value type to specify the type of extra items
+accepted, like so::
+
+    class IntDict(TypedDict, closed=True):
+        __extra_items__: int
+
+where ``closed=True`` is required for ``__extra_items__`` to be treated
+specially, to avoid key collision.
+
+Some members of the community concern about the elegance of the syntax.
+Practiaclly, the key collision with a regular key can be mitigated with
+workarounds, but since using a reserved key is central to this proposal,
+there are limited ways forward to address the concerns.
+
+Support a New Syntax of Specifying Keys
+---------------------------------------
+
+By introducing a new syntax that allows specifying string keys, we could
+deprecate the functional syntax of defining TypedDict types and address the
+key conflict issues if we decide to reserve a special key to type extra items.
+
+For example::
+
+    class Foo(TypedDict):
+        name: str  # Regular item
+        _: bool    # Type of extra items
+        __items__ = {
+            "_": int,   # Literal "_" as a key
+            "class": str,  # Keyword as a key
+            "tricky.name?": float,  # Arbitrary str key
+        }
+
+This was proposed `here by Jukka
+<https://discuss.python.org/t/pep-728-typeddict-with-typed-extra-items/45443/115>`__.
+
+This will allow us to deprecate the functional syntax of defining TypedDict
+types altogether, but adapting to this proposal will make this PEP heavier.
 
 Rejected Ideas
 ==============
@@ -686,45 +722,18 @@ Rejected Ideas
 Allowing Extra Items without Specifying the Type
 ------------------------------------------------
 
-``extra=True`` was originally proposed for defining a TypedDict that accepts extra
-items regardless of the type, like how ``total=True`` works::
+``extra=True`` was originally proposed for defining a TypedDict that accepts
+extra items regardless of the type, like how ``total=True`` works::
 
-    class TypedDict(extra=True):
+    class ExtraDict(TypedDict, extra=True):
         pass
 
 Because it did not offer a way to specify the type of the extra items, the type
 checkers will need to assume that the type of the extra items is ``Any``, which
 compromises type safety. Furthermore, the current behavior of TypedDict already
-allows untyped extra items to be present in runtime, due to structural
-subtyping. ``closed=True`` plays a similar role in the current proposal.
-
-Supporting ``TypedDict(extra=type)``
-------------------------------------
-
-During the discussion of the PEP, there were strong objections against adding
-another place where types are passed as values instead of annotations from some
-authors of type checkers. While this design is potentially viable, there are
-also several partially addressable concerns to consider.
-
-- Usability of forward reference
-  As in the functional syntax, using a quoted type or a type alias will be
-  required when SomeType is a forward reference. This is already a requirement
-  for the functional syntax, so implementations can potentially reuse that piece
-  of logic, but this is still extra work that the ``closed=True`` proposal doesn't
-  have.
-
-- Concerns about using type as a value
-  Whatever is not allowed as the value type in the functional syntax should not
-  be allowed as the argument for extra either. While type checkers might be able
-  to reuse this check, it still needs to be somehow special-cased for the
-  class-based syntax.
-
-- How to teach
-  Notably, the ``extra=type`` often gets brought up due to it being an intuitive
-  solution for the use case, so it is potentially simpler to learn than the less
-  obvious solution. However, the more common used case only requires
-  ``closed=True``, and the other drawbacks mentioned earlier outweigh what is
-  need to teach the usage of the special key.
+allows untyped extra items to be present in runtime, due to :term:`structural`
+:term:`assignability <typing:assignable>`. ``closed=True`` plays a similar role
+in the current proposal.
 
 Support Extra Items with Intersection
 -------------------------------------
@@ -738,17 +747,17 @@ intersections, nor does it necessarily need to be supported through
 intersections.
 
 Moreover, the intersection between ``Mapping[...]`` and ``TypedDict`` is not
-equivalent to a TypedDict type with the proposed ``__extra_items__`` special
+equivalent to a TypedDict type with the proposed ``extra_items`` special
 item, as the value type of all known items in ``TypedDict`` needs to satisfy the
 is-subtype-of relation with the value type of ``Mapping[...]``.
 
-Requiring Type Compatibility of the Known Items with ``__extra_items__``
+Requiring Type Compatibility of the Known Items with ``extra_items``
 ------------------------------------------------------------------------
 
-``__extra_items__`` restricts the value type for keys that are *unknown* to the
+``extra_items`` restricts the value type for keys that are *unknown* to the
 TypedDict type. So the value type of any *known* item is not necessarily
-consistent with ``__extra_items__``'s type, and ``__extra_items__``'s type is
-not necessarily consistent with the value types of all known items.
+assignable to ``extra_items``, and ``extra_items`` is
+not necessarily assignable to the value types of all known items.
 
 This differs from TypeScript's `Index Signatures
 <https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures>`__
@@ -776,10 +785,9 @@ from the index signature so that it is possible to define a type like
 Reference Implementation
 ========================
 
-This proposal is supported in `pyright 1.1.352
+An earlier revision of proposal is supported in `pyright 1.1.352
 <https://github.com/microsoft/pyright/releases/tag/1.1.352>`_, and `pyanalyze
 0.12.0 <https://github.com/quora/pyanalyze/releases/tag/v0.12.0>`_.
-
 
 Acknowledgments
 ===============

--- a/peps/pep-0728.rst
+++ b/peps/pep-0728.rst
@@ -721,9 +721,23 @@ For example::
 
 This was proposed `here by Jukka
 <https://discuss.python.org/t/pep-728-typeddict-with-typed-extra-items/45443/115>`__.
+The ``'_'`` key is chosen for not needing to invent a new name, and its
+similarity with the match statement.
 
 This will allow us to deprecate the functional syntax of defining TypedDict
-types altogether, but adapting to this proposal will make this PEP heavier.
+types altogether, but there are some disadvantages. `For example
+<https://github.com/python/peps/pull/4066#discussion_r1806986861>`__:
+
+- It's less apparent to a reader that ``_: bool`` makes the TypedDict
+  special, relative to adding a class argument like ``extra_items=bool``.
+
+- It's backwards incompatible with existing TypedDicts using the
+  ``_: bool`` key. While such users have a way to get around the issue,
+  it's still a problem for them if they upgrade Python (or
+  typing-extensions).
+
+- The types don't appear in an annotation context, so their evaluation will
+  not be deferred.
 
 Rejected Ideas
 ==============


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

# Change summary

- Move away from `__extra_items__: T` to `extra_items=T`
- Repurpose the 'closed' class parameter to make 'closed=True' an alias of 'extra_items=Never'
- Include references to the typing spec
- Normalize terms like "assignability" and "consistent" to match the typing glossary (https://typing.readthedocs.io/en/latest/spec/glossary.html)
- Update sections that contain documentation quotes to match the up-to-date version
- Add new sections about other ideas
- Bump the target version to 3.14

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4066.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->