### PR TITLE
PEP 352: Fix Sphinx reference warning

### DIFF
--- a/peps/pep-0352.rst
+++ b/peps/pep-0352.rst
@@ -276,6 +276,8 @@ References
 .. [#pycon2007-sprint-email]  python-3000 email ("How far to go with cleaning up exceptions")
     https://mail.python.org/pipermail/python-3000/2007-March/005911.html
 
+* Patch for new-style exceptions:
+  `python/cpython#41459 <https://github.com/python/cpython/issues/41459>`__
 
 Copyright
 =========

--- a/peps/pep-0352.rst
+++ b/peps/pep-0352.rst
@@ -1,11 +1,8 @@
 PEP: 352
 Title: Required Superclass for Exceptions
-Version: $Revision$
-Last-Modified: $Date$
 Author: Brett Cannon, Guido van Rossum
 Status: Final
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 27-Oct-2005
 Python-Version: 2.5
 Post-History:
@@ -276,9 +273,6 @@ References
 .. [#hierarchy-good] python-dev Summary for 2004-08-01 through 2004-08-15
    http://www.python.org/dev/summary/2004-08-01_2004-08-15.html#an-exception-is-an-exception-unless-it-doesn-t-inherit-from-exception
 
-.. [#SF_1104669] SF patch #1104669 (new-style exceptions)
-   https://bugs.python.org/issue1104669
-
 .. [#pycon2007-sprint-email]  python-3000 email ("How far to go with cleaning up exceptions")
     https://mail.python.org/pipermail/python-3000/2007-March/005911.html
 
@@ -287,13 +281,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:

--- a/peps/pep-0352.rst
+++ b/peps/pep-0352.rst
@@ -276,7 +276,7 @@ References
 .. [#pycon2007-sprint-email]  python-3000 email ("How far to go with cleaning up exceptions")
     https://mail.python.org/pipermail/python-3000/2007-March/005911.html
 
-* Patch for new-style exceptions:
+* Issue for new-style exceptions:
   `python/cpython#41459 <https://github.com/python/cpython/issues/41459>`__
 
 Copyright


### PR DESCRIPTION
<!--
This template is for an infra or meta change not belonging to another category.
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->
For https://github.com/python/peps/issues/4087.

The reference was added in https://github.com/python/peps/commit/22d5e43fa52ba6b42553917b0e423ef0ec9f1dc3 and partially removed in https://github.com/python/peps/commit/81eabf7a0d87ee4691e1b45fe81a525d59376eb4.
 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4147.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->