### PR TITLE
PEP 751: make `path`/`url` optional

### DIFF
--- a/peps/pep-0751.rst
+++ b/peps/pep-0751.rst
@@ -499,7 +499,7 @@ See ``groups.requirements.marker``.
 ``packages.sdist.url``
 ''''''''''''''''''''''
 
-- Required if ``path`` is not set
+- Optional; mutually-exclusive with ``path``
 - String
 - The URL to the file.
 
@@ -507,7 +507,7 @@ See ``groups.requirements.marker``.
 ``packages.sdist.path``
 '''''''''''''''''''''''
 
-- Required if ``url`` is not set
+- Optional; mutually-exclusive with ``url``
 - String
 - A path to the file, which may be absolute or relative.
 - If the path is relative it MUST be relative to the lock file.


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4108.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->