### PR TITLE
PEP 739: put base_prefix above base_interpreter

### DIFF
--- a/peps/pep-0739/example.json
+++ b/peps/pep-0739/example.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
-  "base_interpreter": "/usr/bin/python",
   "base_prefix": "/usr",
+  "base_interpreter": "/usr/bin/python",
   "platform": "linux-x86_64",
   "language": {
     "version": "3.14",


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4221.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->