### PR TITLE
PEP 588: Mark as Final

### DIFF
--- a/peps/pep-0588.rst
+++ b/peps/pep-0588.rst
@@ -3,10 +3,13 @@ Title: GitHub Issues Migration Plan
 Author: Mariatta <mariatta@python.org>
 BDFL-Delegate: Barry Warsaw <barry@python.org>
 Discussions-To: https://discuss.python.org/t/13791
-Status: Draft
+Status: Final
 Type: Informational
-Content-Type: text/x-rst
 Created: 27-Mar-2019
+
+.. canonical-doc:: `psf/gh-migration#13 <https://github.com/psf/gh-migration/issues/13>`__
+
+   The migration was carried out in April 2022.
 
 
 Abstract
@@ -200,12 +203,12 @@ Mapping between issues from bpo and GitHub
 ------------------------------------------
 
 Usually when we reference an issue from bpo, we use bpo-XYZ but with
-Github, we will have a new reference with this format
+GitHub, we will have a new reference with this format
 ``https://github.com/python/cpython/issue/XYZ``.
 
 Because we will migrate the issues from bpo to GitHub, we need to have a new
 field on bpo for the reference to the issues on GitHub, and the same thing on
-Github for the 'eventual' reference from bpo.
+GitHub for the 'eventual' reference from bpo.
 
 For GitHub, we need to add ``origin: https://bugs.python.org/issueXYZ``.
 For bpo, add a new field ``moved to:
@@ -309,13 +312,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-..
-   Local Variables:
-   mode: rst
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Fixes https://github.com/python/peps/issues/2497.

The migration was carried out in April 2022. This Informational PEP can be marked as Final, and we can link to the actual plan https://github.com/psf/gh-migration/issues/13.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4086.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->