### PR TITLE
PEP 396: Reclassify as Withdrawn

### DIFF
--- a/peps/pep-0396.rst
+++ b/peps/pep-0396.rst
@@ -40,14 +40,17 @@ has changed significantly in the intervening years since this PEP was
 first written, and APIs such as ``importlib.metadata.version()`` [11]_
 provide for a much better experience.
 
-This rejection was subsequently reclassified as a withdrawal,
+This rejection was reclassified as a withdrawal on 2024-10-21,
 as the previous state was being misinterpreted [12]_ as suggesting
 that *no* modules should be defining ``__version__`` attributes,
 which definitely isn't the case.
 
-Modules may still define ``__version__`` if they choose to,
-but choosing *not* to do so won't interfere with looking up
-the version information for installed distribution packages.
+Modules are still free to define ``__version__`` if they choose to.
+However, choosing *not* to do so won't interfere with looking up
+the version information for installed distribution packages, so an
+Informational PEP isn't the right tool to document community
+conventions around the use of module ``__version__`` attributes
+(they're better covered as part of the Python Packaging User Guide).
 
 
 User Stories

--- a/peps/pep-0396.rst
+++ b/peps/pep-0396.rst
@@ -10,7 +10,7 @@ Content-Type: text/x-rst
 Created: 16-Mar-2011
 Post-History: 05-Apr-2011
 
-.. withdrawn
+.. withdrawn::
 
    Refer to :ref:`packaging:runtime-version-access` and
    :ref:`packaging:single-source-version` in the Python

--- a/peps/pep-0396.rst
+++ b/peps/pep-0396.rst
@@ -1,12 +1,9 @@
 PEP: 396
 Title: Module Version Numbers
-Version: $Revision: 65628 $
-Last-Modified: $Date: 2008-08-10 09:59:20 -0400 (Sun, 10 Aug 2008) $
 Author: Barry Warsaw <barry@python.org>
 Status: Withdrawn
 Type: Informational
 Topic: Packaging
-Content-Type: text/x-rst
 Created: 16-Mar-2011
 Post-History: 05-Apr-2011
 

--- a/peps/pep-0396.rst
+++ b/peps/pep-0396.rst
@@ -3,12 +3,21 @@ Title: Module Version Numbers
 Version: $Revision: 65628 $
 Last-Modified: $Date: 2008-08-10 09:59:20 -0400 (Sun, 10 Aug 2008) $
 Author: Barry Warsaw <barry@python.org>
-Status: Rejected
+Status: Withdrawn
 Type: Informational
 Topic: Packaging
 Content-Type: text/x-rst
 Created: 16-Mar-2011
 Post-History: 05-Apr-2011
+
+.. withdrawn
+
+   Refer to :ref:`packaging:runtime-version-access` and
+   :ref:`packaging:single-source-version` in the Python
+   Packaging User Guide for up to date recommendations on
+   accessing package version information at runtime,
+   and on defining runtime ``__version__`` attributes which are
+   automatically kept consistent with package distribution metadata
 
 
 Abstract
@@ -25,13 +34,24 @@ Conformance with this PEP is optional, however other Python tools
 (such as ``distutils2`` [1]_) may be adapted to use the conventions
 defined here.
 
-PEP Rejection
-=============
+
+PEP Rejection/Withdrawal
+========================
 
 This PEP was formally rejected on 2021-04-14.  The packaging ecosystem
 has changed significantly in the intervening years since this PEP was
 first written, and APIs such as ``importlib.metadata.version()`` [11]_
 provide for a much better experience.
+
+This rejection was subsequently reclassified as a withdrawal,
+as the previous state was being misinterpreted [12]_ as suggesting
+that *no* modules should be defining ``__version__`` attributes,
+which definitely isn't the case.
+
+Modules may still define ``__version__`` if they choose to,
+but choosing *not* to do so won't interfere with looking up
+the version information for installed distribution packages.
+
 
 User Stories
 ============
@@ -286,6 +306,9 @@ References
 
 .. [11] importlib.metadata
    (https://docs.python.org/3/library/importlib.metadata.html#distribution-versions)
+
+.. [12] Misinterpreting the significance of this PEP's rejection
+   (https://discuss.python.org/t/please-make-package-version-go-away/58501)
 
 
 Copyright


### PR DESCRIPTION
The ``__version__`` runtime convention hasn't been rejected, as it's still a good way to version import packages instead of (or in addition to) distribution packages.

We just concluded that this PEP wasn't the right vehicle for documenting it, which is better reflected as a withdrawal rather than as a rejection.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4074.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->