### PR TITLE
PEP 750: Small update to 'alternate layouts' section

### DIFF
--- a/peps/pep-0750.rst
+++ b/peps/pep-0750.rst
@@ -1344,30 +1344,27 @@ Alternate Layouts for ``Template``
 -----------------------------------
 
 During the development of this PEP, we considered several alternate layouts for
-the contents of ``Templates``. Many focused on a single ``args`` tuple that
-contained both strings and interpolations. Variants included:
+the ``Template`` type. Many focused on a single ``args`` tuple that contained 
+both strings and interpolations. Variants included:
 
-- Instead of ``args``, ``Template`` contains a ``strings`` attribute of type 
-  ``tuple[str, ...]`` and an ``interpolations`` attribute of type 
-  ``tuple[Interpolation, ...]``. There are zero or more interpolations and 
-  there is always one more string than there are interpolations. Utility code 
-  could build an interleaved tuple of strings and interpolations from these 
-  separate attributes. This was rejected as being overly complex.
+- ``args`` was a ``tuple[str | Interpolation, ...]``` with the promise that
+  its first and last items were strings and that strings and interpolations 
+  always alternated. This implied that ``args`` was always non-empty and that 
+  empty strings would be inserted between neighboring interpolations. This was
+  rejected because alternation could not be captured by the type system and was
+  not a guarantee we wished to make.
 
-- ``args`` is typed as a ``Sequence[tuple[str, Interpolation | None]]``. Each
-  static string is paired with is neighboring interpolation. The final
-  string part has no corresponding interpolation. This was rejected as being
+- ``args`` remained a ``tuple[str | Interpolation, ...]`` but did not support
+  interleaving. As a result, empty strings were not added to the sequence. It 
+  was no longer possible to obtain static strings with ``args[::2]``; instead,
+  instance checks or structural pattern matching had to be used to distinguish
+  between strings and interpolations. This approach was rejected as offering
+  less future opportunity for performance optimization.
+
+- ``args`` was typed as a ``Sequence[tuple[str, Interpolation | None]]``. Each
+  static string was paired with is neighboring interpolation. The final
+  string part had no corresponding interpolation. This was rejected as being
   overly complex.
-
-- ``args`` remains a ``tuple[str | Interpolation, ...]`` but does not support
-  interleaving. As a result, empty strings are not added to the sequence. It is
-  no longer possible to obtain static strings with ``args[::2]``; instead,
-  instance checks or structural pattern matching must be used to distinguish
-  between strings and interpolations. We believe this approach is easier to
-  explain and, at first glance, more intuitive. However, it was rejected as
-  offering less future opportunty for performance optimization. We also believe
-  that ``args[::2]`` may prove to be a useful shortcut in template processing
-  code.
 
 
 Mechanism to Describe the "Kind" of Template


### PR DESCRIPTION
After merging our [big PR](https://github.com/python/peps/pull/4124) yesterday I noticed that the "Alternate layouts" section was out of date. I've updated it to reflect the correct past history of layouts for the `Template` type.

@AA-Turner Assuming the change looks good, we're happy to merge.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4210.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->