### PR TITLE
PEP 766: Explicit Priority Choices Among Multiple Indexes (index priority)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -642,6 +642,7 @@ peps/pep-0761.rst  @sethmlarson @hugovk
 peps/pep-0762.rst  @pablogsal @ambv @lysnikolaou @emilyemorehouse
 peps/pep-0763.rst  @dstufft
 peps/pep-0765.rst  @iritkatriel @ncoghlan
+peps/pep-0766.rst  @warsaw
 # ...
 peps/pep-0777.rst  @warsaw
 # ...

--- a/peps/pep-0757.rst
+++ b/peps/pep-0757.rst
@@ -147,9 +147,6 @@ Export API
    On success, set *\*export_long* and return 0.
    On error, set an exception and return -1.
 
-   This function always succeeds if *obj* is a Python :class:`int` object or a
-   subclass.
-
    If *export_long->digits* is not ``NULL``, :c:func:`PyLong_FreeExport` must be
    called when the export is no longer needed.
 
@@ -264,12 +261,15 @@ Export: :c:func:`PyLong_Export()` with gmpy2
 
 Code::
 
-    static void
+    static int
     mpz_set_PyLong(mpz_t z, PyObject *obj)
     {
         static PyLongExport long_export;
 
-        PyLong_Export(obj, &long_export);
+        if (PyLong_Export(obj, &long_export) < 0) {
+            return -1;
+        }
+
         if (long_export.digits) {
             mpz_import(z, long_export.ndigits, int_digits_order, int_digit_size,
                        int_endianness, int_nails, long_export.digits);
@@ -295,6 +295,7 @@ Code::
                 }
             }
         }
+        return 0;
     }
 
 Reference code: `mpz_set_PyLong() in the gmpy2 master for commit 9177648

--- a/peps/pep-0757.rst
+++ b/peps/pep-0757.rst
@@ -49,14 +49,19 @@ Specification
 Layout API
 ----------
 
-Data needed by `GMP <https://gmplib.org/>`_-like import-export functions.
+Data needed by `GMP <https://gmplib.org/>`_-like `import
+<https://gmplib.org/manual/Integer-Import-and-Export#index-mpz_005fimport>`_-`export
+<https://gmplib.org/manual/Integer-Import-and-Export#index-mpz_005fexport>`_
+functions.
 
 .. c:struct:: PyLongLayout
 
-   Layout of an array of digits, used by Python :class:`int` object.
+   Layout of an array of "digits" ("limbs" in the GMP terminology), used to
+   represent absolute value for arbitrary precision integers.
 
    Use :c:func:`PyLong_GetNativeLayout` to get the native layout of Python
-   :class:`int` objects.
+   :class:`int` objects, used internally for integers with "big enough"
+   absolute value.
 
    See also :data:`sys.int_info` which exposes similar information to Python.
 
@@ -148,8 +153,9 @@ Export API
    If *export_long->digits* is not ``NULL``, :c:func:`PyLong_FreeExport` must be
    called when the export is no longer needed.
 
-   On CPython 3.14, no memory copy is needed, it's just a thin wrapper to
-   expose Python int internal digits array.
+
+On CPython 3.14, no memory copy is needed in :c:func:`PyLong_Export`, it's just
+a thin wrapper to expose Python :class:`int` internal digits array.
 
 
 .. c:function:: void PyLong_FreeExport(PyLongExport *export_long)
@@ -167,7 +173,8 @@ create a Python :class:`int` object from a digits array.
 
    A Python :class:`int` writer instance.
 
-   The instance must be destroyed by :c:func:`PyLongWriter_Finish`.
+   The instance must be destroyed by :c:func:`PyLongWriter_Finish` or
+   :c:func:`PyLongWriter_Discard`.
 
 
 .. c:function:: PyLongWriter* PyLongWriter_Create(int negative, Py_ssize_t ndigits, void **digits)
@@ -182,13 +189,15 @@ create a Python :class:`int` object from a digits array.
    *ndigits* is the number of digits in the *digits* array. It must be
    greater than or equal to 0.
 
-   The caller must initialize the array of digits *digits* and then call
-   :c:func:`PyLongWriter_Finish` to get a Python :class:`int`.  Digits must be
-   in the range [``0``; ``(1 << sys.int_info.bits_per_digit) - 1``].  Unused digits must
-   be set to ``0``.
+   The caller can either initialize the array of digits *digits* and then call
+   :c:func:`PyLongWriter_Finish` to get a Python :class:`int`, or call
+   :c:func:`PyLongWriter_Discard` to destroy the writer instance.  Digits must
+   be in the range [``0``; ``(1 << sys.int_info.bits_per_digit) - 1``].  Unused
+   digits must be set to ``0``.
 
-   On CPython 3.14, the implementation is a thin wrapper to the private
-   :c:func:`!_PyLong_New()` function.
+
+On CPython 3.14, the :c:func:`PyLongWriter_Create` implementation is a thin
+wrapper to the private :c:func:`!_PyLong_New()` function.
 
 
 .. c:function:: PyObject* PyLongWriter_Finish(PyLongWriter *writer)
@@ -204,7 +213,7 @@ create a Python :class:`int` object from a digits array.
 
 .. c:function:: void PyLongWriter_Discard(PyLongWriter *writer)
 
-   Discard the internal object and destroy the writer instance.
+   Discard a :c:type:`PyLongWriter` created by :c:func:`PyLongWriter_Create`.
 
 
 Optimize import for small integers

--- a/peps/pep-0766.rst
+++ b/peps/pep-0766.rst
@@ -13,67 +13,53 @@ Post-History: `18-Nov-2024 <https://discuss.python.org/t/pep-for-handling-multip
 Abstract
 ========
 
-Package resolution is a key part of the Python user experience as the
-means of extending Python's core functionality. The experience of package
-resolution is mostly taken for granted until someone encounters a
-situation where the package installer does something they don't expect.
-The installer behavior with multiple indexes has been `a common source of unexpected behavior <https://github.com/pypa/pip/issues/8606>`__.
-Through its ubiquity, pip has long defined the standard expected behavior
-across other tools in the ecosystem, but Python installers are diverging
-with respect to how they handle multiple indexes. At the core of this
-divergence is whether index contents are combined before resolving distributions,
-or each index is handled individually in order. Pip merges all indexes
-before matching distributions, while uv matches distributions on one index
-before moving on to the next. Each approach has advantages and disadvantages.
-This PEP aims to describe each of these behaviors, which are referred to
-as “version priority” and “index priority” respectively, so that community
-discussions and troubleshooting can share a common vocabulary, and so that tools can
-implement predictable behavior based on these descriptions.
+Package resolution is a key part of the Python user experience as the means of
+extending Python's core functionality. The experience of package resolution is
+mostly taken for granted until someone encounters a situation where the package
+installer does something they don't expect.  The installer behavior with
+multiple indexes has been `a common source of unexpected behavior
+<https://github.com/pypa/pip/issues/8606>`__.  Through its ubiquity, pip has
+long defined the standard expected behavior across other tools in the ecosystem,
+but Python installers are diverging with respect to how they handle multiple
+indexes. At the core of this divergence is whether index contents are combined
+before resolving distributions, or each index is handled individually in order.
+Pip merges all indexes before matching distributions, while uv matches
+distributions on one index before moving on to the next. Each approach has
+advantages and disadvantages.  This PEP aims to describe each of these
+behaviors, which are referred to as “version priority” and “index priority”
+respectively, so that community discussions and troubleshooting can share a
+common vocabulary, and so that tools can implement predictable behavior based on
+these descriptions.
 
 Motivation
 ==========
 
