### PR TITLE
PEP 751: Ensure consistent "packages" table name

### DIFF
--- a/peps/pep-0751.rst
+++ b/peps/pep-0751.rst
@@ -245,12 +245,12 @@ order. Usage of inline tables SHOULD also be kept consistent.
 
 .. Source
 
-``[packaging.vcs]``
+``[packages.vcs]``
 -------------------
 
 - **Type**: table
-- **Required?**: no; mutually-exclusive with ``packaging.directory``,
-  ``packaging.archive``, ``packaging.sdist``, and ``packaging.wheels``
+- **Required?**: no; mutually-exclusive with ``packages.directory``,
+  ``packages.archive``, ``packages.sdist``, and ``packages.wheels``
 - **Inspiration**: :ref:`packaging:direct-url-data-structure`
 - Record the version control system details for the
   :ref:`source tree <packaging:source-distribution-format-source-tree>` it
@@ -261,7 +261,7 @@ order. Usage of inline tables SHOULD also be kept consistent.
   systems.
 
 
-``packaging.vcs.type``
+``packages.vcs.type``
 ''''''''''''''''''''''
 
 - **Type**: string; supported values specified in
@@ -271,7 +271,7 @@ order. Usage of inline tables SHOULD also be kept consistent.
 - The type of version control system used.
 
 
-``packaging.vcs.url``
+``packages.vcs.url``
 '''''''''''''''''''''
 
 - **Type**: string
@@ -280,7 +280,7 @@ order. Usage of inline tables SHOULD also be kept consistent.
 - The URL to the source tree.
 
 
-``packaging.vcs.path``
+``packages.vcs.path``
 ''''''''''''''''''''''
 
 - **Type**: string
@@ -292,7 +292,7 @@ order. Usage of inline tables SHOULD also be kept consistent.
   for portability.
 
 
-``packaging.vcs.requested-revision``
+``packages.vcs.requested-revision``
 ''''''''''''''''''''''''''''''''''''
 
 - **Type**: string
@@ -304,7 +304,7 @@ order. Usage of inline tables SHOULD also be kept consistent.
   the repository.
 
 
-``packaging.vcs.commit-id``
+``packages.vcs.commit-id``
 '''''''''''''''''''''''''''
 
 - **Type**: string
@@ -316,7 +316,7 @@ order. Usage of inline tables SHOULD also be kept consistent.
   the source code.
 
 
-``packaging.vcs.subdirectory``
+``packages.vcs.subdirectory``
 ''''''''''''''''''''''''''''''
 
 - **Type**: string
@@ -329,12 +329,12 @@ order. Usage of inline tables SHOULD also be kept consistent.
 - The path MUST be relative to the root of the source tree structure.
 
 
-``[packaging.directory]``
+``[packages.directory]``
 -------------------------
 
 - **Type**: table
-- **Required?**: no; mutually-exclusive with ``packaging.vcs``,
-  ``packaging.archive``, ``packaging.sdist``, and ``packaging.wheels``
+- **Required?**: no; mutually-exclusive with ``packages.vcs``,
+  ``packages.archive``, ``packages.sdist``, and ``packages.wheels``
 - **Inspiration**: :ref:`packaging:direct-url-data-structure-local-directory`
 - Record the local directory details for the
   :ref:`source tree <packaging:source-distribution-format-source-tree>` it
@@ -344,7 +344,7 @@ order. Usage of inline tables SHOULD also be kept consistent.
 - Tools SHOULD provide a way for users to opt out of using local directories.
 
 
-``packaging.directory.path``
+``packages.directory.path``
 ''''''''''''''''''''''''''''
 
 - **Type**: string
@@ -356,7 +356,7 @@ order. Usage of inline tables SHOULD also be kept consistent.
   portability.
 
 
-``packaging.directory.editable``
+``packages.directory.editable``
 ''''''''''''''''''''''''''''''''
 
 - **Type**: boolean
@@ -365,13 +365,13 @@ order. Usage of inline tables SHOULD also be kept consistent.
 - A flag representing whether the source tree should be installed as editable.
 
 
-``packaging.directory.subdirectory``
+``packages.directory.subdirectory``
 ''''''''''''''''''''''''''''''''''''
 
-See ``packaging.vcs.subdirectory``.
+See ``packages.vcs.subdirectory``.
 
 
-``[packaging.archive]``
+``[packages.archive]``
 -----------------------
 
 - **Type**: table
@@ -384,19 +384,19 @@ See ``packaging.vcs.subdirectory``.
 - Tools SHOULD provide a way for users to opt out of using archive files.
 
 
-``packaging.archive.url``
+``packages.archive.url``
 '''''''''''''''''''''''''
 
-See ``packaging.vcs.url``.
+See ``packages.vcs.url``.
 
 
-``packaging.archive.path``
+``packages.archive.path``
 ''''''''''''''''''''''''''
 
-See ``packaging.vcs.path``.
+See ``packages.vcs.path``.
 
 
-``packaging.archive.size``
+``packages.archive.size``
 ''''''''''''''''''''''''''
 
 - **Type**: integer
@@ -405,7 +405,7 @@ See ``packaging.vcs.path``.
 - The size of the archive file.
 
 
-``[packaging.archive.hashes]``
+``[packages.archive.hashes]``
 ''''''''''''''''''''''''''''''
 
 - **Type**: Table of strings
@@ -420,10 +420,10 @@ See ``packaging.vcs.path``.
   recommended.
 
 
-``packaging.archive.subdirectory``
+``packages.archive.subdirectory``
 ''''''''''''''''''''''''''''''''''
 
