### PR TITLE
PEP 728: Fix code block syntax

### DIFF
--- a/peps/pep-0728.rst
+++ b/peps/pep-0728.rst
@@ -258,7 +258,7 @@ If ``closed`` is not provided, the behavior is inherited from the superclass.
 If the superclass is TypedDict itself or the superclass does not have ``closed=True``
 or the ``extra_items`` parameter, the previous TypedDict behavior is preserved:
 arbitrary extra items are allowed. If the superclass has ``closed=True``, the
-child class is also closed.
+child class is also closed::
 
     class BaseMovie(TypedDict, closed=True):
         name: str


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4188.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->