### PR TITLE
PEP 691: Fix wrong reference to PEP 529

### DIFF
--- a/peps/pep-0691.rst
+++ b/peps/pep-0691.rst
@@ -948,7 +948,7 @@ Appendix 2: Rough Underlying Data Models
 These are not intended to perfectly match the server, client, or wire
 formats. Rather, these are conceptual models, put to code to make them
 more explicit as to the abstract models underlining the repository API
-as it evolved through :pep:`503`, :pep:`529`, :pep:`629`, :pep:`658`,
+as it evolved through :pep:`503`, :pep:`592`, :pep:`629`, :pep:`658`,
 and now this PEP, :pep:`691`.
 
 The existing HTML, and the new JSON serialization of these models then
@@ -984,11 +984,11 @@ this PEP.
 
 
     @dataclass
-    class PEP529File(File):
+    class PEP592File(File):
         yanked: bool | str
 
     @dataclass
-    class PEP658File(PEP529File):
+    class PEP658File(PEP592File):
         # Limited to a len() of 1 in HTML
         dist_info_metadata: bool | dict[str, str]
 
@@ -1016,12 +1016,12 @@ this PEP.
 
 
     @dataclass
-    class PEP529_Detail(PEP503_Detail):
-        files: set[PEP529File]
+    class PEP592_Detail(PEP503_Detail):
+        files: set[PEP592File]
 
 
     @dataclass
-    class PEP629_Detail(PEP529_Detail):
+    class PEP629_Detail(PEP592_Detail):
         meta: Meta
 
 


### PR DESCRIPTION
<!--
This template is for an infra or meta change not belonging to another category.
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->
Fixes https://github.com/python/peps/issues/4088.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4098.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->