### PR TITLE
Update pep-0515.rst

### DIFF
--- a/peps/pep-0515.rst
+++ b/peps/pep-0515.rst
@@ -67,7 +67,7 @@ For floating-point and complex literals::
    digitpart: digit (["_"] digit)*
    fraction: "." digitpart
    exponent: ("e" | "E") ["+" | "-"] digitpart
-   imagnumber: (floatnumber | digitpart) ("j" | "J")
+   imagnumber: (floatnumber | digitpart) ("j" | "J" | "ⅈ" | "ⅉ" | "𝑖")
 
 Constructors
 ------------


### PR DESCRIPTION
Support Unicode imaginary signs,

https://codepoints.net/U+2148, https://codepoints.net/U+2149

https://discourse.julialang.org/t/what-is-the-unicode-for-the-number-i-the-imaginary-unit-of-the-complex-numbers/30904

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [x] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* ``PEP 515: Underscores in Numeric Literals``