-Goals
------
+Python package users frequently find themselves in need of specifying an index
+or package source other than PyPI. There are many reasons for external indexes
+to exist:
 
-- Standardize verbiage of different approaches, so that cross-tool
-  discussions are talking “apples to apples”
+- File size/quota limitations on PyPI
+- Implementation variants, such as `different GPU library builds in PyTorch <https://pytorch.org/get-started/locally/>`__
+- `Local builds of packages shared internally at an organization <https://github.com/pypa/pip/issues/8606>`__
+- `Situations where a local package has remote dependencies
+  <https://github.com/pypa/pip/issues/11624>`__, and the user wishes to prioritize
+  local packages over remote dependencies, while still falling back to remote
+  dependencies where needed.
 
-- Highlight design criteria for installers that wish to implement index priority
+In most of these cases, it is not desirable to completely forego PyPI. Instead,
+users generally want PyPI to still be a source of packages, but a lower priority
+source. Unfortunately, `pip's current design precludes this concept of priority <https://github.com/pypa/pip/issues/8606>`__.
+Some Python installer tools have developed alternative ways to handle multiple
+indexes that incorporate mechanisms to express index priority, such as `uv
+<https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes>`__
+and `PDM
+<https://pdm-project.org/latest/usage/config/#respect-the-order-of-the-sources>`__.
 
-- Augment :pep:`708` with a more user-configurable system for expressing
-  different levels of trust among configured indexes
-
-Rationale
-=========
-
-This PEP describes two modes of installer behavior when using multiple
-sources in the hopes that the user experience and expectations across
-tools can be more explicit and more predictable. Pip has long defined
-the de-facto standard installer behavior in the ecosystem, but new tools
-have been implementing alternative approaches in response to both security concerns
-and desire to prioritize the contents of one index over another. Uv and PDM have each
-added support for some notion of index priority.
-
-Index priority is `the default behavior in
-uv <https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes>`__,
-and supported, but `not default behavior in
-PDM <https://pdm-project.org/latest/usage/config/#respect-the-order-of-the-sources>`__.
-In uv, `users have reported some
-issues <https://github.com/astral-sh/uv/issues/2775>`__ with the
-behavior and asked for keeping pip’s behavior. Uv provides this choice
-as a ``--index-strategy`` flag, with the ``unsafe-best-match`` value
-matching pip’s current behavior, and the ``first-match`` value matching
-this PEP’s proposed behavior. Defining index priority is expected to
-help with `situations where a local package has remote
-dependencies <https://github.com/pypa/pip/issues/11624>`__, and the user
-wishes to prioritize local packages over remote dependencies, while
-still falling back to remote dependencies where needed.
-
-The topic of prioritizing indexes is being proposed as a PEP rather than as a
-change specifically to a specific installer, because the python installer
-ecosystem is seen as fragmented, and defining common, shared behavior for
-package resolution between tools will help reduce this fragmentation.
+The innovation and the potential for customization is exciting, but it comes at
+the risk of further fragmenting the python packaging ecosystem, which is already
+perceived as one of Python's weak points. The motivation of this PEP is to encourage
+installers to provide more insight into how they handle multiple indexes, and to
+provide a vocabulary that can be common to the broader community.
 
 Specification
 =============
@@ -230,9 +216,13 @@ Mirroring
 As described thus far, the index priority scheme breaks the use case of more
 than one index url serving the same content. Such mirrors may be used with the
 intent of ameliorating network issues or otherwise improving reliability. One
-approach that installers could take to preserve mirroring functionality would be
-to add a notion of user-definable index groups, where each index in the group is
-assumed to be equivalent. Within each group, content could be combined, or each
+approach that installers could take to preserve mirroring functionality while
+adding index priority would be to add a notion of user-definable index groups,
+where each index in the group is assumed to be equivalent. This is related to
+`Poetry's notion of package sources
+<https://python-poetry.org/docs/repositories/>`__, except that this would allow
+arbitrary numbers of prioritizable groups, and that this would assume members of
+a group to be mirrors. Within each group, content could be combined, or each
 member could be fetched concurrently. The fastest responding index would then
 represent the group.
 
@@ -380,18 +370,6 @@ Rejected Ideas
   users. That is, organizations get no improvement from this approach
   unless they proxy/mirror PyPI as a whole, and get users to configure
   their proxy/mirror as their sole index.
-
-- Provide tiers of priorities, but keep version priority within groups.
-  For example, `Poetry specifies “primary” and “supplemental”
-  tiers <https://pip.pypa.io/en/stable/cli/pip_install/>`__.
-
-  This keeps control in the hands of the user, rather than an administrator, but
-  adds complexity. Its behavior within a group is meant to mimic pip’s behavior
-  with version priority, and only extends priority among a very small set of
-  groups. The granularity of `specifying per-package sources
-  <https://python-poetry.org/docs/repositories/#package-source-constraint>`__,
-  solves the ambiguity problem, but at the cost of flexibility/portability of those
-  environment specifications.
 
 - Are build tags and/or local version specifiers enough?
 

--- a/peps/pep-0766.rst
+++ b/peps/pep-0766.rst
@@ -1,13 +1,12 @@
 PEP: 766
 Title: Explicit Priority Choices Among Multiple Indexes
-Author: Michael Sarahan, msarahan@gmail.com
-Sponsor: Barry Warsaw, barry@python.org
+Author: Michael Sarahan <msarahan@gmail.com>
+Sponsor: Barry Warsaw <barry@python.org>
 PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-for-handling-multiple-indexes-index-priority/71589
 Status: Draft
 Type: Informational
 Topic: Packaging
