### PR TITLE
Infra: switch 3.13-dev to 3.14-dev

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         python-version:
         - "3.x"
-        - "3.13-dev"
+        - "3.14-dev"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
3.14 is in alpha, let's dogfood.

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0745/


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4183.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->