### PR TITLE
PEP 740: Mark as Final

### DIFF
--- a/peps/pep-0740.rst
+++ b/peps/pep-0740.rst
@@ -14,7 +14,6 @@ Post-History: `02-Jan-2024 <https://discuss.python.org/t/pre-pep-exposing-truste
               `29-Jan-2024 <https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498>`__
 Resolution: `17-Jul-2024 <https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498/26>`__
 
-
 .. canonical-doc:: `PyPI - Digital Attestations <https://docs.pypi.org/attestations/>`__
 
 Abstract

--- a/peps/pep-0740.rst
+++ b/peps/pep-0740.rst
@@ -6,7 +6,7 @@ Author: William Woodruff <william@yossarian.net>,
 Sponsor: Donald Stufft <donald@stufft.io>
 PEP-Delegate: Donald Stufft <donald@stufft.io>
 Discussions-To: https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498
-Status: Provisional
+Status: Final
 Type: Standards Track
 Topic: Packaging
 Created: 08-Jan-2024

--- a/peps/pep-0740.rst
+++ b/peps/pep-0740.rst
@@ -14,6 +14,8 @@ Post-History: `02-Jan-2024 <https://discuss.python.org/t/pre-pep-exposing-truste
               `29-Jan-2024 <https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498>`__
 Resolution: `17-Jul-2024 <https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498/26>`__
 
+.. canonical-pypa-spec:: :ref:`packaging:index-hosted-attestations`
+
 .. canonical-doc:: `PyPI - Digital Attestations <https://docs.pypi.org/attestations/>`__
 
 Abstract

--- a/peps/pep-0740.rst
+++ b/peps/pep-0740.rst
@@ -12,8 +12,10 @@ Topic: Packaging
 Created: 08-Jan-2024
 Post-History: `02-Jan-2024 <https://discuss.python.org/t/pre-pep-exposing-trusted-publisher-provenance-on-pypi/42337>`__,
               `29-Jan-2024 <https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498>`__
-Resolution: https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498/26
+Resolution: `17-Jul-2024 <https://discuss.python.org/t/pep-740-index-support-for-digital-attestations/44498/26>`__
 
+
+.. canonical-doc:: `PyPI - Digital Attestations <https://docs.pypi.org/attestations/>`__
 
 Abstract
 ========


### PR DESCRIPTION
This is my first time marking a PEP as final, apologies if I've missed a step! I've gone `Provisional -> Final` based on that being a documented valid transition in PEP 1.

Supporting points:

- [x] PEP 740 roadmap on PyPI is complete: https://github.com/pypi/warehouse/issues/15871
- [x] PEP matches the final implementation
- [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
- [x] Pull request title in appropriate format (PEP 123: Mark Final)
- [x] Status changed to Final (and Python-Version is correct)
- [x] Canonical docs/spec linked with a canonical-doc directive (or canonical-pypa-spec, for packaging PEPs)

CC @di @dstufft 🙂 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4114.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->