### PR TITLE
PEP 499: Fix 404 mail.python.org link

### DIFF
--- a/peps/pep-0499.rst
+++ b/peps/pep-0499.rst
@@ -229,7 +229,7 @@ References
 
 .. _issue 19702: http://bugs.python.org/issue19702
 
-.. _I tripped over this issue: https://mail.python.org/pipermail/python-list/2015-August/694905.html
+.. _I tripped over this issue: https://web.archive.org/web/20180715040816/https://mail.python.org/pipermail/python-list/2015-August/694905.html
 
 
 Copyright

--- a/peps/pep-0499.rst
+++ b/peps/pep-0499.rst
@@ -229,7 +229,7 @@ References
 
 .. _issue 19702: http://bugs.python.org/issue19702
 
-.. _I tripped over this issue: https://web.archive.org/web/20180715040816/https://mail.python.org/pipermail/python-list/2015-August/694905.html
+.. _I tripped over this issue: https://mail.python.org/pipermail/python-list/2015-August/845302.html
 
 
 Copyright


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4245.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->