### PR TITLE
PEP 769: Fix a typo

### DIFF
--- a/peps/pep-0769.rst
+++ b/peps/pep-0769.rst
@@ -266,7 +266,7 @@ simplicity and predictability.
 Tuple Return Consistency
 ------------------------
 
-Another rejected proposal was adding a a flag to always return tuple
+Another rejected proposal was adding a flag to always return tuple
 regardless of how many keys/names/indices were sourced to arguments.
 E.g.::
 


### PR DESCRIPTION
Noticed a very small typo.

I did check and it wasn't picked up in #4192.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4197.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->