### PR TITLE
PEP 763: add an appendix comparing ecosystems

### DIFF
--- a/peps/pep-0763.rst
+++ b/peps/pep-0763.rst
@@ -112,7 +112,7 @@ risk and detriment to the Python ecosystem than a benefit.
 In addition to these technical arguments, there is also precedent
 from other packaging ecosystems for limiting the ability of users to delete
 projects and their constituent releases. This precedent is documented in
-:ref:`Appendix A <appendix-a>`.
+:ref:`Appendix A <pep763-appendix-a>`.
 
 Specification
 =============
@@ -269,7 +269,7 @@ usage, this PEP identifies several limitations to this approach:
    PyPI is not straightforward, and there is limited possibility to gather a
    project's download statistics from mirrors or other distributions systems.
 
-.. _appendix-a:
+.. _pep763-appendix-a:
 
 Appendix A: Precedent in other ecosystems
 =========================================

--- a/peps/pep-0763.rst
+++ b/peps/pep-0763.rst
@@ -106,8 +106,13 @@ The Python ecosystem is continuing to grow,
 meaning that future deletions of projects can be reasonably assumed to
 be *just, as if not more,* disruptive than the deletions sampled above.
 
-Given the above, this PEP concludes that deletions now present a greater risk
-and detriment to the Python ecosystem than a benefit.
+Given all of the above, this PEP concludes that deletions now present a greater
+risk and detriment to the Python ecosystem than a benefit.
+
+In addition to these technical arguments, there is also precedent
+from other packaging ecosystems for limiting the ability of users to delete
+projects and their constituent releases. This precedent is documented in
+:ref:`Appendix A <appendix-a>`.
 
 Specification
 =============
@@ -263,6 +268,115 @@ usage, this PEP identifies several limitations to this approach:
 3. *Technical complexity.* Accessing the download count of a project within
    PyPI is not straightforward, and there is limited possibility to gather a
    project's download statistics from mirrors or other distributions systems.
+
+.. _appendix-a:
+
+Appendix A: Precedent in other ecosystems
+=========================================
+
+The following is a table of support for deletion in different packaging
+ecosystems. An ecosystem is considered to **not** support deletion
+if it restrict's a user's ability to perform deletions in a manner similar
+to this PEP.
+
+An earlier version of this table, showing only deletion, was
+compiled by Donald Stufft and others on the Python discussion forum in
+`July 2022 <https://discuss.python.org/t/17227/58>`__.
+
+.. list-table::
+  :header-rows: 1
+
+  * - Ecosystem (Index)
+    - Deletion
+    - Yanking
+    - Notes
+  * - Python (PyPI)
+    - ✅ [#f1]_
+    - ✅ [#f2]_
+    - Deletion currently completely unrestricted.
+  * - Rust (crates.io)
+    - ❌
+    - ✅ [#f3]_
+    - Deletion by users not allowed at all.
+  * - JavaScript (npm)
+    - ❌ [#f4]_
+    - ✅ [#f5]_
+    - Deletion is limited by criteria similar to this PEP.
+  * - Ruby (RubyGems)
+    - ✅ [#f6]_
+    - ❌
+    - RubyGems calls deletion "yanking." Yanking in PyPI's terms is not supported at all.
+  * - Java (Maven Central)
+    - ❌ [#f7]_
+    - ❌
+    - Deletion by users not allowed at all.
+  * - PHP (Packagist)
+    - ❌
+    - ❌
+    - Deletion restricted after an undocumented number of installs [#f8]_.
+  * - .NET (NuGet)
+    - ❌ [#f9]_
+    - ✅ [#f10]_
+    - NuGet calls yanking "unlisting."
+  * - Elixir (Hex)
+    - ❌ [#f11]_
+    - ✅ [#f11]_
+    - Hex calls yanking "retiring."
+  * - R (CRAN)
+    - ❌ [#f12]_
+    - ✅ [#f12]_
+    - Deletion is limited to within 24 hours of initial release or
+      60 minutes for subsequent versions. CRAN calls yanking "archiving."
+  * - Perl (CPAN)
+    - ✅
+    - ❌
+    - Yanking is not supported at all. Deletion seemingly encouraged,
+      at least as of 2021 [#f13]_.
+  * - Lua (LuaRocks)
+    - ✅ [#f14]_
+    - ✅ [#f14]_
+    - LuaRocks calls yanking "archiving."
+
+The following trends are present:
+
+* A strong majority of indices **do not** support deletion (7 vs. 4)
+* A strong majority of indices **do** support yanking (7 vs. 4)
+* The overwhelming majority of indices support one or the other or neither,
+  but **not** both (13 vs. 2)
+
+  * PyPI and LuaRocks are notable outliers in supporting **both** deletion and
+    yanking.
+
+Footnotes
+=========
+
+.. [#f1] https://pypi.org/help/#deletion
+
+.. [#f2] https://pypi.org/help/#yanked
+
+.. [#f3] https://doc.rust-lang.org/cargo/commands/cargo-yank.html
+
+.. [#f4] https://docs.npmjs.com/unpublishing-packages-from-the-registry
+
+.. [#f5] https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions
+
+.. [#f6] https://guides.rubygems.org/removing-a-published-gem/
+
+.. [#f7] https://central.sonatype.org/faq/can-i-change-a-component/
+
+.. [#f8] https://github.com/composer/packagist/issues/875
+
+.. [#f9] https://learn.microsoft.com/en-us/nuget/nuget-org/policies/deleting-packages
+
+.. [#f10] https://learn.microsoft.com/en-us/nuget/nuget-org/policies/deleting-packages#unlisting-a-package
+
+.. [#f11] https://hex.pm/docs/faq#can-packages-be-removed-from-the-repository
+
+.. [#f12] https://cran.r-project.org/web/packages/policies.html
+
+.. [#f13] https://neilb.org/2021/05/10/delete-your-old-releases.html
+
+.. [#f14] https://luarocks.org/changes
 
 Copyright
 =========

--- a/peps/pep-0763.rst
+++ b/peps/pep-0763.rst
@@ -281,7 +281,7 @@ to this PEP.
 
 An earlier version of this table, showing only deletion, was
 compiled by Donald Stufft and others on the Python discussion forum in
-`July 2022 <https://discuss.python.org/t/17227/58>`__.
+`July 2022 <https://discuss.python.org/t/17227/59>`__.
 
 .. list-table::
   :header-rows: 1


### PR DESCRIPTION
Follows https://github.com/python/peps/pull/4080 by adding an appendix comparing different ecosystems' support for deletion and yanking, per @JelleZijlstra's request 🙂 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4091.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->