### PR TITLE
PEP 767: Include `__init_subclass__` in initialization

### DIFF
--- a/peps/pep-0767.rst
+++ b/peps/pep-0767.rst
@@ -2,12 +2,13 @@ PEP: 767
 Title: Annotating Read-Only Attributes
 Author: Eneg <eneg at discuss.python.org>
 Sponsor: Carl Meyer <carl@oddbird.net>
-Discussions-To: https://discuss.python.org/t/expanding-readonly-to-normal-classes-protocols/67359
+Discussions-To: https://discuss.python.org/t/pep-767-annotating-read-only-attributes/73408
 Status: Draft
 Type: Standards Track
 Topic: Typing
 Created: 18-Nov-2024
 Python-Version: 3.14
+Post-History: `09-Oct-2024 <https://discuss.python.org/t/expanding-readonly-to-normal-classes-protocols/67359>`__
 
 
 Abstract

--- a/peps/pep-0767.rst
+++ b/peps/pep-0767.rst
@@ -98,8 +98,7 @@ Today, there are three major ways of achieving read-only attributes, honored by 
 Protocols
 ---------
 
-A read-only attribute ``name: T`` on a :class:`~typing.Protocol` in principle
-defines two requirements:
+Suppose a :class:`~typing.Protocol` member ``name: T`` defining two requirements:
 
 1. ``hasattr(obj, "name")``
 2. ``isinstance(obj.name, T)``
@@ -251,7 +250,12 @@ Initialization
 
 Assignment to a read-only attribute can only occur in the class declaring the attribute.
 There is no restriction to how many times the attribute can be assigned to.
-The assignment must be allowed in the following contexts:
+Depending on the kind of the attribute, they can be assigned to at different sites:
+
+Instance Attributes
+'''''''''''''''''''
+
+Assignment to an instance attribute must be allowed in the following contexts:
 
 * In ``__init__``, on the instance received as the first parameter (likely, ``self``).
 * In ``__new__``, on instances of the declaring class created via a call
@@ -266,9 +270,6 @@ Additionally, a type checker may choose to allow the assignment:
   for the simplicity of implementation.)
 * In ``@classmethod``\ s, on instances of the declaring class created via
   a call to the class' or super-class' ``__new__`` method.
-
-Note that a child class cannot assign to any read-only attributes of a parent class
-in any of the aforementioned contexts, unless the attribute is redeclared.
 
 .. code-block:: python
 
@@ -332,6 +333,25 @@ in any of the aforementioned contexts, unless the attribute is redeclared.
             self.numerator, self.denominator = f.as_integer_ratio()
             return self
 
+Class Attributes
+''''''''''''''''
+
+Read-only class attributes are attributes annotated as both ``ReadOnly`` and ``ClassVar``.
+Assignment to such attributes must be allowed in the following contexts:
+
+* At declaration in the body of the class.
+* In ``__init_subclass__``, on the class object received as the first parameter (likely, ``cls``).
+
+.. code-block:: python
+
+    class URI:
+        protocol: ReadOnly[ClassVar[str]] = ""
+
+        def __init_subclass__(cls, protocol: str = "") -> None:
+            cls.foo = protocol
+
+    class File(URI, protocol="file"): ...
+
 When a class-level declaration has an initializing value, it can serve as a `flyweight <https://en.wikipedia.org/wiki/Flyweight_pattern>`_
 default for instances:
 
@@ -367,8 +387,8 @@ protocols or ABCs)::
 Subtyping
 ---------
 
-Read-only attributes are covariant. This has a few subtyping implications.
-Borrowing from :pep:`705#inheritance`:
+The inability to reassign read-only attributes makes them covariant.
+This has a few subtyping implications. Borrowing from :pep:`705#inheritance`:
 
 * Read-only attributes can be redeclared as writable attributes, descriptors
   or class variables::
@@ -493,9 +513,6 @@ Interaction with Other Type Qualifiers
 This is consistent with the interaction of ``ReadOnly`` and :class:`typing.TypedDict`
 defined in :pep:`705`.
 
-An attribute annotated as both ``ReadOnly`` and ``ClassVar`` can only be assigned to
-at declaration in the class body.
-
 An attribute cannot be annotated as both ``ReadOnly`` and ``Final``, as the two
 qualifiers differ in semantics, and ``Final`` is generally more restrictive.
 ``Final`` remains allowed as an annotation of attributes that are only implied
@@ -603,23 +620,6 @@ regard, requiring end users to manually specify a set of methods they wish
 to allow initialization in. This however could easily result in users mistakenly
 or purposefully breaking the aforementioned invariants. It is also a fairly
 big ask for a relatively niche feature.
-
-``ReadOnly[ClassVar[...]]`` and ``__init_subclass__``
------------------------------------------------------
-
-Should read-only class variables be assignable to within the declaring class'
-``__init_subclass__``?
-
-.. code-block:: python
-
-    class URI:
-        protocol: ReadOnly[ClassVar[str]] = ""
-
-        def __init_subclass__(cls, protocol: str = "") -> None:
-            cls.foo = protocol
-
-    class File(URI, protocol="file"): ...
-
 
 Footnotes
 =========

--- a/peps/pep-0767.rst
+++ b/peps/pep-0767.rst
@@ -348,7 +348,7 @@ Assignment to such attributes must be allowed in the following contexts:
         protocol: ReadOnly[ClassVar[str]] = ""
 
         def __init_subclass__(cls, protocol: str = "") -> None:
-            cls.foo = protocol
+            cls.protocol = protocol
 
     class File(URI, protocol="file"): ...
 


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4181.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->