### PR TITLE
PEP 763: add Hackage and OPAM

### DIFF
--- a/peps/pep-0763.rst
+++ b/peps/pep-0763.rst
@@ -311,9 +311,9 @@ compiled by Donald Stufft and others on the Python discussion forum in
     - ❌
     - Deletion by users not allowed at all.
   * - PHP (Packagist)
+    - ❌ [#f8]_
     - ❌
-    - ❌
-    - Deletion restricted after an undocumented number of installs [#f8]_.
+    - Deletion restricted after an undocumented number of installs.
   * - .NET (NuGet)
     - ❌ [#f9]_
     - ✅ [#f10]_
@@ -336,13 +336,23 @@ compiled by Donald Stufft and others on the Python discussion forum in
     - ✅ [#f14]_
     - ✅ [#f14]_
     - LuaRocks calls yanking "archiving."
+  * - Haskell (Hackage)
+    - ❌ [#f15]_
+    - ✅ [#f16]_
+    - Hackage calls yanking "deprecating."
+  * - OCaml (OPAM)
+    - ❌ [#f17]_
+    - ✅ [#f17]_
+    - Deletion is allowed if it occurs "reasonably soon" after inclusion.
+      Yanking is *de facto* supported by the ``available: false`` marker, which
+      effectively disables resolution.
 
 The following trends are present:
 
-* A strong majority of indices **do not** support deletion (7 vs. 4)
-* A strong majority of indices **do** support yanking (7 vs. 4)
-* The overwhelming majority of indices support one or the other or neither,
-  but **not** both (13 vs. 2)
+* A strong majority of indices **do not** support deletion (9 vs. 4)
+* A strong majority of indices **do** support yanking (9 vs. 4)
+* An overwhelming majority of indices support one or the other or neither,
+  but **not** both (11 vs. 2)
 
   * PyPI and LuaRocks are notable outliers in supporting **both** deletion and
     yanking.
@@ -377,6 +387,12 @@ Footnotes
 .. [#f13] https://neilb.org/2021/05/10/delete-your-old-releases.html
 
 .. [#f14] https://luarocks.org/changes
+
+.. [#f15] https://hackage.haskell.org/upload
+
+.. [#f16] https://hackage.haskell.org/packages/deprecated
+
+.. [#f17] https://github.com/ocaml/opam-repository/wiki/Policies#1-removal-of-packages-should-be-avoided
 
 Copyright
 =========


### PR DESCRIPTION
Adds two more ecosystems for comparison, thanks to @JelleZijlstra.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4092.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->