-Requires: 777
 Created: 18-Nov-2024
 Post-History: `18-Nov-2024 <https://discuss.python.org/t/pep-for-handling-multiple-indexes-index-priority/71589>`__,
 
@@ -37,31 +36,13 @@ Motivation
 Goals
 -----
 
-- Establish standard for evaluation order of various levels of priority
-  between indexes and packages
 - Standardize verbiage of different approaches, so that cross-tool
   discussions are talking “apples to apples”
-- Suggest standard configuration options, to minimize user cognitive
-  load between tools
-- Provide guidelines for how ecosystem tools should implement index
-  priority if they would like, and suggest reasons why they might want
-  to do so
-- Augment `PEP 708 <https://peps.python.org/pep-0708/>`__ as a more
-  user-configurable system for expressing different levels of trust
-  among configured indexes
 
-Non-goals
----------
+- Highlight design criteria for installers that wish to implement index priority
 
-- Do not relax the simplifying assumption that for a given distribution
-  filename, all indexes must have the same file. This has been expressed
-  as “all indexes are equal priority”, but can be more accurately
-  described as “`pip considers all distributions with the same name and
-  version to be interchangeable regardless of which index they came
-  from <https://github.com/astral-sh/uv/issues/171#issuecomment-1952079681>`__.”
-  This is a key assumption for how pip behaves today, and changing this
-  assumption is deemed too disruptive for this PEP.
-- Do not dictate that every tool must implement every strategy
+- Augment :pep:`708` with a more user-configurable system for expressing
+  different levels of trust among configured indexes
 
 Rationale
 =========
@@ -70,8 +51,8 @@ This PEP describes two modes of installer behavior when using multiple
 sources in the hopes that the user experience and expectations across
 tools can be more explicit and more predictable. Pip has long defined
 the de-facto standard installer behavior in the ecosystem, but new tools
-have been implementing new approaches in response to both security concerns
-and desire to prioritize one index over another. Uv and PDM have each
+have been implementing alternative approaches in response to both security concerns
+and desire to prioritize the contents of one index over another. Uv and PDM have each
 added support for some notion of index priority.
 
 Index priority is `the default behavior in
@@ -89,10 +70,10 @@ dependencies <https://github.com/pypa/pip/issues/11624>`__, and the user
 wishes to prioritize local packages over remote dependencies, while
 still falling back to remote dependencies where needed.
 
-The topic of prioritizing indexes is being proposed as a PEP rather than
-as a change specifically to pip, because predictable index behavior
-across the many tools in our ecosystem is important for consistent,
-predictable package resolution between tools.
+The topic of prioritizing indexes is being proposed as a PEP rather than as a
+change specifically to a specific installer, because the python installer
+ecosystem is seen as fragmented, and defining common, shared behavior for
+package resolution between tools will help reduce this fragmentation.
 
 Specification
 =============
@@ -101,47 +82,32 @@ Specification
 ------------------
 
 This behavior is characterized by the installer always getting the
-latest version of a package, regardless of the index that it comes
-from. It is especially useful when all configured indexes are
-equally trusted and well-behaved regarding the distribution
-interchangeability assumption. That interchangeability assumption is
-what makes comparing distributions of a given package meaningful -
-without it, the installer is no longer comparing “apples to apples.” In
-practice, it is common for different indexes to have files that have
-different contents than other indexes, such as builds for special
-hardware, and this version priority behavior can lead to undesirable,
-unexpected outcomes, and this is when users generally look for some kind
-of index priority. Additionally, when there is a difference in trust among
-indexes, version priority does not provide a way to prefer more trusted
-indexes over less trusted indexes. This has been the subject of dependency
-confusion attacks, and :pep:`708` was
-proposed as a way of hard-coding a notion of trusted external indexes into
-the index.
+"best" version of a package, regardless of the index that it comes
+from. "Best" is defined by the installer's algorithm for optimizing
+the various traits of a package, also factoring in user input (such as
+preferring only binaries, or no binaries). While installers may differ
+in their optimization criteria and user options, the general trait that
+all version priority installers share is that the index
+contents are collated prior to candidate selection.
 
-Version priority is pip’s current behavior. All distributions from all configured
-and enabled indexes are collated, and the “best” among them is selected. The
-criteria for what is “best” are:
+Version priority is most useful when all configured indexes are equally trusted
+and well-behaved regarding the distribution interchangeability assumption.
+Mirrors are especially well-behaved in this regard. That interchangeability
+assumption is what makes comparing distributions of a given package meaningful.
+Without it, the installer is no longer comparing “apples to apples.” In
+practice, it is common for different indexes to have files that have different
+contents than other indexes, such as builds for special hardware, or differing
+metadata for the same package. Version priority behavior can lead to
+undesirable, unexpected outcomes in these cases, and this is where `users
+generally look for some kind of index priority
+<https://github.com/pypa/pip/issues/8606>`__. Additionally, when there is a
+difference in trust among indexes, version priority does not provide a way to
+prefer more trusted indexes over less trusted indexes. This has been exploited by
+dependency confusion attacks, and :pep:`708` was proposed as a way of
+hard-coding a notion of trusted external indexes into the index.
 
