### PR TITLE
Withdraw PEP 759

### DIFF
--- a/peps/pep-0759.rst
+++ b/peps/pep-0759.rst
@@ -8,8 +8,8 @@ Status: Withdrawn
 Type: Standards Track
 Topic: Packaging
 Created: 01-Oct-2024
-Resolution: `2025-01-31 <TBD>`_
-Post-History:
+Post-History: 10-Oct-2024, 31-Jan-2025
+Resolution: `31-Jan-2025 <TBD>`__
 
 Abstract
 ========

--- a/peps/pep-0759.rst
+++ b/peps/pep-0759.rst
@@ -4,10 +4,11 @@ Author: Barry Warsaw <barry@python.org>,
         Emma Harper Smith <emma@python.org>
 PEP-Delegate: Donald Stufft <donald@python.org>
 Discussions-To: https://discuss.python.org/t/pep-759-external-wheel-hosting/66458
-Status: Draft
+Status: Withdrawn
 Type: Standards Track
 Topic: Packaging
 Created: 01-Oct-2024
+Resolution: `2025-01-31 <TBD>`_
 Post-History:
 
 Abstract
@@ -29,6 +30,19 @@ files affect the metadata returned for a package's :ref:`Simple Repository API
 <packaging:simple-repository-api>`
 in both HTML and JSON formats, and how traditional wheels can easily be turned
 into ``.rim`` files.
+
+PEP withdrawn
+=============
+
+This PEP was withdrawn by the authors on 2025-01-31.  Our reading of the sentiment in the discussion
+thread is that, while the problems this PEP attempts to solve are valid, most folks would prefer a
+different approach.  Specifically, our read is that most users would prefer more control over the
+ability to specify multiple indexes, how those indexes interoperate, and the priority and trust
+assertions for those indexes.  For example, solutions such as :pep:`766` may provide a better way
+forward.  Existing stop gap measures (e.g. PyPI limit increase requests and the `"wheel-stub"
+<https://pypi.org/project/wheel-stub/>`_ approach) are sufficient -- if not ideal -- in the
+meantime.  The authors wish to thank everyone who contributed to the constructive discussion, and
+especially those who showed their support for this PEP, both in public and private.
 
 Rationale
 =========

--- a/peps/pep-0759.rst
+++ b/peps/pep-0759.rst
@@ -9,7 +9,7 @@ Type: Standards Track
 Topic: Packaging
 Created: 01-Oct-2024
 Post-History: 10-Oct-2024, 31-Jan-2025
-Resolution: `31-Jan-2025 <TBD>`__
+Resolution: `31-Jan-2025 <https://discuss.python.org/t/pep-759-external-wheel-hosting/66458/48>`__
 
 Abstract
 ========


### PR DESCRIPTION
After discussion among the authors @emmatyping and myself, we have decided to withdraw PEP 759.  This PR changes the `Status` to `Withdrawn`, include a `PEP withdrawn` section for the withdrawal rationale, and and *incomplete* `Resolution` header.

I'm setting this PR to Draft to prevent merging until I have a chance to post on the DPO thread that the PEP is withdrawn.  Then I'll update the `Resolution` header with the link, and merge the PR.  However, please do review for copyediting purposes.  Thanks!

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4248.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->