### PR TITLE
Infra: don't let generated `numerical.rst` trigger rebuild loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ htmlview: html
 htmllive: SPHINXBUILD = PATH=$(VENVDIR)/bin:$$PATH sphinx-autobuild
 # Arbitrarily selected ephemeral port between 49152–65535
 # to avoid conflicts with other processes:
-htmllive: SPHINXERRORHANDLING = --re-ignore="/\.idea/|/venv/|/pep-0000.rst|/topic/" --open-browser --delay 0 --port 55302
+htmllive: SPHINXERRORHANDLING = --re-ignore="/\.idea/|/venv/|/numerical.rst|/pep-0000.rst|/topic/" --open-browser --delay 0 --port 55302
 htmllive: _ensure-sphinx-autobuild html
 
 ## dirhtml        to render PEPs to "index.html" files within "pep-NNNN" directories


### PR DESCRIPTION
To reproduce:

```console
$ make htmllive
...
The HTML pages are in build.
[sphinx-autobuild] Serving on http://127.0.0.1:55302
[sphinx-autobuild] Waiting to detect changes...
```

Then edit a file, for example `peps/pep-0101.rst` and it will rebuild it. So far, so good.

But then because `peps/numerical.rst` is regenerated, `sphinx-autobuild` detects a change and begins an infinite rebuild loop:

```console
[sphinx-autobuild] Detected changes (peps/pep-0101.rst)
[sphinx-autobuild] Rebuilding...
...
The HTML pages are in build.
[sphinx-autobuild] Serving on http://127.0.0.1:55302
[sphinx-autobuild] Detected changes (peps/numerical.rst)
[sphinx-autobuild] Rebuilding...
...
The HTML pages are in build.
[sphinx-autobuild] Serving on http://127.0.0.1:55302
[sphinx-autobuild] Detected changes (peps/numerical.rst)
[sphinx-autobuild] Rebuilding...
```

Instead, ignore `numerical.rst`, just like the other generated files such as `pep-0000.rst`:

```console
❯ make htmllive
...
The HTML pages are in build.
[sphinx-autobuild] Serving on http://127.0.0.1:55302
[sphinx-autobuild] Waiting to detect changes...
[sphinx-autobuild] Detected changes (peps/pep-0101.rst)
[sphinx-autobuild] Rebuilding...
...
The HTML pages are in build.
[sphinx-autobuild] Serving on http://127.0.0.1:55302
```



<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4103.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->