### PR TITLE
PEP 659: Mark as Final

### DIFF
--- a/peps/pep-0659.rst
+++ b/peps/pep-0659.rst
@@ -1,11 +1,12 @@
 PEP: 659
 Title: Specializing Adaptive Interpreter
 Author: Mark Shannon <mark@hotpy.org>
-Status: Draft
+Status: Final
 Type: Informational
-Content-Type: text/x-rst
 Created: 13-Apr-2021
 Post-History: 11-May-2021
+
+.. canonical-doc:: :ref:`Specializing Adaptive Interpreter <whatsnew311-pep659>`
 
 
 Abstract
@@ -376,14 +377,3 @@ Copyright
 
 This document is placed in the public domain or under the
 CC0-1.0-Universal license, whichever is more permissive.
-
-
-
-..
-    Local Variables:
-    mode: indented-text
-    indent-tabs-mode: nil
-    sentence-end-double-space: t
-    fill-column: 70
-    coding: utf-8
-    End:


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [ ] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

This is an informational PEP for the Specializing Adaptive Interpreter that went into 3.11, so could be marked as Final now.

I added "canonical docs" pointing to the long [3.11 what's new entry](https://docs.python.org/3/whatsnew/3.11.html#pep-659-specializing-adaptive-interpreter), unless there a better place to link to?


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4090.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->