### PR TITLE
PEP 472: Fix Sphinx reference warnings

### DIFF
--- a/peps/pep-0472.rst
+++ b/peps/pep-0472.rst
@@ -1,12 +1,9 @@
 PEP: 472
 Title: Support for indexing with keyword arguments
-Version: $Revision$
-Last-Modified: $Date$
 Author: Stefano Borini, Joseph Martinot-Lagarde
 Discussions-To: python-ideas@python.org
 Status: Rejected
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 24-Jun-2014
 Python-Version: 3.6
 Post-History: 02-Jul-2014
@@ -282,7 +279,8 @@ Pros
 
 Cons
 ''''
-- According to some sources [#namedtuple]_ namedtuple is not well developed.
+- According to `some sources <https://mail.python.org/pipermail/python-ideas/2013-June/021257.html>`__
+  namedtuple is not well developed.
   To include it as such important object would probably require rework
   and improvement;
 - The namedtuple fields, and thus the type, will have to change according
@@ -623,29 +621,16 @@ is not the same thing as ``f((1, 2))``.".
 References
 ==========
 
-.. [#keyword-1] "keyword-only args in __getitem__"
-       (http://article.gmane.org/gmane.comp.python.ideas/27584)
+* `"keyword-only args in __getitem__"
+  <https://mail.python.org/archives/list/python-ideas@python.org/thread/MNBVLLYNQU3OVJR3JSEEQUDXMM3X5Z3J/#MNBVLLYNQU3OVJR3JSEEQUDXMM3X5Z3J>`__
 
-.. [#keyword-2] "Accepting keyword arguments for __getitem__"
-       (https://mail.python.org/pipermail/python-ideas/2014-June/028164.html)
+* `"Accepting keyword arguments for __getitem__"
+  <https://mail.python.org/archives/list/python-ideas@python.org/thread/GDSUYS7BT6YEXHM73HMJAMAENNCK7RDP/#N2JVLQD6REAV2KGBKASNTOTHJJSKOPTH>`__
 
-.. [#keyword-3] "PEP pre-draft: Support for indexing with keyword arguments"
-       https://mail.python.org/pipermail/python-ideas/2014-July/028250.html
-
-.. [#namedtuple] "namedtuple is not as good as it should be"
-       (https://mail.python.org/pipermail/python-ideas/2013-June/021257.html)
+* `"PEP pre-draft: Support for indexing with keyword arguments"
+  <https://mail.python.org/pipermail/python-ideas/2014-July/028250.html>`__
 
 Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   End:


### PR DESCRIPTION
For https://github.com/python/peps/issues/4087.

The `keyword-X` footnotes were added in the PEP's first commit and never referenced:

https://github.com/python/peps/commit/84d82f06f22a789b7ed3923e37552daef13eba14

I've turned them into bullet points, and replaced the broken https://article.gmane.org/gmane.comp.python.ideas/ links with corresponding https://mail.python.org/archives/list/python-ideas@python.org/ ones.

I also turned the one remaining footnote into an inline link.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4174.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->