-- `Match any specified
-  hashes <https://github.com/pypa/pip/blob/111eed14b6e9fba7c78a5ec2b7594812d17b5d2b/src/pip/_internal/index/package_finder.py#L541>`__
-- `Absence of
-  yanking <https://github.com/pypa/pip/blob/111eed14b6e9fba7c78a5ec2b7594812d17b5d2b/src/pip/_internal/index/package_finder.py#L542>`__
-- `Wheels over
-  sdists <https://github.com/pypa/pip/blob/111eed14b6e9fba7c78a5ec2b7594812d17b5d2b/src/pip/_internal/index/package_finder.py#L504>`__
-- `Maximize
-  version <https://github.com/pypa/pip/blob/111eed14b6e9fba7c78a5ec2b7594812d17b5d2b/src/pip/_internal/index/package_finder.py#L544>`__
-  (including `Local version
-  tags <https://peps.python.org/pep-0440/#local-version-identifiers>`__,
-  `restricted to locally patched private
-  versions <https://discuss.python.org/t/lets-permit-local-version-label-in-version-specifiers/22781/2>`__)
-- `Maximize specificity of platform
-  tag <https://github.com/pypa/pip/blob/111eed14b6e9fba7c78a5ec2b7594812d17b5d2b/src/pip/_internal/index/package_finder.py#L520>`__
-- `Build
-  tags <https://github.com/pypa/pip/blob/111eed14b6e9fba7c78a5ec2b7594812d17b5d2b/src/pip/_internal/index/package_finder.py#L535>`__
-  with the first value being an integer interpreted as ascending values
-  being “better”, and the second being a string with lexical sorting
-
-Uv refers to `its implementation of the version priority
+The "version priority" name is new, and introduction of new terms should always
+be minimized. This PEP looks toward the uv project, which refers to `its implementation of the version priority
 behavior <https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes>`__
 as “``unsafe-best-match``.” Naming is really hard here. On one hand, it
 isn’t accurate to call pip’s default behavior intrinsically “unsafe.”
@@ -161,23 +127,29 @@ packages are compared.
 ----------------
 
 In index priority, the resolver finds candidates for each index, one at a time.
-The resolver proceeds to subsequent indexes only if the current
-package request has no viable candidates. Index priority does not combine
-indexes into one global, flat namespace. Because indexes are searched in order,
-the package from an earlier index  will be preferred over a package from a later index, regardless of whether
-the later index had a better match. Uv’s calls this "first-match"
-behavior, and the version priority behavior "best-match". The criteria and process for
-evaluating “best match” is the same for both index priority and version
-priority. It is only the treatment of multiple indexes that differs:
-all together for version priority, and individually for index priority.
+The resolver proceeds to subsequent indexes only if the current package request
+has no viable candidates. Index priority does not combine indexes into one
+global, flat namespace. Because indexes are searched in order, the package from
+an earlier index will be preferred over a package from a later index,
+regardless of whether the later index had a better match with the installer's
+optimization criteria. For a given installer, the optimization criteria and
+selection algorithm should be the same for both index priority and version
+priority. It is only the treatment of multiple indexes that differs: all
+together for version priority, and individually for index priority.
 
-The index (or “source” in PDM terms) priority is
-explicitly defined by a configuration hierarchy. Each package’s finder
-starts at the beginning of the list of indexes, so each package
-starts over with the index list. In other words, if one package has
-no valid candidates on the first index, but finds a hit on the second
-index, subsequent packages still start their search on the first index,
-rather than starting on the second.
+The order of specification of indexes determines their priority in the
+finding process. As a result, the way that installers load the index
+configuration must be predictable and reproducible. This PEP does not prescribe
+any particular mechanism, other than to say that installers should provide
+a way of ordering their collection of sources. Installers should also
+ideally provide optional debugging output that provides insight into
+which index is being considered.
+
+Each package’s finder should start at the beginning of the list of indexes, so each
+package starts over with the index list. In other words, if one package has no
+valid candidates on the first index, but finds a hit on the second index,
+subsequent packages should still start their search on the first index, rather than
+starting on the second.
 
 One desirable behavior that the index priority strategy implies is that
 there are no “surprise” updates, where a version bump on a
@@ -187,18 +159,21 @@ packages can restrict the external indexes that distributions can come
 from, but index priority is more configurable by end users. The package installs are
 only expected to change when either the higher-priority index or the
 index priority configuration change. This stability and predictability
-makes it viable to configure indexes as a more persistent property of an
+makes it more viable to configure indexes as a more persistent property of an
 environment, rather than a one-off argument for one install command.
 
-One important implementation detail of index priority is that caching
-and lockfiles should now include the index from which distributions were downloaded.
-Without this aspect, it is possible that after changing the list of
-configured indexes, the cache or lockfile could provide a similarly-named
-distribution from a lower-priority index. If every index follows the
-recommended behavior of providing identical files across indexes for a
-given filename, this is not an issue. However, that recommendation is
-not readily enforceable, and augmenting the cache key with origin index
-would be a wise defensive change.
+Cache keys
+~~~~~~~~~~
+
+Because index priority is acknowledging the possibility that different indexes
+may have different content for a given package, caching and lockfiles should now
+include the index from which distributions were downloaded.  Without this
+aspect, it is possible that after changing the list of configured indexes, the
+cache or lockfile could provide a similarly-named distribution from a
+lower-priority index. If every index follows the recommended behavior of
+providing identical files across indexes for a given filename, this is not an
+issue. However, that recommendation is not readily enforceable, and augmenting
+the cache key with origin index would be a wise defensive change.
 
 Ways that a request falls through to a lower priority index
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -206,8 +181,8 @@ Ways that a request falls through to a lower priority index
 - Package name is not present at all in higher priority index
 - All distributions from higher priority index filtered out due to
   version specifier, compatible Python version, platform tag, yanking or otherwise
-- A denylist specifies that a particular package name should be ignored
-  on a given index
+- A denylist configuration for the installer specifies that a particular package
+  name should be ignored on a given index
 - A higher priority index is unreachable (e.g. blocked by firewall
   rules, temporarily unavailable due to maintenance, other miscellaneous
   and temporary networking issues). This is a less clear-cut detail that
@@ -218,10 +193,11 @@ Ways that a request falls through to a lower priority index
   safely assume that all of their indexes are equally trusted. Pip’s
   behavior today is graceful fallback: you see warnings if an index is
   having connection issues, but the installation will proceed with any
-  other available indexes. Because index priority can convey different
-  trust levels between indexes, installers should default to raising
-  errors and aborting on network issues, but there should be a flag to
-  allow fall-through to lower-priority indexes.
+  other available indexes. Because index priority can convey different trust
+  levels between indexes, installers that implement index priority should
+  default to raising errors and aborting on network issues. Installers may
+  choose to provide a flag to allow fall-through to lower-priority indexes in
+  case of network error.
 
 Treatment within a given index follows existing behavior, but stops at
 the bounds of one index and moves on to the next index only after all
@@ -230,172 +206,35 @@ existing priorities among the unified collection of packages apply to
 each index individually before falling through to a lower priority
 index.
 
-- wheel vs sdist: Wheels are preferred within one index. The resolution
-  will use an sdist from a higher-priority index before trying a wheel
-  from a lower-priority index.
-- more platform-specific wheels before less specific ones. The
-  resolution will use less specific wheels from higher-priority indexes
-  before using more specific wheels from lower priority indexes.
+There are tradeoffs to make at every level of the optimization criteria:
 
-Priority configuration
-~~~~~~~~~~~~~~~~~~~~~~
+- version: index priority will use an older version from a higher-priority index
+  even if a newer version is available on another index.
+- wheel vs sdist: Should the installer use an sdist from a higher-priority
+  index before trying a wheel from a lower-priority index?
+- more platform-specific wheels before less specific ones: Should the
+  installer use less specific wheels from higher-priority indexes
+  before using more specific wheels from lower priority indexes?
+- flags such as pip's ``--prefer-binary``: Should the installer use an sdist from a higher
+  priority index before considering wheels on a lower priority index?
 
-The order of specification of indexes determines their priority in the
-finding process. As a result, the way that installers load the index
-configuration must be predictable and reproducible. The configuration
-precedence hierarchy proposed here matches `the existing pip
-configuration
-hierarchy <https://pip.pypa.io/en/stable/topics/configuration/#precedence-override-order>`__.
-Other tools should ideally conform to this hierarchy for predictable
-behavior, but ultimately are free to define or retain their existing
-configuration schemes to maintain idiomatic usage for themselves.
-Notably, some tools differ in whether multiple sources of configuration
-add to one another (conda), or preclude/clobber one another (pip).
+Installers are free to implement these priorities in different ways for
+themselves, but they should document their optimization criteria and how they
+handle fall-through to lower-priority indexes. For example, an installer could
+say that ``--prefer-binary`` should not install an sdist unless it had iterated
+through all configured indexes and found no installable binary candidates.
 
