### PR TITLE
Infra: Remove "Contents" and source link from 404

### DIFF
--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -49,12 +49,12 @@
         <article>
             {{ body }}
         </article>
-        {%- if not pagename == "numerical" %}
+        {%- if not pagename.startswith(("404", "numerical")) %}
         <nav id="pep-sidebar">
             <h2>Contents</h2>
             {{ toc }}
             <br>
-            {%- if not pagename.startswith(("numerical", "pep-0000", "topic")) %}
+            {%- if not pagename.startswith(("pep-0000", "topic")) %}
             <a id="source" href="https://github.com/python/peps/blob/main/peps/{{pagename}}.rst">Page Source (GitHub)</a>
             {%- endif %}
         </nav>


### PR DESCRIPTION
Follow on from https://github.com/python/peps/pull/4184.

We don't need the empty "Contents" and "[Page Source (GitHub)](https://github.com/python/peps/blob/main/peps/404.rst)" (itself a 404):

<img width="847" alt="image" src="https://github.com/user-attachments/assets/60fa9bb9-4f1e-4b48-8d24-8ef12c510cbe" />

Let's remove those for 404 pages:

<img width="847" alt="image" src="https://github.com/user-attachments/assets/8dc17e1a-aa14-4b8e-98a2-7fbeaa3424b1" />

(It's also possible to adjust the title and body with config: https://sphinx-notfound-page.readthedocs.io/en/stable/configuration.html#confval-notfound_context)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4185.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->