### PR TITLE
PEP 421: Fix Sphinx reference warnings

### DIFF
--- a/peps/pep-0421.rst
+++ b/peps/pep-0421.rst
@@ -1,12 +1,9 @@
 PEP: 421
 Title: Adding sys.implementation
-Version: $Revision$
-Last-Modified: $Date$
 Author: Eric Snow <ericsnowcurrently@gmail.com>
 BDFL-Delegate: Barry Warsaw
 Status: Final
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 26-Apr-2012
 Python-Version: 3.3
 Post-History: 26-Apr-2012
@@ -466,14 +463,8 @@ References
 .. [#ironpython] Feedback from the IronPython developers:
    https://mail.python.org/pipermail/ironpython-users/2012-May/015980.html
 
-.. [#dino_viehland_2009] (2009) Dino Viehland offers his opinion:
-   https://mail.python.org/pipermail/python-dev/2009-October/092894.html
-
 .. [#jeff_hardy_2012] (2012) Jeff Hardy offers his opinion:
    https://mail.python.org/pipermail/ironpython-users/2012-May/015981.html
-
-.. [#jython] Feedback from the Jython developers:
-   ???
 
 .. [#frank_wierzbicki_2009] (2009) Frank Wierzbicki offers his opinion:
    https://mail.python.org/pipermail/python-dev/2009-October/092974.html
@@ -486,15 +477,6 @@ References
 
 .. [#guess] The ``platform`` code which divines the implementation name:
    http://hg.python.org/cpython/file/2f563908ebc5/Lib/platform.py#l1247
-
-.. [#tag_impl] The original implementation of the cache tag in CPython:
-   http://hg.python.org/cpython/file/2f563908ebc5/Python/import.c#l121
-
-.. [#tests] Examples of implementation-specific handling in test.support:
-   * http://hg.python.org/cpython/file/2f563908ebc5/Lib/test/support.py#l509
-   * http://hg.python.org/cpython/file/2f563908ebc5/Lib/test/support.py#l1246
-   * http://hg.python.org/cpython/file/2f563908ebc5/Lib/test/support.py#l1252
-   * http://hg.python.org/cpython/file/2f563908ebc5/Lib/test/support.py#l1275
 
 .. [#os_name] The standard library entry for os.name:
    http://docs.python.org/3.3/library/os.html#os.name
@@ -519,14 +501,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
For https://github.com/python/peps/issues/4087.


`#dino_viehland_2009` and `#jython` were added in https://github.com/python/peps/commit/99d6530667ba1a869911ade255f4715a96da241c but never referenced.

`#tag_impl` and `#tests` were added in https://github.com/python/peps/commit/b5d1d9475009d448aa6d0d21c8ffae0de538cb1e but never referenced.
