### PR TITLE
PEP 3141: Fix Sphinx reference warning

### DIFF
--- a/peps/pep-3141.rst
+++ b/peps/pep-3141.rst
@@ -1,11 +1,8 @@
 PEP: 3141
 Title: A Type Hierarchy for Numbers
-Version: $Revision$
-Last-Modified: $Date$
 Author: Jeffrey Yasskin <jyasskin@google.com>
 Status: Final
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 23-Apr-2007
 Python-Version: 3.0
 Post-History: 25-Apr-2007, 16-May-2007, 02-Aug-2007
@@ -519,8 +516,8 @@ tower.
 References
 ==========
 
-.. [#classtree] Possible Python 3K Class Tree?, wiki page by Bill Janssen
-   (http://wiki.python.org/moin/AbstractBaseClasses)
+* Possible Python 3K Class Tree?, wiki page by Bill Janssen
+   (https://wiki.python.org/moin/AbstractBaseClasses)
 
 .. [#numericprelude] NumericPrelude: An experimental alternative hierarchy
    of numeric type classes
@@ -544,14 +541,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
For https://github.com/python/peps/issues/4087.

The reference was added in https://github.com/python/peps/commit/66baf214a23fb052bb26527419771be9ee02e259 but never referenced in the text.

This PR turns it into a bullet point to remove the warning.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4241.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->