### PR TITLE
PEP 765: link with pep 601

### DIFF
--- a/peps/pep-0601.rst
+++ b/peps/pep-0601.rst
@@ -9,6 +9,7 @@ Content-Type: text/x-rst
 Created: 26-Aug-2019
 Python-Version: 3.8
 Post-History: 26-Aug-2019, 23-Sep-2019
+Superseded-By: 765
 Resolution: https://discuss.python.org/t/pep-601-forbid-return-break-continue-breaking-out-of-finally/2239/32
 
 Rejection Note

--- a/peps/pep-0765.rst
+++ b/peps/pep-0765.rst
@@ -8,6 +8,7 @@ Created: 15-Nov-2024
 Python-Version: 3.14
 Post-History: `09-Nov-2024 <https://discuss.python.org/t/an-analysis-of-return-in-finally-in-the-wild/70633>`__,
               `16-Nov-2024 <https://discuss.python.org/t/pep-765-disallow-return-break-continue-that-exit-a-finally-block/71348>`__,
+Replaces: 601
 
 Abstract
 ========


### PR DESCRIPTION
As suggested in https://discuss.python.org/t/pep-765-disallow-return-break-continue-that-exit-a-finally-block/71348/31.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4128.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->