### PR TITLE
PEP 693, 719: 3.12.9 and 3.13.1 released 2025-02-04

### DIFF
--- a/peps/pep-0693.rst
+++ b/peps/pep-0693.rst
@@ -65,10 +65,10 @@ Actual:
 - 3.12.6: Friday, 2024-09-06
 - 3.12.7: Tuesday, 2024-10-01
 - 3.12.8: Tuesday, 2024-12-03
+- 3.12.9: Tuesday, 2025-02-04
 
 Expected:
 
-- 3.12.9: Tuesday, 2025-02-04
 - 3.12.10: Tuesday, 2025-04-08
 
 Source-only security fix releases

--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -52,13 +52,13 @@ Actual:
 - 3.13.0 candidate 3: Tuesday, 2024-10-01
 - 3.13.0 final: Monday, 2024-10-07
 - 3.13.1: Tuesday, 2024-12-03
+- 3.13.2: Tuesday, 2025-02-04
 
 Bugfix releases
 ---------------
 
 Expected:
 
-- 3.13.2: Tuesday, 2025-02-04
 - 3.13.3: Tuesday, 2025-04-08
 - 3.13.4: Tuesday, 2025-06-03
 - 3.13.5: Tuesday, 2025-08-05


### PR DESCRIPTION
* https://discuss.python.org/t/python-3-13-2-and-3-12-9-now-available/79509
* https://www.python.org/downloads/release/python-3129/
* https://www.python.org/downloads/release/python-3132/


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4265.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->