### PR TITLE
PEP 376: Fix Sphinx reference warnings

### DIFF
--- a/peps/pep-0376.rst
+++ b/peps/pep-0376.rst
@@ -4,7 +4,6 @@ Author: Tarek Ziadé <tarek@ziade.org>
 Status: Final
 Type: Standards Track
 Topic: Packaging
-Content-Type: text/x-rst
 Created: 22-Feb-2009
 Python-Version: 2.7, 3.2
 Post-History: `22-Jun-2009 <https://mail.python.org/archives/list/python-dev@python.org/thread/ILLTIOZAULMDY5CAS6GOITEYJ4HNFATQ/>`__
@@ -607,12 +606,6 @@ formats in addition to the new format, in order to ease the transition.
 References
 ==========
 
-.. [#distutils]
-   http://docs.python.org/distutils
-
-.. [#distutils2]
-   http://hg.python.org/distutils2
-
 .. [#setuptools]
    http://peak.telecommunity.com/DevCenter/setuptools
 
@@ -644,14 +637,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:

--- a/peps/pep-0376.rst
+++ b/peps/pep-0376.rst
@@ -607,25 +607,25 @@ References
 ==========
 
 .. [#setuptools]
-   http://peak.telecommunity.com/DevCenter/setuptools
+   https://peak.telecommunity.com/DevCenter/setuptools
 
 .. [#easyinstall]
-   http://peak.telecommunity.com/DevCenter/EasyInstall
+   https://peak.telecommunity.com/DevCenter/EasyInstall
 
 .. [#pip]
-   http://pypi.python.org/pypi/pip
+   https://pypi.org/project/pip/
 
 .. [#eggformats]
-   http://peak.telecommunity.com/DevCenter/EggFormats
+   https://peak.telecommunity.com/DevCenter/EggFormats
 
 .. [#fedora]
-   http://fedoraproject.org/wiki/Packaging/Python/Eggs#Providing_Eggs_using_Setuptools
+   https://fedoraproject.org/wiki/Packaging/Python/Eggs#Providing_Eggs_using_Setuptools
 
 .. [#debian]
-   http://wiki.debian.org/DebianPython/NewPolicy
+   https://wiki.debian.org/DebianPython/NewPolicy
 
 .. [#prototype]
-   http://bitbucket.org/tarek/pep376/
+   https://web.archive.org/web/20090726092550/http://bitbucket.org/tarek/pep376/
 
 Acknowledgements
 ================


### PR DESCRIPTION
For https://github.com/python/peps/issues/4087.

`#distutils` was added in https://github.com/python/peps/commit/c8bc9c1f233af3dc72d1200da7d0443a43c2b445 and partially removed in https://github.com/python/peps/commit/e7b6ac276c441d43f66377dadce3982a5ec9d066. 

`#distutils2` was added in https://github.com/python/peps/commit/1dfaf5580f383a862e4533da025ce3a6c1d5cc8b but never referenced.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4148.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->