### PR TITLE
PEP 765: Disallow return/break/continue that exit a finally block

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -641,6 +641,7 @@ peps/pep-0760.rst  @pablogsal @brettcannon
 peps/pep-0761.rst  @sethmlarson @hugovk
 peps/pep-0762.rst  @pablogsal @ambv @lysnikolaou @emilyemorehouse
 peps/pep-0763.rst  @dstufft
+peps/pep-0765.rst  @iritkatriel @ncoghlan
 # ...
 peps/pep-0777.rst  @warsaw
 # ...

--- a/peps/pep-0765.rst
+++ b/peps/pep-0765.rst
@@ -6,9 +6,7 @@ Status: Draft
 Type: Standards Track
 Created: 15-Nov-2024
 Python-Version: 3.14
-Post-History: 09-Nov-2024
-
-.. highlight:: rst
+Post-History: `09-Nov-2024 <https://discuss.python.org/t/an-analysis-of-return-in-finally-in-the-wild/70633>`__,
 
 Abstract
 ========
@@ -26,14 +24,15 @@ Motivation
 
 The semantics of ``return``, ``break`` and ``continue`` in a
 finally block are surprising for many developers.
-The documentation [1]_ mentions that
+The :ref:`documentation <python:tut-cleanup>` mentions that:
 
-1. If the ``finally`` clause executes a ``break``, ``continue``
-or ``return`` statement, exceptions are not re-raised.
-2. If a ``finally`` clause includes a ``return`` statement, the
-returned value will be the one from the ``finally`` clause’s
-``return`` statement, not the value from the ``try`` clause’s
-``return`` statement.
+- If the ``finally`` clause executes a ``break``, ``continue``
+  or ``return`` statement, exceptions are not re-raised.
+
+- If a ``finally`` clause includes a ``return`` statement, the
+  returned value will be the one from the ``finally`` clause’s
+  ``return`` statement, not the value from the ``try`` clause’s
+  ``return`` statement.
 
 Both of these behaviours cause confusion, but the first is
 particularly dangerous because a swallowed exception is more
@@ -44,15 +43,19 @@ In 2019, :pep:`601` proposed to change Python to emit a
 ``SyntaxError``. It was rejected in favour of viewing this
 as a programming style issue, to be handled by linters and :pep:`8`.
 Indeed, :pep:`8` now recommends not to use control flow statements
-in a ``finally`` block, and linters such as pylint [2]_, ruff [3]_
-and flake8-bugbear [4]_ flag them as a problem.
+in a ``finally`` block, and linters such as
+`Pylint <https://pylint.readthedocs.io/en/stable/>`__,
+`Ruff <https://docs.astral.sh/ruff/>`__ and
+`flake8-bugbear <https://github.com/PyCQA/flake8-bugbear>`__
+flag them as a problem.
 
 Rationale
 =========
 
-A recent analysis of real world code [5]_ shows that:
+A recent `analysis of real world code
+<https://github.com/iritkatriel/finally/blob/main/README.md>`_ shows that:
 
