### PR TITLE
PEP 2026: Mark as Rejected

### DIFF
--- a/peps/pep-2026.rst
+++ b/peps/pep-2026.rst
@@ -2,11 +2,12 @@ PEP: 2026
 Title: Calendar versioning for Python
 Author: Hugo van Kemenade
 Discussions-To: https://discuss.python.org/t/pep-2026-calendar-versioning-for-python/55782
-Status: Draft
+Status: Rejected
 Type: Process
 Created: 11-Jun-2024
 Python-Version: 3.26
 Post-History: `14-Jun-2024 <https://discuss.python.org/t/pep-2026-calendar-versioning-for-python/55782>`__
+Resolution: https://discuss.python.org/t/pep-2026-calendar-versioning-for-python/55782/126
 
 
 Abstract


### PR DESCRIPTION
* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` link points directly to SC/PEP Delegate official acceptance/rejected post
* [x] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4258.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->