### PR TITLE
Infra: Lint and test via uv

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,16 +20,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          cache: pip
 
       - name: Run pre-commit hooks
-        uses: pre-commit/action@v3.0.1
+        uses: tox-dev/action-pre-commit-uv@v1
 
       - name: Check spelling
-        uses: pre-commit/action@v3.0.1
+        uses: tox-dev/action-pre-commit-uv@v1
         with:
           extra_args: --all-files --hook-stage manual codespell || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,16 +29,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-        - "3.9"
-        - "3.10"
-        - "3.11"
-        - "3.12"
-        - "3.13"
-        os:
-        - "windows-latest"
-        - "macos-latest"
-        - "ubuntu-latest"
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         # Python 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
         # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
         exclude:
@@ -46,25 +38,26 @@ jobs:
         include:
         - { python-version: "3.9", os: "macos-13" }
 
-
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
           allow-prereleases: true
 
-      - name: Install dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U wheel
-          python -m pip install -U tox
+      - name: Install uv
+        uses: hynek/setup-cached-uv@v2
+        with:
+          cache-dependency-path: |
+            requirements.txt
 
-      - name: Run tests
+      - name: Tox tests
         run: |
-          tox -e py -- -v --cov-report term
+          uvx --with tox-uv tox -e py -- -v --cov-report term
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        python-version:
+        - "3.9"
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        os:
+        - "windows-latest"
+        - "macos-latest"
+        - "ubuntu-latest"
 
     steps:
       - uses: actions/checkout@v4
@@ -49,7 +57,7 @@ jobs:
           cache-dependency-path: |
             requirements.txt
 
-      - name: Tox tests
+      - name: Run tests with tox
         run: |
           uvx --with tox-uv tox -e py -- -v --cov-report term
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,12 +31,6 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest, macos-latest, ubuntu-latest]
-        # Python 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
-        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
-        exclude:
-        - { python-version: "3.9", os: "macos-latest" }
-        include:
-        - { python-version: "3.9", os: "macos-13" }
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Like https://github.com/python/blurb/pull/32.

We can also now test Python 3.9 on macos-latest, so can remove its restriction to macos-13: https://github.com/actions/setup-python/issues/696#issuecomment-2302006143

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4102.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->