### PR TITLE
PEP 693: 3.12.10 is final planned bugfix release

### DIFF
--- a/peps/pep-0693.rst
+++ b/peps/pep-0693.rst
@@ -81,7 +81,7 @@ Provided irregularly on an as-needed basis until October 2028.
 
 3.12 will receive bugfix updates approximately every 2 months for
 approximately 18 months.  Some time after the release of 3.13.0 final,
-the ninth and final 3.12 bugfix update will be released.  After that,
+the tenth and final 3.12 bugfix update will be released.  After that,
 it is expected that security updates (source only) will be released
 until 5 years after the release of 3.12.0 final, so until approximately
 October 2028.


### PR DESCRIPTION
3.12.6 was an extra odd-month release between the regularly scheduled even-month releases, so we'll be going up to 10.

https://peps.python.org/pep-0693/#bugfix-releases


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4280.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->