-See ``packaging.vcs.subdirectory``.
+See ``packages.vcs.subdirectory``.
 
 
 ``packages.index``
@@ -442,8 +442,8 @@ See ``packaging.vcs.subdirectory``.
 --------------------
 
 - **Type**: table
-- **Required?**: no; mutually-exclusive with ``packaging.vcs``,
-  ``packaging.directory``, and ``packaging.archive``
+- **Required?**: no; mutually-exclusive with ``packages.vcs``,
+  ``packages.directory``, and ``packages.archive``
 - **Inspiration**: uv_
 - Details of a :ref:`packaging:source-distribution-format-sdist` for the
   package.
@@ -476,25 +476,25 @@ See ``packaging.vcs.subdirectory``.
 ``packages.sdist.url``
 ''''''''''''''''''''''
 
-See ``packaging.archive.url``.
+See ``packages.archive.url``.
 
 
 ``packages.sdist.path``
 '''''''''''''''''''''''
 
-See ``packaging.archive.path``.
+See ``packages.archive.path``.
 
 
 ``packages.sdist.size``
 '''''''''''''''''''''''
 
-See ``packaging.archive.size``.
+See ``packages.archive.size``.
 
 
 ``packages.sdist.hashes``
 '''''''''''''''''''''''''
 
-See ``packaging.archive.hashes``.
+See ``packages.archive.hashes``.
 
 
 
@@ -502,8 +502,8 @@ See ``packaging.archive.hashes``.
 -----------------------
 
 - **Type**: array of tables
-- **Required?**: no; mutually-exclusive with ``packaging.vcs``,
-  ``packaging.directory``, and ``packaging.archive``
+- **Required?**: no; mutually-exclusive with ``packages.vcs``,
+  ``packages.directory``, and ``packages.archive``
 - **Inspiration**: PDM_, Poetry_, uv_
 - For recording the wheel files as specified by
   :ref:`packaging:binary-distribution-format` for the package.
@@ -529,25 +529,25 @@ See ``packages.sdist.upload-time``.
 ``packages.wheels.url``
 '''''''''''''''''''''''
 
-See ``packaging.archive.url``.
+See ``packages.archive.url``.
 
 
 ``packages.wheels.path``
 ''''''''''''''''''''''''
 
-See ``packaging.archive.path``.
+See ``packages.archive.path``.
 
 
 ``packages.wheels.size``
 ''''''''''''''''''''''''
 
-See ``packaging.archive.size``.
+See ``packages.archive.size``.
 
 
 ``packages.wheels.hashes``
 ''''''''''''''''''''''''''
 
-See ``packaging.archive.hashes``.
+See ``packages.archive.hashes``.
 
 
 
@@ -816,7 +816,7 @@ At one point, to handle the issue of metadata varying between files and thus
 require examining every released file for a package and version for accurate
 locking results, the idea was floated to introduce a new core metadata version
 which would require all metadata for all wheel files be the same for a single
-version of a packages. Ultimately, though, it was deemed unnecessary as this PEP
+version of a package. Ultimately, though, it was deemed unnecessary as this PEP
 will put pressure on people to make files consistent for performance reasons or
 to make indexes provide all the metadata separate from the wheel files
 themselves. As well, there's no easy enforcement mechanism, and so community
@@ -1046,7 +1046,7 @@ although the chances are people will expect it to be implemented as it shouldn't
 increase the complexity of an installer drastically.
 
 
-Make ``packaging.wheels`` a table
+Make ``packages.wheels`` a table
 =================================
 
 One could see writing out wheel file details as a table keyed on the file name.


### PR DESCRIPTION
Several parts of the specification referred to a `[[packaging]]` array of tables, which presumably should refer to `[[packages]]` etc. (There's no attempt to describe a separate top-level `[[packaging]]`.)

Searched and replaced these mentions.

Also fixed a typo ("packages" -> "package") noticed while verifying the search-and-replace result.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4212.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->