### PR TITLE
PEP 735: Add a canonical spec link

### DIFF
--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -13,6 +13,7 @@ Resolution: `10-Oct-2024 <https://discuss.python.org/t/39233/312>`__
 
 .. canonical-pypa-spec:: :ref:`packaging:dependency-groups`
 
+
 Abstract
 ========
 

--- a/peps/pep-0735.rst
+++ b/peps/pep-0735.rst
@@ -11,6 +11,7 @@ Created: 20-Nov-2023
 Post-History: `14-Nov-2023 <https://discuss.python.org/t/29684>`__, `20-Nov-2023 <https://discuss.python.org/t/39233>`__
 Resolution: `10-Oct-2024 <https://discuss.python.org/t/39233/312>`__
 
+.. canonical-pypa-spec:: :ref:`packaging:dependency-groups`
 
 Abstract
 ========


### PR DESCRIPTION
Now that a specification document is in place on the packaging site, it is possible to update this PEP to link to it.

---

The PR templates don't seem to fit this case exactly, so I assume it's fine to make this change like so.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4209.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->