-- These features are rare (2 per million LOC in the top 8000 PyPI
+- These features are rare (2 per million LOC in the top 8,000 PyPI
   packages, 4 per million LOC in a random selection of packages).
   This could be thanks to the linters that flag this pattern.
 - Most of the usages are incorrect, and introduce unintended
@@ -63,7 +66,8 @@ A recent analysis of real world code [5]_ shows that:
 This new data indicates that it would benefit Python's users if
 Python itself moved them away from this harmful feature.
 
-One of the arguments brought up [6]_ in the discussion about :pep:`601`
+`One of the arguments brought up
+<https://discuss.python.org/t/pep-601-forbid-return-break-continue-breaking-out-of-finally/2239/24>`__
 was that language features should be orthogonal, and combine without
 context-based restrictions. However, in the meantime :pep:`654` has
 been implemented, and it forbids ``return``, ``break`` and ``continue``
@@ -86,6 +90,7 @@ of it.
 This includes the following examples:
 
 .. code-block::
+   :class: bad
 
     def f():
         try:
@@ -97,11 +102,12 @@ This includes the following examples:
         try:
             ...
         finally:
-            break # (or continue)
+            break  # (or continue)
 
 But excludes these:
 
 .. code-block::
+   :class: good
 
     try:
         ...
@@ -113,7 +119,7 @@ But excludes these:
         ...
     finally:
         for x in o:
-            break # (or continue)
+            break  # (or continue)
 
 
 CPython will emit a ``SyntaxWarning`` in version 3.14, and we leave
@@ -142,25 +148,10 @@ How to Teach This
 
 The change will be documented in the language spec and in the
 What's New documentation. The ``SyntaxWarning`` will alert users
-that their code needs to change. The empirical evidence [5]_
+that their code needs to change. The `empirical evidence
+<https://github.com/iritkatriel/finally/blob/main/README.md>`__
 shows that the changes necessary are typically quite
 straightforward.
-
-References
-==========
-
-.. [1] https://docs.python.org/3/tutorial/errors.html#defining-clean-up-actions
-
-.. [2] https://pylint.readthedocs.io/en/stable/
-
-.. [3] https://docs.astral.sh/ruff/
-
-.. [4] https://github.com/PyCQA/flake8-bugbear
-
-.. [5] https://github.com/iritkatriel/finally/blob/main/README.md
-
-.. [6] https://discuss.python.org/t/pep-601-forbid-return-break-continue-breaking-out-of-finally/2239/24
-
 
 Copyright
 =========

--- a/peps/pep-0765.rst
+++ b/peps/pep-0765.rst
@@ -6,7 +6,7 @@ Status: Draft
 Type: Standards Track
 Created: 15-Nov-2024
 Python-Version: 3.14
-Post-History: 9-Nov-2024
+Post-History: 09-Nov-2024
 
 .. highlight:: rst
 

--- a/peps/pep-0765.rst
+++ b/peps/pep-0765.rst
@@ -1,4 +1,4 @@
-PEP: 9999
+PEP: 765
 Title: Disallow return/break/continue that exit a finally block
 Author: Irit Katriel <irit@python.org>, Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: https://discuss.python.org/t/an-analysis-of-return-in-finally-in-the-wild/70633
@@ -50,15 +50,15 @@ and flake8-bugbear [4]_ flag them as a problem.
 Rationale
 =========
 
-A recent analysis of real world code [5]_ shows that::
+A recent analysis of real world code [5]_ shows that:
 
 - These features are rare (2 per million LOC in the top 8000 PyPI
-packages, 4 per million LOC in a random selection of packages).
-This could be thanks to the linters that flag this pattern.
+  packages, 4 per million LOC in a random selection of packages).
+  This could be thanks to the linters that flag this pattern.
 - Most of the usages are incorrect, and introduce unintended
-exception-swallowing bugs.
+  exception-swallowing bugs.
 - Code owners are typically receptive to fixing the bugs, and
-find that easy to do.
+  find that easy to do.
 
 This new data indicates that it would benefit Python's users if
 Python itself moved them away from this harmful feature.

--- a/peps/pep-0765.rst
+++ b/peps/pep-0765.rst
@@ -6,7 +6,7 @@ Status: Draft
 Type: Standards Track
 Created: 15-Nov-2024
 Python-Version: 3.14
-Post-History: 15-Nov-2024
+Post-History: 9-Nov-2024
 
 .. highlight:: rst
 

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -21,8 +21,8 @@ this change, which did not exist at the time that :pep:`601`
 was rejected. It also proposes a slightly different solution
 than that which was proposed by :pep:`601`.
 
-Rationale
-=========
+Motivation
+==========
 
 The semantics of ``return``, ``break`` and ``continue`` in a
 finally block are surprising for many developers.
@@ -47,6 +47,9 @@ Indeed, :pep:`8` now recommends not to use control flow statements
 in a ``finally`` block, and linters such as pylint [2]_, ruff [3]_
 and flake8-bugbear [4]_ flag them as a problem.
 
