### PR TITLE
PEP-765: rewrote two sentences as proposed by Jeff Glass

### DIFF
--- a/peps/pep-0765.rst
+++ b/peps/pep-0765.rst
@@ -91,7 +91,7 @@ when a ``return``, ``break`` or ``continue`` would transfer
 control flow from within a ``finally`` block to a location outside
 of it.
 
-This includes the following examples:
+These examples may emit a ``SyntaxWarning`` or ``SyntaxError``:
 
 .. code-block::
    :class: bad
@@ -108,7 +108,7 @@ This includes the following examples:
         finally:
             break  # (or continue)
 
-But excludes these:
+These examples would not emit the warning or error:
 
 .. code-block::
    :class: good


### PR DESCRIPTION

As [proposed](https://discuss.python.org/t/pep-765-disallow-return-break-continue-that-exit-a-finally-block/71348/108) by @JeffersGlass.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4164.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->