### PR TITLE
Infra: Specify Sphinx config path for Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
     python: "3"
 
@@ -17,6 +17,7 @@ build:
 
 sphinx:
   builder: dirhtml
+  configuration: peps/conf.py
 
 search:
   ignore: ['*']


### PR DESCRIPTION
_Not_ explicitly specifying the path to the `conf.py` is deprecated and will stop working on 20th January 2025:

https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

Let's also bump the Ubuntu version. I expect we should be fine with "latest LTS" rather than pinning a specific version.

https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4177.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->