### PR TITLE
PEP 768: Add Discussions-To and Post-History headers

### DIFF
--- a/peps/pep-0768.rst
+++ b/peps/pep-0768.rst
@@ -1,10 +1,12 @@
 PEP: 768
 Title: Safe external debugger interface for CPython
 Author: Pablo Galindo Salgado <pablogsal@python.org>, Matt Wozniski <godlygeek@gmail.com>, Ivona Stojanovic <stojanovic.i@hotmail.com>
+Discussions-To: https://discuss.python.org/t/pep-768-safe-external-debugger-interface-for-cpython/73969
 Status: Draft
 Type: Standards Track
 Created: 25-Nov-2024
 Python-Version: 3.14
+Post-History: `11-Dec-2024 <https://discuss.python.org/t/pep-768-safe-external-debugger-interface-for-cpython/73969>`__
 
 Abstract
 ========


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4165.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->