### PR TITLE
PEP 739: add language.version_info and libpython.dynamic_stableabi

### DIFF
--- a/peps/pep-0739.rst
+++ b/peps/pep-0739.rst
@@ -174,6 +174,82 @@ below, which is rendered in an human-readable format here.
     * - Required
       - **True**
 
+``language.version_info``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+    :widths: 25 75
+
+    * - Type
+      - ``object``
+    * - Description
+      - Object in the format of :py:data:`sys.version_info`.
+
+        This section SHOULD be equivalent to
+        :py:data:`sys.version_info`.
+    * - Examples
+      - - ``{'major': 3, 'minor': 14, 'micro': 1, 'releaselevel': 'final', 'serial': 0}``
+        - etc.
+    * - Required
+      - **False**
+    * - Additional properties
+      - **Not allowed**
+
+``language.version_info.major``
++++++++++++++++++++++++++++++++
+
+.. list-table::
+    :widths: 25 75
+
+    * - Type
+      - ``number``
+    * - Required
+      - **True**
+
+``language.version_info.minor``
++++++++++++++++++++++++++++++++
+
+.. list-table::
+    :widths: 25 75
+
+    * - Type
+      - ``number``
+    * - Required
+      - **True**
+
+``language.version_info.micro``
++++++++++++++++++++++++++++++++
+
+.. list-table::
+    :widths: 25 75
+
+    * - Type
+      - ``number``
+    * - Required
+      - **True**
+
+``language.version_info.releaselevel``
+++++++++++++++++++++++++++++++++++++++
+
+.. list-table::
+    :widths: 25 75
+
+    * - Type
+      - ``string`` (enum — ``alpha``, ``beta``, ``candidate``, ``final``)
+    * - Required
+      - **True**
+
+``language.version_info.serial``
+++++++++++++++++++++++++++++++++
+
+.. list-table::
+    :widths: 25 75
+
+    * - Type
+      - ``number``
+    * - Required
+      - **True**
+
 ``implementation``
 ------------------
 

--- a/peps/pep-0739.rst
+++ b/peps/pep-0739.rst
@@ -539,6 +539,29 @@ below, which is rendered in an human-readable format here.
     * - Required
       - **False**
 
+``libpython.dynamic_stableabi``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+    :widths: 25 75
+
+    * - Type
+      - ``string``
+    * - Description
+      - The path to the dynamic ``libpython`` library for the stable
+        ABI. Either an absolute path, or a relative path to the path
+        defined in the ``base_prefix`` key.
+
+        This field MUST be present if the Python installation provides a
+        dynamic ``libpython`` library, otherwise this entry will be
+        missing.
+    * - Examples
+      - - ``/usr/lib/libpython3.so``
+        - ``lib/libpython3.so``
+        - etc.
+    * - Required
+      - **False**
+
 ``libpython.static``
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/peps/pep-0739.rst
+++ b/peps/pep-0739.rst
@@ -298,7 +298,7 @@ below, which is rendered in an human-readable format here.
       - Object in the format of :py:data:`sys.version_info`, containing
         the implementation version.
     * - Examples
-      - - ``{'major': 3, 'minor': 13, 'micro': 1, 'releaselevel': 'final', 'serial': 0}``
+      - - ``{'major': 3, 'minor': 14, 'micro': 1, 'releaselevel': 'final', 'serial': 0}``
         - ``{'major': 7, 'minor': 3, 'micro': 16, 'releaselevel': 'final', 'serial': 0}``
         - etc.
     * - Required

--- a/peps/pep-0739/example.json
+++ b/peps/pep-0739/example.json
@@ -10,7 +10,7 @@
       "micro": 0,
       "releaselevel": "alpha",
       "serial": 0
-    },
+    }
   },
   "implementation": {
     "name": "cpython",

--- a/peps/pep-0739/example.json
+++ b/peps/pep-0739/example.json
@@ -42,6 +42,7 @@
   },
   "libpython": {
     "dynamic": "/usr/lib/libpython3.14.so.1.0",
+    "dynamic_stableabi": "/usr/lib/libpython3.so",
     "static": "/usr/lib/python3.14/config-3.14-x86_64-linux-gnu/libpython3.14.a",
     "link_to_libpython": true
   },

--- a/peps/pep-0739/example.json
+++ b/peps/pep-0739/example.json
@@ -3,7 +3,14 @@
   "base_prefix": "/usr",
   "platform": "linux-x86_64",
   "language": {
-    "version": "3.14"
+    "version": "3.14",
+    "version_info": {
+      "major": 3,
+      "minor": 14,
+      "micro": 0,
+      "releaselevel": "alpha",
+      "serial": 0
+    },
   },
   "implementation": {
     "name": "cpython",

--- a/peps/pep-0739/python-build-info-v1.schema.json
+++ b/peps/pep-0739/python-build-info-v1.schema.json
@@ -103,7 +103,7 @@
           "examples": [
             {
               "major": 3,
-              "minor": 13,
+              "minor": 14,
               "micro": 1,
               "releaselevel": "final",
               "serial": 0
@@ -212,6 +212,14 @@
           "examples": [
             "/usr/lib/libpython3.14.so.1.0",
             "lib/libpython3.14.so.1.0"
+          ]
+        },
+        "dynamic_stableabi": {
+          "type": "string",
+          "description": "The path to the dynamic ``libpython`` library for the stable ABI. Either an absolute path, or a relative path to the path defined in the ``base_prefix`` key.\n\nThis field MUST be present if the Python installation provides a dynamic ``libpython`` library, otherwise this entry will be missing.",
+          "examples": [
+            "/usr/lib/libpython3.so",
+            "lib/libpython3.so"
           ]
         },
         "static": {

--- a/peps/pep-0739/python-build-info-v1.schema.json
+++ b/peps/pep-0739/python-build-info-v1.schema.json
@@ -43,6 +43,39 @@
           "type": "string",
           "description": "String representation the Python language version — a version string consisting only of the *major* and *minor* components.\n\nThis field SHOULD be equivalent to ``sysconfig.get_python_version()``.",
           "examples": ["3.14"]
+        },
+        "version_info": {
+          "type": "object",
+          "description": "Object in the format of :py:data:`sys.version_info`.\n\nThis section SHOULD be equivalent to :py:data:`sys.version_info`.",
+          "required": ["major", "minor", "micro", "releaselevel", "serial"],
+          "additionalProperties": false,
+          "examples": [
+            {
+              "major": 3,
+              "minor": 14,
+              "micro": 1,
+              "releaselevel": "final",
+              "serial": 0
+            }
+          ],
+          "properties": {
+            "major": {
+              "type": "number"
+            },
+            "minor": {
+              "type": "number"
+            },
+            "micro": {
+              "type": "number"
+            },
+            "releaselevel": {
+              "type": "string",
+              "enum": ["alpha", "beta", "candidate", "final"]
+            },
+            "serial": {
+              "type": "number"
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@riseup.net><!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4100.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->