+Rationale
+=========
+
 A recent analysis of real world code [5]_ shows that::
 
 - These features are rare (2 per million LOC in the top 8000 PyPI
@@ -63,7 +66,7 @@ Python itself moved them away from this harmful feature.
 One of the arguments brought up [6]_ in the discussion about :pep:`601`
 was that language features should be orthogonal, and combine without
 context-based restrictions. However, in the meantime :pep:`654` has
-been implemented, and it forbids `return`, `break` and `continue`
+been implemented, and it forbids ``return``, ``break`` and ``continue`
 in an ``except*`` clause because the semantics of that would violate
 the property that ``except*`` clauses operate *in parallel*, so the
 code of one clause should not suppress the invocation of another.
@@ -138,7 +141,7 @@ How to Teach This
 =================
 
 The change will be documented in the language spec and in the
-What's New documentation. The `SyntaxWarning` will alert users
+What's New documentation. The ``SyntaxWarning`` will alert users
 that their code needs to change. The empirical evidence [5]_
 shows that the changes necessary are typically quite
 straightforward.

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -1,10 +1,11 @@
 PEP: 9999
 Title: Disallow return/break/continue that exit a finally block
-Author: Alyssa Coghlan <ncoghlan at gmail.com> and Irit Katriel <irit at python.org>
+Author: Irit Katriel <irit at python.org>, Alyssa Coghlan <ncoghlan at gmail.com>
+Discussions-To: https://discuss.python.org/t/an-analysis-of-return-in-finally-in-the-wild/70633
 Status: Draft
 Type: Standards Track
-Created: 14-Nov-2024
-Post-History:
+Created: 15-Nov-2024
+Post-History: 15-Nov-2024
 
 .. highlight:: rst
 
@@ -41,7 +42,7 @@ In 2019, :pep:`601` proposed to change Python to emit a
 ``SyntaxWarning`` for a few releases and then turn it into a
 ``SyntaxError``. It was rejected in favour of viewing this
 as a programming style issue, to be handled by linters and :pep:`8`.
-Indeed, :pep:`8` now recommends not to used control flow statements
+Indeed, :pep:`8` now recommends not to use control flow statements
 in a ``finally`` block, and linters such as pylint [2]_, ruff [3]_
 and flake8-bugbear [4]_ flag them as a problem.
 
@@ -92,7 +93,7 @@ This includes the following examples:
         try:
             ...
         finally:
-            break (or continue)
+            break # (or continue)
 
 But excludes these:
 
@@ -108,7 +109,7 @@ But excludes these:
         ...
     finally:
         for x in o:
-            break (or continue)
+            break # (or continue)
 
 
 CPython will emit a ``SyntaxWarning`` in version 3.14, and we leave

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -1,0 +1,164 @@
+PEP: 9999
+Title: Disallow return/break/continue that exit a finally block
+Author: Alyssa Coghlan <ncoghlan at gmail.com> and Irit Katriel <irit at python.org>
+Status: Draft
+Type: Standards Track
+Created: 14-Nov-2024
+Post-History:
+
+.. highlight:: rst
+
+Abstract
+========
+
+This PEP proposes to withdraw support for ``return``, ``break`` and
+``continue`` statements that break out of a ``finally`` block.
+This was proposed in the past by :pep:`601`. The current PEP
+is based on empirical evidence regarding the cost/benefit of
+this change, which did not exist at the time that :pep:`601`
+was rejected. It also proposes a slightly different solution
+than that which was proposed by :pep:`601`.
+
+Rationale
+=========
+
+The semantics of ``return``, ``break`` and ``continue`` in a
+finally block are surprising for many developers.
+The documentation [1]_ mentions that
+
+1. If the ``finally`` clause executes a ``break``, ``continue``
+or ``return`` statement, exceptions are not re-raised.
+2. If a ``finally`` clause includes a ``return`` statement, the
+returned value will be the one from the ``finally`` clause’s
+``return`` statement, not the value from the ``try`` clause’s
+``return`` statement.
+
+Both of these behaviours cause confusion, but the first is
+particularly dangerous because a swallowed exception is more
+likely to slip through testing, than an incorrect return value.
+
+In 2019, :pep:`601` proposed to change Python to emit a
+``SyntaxWarning`` for a few releases and then turn it into a
+``SyntaxError``. It was rejected in favour of viewing this
+as a programming style issue, to be handled by linters and :pep:`8`.
+Indeed, :pep:`8` now recommends not to used control flow statements
+in a ``finally`` block, and linters such as pylint [2]_, ruff [3]_
+and flake8-bugbear [4]_ flag them as a problem.
+
+A recent analysis of real world code [5]_ shows that::
+
+- These features are rare (2 per million LOC in the top 8000 PyPI
+packages, 4 per million LOC in a random selection of packages).
+This could be thanks to the linters that flag this pattern.
+- Most of the usages are incorrect, and introduce unintended
+exception-swallowing bugs.
+- Code owners are typically receptive to fixing the bugs, and
+find that easy to do.
+
+This new data indicates that it would benefit Python's users if
+Python itself moved them away from this harmful feature.
+
+One of the arguments brought up [6]_ in the discussion about :pep:`601`
+was that language features should be orthogonal, and combine without
+context-based restrictions. However, in the meantime :pep:`654` has
+been implemented, and it forbids `return`, `break` and `continue`
+in an ``except*`` clause because the semantics of that would violate
+the property that ``except*`` clauses operate *in parallel*, so the
+code of one clause should not suppress the invocation of another.
+In that case we accepted that a combination of features can be
+harmful enough that it makes sense to disallow it.
+
+
+Specification
+=============
+
+The change is to specify as part of the language spec that
+Python's compiler may emit a ``SyntaxWarning`` or ``SyntaxError``
+when a ``return``, ``break`` or ``continue`` would transfer
+control flow from within a ``finally`` block to a location outside
+of it.
+
+This includes the following examples:
+
+.. code-block::
+
+    def f():
+        try:
+            ...
+        finally:
+            return 42
+
+    for x in o:
+        try:
+            ...
+        finally:
+            break (or continue)
+
+But excludes these:
+
+.. code-block::
+
+    try:
+        ...
+    finally:
+        def f():
+            return 42
+
+    try:
+        ...
+    finally:
+        for x in o:
+            break (or continue)
+
+
+CPython will emit a ``SyntaxWarning`` in version 3.14, and we leave
+it open whether, and when, this will become a ``SyntaxError``.
+However, we specify here that a ``SyntaxError`` is permitted by
+the language spec, so that other Python implementations can choose
+to implement that.
+
+Backwards Compatibility
+=======================
+
+For backwards compatibility reasons, we are proposing that CPython
+emit only a ``SyntaxWarning``, with no concrete plan to upgrade that
+to an error. Code running with ``-We`` may stop working once this
+is introduced.
+
+Security Implications
+=====================
+
+The warning/error will help programmers avoid some hard to find bugs,
+so will have a security benefit. We are not aware of security issues
+related to raising a new ``SyntaxWarning`` or ``SyntaxError``.
+
+How to Teach This
+=================
+
+The change will be documented in the language spec and in the
+What's New documentation. The `SyntaxWarning` will alert users
+that their code needs to change. The empirical evidence [5]_
+shows that the changes necessary are typically quite
+straightforward.
+
+References
+==========
+
+.. [1] https://docs.python.org/3/tutorial/errors.html#defining-clean-up-actions
+
+.. [2] https://pylint.readthedocs.io/en/stable/
+
+.. [3] https://docs.astral.sh/ruff/
+
+.. [4] https://github.com/PyCQA/flake8-bugbear
+
+.. [5] https://github.com/iritkatriel/finally/blob/main/README.md
+
+.. [6] https://discuss.python.org/t/pep-601-forbid-return-break-continue-breaking-out-of-finally/2239/24
+
+
+Copyright
+=========
+
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -5,6 +5,7 @@ Discussions-To: https://discuss.python.org/t/an-analysis-of-return-in-finally-in
 Status: Draft
 Type: Standards Track
 Created: 15-Nov-2024
+Python-Version: 3.14
 Post-History: 15-Nov-2024
 
 .. highlight:: rst

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -1,6 +1,6 @@
 PEP: 9999
 Title: Disallow return/break/continue that exit a finally block
-Author: Irit Katriel <irit at python.org>, Alyssa Coghlan <ncoghlan at gmail.com>
+Author: Irit Katriel <irit@python.org>, Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: https://discuss.python.org/t/an-analysis-of-return-in-finally-in-the-wild/70633
 Status: Draft
 Type: Standards Track

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -66,7 +66,7 @@ Python itself moved them away from this harmful feature.
 One of the arguments brought up [6]_ in the discussion about :pep:`601`
 was that language features should be orthogonal, and combine without
 context-based restrictions. However, in the meantime :pep:`654` has
-been implemented, and it forbids ``return``, ``break`` and ``continue`
+been implemented, and it forbids ``return``, ``break`` and ``continue``
 in an ``except*`` clause because the semantics of that would violate
 the property that ``except*`` clauses operate *in parallel*, so the
 code of one clause should not suppress the invocation of another.


### PR DESCRIPTION
<!--
You can use the following checklist when double-checking your PEP,
and you can help complete some of it yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about anything, just leave it blank and we'll take a look.

If your PEP is not Standards Track, remove the corresponding section.
-->

## Basic requirements (all PEP Types)

* [x] Read and followed [PEP 1](https://peps.python.org/1) & [PEP 12](https://peps.python.org/12)
* [x] File created from the [latest PEP template](https://github.com/python/peps/blob/main/peps/pep-0012/pep-NNNN.rst?plain=1)
* [x] PEP has next available number, & set in filename (``pep-NNNN.rst``), PR title (``PEP 123: <Title of PEP>``) and ``PEP`` header
* [x] Title clearly, accurately and concisely describes the content in 79 characters or less
* [x] Core dev/PEP editor listed as ``Author`` or ``Sponsor``, and formally confirmed their approval
* [x] ``Author``, ``Status`` (``Draft``), ``Type`` and ``Created`` headers filled out correctly
* [x] ``PEP-Delegate``, ``Topic``, ``Requires`` and ``Replaces`` headers completed if appropriate
* [x] Required sections included
    * [x] Abstract (first section)
    * [x] Copyright (last section; exact wording from template required)
* [x] Code is well-formatted (PEP 7/PEP 8) and is in [code blocks, with the right lexer names](https://peps.python.org/pep-0012/#literal-blocks) if non-Python
* [x] PEP builds with no warnings, pre-commit checks pass and content displays as intended in the rendered HTML
* [x] Authors/sponsor added to ``.github/CODEOWNERS`` for the PEP


## Standards Track requirements

* [x] PEP topic [discussed in a suitable venue](https://peps.python.org/pep-0001/#start-with-an-idea-for-python) with general agreement that a PEP is appropriate
* [x] [Suggested sections](https://peps.python.org/pep-0012/#suggested-sections) included (unless not applicable)
    * [x] Motivation
    * [x] Rationale
    * [x] Specification
    * [x] Backwards Compatibility
    * [x] Security Implications
    * [x] How to Teach This
    * [ ] Reference Implementation
    * [ ] Rejected Ideas
    * [ ] Open Issues
* [x] ``Python-Version`` set to valid (pre-beta) future Python version, if relevant
* [x] Any project stated in the PEP as supporting/endorsing/benefiting from the PEP formally confirmed such
* [ ] Right before or after initial merging, [PEP discussion thread](https://peps.python.org/pep-0001/#discussing-a-pep) created and linked to in ``Discussions-To`` and ``Post-History``


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4119.org.readthedocs.build/pep-0765/

<!-- readthedocs-preview pep-previews end -->