### PR TITLE
PEP 11: Promote aarch64-unknown-linux-gnu (gcc, glibc) to tier-1

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -77,15 +77,16 @@ Tier 1
   platforms, working.
 - Failures on these platforms **block a release**.
 
-======================== =====
-Target Triple            Notes
-======================== =====
-aarch64-apple-darwin     clang
+========================= =====
+Target Triple             Notes
+========================= =====
+aarch64-apple-darwin      clang
+aarch64-unknown-linux-gnu glibc, gcc
 i686-pc-windows-msvc
 x86_64-pc-windows-msvc
-x86_64-apple-darwin      BSD libc, clang
-x86_64-unknown-linux-gnu glibc, gcc
-======================== =====
+x86_64-apple-darwin       BSD libc, clang
+x86_64-unknown-linux-gnu  glibc, gcc
+========================= =====
 
 
 Tier 2
@@ -101,9 +102,7 @@ Tier 2
 ============================= ========================== ========
 Target Triple                 Notes                      Contacts
 ============================= ========================== ========
-aarch64-unknown-linux-gnu     glibc, gcc                 Petr Viktorin, Victor Stinner
-
-                              glibc, clang               Victor Stinner, Gregory P. Smith
+aarch64-unknown-linux-gnu     glibc, clang               Victor Stinner, Gregory P. Smith
 wasm32-unknown-wasip1         WASI SDK, Wasmtime         Brett Cannon, Eric Snow
 x86_64-unknown-linux-gnu      glibc, clang               Victor Stinner, Gregory P. Smith
 ============================= ========================== ========


### PR DESCRIPTION

As promised in Discourse (https://discuss.python.org/t/pep-11-proposal-to-promote-aarch64-plaftorms-to-tier-1/44774/29) this is the PR to promote `aarch64-unknown-linux-gnu` to Tier-1.
Since we enabled Arm runners on Github, we haven't seen any issue with those hence the promotion to Tier 1.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4215.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->