### PR TITLE
Revert gh-3899

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,7 +45,7 @@ peps/pep-0012.rst  @brettcannon @warsaw
 peps/pep-0012/     @brettcannon
 # peps/pep-0013.rst is owned by the entire core team.
 # ...
-#peps/pep-0020.rst
+peps/pep-0020.rst  @tim-one
 # ...
 peps/pep-0042.rst  @jeremyhylton
 # ...
@@ -79,7 +79,7 @@ peps/pep-0218.rst  @rhettinger
 # peps/pep-0220.rst
 peps/pep-0221.rst  @Yhg1s
 # peps/pep-0222.rst
-# peps/pep-0223.rst
+peps/pep-0223.rst  @tim-one
 peps/pep-0224.rst  @malemburg
 # peps/pep-0225.rst
 peps/pep-0226.rst  @jeremyhylton
@@ -91,8 +91,8 @@ peps/pep-0231.rst  @warsaw
 peps/pep-0232.rst  @warsaw
 # peps/pep-0233.rst
 peps/pep-0234.rst  @gvanrossum
-# peps/pep-0235.rst
-# peps/pep-0236.rst
+peps/pep-0235.rst  @tim-one
+peps/pep-0236.rst  @tim-one
 peps/pep-0237.rst  @gvanrossum
 peps/pep-0238.rst  @gvanrossum
 # peps/pep-0239.rst
@@ -111,7 +111,7 @@ peps/pep-0251.rst  @warsaw @gvanrossum
 peps/pep-0252.rst  @gvanrossum
 peps/pep-0253.rst  @gvanrossum
 peps/pep-0254.rst  @gvanrossum
-peps/pep-0255.rst  @nascheme
+peps/pep-0255.rst  @nascheme @tim-one
 # peps/pep-0256.rst
 peps/pep-0257.rst  @gvanrossum
 # peps/pep-0258.rst
@@ -162,7 +162,7 @@ peps/pep-0302.rst  @pfmoore
 # peps/pep-0304.rst
 # peps/pep-0305.rst
 peps/pep-0306.rst  @jackdied @ncoghlan @benjaminp
-peps/pep-0307.rst  @gvanrossum
+peps/pep-0307.rst  @gvanrossum @tim-one
 peps/pep-0308.rst  @gvanrossum @rhettinger
 # peps/pep-0309.rst
 peps/pep-0310.rst  @pfmoore
@@ -354,17 +354,17 @@ peps/pep-0490.rst  @vstinner
 peps/pep-0492.rst  @1st1
 peps/pep-0493.rst  @ncoghlan @malemburg
 peps/pep-0494.rst  @ned-deily
-peps/pep-0495.rst  @abalkin
-peps/pep-0495-gap.png  @abalkin
-peps/pep-0495-gap.svg  @abalkin
-peps/pep-0495-fold.svg  @abalkin
-peps/pep-0495-fold-2.png  @abalkin
-peps/pep-0495-daylightsavings.png  @abalkin
+peps/pep-0495.rst  @abalkin @tim-one
+peps/pep-0495-gap.png  @abalkin @tim-one
+peps/pep-0495-gap.svg  @abalkin @tim-one
+peps/pep-0495-fold.svg  @abalkin @tim-one
+peps/pep-0495-fold-2.png  @abalkin @tim-one
+peps/pep-0495-daylightsavings.png  @abalkin @tim-one
 # peps/pep-0496.rst
 # peps/pep-0497.rst
 peps/pep-0498.rst  @ericvsmith
 # peps/pep-0499.rst
-peps/pep-0500.rst  @abalkin
+peps/pep-0500.rst  @abalkin @tim-one
 peps/pep-0501.rst  @ncoghlan
 # peps/pep-0502.rst
 peps/pep-0503.rst  @dstufft
@@ -442,7 +442,7 @@ peps/pep-0568.rst  @njsmith
 peps/pep-0569.rst  @ambv
 peps/pep-0570.rst  @larryhastings @pablogsal
 # peps/pep-0571.rst
-peps/pep-0572.rst  @gvanrossum
+peps/pep-0572.rst  @tim-one @gvanrossum
 peps/pep-0573.rst  @encukou @ncoghlan @ericsnowcurrently
 peps/pep-0574.rst  @pitrou
 # peps/pep-0575.rst
@@ -719,7 +719,7 @@ peps/pep-3156.rst  @gvanrossum
 # peps/pep-3333.rst
 # ...
 peps/pep-8000.rst  @warsaw
-peps/pep-8001.rst  @brettcannon @tiran @dstufft @ericsnowcurrently @gpshead @ambv @Mariatta @njsmith @pablogsal @rhettinger @taleinat @zware
+peps/pep-8001.rst  @brettcannon @tiran @dstufft @ericsnowcurrently @gpshead @ambv @Mariatta @njsmith @pablogsal @rhettinger @taleinat @tim-one @zware
 peps/pep-8002.rst  @warsaw @ambv @pitrou @dhellmann @willingc
 peps/pep-8010.rst  @warsaw
 peps/pep-8011.rst  @Mariatta @warsaw


### PR DESCRIPTION
core-dev membership is restored

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4106.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->