### PR TITLE
PEP 745: 3.14.0a3 was released on 2024-12-17

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -38,10 +38,10 @@ Actual:
 - 3.14 development begins: Wednesday, 2024-05-08
 - 3.14.0 alpha 1: Tuesday, 2024-10-15
 - 3.14.0 alpha 2: Tuesday, 2024-11-19
+- 3.14.0 alpha 3: Tuesday, 2024-12-17
 
 Expected:
 
-- 3.14.0 alpha 3: Tuesday, 2024-12-17
 - 3.14.0 alpha 4: Tuesday, 2025-01-14
 - 3.14.0 alpha 5: Tuesday, 2025-02-11
 - 3.14.0 alpha 6: Friday, 2025-03-14


### PR DESCRIPTION
https://discuss.python.org/t/python-3-14-0-alpha-3/74542

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4176.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->