-The order of specified URLs will follow:
+Mirroring
+~~~~~~~~~
 
-1. | CLI arguments (if present), as in:
-   | ``--extra-index-url <highest> --find-links <next_priority> --extra-index-url <lowest>``
-
-2. Environment variables (if present), with ordered evaluation:
-
-   1. PIP FIND_LINKS=”<highest_links> <next_priority_links> <lowest_links>”
-   2. PIP_EXTRA_INDEX_URL=”<highest_index> <next_priority_index> <lowest_index>”
-
-3. Configuration files, as in \`pip.conf\`:
-
-   | [global]
-   | extra_index_url =
-   | <highest_index>
-   | <next_priority_index>
-   | <lowest_index>
-   | find_links =
-   | <highest_links>
-   | <next_priority_links>
-   | <lowest_links>
-
-Ordering source types
-~~~~~~~~~~~~~~~~~~~~~
-
-There are two "source types" supported by pip:
-
-- ``find-links / PIP_FIND_LINKS``
-- ``extra-index-url / PIP_EXTRA_INDEX_URL``
-
-The ``find-links`` option specifies one or more paths to search for
-packages. It behaves very much like an index URL, except that it
-searches filesystems, rather than resolving distribution filenames from
-PEP 503 HTML or PEP 691 JSON data. This parameter is often passed with
-the \`no-index\` parameter as a way of forcing the local packages to be
-used. For the purposes of index priority, the ``find-links`` parameter
-takes precedence over the values from ``extra-index-url``. The order of
-these flags in a configuration file must not affect this evaluation
-order. If both are defined, the value of ``extra-index-url`` is appended
-to the value of ``find-links``. This is in keeping with `pip’s current
-handling <https://github.com/pypa/pip/blob/e98cc5ce078d8c8afd6804ff4e61aa2b12d05715/src/pip/_internal/index/package_finder.py#L849>`__
-of these options.
-
-These source types can be specified in the three ways listed above: CLI,
-environment variables, and configuration files. Among these, CLI flags have an
-intrinsic evaluation order from left to right, and different source types can be
-interleaved. In contrast, configuration files and in environment variables, the
-state of several variables all exists simultaneously. There is no way to
-interleave source types. For the sake of consistency among the three places
-where configuration can be specified, the interleaving capability of the CLI
-should not be respected. Instead, entries from each of the two source types should
-be collected into their respective groups, and these groups should be evaluated
-in the same order as environment variables and configuration files.
-
-For example, the CLI example given above will evaluate with pseudocode:
-
-::
-
-   --extra-index-url <highest> --find-links <next_priority> --extra-index-url <lowest>
-   # ------------
-   find_links = []
-   extra_index_urls = []
-   for argname, value in cli_args:
-     match argname:
-       case "find-links":
-         find_links.append(value)
-       case "extra-index-url":
-         extra_index_urls.append(value)
-   search_urls = find_links + extra_index_urls
-
-
-The ultimate result of this evalution will be:
-
-1. next_priority
-2. highest
-3. lowest
-
-The value of ``index-url`` (or its default value of PyPI) is always the
-lowest-priority entry in the search order.
-
-Requirements.txt file inclusions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-As a further complication, `requirements.txt files can include index url
-options <https://pip.pypa.io/en/stable/reference/requirements-file-format/#global-options>`__,
-including ``--extra-index-url`` and ``--find-links``. Requirements.txt
-can be included via an environment variable (PIP_REQUIREMENT) and `by
-command line
-arguments <https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-r>`__.
-For the purposes of evaluating priority, these requirements files should
-be evaluated where they are specified (i.e. their position on the CLI
-args), and place their index url options at the priority of the
-originating file inclusion (either the env var or CLI args). For
-example, if a requirements.txt file has:
-
-::
-
-   --extra-index-url <req_file_index_url_1>
-   --find-links <some_local_path>
-   --extra-index-url <req_file_index_url_2>
-   my-package
-
-The CLI command of:
-
-::
-
-   pip install --extra-index-url <something> -r requirements.txt --extra-index-url <another>
-
-Would expand to an index priority list of:
-
-1. <some_local_path>
-2. <something>
-3. <req_file_index_url_1>
-4. <req_file_index_url_2>
-5. <another>
-6. <fallback to value of index-url>
-
-Because the requirements.txt file is parsed from top to bottom, it
-evaluates ``--extra-index-url`` and ``--find-links`` arguments in the
-order that they appear in the requirements.txt file, as opposed to
-reordering them such that ``--find-links`` arguments always come before
-any ``--extra-index-url`` arguments. Requirements files may also include
-other requirements files. In the general case, depth-first
-traversal of requirements files defines the collection and ordering
-of index-urls and find-links options.
-
-Proposed deny list format
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-As described above, `it may be desirable to intentionally omit one or
-more packages from consideration on a given
-index <https://github.com/astral-sh/uv/issues/4753>`__. For example, if
-a index includes builds of a package that introduces issues, but
-otherwise has more desirable packages, the one problematic package can
-be omitted. The configuration for this denylist should include a list of
-mappings from index URL to a list of package names with optional
-version constraints:
-
-::
-
-   index_package_exclusions:
-     - url: https://some-index.com
-       packages:
-         - some-problem-package-name<=3.5
+As described thus far, the index priority scheme breaks the use case of more
+than one index url serving the same content. Such mirrors may be used with the
+intent of ameliorating network issues or otherwise improving reliability. One
+approach that installers could take to preserve mirroring functionality would be
+to add a notion of user-definable index groups, where each index in the group is
+assumed to be equivalent. Within each group, content could be combined, or each
+member could be fetched concurrently. The fastest responding index would then
+represent the group.
 
 Backwards Compatibility
 =======================
