### PR TITLE
PEP 3108: Fix Sphinx reference warning

### DIFF
--- a/peps/pep-3108.rst
+++ b/peps/pep-3108.rst
@@ -1,11 +1,8 @@
 PEP: 3108
 Title: Standard Library Reorganization
-Version: $Revision$
-Last-Modified: $Date$
 Author: Brett Cannon <brett@python.org>
 Status: Final
 Type: Standards Track
-Content-Type: text/x-rst
 Created: 01-Jan-2007
 Python-Version: 3.0
 Post-History: 28-Apr-2008
@@ -1128,17 +1125,11 @@ been chosen as the guiding force for PEPs to create.
 References
 ==========
 
-.. [#module-index] Python Documentation: Global Module Index
-    (http://docs.python.org/modindex.html)
-
 .. [#silly-old-stuff] Python-Dev email: "Py3k release schedule worries"
     (https://mail.python.org/pipermail/python-3000/2006-December/005130.html)
 
 .. [#thread-deprecation] Python-Dev email: Autoloading?
     (https://mail.python.org/pipermail/python-dev/2005-October/057244.html)
-
-.. [#py-dev-summary-2004-11-01] Python-Dev Summary: 2004-11-01
-    (http://www.python.org/dev/summary/2004-11-01_2004-11-15/#id10)
 
 .. [#2to3] 2to3 refactoring tool
     (http://svn.python.org/view/sandbox/trunk/2to3/)
@@ -1159,9 +1150,6 @@ References
 .. [#irix-forms] FORMS Library by Mark Overmars
     (ftp://ftp.cs.ruu.nl/pub/SGI/FORMS)
 
-.. [#sun-au] Wikipedia: Au file format
-    (http://en.wikipedia.org/wiki/Au_file_format)
-
 .. [#appscript] appscript
     (http://appscript.sourceforge.net/)
 
@@ -1179,14 +1167,3 @@ Copyright
 =========
 
 This document has been placed in the public domain.
-
-
-
-..
-   Local Variables:
-   mode: indented-text
-   indent-tabs-mode: nil
-   sentence-end-double-space: t
-   fill-column: 70
-   coding: utf-8
-   End:


### PR DESCRIPTION
For https://github.com/python/peps/issues/4087.

These references were all used at some point, then their uses were later removed but the refs left intact. We can remove them now:

* module-index: https://github.com/python/peps/commit/ea3b5e5b6413db13cbc07e350eb1214c79001701
* py-dev-summary-2004-11-01: https://github.com/python/peps/commit/6099923396b1158bb6cc2b1c832071e7d0fbfe4c
* twisted: https://github.com/python/peps/commit/6099923396b1158bb6cc2b1c832071e7d0fbfe4c
* sun-au: https://github.com/python/peps/commit/f0e39dc4ce0860284357b27a30529c70905192e1



<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4243.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->