### PR TITLE
PEP 745: Update 3.14.0 final release date

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -53,7 +53,7 @@ Expected:
 - 3.14.0 beta 4: Tuesday, 2025-07-08
 - 3.14.0 candidate 1: Tuesday, 2025-07-22
 - 3.14.0 candidate 2: Tuesday, 2025-08-26
-- 3.14.0 final: Wednesday, 2025-10-01
+- 3.14.0 final: Tuesday, 2025-10-07
 
 Subsequent bugfix releases every two months.
 


### PR DESCRIPTION
I'll be attending [PyCon Estonia](https://pycon.ee/) on 2-3 October, so will be unavailable for release on Wednesday 2025-10-01, so let's move it to Tuesday 2025-10-07.

This is similar to 3.13.0 final, which went out on 2024-10-07.

As it happens, 3.13.6 is also planned for Tuesday 2025-10-07.

cc:

* @doko42 @mitya57 / Debian
* @hroncok / @befeleme / Fedora / RHEL
* @mgorny / Gentoo
* @danigm @mcepl / openSUSE

Would this cause significant problems for you? Alternatively, we may be able to move it to the end of September.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4199.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->