@@ -405,62 +244,64 @@ so it only introduces compatibility concerns if tools choose to adopt an
 index behavior other than the behavior(s) they currently implement.
 
 This PEP’s language does not quite align with existing tools, including
-pip and uv. Either this PEP’s language can change during review, or if
+pip and uv. Either this PEP’s language can change during review of this PEP, or if
 this PEP’s language is preferred, other projects could conform to it.
-The important thing is that all the projects are using the same language
-for the same concepts.
+The only goal of proposing these terms is to create a central, common vocabulary
+that makes it easier for users to learn about other installers.
 
 As some tools rely on one or the other behavior, there are some possible
 issues that may emerge, where tailoring available resources/packages for
 a particular behavior may detract from the user experience for people
 who rely on the other behavior.
 
-- Different indexes may have different metadata. For example, one cannot
-  assume that the metadata for package “something” on index “A” has
-  the same dependencies as “something” on index “B”. When an
-  installer falls back to a different index in the search order, it
-  implies refreshing the package metadata from the new index. This
-  is both an improvement and a complication. It is a complication in the
-  sense that a cached metadata entry must be keyed by both package name
-  and index url, instead of just package name. It is a potential
-  improvement in that different implementation variants of a package can
-  differ in dependencies as long as their distributions are separated
-  into different indexes.
-- Users may not get updates as they expect, because some higher priority
+- Different indexes may have different metadata. For example, one cannot assume
+  that the metadata for package “something” on index “A” has the same dependencies
+  as “something” on index “B”. This breaks fundamental assumptions of version
+  priority, but index priority can handle this. When an installer falls through to a
+  lower-priority index in the search order, it implies refreshing the package metadata
+  from the new index. This is both an improvement and a complication. It is a
+  complication in the sense that a cached metadata entry must be keyed by both
+  package name and index url, instead of just package name. It is a potential
+  improvement in that different implementation variants of a package can differ in
+  dependencies as long as their distributions are separated into different indexes.
+
+- Users may not get updates as they expect when using index priority, because some higher priority
   index has not updated/synchronized with PyPI to get the latest
   packages. If the higher priority index has a valid candidate, newer
   packages will not be found. This will need to be communicated
   verbosely, because it is counter to pip’s well-established behavior.
-- Improving the predictability of which index will be selected may
-  tempt people into using index priority as a way of having similarly
-  named files that have different contents. It would be helpful if tools
-  errored on mismatching hashes, or otherwise gave the user feedback
-  that they are breaking a key assumption. This PEP does not mandate
-  alternative fixes, such as augmenting the cache key with the index,
-  because these changes have unknown unintended consequences. However,
-  it is advisable to augment the cache key with the index, as doing so
-  would remedy known “gotchas.”
+
+- By adding index priority, an installer will improve the predictability of
+  which index will be selected, and index hosts may abuse this as a way of having
+  similarly named files that have different contents. With version priority,
+  this violates the key package interchangeability assumption, and insanity will ensue.
+  Index priority would be more workable, but the situation still
+  has great potential for confusion. It would be helpful to develop tools that
+  support installers in identifying these confusing issues.  These tools could
+  operate independently of the installer process, as a means of validating the
+  sanity of a set of indexes. Depending on the time cost of these tools, the
+  installers could run them as part of their process.  Users could, of course,
+  ignore the recommendations at their own risk.
 
 Security Implications
 =====================
 
-Index priority creates a mechanism for users to explicitly specify a
-trust hierarchy among their indexes. As such, it limits the potential
-for dependency confusion attacks. Index priority was `rejected by PEP
-708 <https://peps.python.org/pep-0708/#provide-a-mechanism-to-order-the-repositories>`__
-as a solution for dependency confusion attacks. This PEP requests that
-the rejection be reconsidered, with index priority serving a different
-purpose. This PEP is primarily motivated by the desire to support
-implementation variants, which is the subject of `another discussion
-that hopefully leads to a
-PEP <https://discuss.python.org/t/selecting-variant-wheels-according-to-a-semi-static-specification/53446>`__.
-It is not mutually exclusive with PEP 708, nor does it suggest reverting
-or withdrawing PEP 708. It is an answer to `how we could allow users
-to choose which index to use at a more fine grained level than “per
-install”. <https://github.com/astral-sh/uv/issues/171#issuecomment-1952291242>`__
+Index priority creates a mechanism for users to explicitly specify a trust
+hierarchy among their indexes. As such, it limits the potential for dependency
+confusion attacks. Index priority was rejected by :pep:`708` as a solution for
+dependency confusion attacks. This PEP requests that the rejection be
+reconsidered, with index priority serving a different purpose. This PEP is
+primarily motivated by the desire to support implementation variants, which is
+the subject of `another discussion that hopefully leads to a PEP
+<https://discuss.python.org/t/selecting-variant-wheels-according-to-a-semi-static-specification/53446>`__.
+It is not mutually exclusive with :pep:`708`, nor does it suggest reverting or
+withdrawing :pep:`708`. It is an answer to `how we could allow users to choose
+which index to use at a more fine grained level than “per install”.
+<https://github.com/astral-sh/uv/issues/171#issuecomment-1952291242>`__
 
-For a more thorough discussion of the PEP 708 rejection of index
-priority, please see the discuss.python.org thread for this PEP (TO BE POSTED).
+For a more thorough discussion of the :pep:`708` rejection of index
+priority, please see the `discuss.python.org thread for this PEP
+<https://discuss.python.org/t/pep-766-handling-multiple-indexes-index-priority/71589>`__
 
 How to Teach This
 =================
@@ -483,7 +324,7 @@ minimum, we expect to add to the
 `PyPUG <https://packaging.python.org/en/latest/>`__ and to `pip’s
 documentation <https://pip.pypa.io/en/stable/cli/pip_install/>`__.
 
-It will be important to advertise the active behavior, especially in
+It will be important for installers to advertise the active behavior, especially in
 error messaging, and that will provide ways to provide resources to
 users about these behaviors.
 
@@ -544,13 +385,13 @@ Rejected Ideas
   For example, `Poetry specifies “primary” and “supplemental”
   tiers <https://pip.pypa.io/en/stable/cli/pip_install/>`__.
 
