### PR TITLE
PEP 3126: Fix Sphinx reference warning

### DIFF
--- a/peps/pep-3126.rst
+++ b/peps/pep-3126.rst
@@ -1,12 +1,9 @@
 PEP: 3126
 Title: Remove Implicit String Concatenation
-Version: $Revision$
-Last-Modified: $Date$
 Author: Jim J. Jewett <JimJJewett@gmail.com>,
         Raymond Hettinger <python@rcn.com>
 Status: Rejected
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 29-Apr-2007
 Post-History: 29-Apr-2007, 30-Apr-2007, 07-May-2007
 
@@ -109,7 +106,7 @@ Calls to this function can silently do the wrong thing::
     g("arg1 on this line"
       "arg2 on this line")
 
-To quote Jason Orendorff [#Orendorff]
+To quote Jason Orendorff [#Orendorff]_:
 
     Oh.  I just realized this happens a lot out here.  Where I work,
     we use scons, and each SConscript has a long list of filenames::
@@ -374,14 +371,3 @@ Copyright
 =========
 
     This document has been placed in the public domain.
-
-
-
-..
-    Local Variables:
-    mode: indented-text
-    indent-tabs-mode: nil
-    sentence-end-double-space: t
-    fill-column: 70
-    coding: utf-8
-    End:


### PR DESCRIPTION
For https://github.com/python/peps/issues/4087.

The reference here is mentioned in the text, but was missing an underscore. Also, not needed to fix the ref, editorially added a colon.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4242.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->