### PR TITLE
Infra: Add nicer 404 page

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -42,7 +42,9 @@ jobs:
           python -m pip install --upgrade pip
 
       - name: Render PEPs
-        run: make dirhtml JOBS=$(nproc)
+        run: |
+          make dirhtml JOBS=$(nproc)
+          mv build/404/index.html build/404.html
 
         # remove the .doctrees folder when building for deployment as it takes two thirds of disk space
       - name: Clean up files

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -42,9 +42,7 @@ jobs:
           python -m pip install --upgrade pip
 
       - name: Render PEPs
-        run: |
-          make dirhtml JOBS=$(nproc)
-          mv build/404/index.html build/404.html
+        run: make dirhtml JOBS=$(nproc)
 
         # remove the .doctrees folder when building for deployment as it takes two thirds of disk space
       - name: Clean up files

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ htmllive: _ensure-sphinx-autobuild html
 .PHONY: dirhtml
 dirhtml: BUILDER = dirhtml
 dirhtml: html
+dirhtml: mv $(BUILDDIR)/404/index.html $(BUILDDIR)/404.html
 
 ## linkcheck      to check validity of links within PEP sources
 .PHONY: linkcheck

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ htmllive: _ensure-sphinx-autobuild html
 .PHONY: dirhtml
 dirhtml: BUILDER = dirhtml
 dirhtml: html
-dirhtml: mv $(BUILDDIR)/404/index.html $(BUILDDIR)/404.html
+	mv $(BUILDDIR)/404/index.html $(BUILDDIR)/404.html
 
 ## linkcheck      to check validity of links within PEP sources
 .PHONY: linkcheck

--- a/peps/conf.py
+++ b/peps/conf.py
@@ -19,6 +19,7 @@ master_doc = "contents"
 
 # Add any Sphinx extension module names here, as strings.
 extensions = [
+    "notfound.extension",
     "pep_sphinx_extensions",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
@@ -84,6 +85,10 @@ intersphinx_disabled_reftypes = []
 extlinks = {
     "pypi": ("https://pypi.org/project/%s/", "%s"),
 }
+
+# sphinx-notfound-page
+# https://sphinx-notfound-page.readthedocs.io/en/latest/faq.html#does-this-extension-work-with-github-pages
+notfound_urls_prefix = None
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Pygments >= 2.9.0
 # See https://github.com/sphinx-doc/sphinx/pull/11100
 Sphinx >= 5.1.1, != 6.1.0, != 6.1.1, < 8.1.0
 docutils >= 0.19.0
+sphinx-notfound-page
 
 # For tests
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Pygments >= 2.9.0
 # See https://github.com/sphinx-doc/sphinx/pull/11100
 Sphinx >= 5.1.1, != 6.1.0, != 6.1.1, < 8.1.0
 docutils >= 0.19.0
-sphinx-notfound-page
+sphinx-notfound-page >= 1.0.2
 
 # For tests
 pytest


### PR DESCRIPTION
<!--
This template is for an infra or meta change not belonging to another category.
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->


Right now if you typo a PEP (e.g. https://peps.python.org/pep-123456) you get the default GitHub Pages 404 page:

<img width="803" alt="image" src="https://github.com/user-attachments/assets/13ddc5e4-144f-4c46-8168-85ee53beaf82" />

This is an attempt to use a nicer one using our own Sphinx theme:

<img width="803" alt="image" src="https://github.com/user-attachments/assets/5bd00e38-fbc5-4cb4-b027-51f6f0eaabd0" />

I have this on my fork right now: https://hugovk.github.io/peps/pep-123456

The one difference is I have `notfound_urls_prefix = "/peps/"` in `conf.py` because it's using the github.io domain and a `peps/` subdir. See:

https://sphinx-notfound-page.readthedocs.io/en/latest/faq.html#does-this-extension-work-with-github-pages

We'll probably need to merge this to see if it works properly.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4184.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->