### PR TITLE
PEP 11: Add zlib less builds unsupported entry

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -371,9 +371,9 @@ No-longer-supported platforms
   | Unsupported in:   Python 3.13
   | Code removed in:  Unknown
 
-* | Name:             Systems without `zlib`, except WASI
+* | Name:             Systems without zlib, except WASI
   | Unsupported in:   Python 3.14
-  | Code removed in:  Unknown (see `Lib/test/test_zlib.py` for details)
+  | Code removed in:  Unknown (see ``Lib/test/test_zlib.py`` for details)
 
 
 Discussions

--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -371,6 +371,10 @@ No-longer-supported platforms
   | Unsupported in:   Python 3.13
   | Code removed in:  Unknown
 
+* | Name:             Systems without `zlib`, except WASI
+  | Unsupported in:   Python 3.14
+  | Code removed in:  Unknown (see `Lib/test/test_zlib.py` for details)
+
 
 Discussions
 ===========


### PR DESCRIPTION
Once https://github.com/python/cpython/pull/130297 is complete. (soon)

Previous discussion: [Discuss](https://discuss.python.org/t/lets-make-zlib-required-rather-than-optional-to-build-cpython/), https://github.com/python/cpython/pull/32043

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [ ] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4276.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->