### PR TITLE
PEP 768: Add pablogsal to `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -645,6 +645,7 @@ peps/pep-0763.rst  @dstufft
 peps/pep-0765.rst  @iritkatriel @ncoghlan
 peps/pep-0766.rst  @warsaw
 peps/pep-0767.rst  @carljm
+peps/pep-0768.rst  @pablogsal
 # ...
 peps/pep-0777.rst  @warsaw
 # ...


### PR DESCRIPTION
Follow on from https://github.com/python/peps/pull/4158.