### PR TITLE
PEP 753: link to PyPA spec

### DIFF
--- a/peps/pep-0753.rst
+++ b/peps/pep-0753.rst
@@ -14,6 +14,8 @@ Post-History: `26-Aug-2024 <https://discuss.python.org/t/core-metadata-should-ho
 Resolution: `10-Oct-2024 <https://discuss.python.org/t/62792/30>`__
 
 
+.. canonical-pypa-spec:: :ref:`packaging:well-known-project-urls`
+
 Abstract
 ========
 


### PR DESCRIPTION
The equivalent PyPI page is now live at https://packaging.python.org/en/latest/specifications/well-known-project-urls/, so this adds the appropriate banner.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4095.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->