### PR TITLE
PEP 738: Better specify platform tags

### DIFF
--- a/peps/pep-0738.rst
+++ b/peps/pep-0738.rst
@@ -358,6 +358,18 @@ the wheel was compiled. Installation tools such as pip should interpret this in
 a similar way to the existing macOS tags, i.e. an app with a minimum API level
 of N can incorporate wheels tagged with API level N or older.
 
+* The lowest possible value for this component is ``"21"``;
+* There is no upper bound.
+
+The ``<abi>`` must be one of the supported architectures in `Architectures`_,
+normalized to conform to :pep:`491` by replacing runs of non-alphanumeric
+characters with an underscore. Thus there are four valid ``<abi>`` components:
+
+* ``armeabi_v7a``
+* ``arm64_v8a``
+* ``x86``
+* ``x86_64``
+
 This format originates from the Chaquopy project, which currently maintains a
 `wheel repository <https://chaquo.com/pypi-13.1/>`__ with tags varying between
 API levels 16 and 21.
@@ -372,8 +384,8 @@ builds to their CI and release tooling. Adding Android support to tools like
 `crossenv <https://crossenv.readthedocs.io/>`__ and `cibuildwheel
 <https://cibuildwheel.readthedocs.io/>`__ may be one way to achieve this.
 
-The Android wheel tag format should also be added to the list of tags accepted
-by PyPI.
+The tag format for these Android platforms MUST be permitted as valid wheel
+platform tags for a package index.
 
 
 PEP 11 Update


### PR DESCRIPTION
Found this when working on https://github.com/pypi/warehouse/issues/17549:

* Better specify the upper/lower bounds for the API version;
* Explain that the architectures must be normalized to be included in valid wheel tags;
* Strengthen the requirement that package indices must add support;

cc @mhsmith @encukou.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4250.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->