-  This keeps control in the hands of the user, rather than an
-  administrator, but adds complexity. Its behavior within a group is
-  meant to mimic pip’s behavior without index priority, which is an
-  anti-goal of this proposal. The granularity of `specifying per-package
-  sources <https://python-poetry.org/docs/repositories/#package-source-constraint>`__,
-  solves the ambiguity problem, at the cost of flexibility/portability
-  of those sources.
+  This keeps control in the hands of the user, rather than an administrator, but
+  adds complexity. Its behavior within a group is meant to mimic pip’s behavior
+  with version priority, and only extends priority among a very small set of
+  groups. The granularity of `specifying per-package sources
+  <https://python-poetry.org/docs/repositories/#package-source-constraint>`__,
+  solves the ambiguity problem, but at the cost of flexibility/portability of those
+  environment specifications.
 
 - Are build tags and/or local version specifiers enough?
 
@@ -572,10 +413,10 @@ Rejected Ideas
 
   https://discuss.python.org/t/dependency-notation-including-the-index-url/5659/21
 
-- What about `PEP 708 <https://peps.python.org/pep-0708>`__? Isn’t that
+- What about :pep:`708`? Isn’t that
   enough?
 
-  PEP 708 is aimed specifically at addressing dependency confusion
+  :pep:`708` is aimed specifically at addressing dependency confusion
   attacks, and doesn’t address the potential for implementation variants
   among indexes. It is a way of filtering external URLs and encoding an
   allow-list for external indexes in index metadata. It does not change
@@ -586,8 +427,7 @@ Rejected Ideas
 
   Namespacing is a means of specifying a package such that the Python
   usage of the package does not change, but the package installation
-  restricts where the package comes from. `PEP
-  752 <https://peps.python.org/pep-0752/>`__ recently proposed a way to
+  restricts where the package comes from. :pep:`752` recently proposed a way to
   multiplex a package’s owners in a flat package namespace (e.g.
   PyPI) by reserving prefixes as grouping elements. `NPM’s concept
   of “scopes” <https://docs.npmjs.com/cli/v10/using-npm/scope>`__ has

--- a/peps/pep-0766.rst
+++ b/peps/pep-0766.rst
@@ -23,7 +23,7 @@ long defined the standard expected behavior across other tools in the ecosystem,
 but Python installers are diverging with respect to how they handle multiple
 indexes. At the core of this divergence is whether index contents are combined
 before resolving distributions, or each index is handled individually in order.
-Pip merges all indexes before matching distributions, while uv matches
+pip merges all indexes before matching distributions, while uv matches
 distributions on one index before moving on to the next. Each approach has
 advantages and disadvantages.  This PEP aims to describe each of these
 behaviors, which are referred to as “version priority” and “index priority”
@@ -44,7 +44,7 @@ to exist:
 - `Situations where a local package has remote dependencies
   <https://github.com/pypa/pip/issues/11624>`__, and the user wishes to prioritize
   local packages over remote dependencies, while still falling back to remote
-  dependencies where needed.
+  dependencies where needed
 
 In most of these cases, it is not desirable to completely forego PyPI. Instead,
 users generally want PyPI to still be a source of packages, but a lower priority
@@ -176,7 +176,7 @@ Ways that a request falls through to a lower priority index
   to less predictable, likely unreproducible results by unexpectedly
   falling through to lower priority indexes. On the other hand, graceful
   fallback may be more valuable to some users, especially if they can
-  safely assume that all of their indexes are equally trusted. Pip’s
+  safely assume that all of their indexes are equally trusted. pip’s
   behavior today is graceful fallback: you see warnings if an index is
   having connection issues, but the installation will proceed with any
   other available indexes. Because index priority can convey different trust
@@ -291,7 +291,7 @@ which index to use at a more fine grained level than “per install”.
 
 For a more thorough discussion of the :pep:`708` rejection of index
 priority, please see the `discuss.python.org thread for this PEP
-<https://discuss.python.org/t/pep-766-handling-multiple-indexes-index-priority/71589>`__
+<https://discuss.python.org/t/pep-766-handling-multiple-indexes-index-priority/71589>`__.
 
 How to Teach This
 =================
@@ -318,7 +318,7 @@ It will be important for installers to advertise the active behavior, especially
 error messaging, and that will provide ways to provide resources to
 users about these behaviors.
 
-Uv users are already experiencing index priority. Uv `documents this
+uv users are already experiencing index priority. uv `documents this
 behavior <https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes>`__
 well, but it is always possible to `improve the
 discoverability <https://github.com/astral-sh/uv/issues/4389>`__ of that
@@ -329,14 +329,14 @@ behavior <https://github.com/astral-sh/uv/issues/5146>`__.
 Reference Implementation
 ========================
 
-The uv project demonstrates index priority with its default behavior. Uv
+The uv project demonstrates index priority with its default behavior. uv
 is implemented in Rust, though, so if a  reference implementation to a Python-based tool
 is necessary, we, the authors of this PEP, will provide one. For pip in
 particular, we see the implementation plan as something like:
 
 - For users who don’t use ``--extra-index-url`` or ``--find-links``,
   there will be no change, and no migration is necessary.
-- Pip users would be able opt in to the index priority behavior with a
+- pip users would be able opt in to the index priority behavior with a
   new config setting in the CLI and in ``pip.conf``. This proposal does not
   recommend any strategy as the default for any installer. It only
   recommends documenting the strategies that a tool provides.
@@ -357,7 +357,8 @@ particular, we see the implementation plan as something like:
 Rejected Ideas
 ==============
 
-- Tell users to set up a proxy/mirror, such as `devpi <https://github.com/devpi/devpi>`__ or `artifactory <https://jfrog.com/help/r/jfrog-artifactory-documentation/pypi-repositories>`__ that
+- Tell users to set up a proxy/mirror, such as `devpi <https://github.com/devpi/devpi>`__
+  or `Artifactory <https://jfrog.com/help/r/jfrog-artifactory-documentation/pypi-repositories>`__ that
   serves local files if present, and forwards to another server (PyPI)
   if no local files match
 
@@ -432,8 +433,8 @@ Acknowledgements
 
 This work was supported financially by NVIDIA through employment of the author.
 NVIDIA teammates dramatically improved this PEP with their
-input.  Astral Software pioneered the behaviors of index priority and thus layed the
-foundation of this document. The Pip authors deserve great praise for their
+input.  Astral Software pioneered the behaviors of index priority and thus laid the
+foundation of this document. The pip authors deserve great praise for their
 consistent direction and patient communication of the version priority behavior,
 especially in the face of contentious security concerns.
 

--- a/peps/pep-0766.rst
+++ b/peps/pep-0766.rst
@@ -1,34 +1,34 @@
-PEP: 9999
+PEP: 766
 Title: Explicit Priority Choices Among Multiple Indexes
 Author: Michael Sarahan, msarahan@gmail.com
 Sponsor: Barry Warsaw, barry@python.org
