### PR TITLE
Infra: use same admonition for canonical-doc, canonical-pypa-spec and canonical-typing-spec

### DIFF
--- a/pep_sphinx_extensions/pep_processor/parsing/pep_banner_directive.py
+++ b/pep_sphinx_extensions/pep_processor/parsing/pep_banner_directive.py
@@ -77,7 +77,6 @@ class CanonicalDocBanner(PEPBanner):
     admonition_post_text = (
         "See :pep:`1` for how to propose changes."
     )
-
     css_classes = ["canonical-doc", "sticky-banner"]
 
 
@@ -99,8 +98,6 @@ class CanonicalPyPASpecBanner(PEPBanner):
         "<https://www.pypa.io/en/latest/specifications/#handling-fixes-and-other-minor-updates>`__ "
         "for how to propose changes."
     )
-    admonition_class = nodes.attention
-
     css_classes = ["canonical-pypa-spec", "sticky-banner"]
 
 
@@ -119,8 +116,6 @@ class CanonicalTypingSpecBanner(PEPBanner):
         "<https://typing.readthedocs.io/en/latest/spec/meta.html>`__ "
         "for how to propose changes to the typing spec."
     )
-    admonition_class = nodes.attention
-
     css_classes = ["canonical-typing-spec", "sticky-banner"]
 
 


### PR DESCRIPTION
Follow-up to https://github.com/python/peps/pull/4114#issuecomment-2515273831.

Use the base class `admonition_class = nodes.important` for all.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4152.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->