### PR TITLE
Infra: only create peps.json at /api/peps.json

### DIFF
--- a/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
+++ b/pep_sphinx_extensions/pep_zero_generator/pep_index_generator.py
@@ -55,7 +55,6 @@ def create_pep_json(peps: list[parser.PEP]) -> str:
 def write_peps_json(peps: list[parser.PEP], path: Path) -> None:
     # Create peps.json
     json_peps = create_pep_json(peps)
-    Path(path, "peps.json").write_text(json_peps, encoding="utf-8")
     os.makedirs(os.path.join(path, "api"), exist_ok=True)
     Path(path, "api", "peps.json").write_text(json_peps, encoding="utf-8")
 


### PR DESCRIPTION
Re: https://github.com/python/peps/issues/2584#issuecomment-1758957285

The API should only be available at https://peps.python.org/api/peps.json and not the root https://peps.python.org/peps.json.

We advertise https://peps.python.org/api/peps.json at https://peps.python.org/#api and https://peps.python.org/api/, and a GitHub code search only shows this one in use and not the incorrect one.