-PEP-Delegate: <PEP delegate’s real name>
-Discussions-To: <REQUIRED: URL of current canonical discussion thread>
+PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
+Discussions-To: https://discuss.python.org/t/pep-for-handling-multiple-indexes-index-priority/71589
 Status: Draft
 Type: Informational
 Topic: Packaging
 Requires: 777
-Created: 05-Nov-2024
-Post-History: <REQUIRED: dates, in dd-mmm-yyyy format, and corresponding links to PEP discussion threads>
+Created: 18-Nov-2024
+Post-History: `18-Nov-2024 <https://discuss.python.org/t/pep-for-handling-multiple-indexes-index-priority/71589>`__,
 
 Abstract
 ========
 
-Package resolution is a key part of the Python user experience as the 
-means of extending Python's core functionality. The experience of package 
-resolution is mostly taken for granted until someone encounters a 
-situation where the package installer does something they don't expect. 
+Package resolution is a key part of the Python user experience as the
+means of extending Python's core functionality. The experience of package
+resolution is mostly taken for granted until someone encounters a
+situation where the package installer does something they don't expect.
 The installer behavior with multiple indexes has been `a common source of unexpected behavior <https://github.com/pypa/pip/issues/8606>`__.
-Through its ubiquity, pip has long defined the standard expected behavior 
-across other tools in the ecosystem, but Python installers are diverging 
-with respect to how they handle multiple indexes. At the core of this 
-divergence is whether index contents are combined before resolving distributions, 
+Through its ubiquity, pip has long defined the standard expected behavior
+across other tools in the ecosystem, but Python installers are diverging
+with respect to how they handle multiple indexes. At the core of this
+divergence is whether index contents are combined before resolving distributions,
 or each index is handled individually in order. Pip merges all indexes
 before matching distributions, while uv matches distributions on one index
 before moving on to the next. Each approach has advantages and disadvantages.
-This PEP aims to describe each of these behaviors, which are referred to 
+This PEP aims to describe each of these behaviors, which are referred to
 as “version priority” and “index priority” respectively, so that community
-discussions and troubleshooting can share a common vocabulary, and so that tools can 
+discussions and troubleshooting can share a common vocabulary, and so that tools can
 implement predictable behavior based on these descriptions.
 
 Motivation
@@ -46,7 +46,7 @@ Goals
 - Provide guidelines for how ecosystem tools should implement index
   priority if they would like, and suggest reasons why they might want
   to do so
-- Augment `PEP 708 <https://peps.python.org/pep-0708/>`__ as a more 
+- Augment `PEP 708 <https://peps.python.org/pep-0708/>`__ as a more
   user-configurable system for expressing different levels of trust
   among configured indexes
 
@@ -67,11 +67,11 @@ Rationale
 =========
 
 This PEP describes two modes of installer behavior when using multiple
-sources in the hopes that the user experience and expectations across 
-tools can be more explicit and more predictable. Pip has long defined 
-the de-facto standard installer behavior in the ecosystem, but new tools 
+sources in the hopes that the user experience and expectations across
+tools can be more explicit and more predictable. Pip has long defined
+the de-facto standard installer behavior in the ecosystem, but new tools
 have been implementing new approaches in response to both security concerns
-and desire to prioritize one index over another. Uv and PDM have each 
+and desire to prioritize one index over another. Uv and PDM have each
 added support for some notion of index priority.
 
 Index priority is `the default behavior in
@@ -112,8 +112,8 @@ different contents than other indexes, such as builds for special
 hardware, and this version priority behavior can lead to undesirable,
 unexpected outcomes, and this is when users generally look for some kind
 of index priority. Additionally, when there is a difference in trust among
-indexes, version priority does not provide a way to prefer more trusted 
-indexes over less trusted indexes. This has been the subject of dependency 
+indexes, version priority does not provide a way to prefer more trusted
+indexes over less trusted indexes. This has been the subject of dependency
 confusion attacks, and :pep:`708` was
 proposed as a way of hard-coding a notion of trusted external indexes into
 the index.
@@ -160,15 +160,15 @@ packages are compared.
 “Index priority”
 ----------------
 
-In index priority, the resolver finds candidates for each index, one at a time. 
+In index priority, the resolver finds candidates for each index, one at a time.
 The resolver proceeds to subsequent indexes only if the current
 package request has no viable candidates. Index priority does not combine
-indexes into one global, flat namespace. Because indexes are searched in order, 
+indexes into one global, flat namespace. Because indexes are searched in order,
 the package from an earlier index  will be preferred over a package from a later index, regardless of whether
 the later index had a better match. Uv’s calls this "first-match"
 behavior, and the version priority behavior "best-match". The criteria and process for
 evaluating “best match” is the same for both index priority and version
-priority. It is only the treatment of multiple indexes that differs: 
+priority. It is only the treatment of multiple indexes that differs:
 all together for version priority, and individually for index priority.
 
 The index (or “source” in PDM terms) priority is


### PR DESCRIPTION
<!--
You can use the following checklist when double-checking your PEP,
and you can help complete some of it yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about anything, just leave it blank and we'll take a look.

If your PEP is not Standards Track, remove the corresponding section.
-->

## Basic requirements (all PEP Types)

* [x] Read and followed [PEP 1](https://peps.python.org/1) & [PEP 12](https://peps.python.org/12)
* [x] File created from the [latest PEP template](https://github.com/python/peps/blob/main/peps/pep-0012/pep-NNNN.rst?plain=1)
* [x] PEP has next available number, & set in filename (``pep-NNNN.rst``), PR title (``PEP 123: <Title of PEP>``) and ``PEP`` header
* [x] Title clearly, accurately and concisely describes the content in 79 characters or less
* [x] Core dev/PEP editor listed as ``Author`` or ``Sponsor``, and formally confirmed their approval
* [x] ``Author``, ``Status`` (``Draft``), ``Type`` and ``Created`` headers filled out correctly
* [x] ``PEP-Delegate``, ``Topic``, ``Requires`` and ``Replaces`` headers completed if appropriate
* [x] Required sections included
    * [x] Abstract (first section)
    * [x] Copyright (last section; exact wording from template required)
* [x] Code is well-formatted (PEP 7/PEP 8) and is in [code blocks, with the right lexer names](https://peps.python.org/pep-0012/#literal-blocks) if non-Python
* [x] PEP builds with no warnings, pre-commit checks pass and content displays as intended in the rendered HTML
* [x] Authors/sponsor added to ``.github/CODEOWNERS`` for the PEP


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4123.org.readthedocs.build/pep-0766/

<!-- readthedocs-preview pep-previews end -->