### PR TITLE
PEP 13: Add deadline of one week to second a vote of no confidence

### DIFF
--- a/peps/pep-0013.rst
+++ b/peps/pep-0013.rst
@@ -343,8 +343,8 @@ History of council elections
 History of amendments
 ---------------------
 
-2019-04-17: Added the vote length for core devs and changes to this document.
-2024-12-10: Added a one-week deadline for seconding a vote of no confidence.
+* 2019-04-17: Added the vote length for core devs and changes to this document.
+* 2024-12-10: Added a one-week deadline for seconding a vote of no confidence.
 
 
 

--- a/peps/pep-0013.rst
+++ b/peps/pep-0013.rst
@@ -354,10 +354,10 @@ History of amendments
 ---------------------
 
 * 2019-04-17: Added the vote length for core devs and changes to this document.
-* 2024-12-10: `Adopted
-  <https://discuss.python.org/t/changing-pep-13-to-adopt-bloc-star-voting/64971>`__
-  Multi-winner Bloc STAR voting for council elections.
-* 2024-12-10: Added a one-week deadline for seconding a vote of no confidence.
+* `2024-12-10 <https://discuss.python.org/t/64971>`__:
+  Adopted Multi-winner Bloc STAR voting for council elections.
+* `2024-12-10 <https://discuss.python.org/t/72293/4>`__:
+  Added a one-week deadline for seconding a vote of no confidence.
 
 
 

--- a/peps/pep-0013.rst
+++ b/peps/pep-0013.rst
@@ -190,7 +190,7 @@ council member, or the entire council, via a vote of no confidence.
 
 A no-confidence vote is triggered when a core team member calls for
 one publicly on an appropriate project communication channel, and
-another core team member seconds the proposal.
+another core team member seconds the proposal within one week.
 
 The vote lasts for two weeks. Core team members vote for or against.
 If at least two thirds of voters express a lack of confidence, then
@@ -344,6 +344,7 @@ History of amendments
 ---------------------
 
 2019-04-17: Added the vote length for core devs and changes to this document.
+2024-12-10: Added a one-week deadline for seconding a vote of no confidence.
 
 
 


### PR DESCRIPTION
Update following the vote:

https://discuss.python.org/t/pep-13-add-deadline-for-seconding-vote-of-no-confidence/72293

![image](https://github.com/user-attachments/assets/c1be85fe-bea2-4ba3-b371-6d31c625cfb1)

![image](https://github.com/user-attachments/assets/d9c301e8-17ec-4ed5-bc67-0e7a7ff3a6d7)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4163.org.readthedocs.build/pep-0013/

<!-- readthedocs-preview pep-previews end -->