### PR TITLE
PEP 695: Fix runtime behavior example of generic classes

### DIFF
--- a/peps/pep-0695.rst
+++ b/peps/pep-0695.rst
@@ -1033,7 +1033,7 @@ Equivalent to::
 
    def695 __generic_parameters_of_C():
        T = typing.TypeVar('T')
-       class C(Base):
+       class C(Base, typing.Generic[T]):
            __type_params__ = (T,)
            def __init__(self, x: T):
                self.x = x


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

At runtime, `Generic` is added as a base class:

```python
class A[T](Base):
    pass

A.__bases__
#> (<class '__main__.Base'>, <class 'typing.Generic'>)
```

Note: I know the PEP is a historical document and this one is marked as final. However, this seems to be the only place where the runtime behavior is documented.

* Change is either:
    * [ ] To a Draft PEP
    * [x] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4172.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->