### PR TITLE
PEP 386: Fix Sphinx reference warning

### DIFF
--- a/peps/pep-0386.rst
+++ b/peps/pep-0386.rst
@@ -472,31 +472,31 @@ References
 ==========
 
 .. [#distutils]
-   http://docs.python.org/distutils
+   https://docs.python.org/3.11/distutils/
 
 .. [#setuptools]
-   http://peak.telecommunity.com/DevCenter/setuptools
+   https://peak.telecommunity.com/DevCenter/setuptools
 
 .. [#setuptools-version]
-   http://peak.telecommunity.com/DevCenter/setuptools#specifying-your-project-s-version
+   https://peak.telecommunity.com/DevCenter/setuptools#specifying-your-project-s-version
 
 .. [#pypi]
-   http://pypi.python.org/pypi
+   https://pypi.org/
 
 .. [#pip]
-   http://pypi.python.org/pypi/pip
+   https://pypi.org/project/pip/
 
 .. [#ezinstall]
-   http://peak.telecommunity.com/DevCenter/EasyInstall
+   https://peak.telecommunity.com/DevCenter/EasyInstall
 
 .. [#zc.buildout]
-   http://pypi.python.org/pypi/zc.buildout
+   https://pypi.org/project/zc.buildout/
 
 .. [#twisted]
-   http://twistedmatrix.com/trac/
+   https://twisted.org/
 
 .. [#prototype]
-   http://bitbucket.org/tarek/distutilsversion/
+   https://web.archive.org/web/20090726093825/http://bitbucket.org/tarek/distutilsversion/
 
 Acknowledgments
 ===============

--- a/peps/pep-0386.rst
+++ b/peps/pep-0386.rst
@@ -1,12 +1,9 @@
 PEP: 386
 Title: Changing the version comparison module in Distutils
-Version: $Revision$
-Last-Modified: $Date$
 Author: Tarek Ziadé <tarek@ziade.org>
 Status: Superseded
 Type: Standards Track
 Topic: Packaging
-Content-Type: text/x-rst
 Created: 04-Jun-2009
 Superseded-By: 440
 
@@ -498,9 +495,6 @@ References
 .. [#twisted]
    http://twistedmatrix.com/trac/
 
-.. [#requires]
-   http://peak.telecommunity.com/DevCenter/setuptools
-
 .. [#prototype]
    http://bitbucket.org/tarek/distutilsversion/
 
@@ -514,14 +508,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
For https://github.com/python/peps/issues/4087.

`#requires` was added in https://github.com/python/peps/commit/526ad628ce51892e4e7bd38402c74b59f8b626bd and partially removed in https://github.com/python/peps/commit/8436e4f7bb2e30c1609c9ed13b5f8149096d4fe4.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4149.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->