### PR TITLE
Remove trailing slashes from intersphinx inventory URLs

### DIFF
--- a/peps/conf.py
+++ b/peps/conf.py
@@ -66,16 +66,16 @@ del role, name
 
 # Intersphinx configuration (keep this in alphabetical order)
 intersphinx_mapping = {
-    "devguide": ("https://devguide.python.org/", None),
-    "mypy": ("https://mypy.readthedocs.io/en/latest/", None),
-    "packaging": ("https://packaging.python.org/en/latest/", None),
-    "py3.11": ("https://docs.python.org/3.11/", None),
-    "py3.12": ("https://docs.python.org/3.12/", None),
-    "py3.13": ("https://docs.python.org/3.13/", None),
-    "py3.14": ("https://docs.python.org/3.14/", None),
-    "python": ("https://docs.python.org/3/", None),
-    "trio": ("https://trio.readthedocs.io/en/latest/", None),
-    "typing": ("https://typing.readthedocs.io/en/latest/", None),
+    "devguide": ("https://devguide.python.org", None),
+    "mypy": ("https://mypy.readthedocs.io/en/latest", None),
+    "packaging": ("https://packaging.python.org/en/latest", None),
+    "py3.11": ("https://docs.python.org/3.11", None),
+    "py3.12": ("https://docs.python.org/3.12", None),
+    "py3.13": ("https://docs.python.org/3.13", None),
+    "py3.14": ("https://docs.python.org/3.14", None),
+    "python": ("https://docs.python.org/3", None),
+    "trio": ("https://trio.readthedocs.io/en/latest", None),
+    "typing": ("https://typing.readthedocs.io/en/latest", None),
 }
 intersphinx_disabled_reftypes = []
 


### PR DESCRIPTION
From the Sphinx output:

```sh
loading intersphinx inventory 'devguide' from https://devguide.python.org//objects.inv ...
loading intersphinx inventory 'mypy' from https://mypy.readthedocs.io/en/latest//objects.inv ...
loading intersphinx inventory 'packaging' from https://packaging.python.org/en/latest//objects.inv ...
loading intersphinx inventory 'py3.11' from https://docs.python.org/3.11//objects.inv ...
loading intersphinx inventory 'py3.12' from https://docs.python.org/3.12//objects.inv ...
loading intersphinx inventory 'py3.13' from https://docs.python.org/3.13//objects.inv ...
loading intersphinx inventory 'py3.14' from https://docs.python.org/3.14//objects.inv ...
loading intersphinx inventory 'python' from https://docs.python.org/3//objects.inv ...
loading intersphinx inventory 'trio' from https://trio.readthedocs.io/en/latest//objects.inv ...
loading intersphinx inventory 'typing' from https://typing.readthedocs.io/en/latest//objects.inv ...
intersphinx inventory has moved: https://packaging.python.org/en/latest//objects.inv -> https://packaging.python.org/en/latest/objects.inv
intersphinx inventory has moved: https://typing.readthedocs.io/en/latest//objects.inv -> https://typing.readthedocs.io/en/latest/objects.inv
intersphinx inventory has moved: https://mypy.readthedocs.io/en/latest//objects.inv -> https://mypy.readthedocs.io/en/latest/objects.inv
intersphinx inventory has moved: https://trio.readthedocs.io/en/latest//objects.inv -> https://trio.readthedocs.io/en/latest/objects.inv
```

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4239.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->