### PR TITLE
PEP 751: provide explanation for why `path` and `url` are optional

### DIFF
--- a/peps/pep-0751.rst
+++ b/peps/pep-0751.rst
@@ -1083,6 +1083,19 @@ simply defaulting to the baseline in tools without considering the security
 ramifications of that hash algorithm.
 
 
+------------------------------------
+Require a URL or file path for files
+------------------------------------
+
+Originally references to files were required, e.g., ``packages.sdist.url`` or
+``packages.sdist.path``. But at least
+`one use-case <https://discuss.python.org/t/pep-751-now-with-graphs/69721/34>`__
+surfaced during discussions about this PEP where statically specifying the
+location of files would be problematic. And in earlier discussions the idea of
+the location being a hint wasn't preferred. Hence the PEP now makes the data
+optional, but considers the locations accurate if specified.
+
+
 -----------
 File naming
 -----------


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4109.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->