### PR TITLE
PEP 540: Correct `sys.output` to `sys.stdout`

### DIFF
--- a/peps/pep-0540.rst
+++ b/peps/pep-0540.rst
@@ -259,7 +259,7 @@ The "Legacy Windows FS encoding" is enabled by the
 ``PYTHONLEGACYWINDOWSFSENCODING`` environment variable.
 
 If stdin and/or stdout is redirected to a pipe, ``sys.stdin`` and/or
-``sys.output`` uses ``mbcs`` encoding by default rather than UTF-8.
+``sys.stdout`` uses ``mbcs`` encoding by default rather than UTF-8.
 But in UTF-8 Mode, ``sys.stdin`` and ``sys.stdout`` always use the UTF-8
 encoding.
 


### PR DESCRIPTION
It's unclear what sys.output is.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4122.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->