### PR TITLE
PEP 3146: Fix Sphinx reference warning

### DIFF
--- a/peps/pep-3146.rst
+++ b/peps/pep-3146.rst
@@ -1,13 +1,10 @@
 PEP: 3146
 Title: Merging Unladen Swallow into CPython
-Version: $Revision$
-Last-Modified: $Date$
 Author: Collin Winter <collinwinter@google.com>,
         Jeffrey Yasskin <jyasskin@google.com>,
         Reid Kleckner <rnk@mit.edu>
 Status: Withdrawn
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 01-Jan-2010
 Python-Version: 3.3
 Post-History:
@@ -1296,8 +1293,7 @@ References
 .. [#rubinius]
    http://rubini.us/
 
-.. [#parrot-on-llvm]
-   http://lists.parrot.org/pipermail/parrot-dev/2009-September/002811.html
+* https://lists.parrot.org/pipermail/parrot-dev/2009-September/002811.html
 
 .. [#macruby]
    http://www.macruby.org/
@@ -1478,15 +1474,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:
-
-
-


### PR DESCRIPTION
For https://github.com/python/peps/issues/4087.

The reference was added in https://github.com/python/peps/commit/b3dd94c365a3ec92501cbf5305e26709d3b49cb9 when the PEP was added, and never referenced in the text.

This PR turns it into a bullet point to remove the warning.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4240.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->