### PR TITLE
Infra: let codespell run in parallel and output in order

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,6 +93,7 @@ repos:
     hooks:
       - id: codespell
         name: "Check for common misspellings in text files"
+        require_serial: true
         stages: [manual]
 
   # Local checks for PEP headers and more


### PR DESCRIPTION
Send all the files to codespell so we get the output in codespell's alphabetical order.

> `require_serial`: (optional: default false) if true this hook will execute using a single process instead of in parallel.

https://pre-commit.com/#hooks-require_serial

# Before

```console
❯ make spellcheck
...
Check for common misspellings in text files..............................Failed
- hook id: codespell
- exit code: 65

peps/pep-0728.rst:381: overriden ==> overridden
peps/pep-0728.rst:676: othere ==> other
peps/pep-0739/python-build-info-v1.0.schema.json:267: Implamentations ==> Implementations
peps/pep-0747.rst:548: alowed ==> allowed
peps/pep-0777.rst:357: introducted ==> introduced
peps/pep-0757.rst:457: bufferes ==> buffers, buffered
peps/pep-0758.rst:60: paretheses ==> parentheses
peps/pep-0739.rst:48: feasable ==> feasible
peps/pep-0739.rst:694: Implamentations ==> Implementations
peps/pep-0751.rst:868: tread ==> thread, treat
peps/pep-0751.rst:1230: everytime ==> every time
peps/pep-0755.rst:267: mistakingly ==> mistakenly
peps/pep-0750.rst:1288: opportunty ==> opportunity

make: *** [spellcheck] Error 1
```

# After

```console
❯ make spellcheck
...
Check for common misspellings in text files..............................Failed
- hook id: codespell
- exit code: 65

peps/pep-0728.rst:381: overriden ==> overridden
peps/pep-0728.rst:676: othere ==> other
peps/pep-0739.rst:48: feasable ==> feasible
peps/pep-0739.rst:694: Implamentations ==> Implementations
peps/pep-0739/python-build-info-v1.0.schema.json:267: Implamentations ==> Implementations
peps/pep-0747.rst:548: alowed ==> allowed
peps/pep-0750.rst:1288: opportunty ==> opportunity
peps/pep-0751.rst:868: tread ==> thread, treat
peps/pep-0751.rst:1230: everytime ==> every time
peps/pep-0755.rst:267: mistakingly ==> mistakenly
peps/pep-0757.rst:457: bufferes ==> buffers, buffered
peps/pep-0758.rst:60: paretheses ==> parentheses
peps/pep-0777.rst:357: introducted ==> introduced

make: *** [spellcheck] Error 1
```

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4146.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->