### PR TITLE
PEP 761: Deprecation doesn't affect previous signatures

### DIFF
--- a/peps/pep-0761.rst
+++ b/peps/pep-0761.rst
@@ -197,6 +197,14 @@ commitment that is typically done on a volunteer basis. Thus we see removal
 of PGP key management duties as a step towards reducing burnout and stress
 of future release managers and improving the sustainability of CPython.
 
+Removing previous PGP signatures
+--------------------------------
+
+This PEP doesn't intend to break any infrastructure built around existing Python
+versions, instead only changing the expectations around future Python versions.
+Thus all PGP signatures that are already available on python.org will continue
+to be available even after PGP discontinuance.
+
 Appendix
 ========
 


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

A small update to make this explicit after I received a question about it.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4069.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->