### PR TITLE
PEP 639: Mark as Final

### DIFF
--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -5,7 +5,7 @@ Author: Philippe Ombredanne <pombredanne@nexb.com>,
         Karolina Surma <karolina.surma@gazeta.pl>,
 PEP-Delegate: Brett Cannon <brett@python.org>
 Discussions-To: https://discuss.python.org/t/53020
-Status: Provisional
+Status: Final
 Type: Standards Track
 Topic: Packaging
 Created: 15-Aug-2019
@@ -14,16 +14,7 @@ Post-History: `15-Aug-2019 <https://discuss.python.org/t/2154>`__,
               `10-May-2024 <https://discuss.python.org/t/53020>`__,
 Resolution: https://discuss.python.org/t/53020/106
 
-
-Provisional Acceptance
-======================
-
-This PEP has been **provisionally accepted**,
-with the following required conditions before the PEP is made Final:
-
-1. An implementation of the PEP in two build back-ends.
-2. An implementation of the PEP in PyPI.
-
+.. canonical-pypa-spec:: :ref:`core-metadata`
 
 .. _639-abstract:
 

--- a/peps/pep-0639.rst
+++ b/peps/pep-0639.rst
@@ -14,7 +14,9 @@ Post-History: `15-Aug-2019 <https://discuss.python.org/t/2154>`__,
               `10-May-2024 <https://discuss.python.org/t/53020>`__,
 Resolution: https://discuss.python.org/t/53020/106
 
+
 .. canonical-pypa-spec:: :ref:`core-metadata`
+
 
 .. _639-abstract:
 

--- a/peps/pep-0639/appendix-examples.rst
+++ b/peps/pep-0639/appendix-examples.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. canonical-pypa-spec:: :ref:`licensing-examples-and-user-scenarios`
+
 Appendix: Licensing Examples
 ============================
 

--- a/peps/pep-0639/appendix-user-scenarios.rst
+++ b/peps/pep-0639/appendix-user-scenarios.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. canonical-pypa-spec:: :ref:`licensing-examples-and-user-scenarios`
+
 Appendix: User Scenarios
 ========================
 


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [x] Any substantial changes since the accepted version approved by the SC/PEP delegate (no changes)
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive 
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4227.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->