### PR TITLE
PEP 775: Make zlib required to build CPython

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -653,7 +653,7 @@ peps/pep-0771.rst  @pradyunsg
 peps/pep-0772.rst  @warsaw @pradyunsg
 peps/pep-0773.rst  @zooba
 peps/pep-0774.rst  @savannahostrowski
-peps/pep-0775.rst  @stanfromireland @encukou
+peps/pep-0775.rst  @encukou
 # ...
 peps/pep-0777.rst  @warsaw
 # ...

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -653,6 +653,7 @@ peps/pep-0771.rst  @pradyunsg
 peps/pep-0772.rst  @warsaw @pradyunsg
 peps/pep-0773.rst  @zooba
 peps/pep-0774.rst  @savannahostrowski
+peps/pep-0775.rst  @stanfromireland @encukou
 # ...
 peps/pep-0777.rst  @warsaw
 # ...

--- a/peps/pep-0775.rst
+++ b/peps/pep-0775.rst
@@ -2,12 +2,13 @@ PEP: 775
 Title: Make zlib required to build Python
 Author: Stan Ulbrych <stanulbrych@gmail.com>,
         Petr Viktorin <encukou@gmail.com>
-Discussions-To: https://discuss.python.org/t/lets-make-zlib-required-rather-than-optional-to-build-cpython/23062
+Discussions-To: https://discuss.python.org/t/23062
 Status: Draft
 Type: Standards Track
 Created: 24-Feb-2025
 Python-Version: 3.14
 Post-History: `23-Jan-2023 <https://discuss.python.org/t/23062>`__
+
 
 Abstract
 ========
@@ -64,7 +65,7 @@ Specification
 
 In standard library modules that use zlib for optional functionality,
 that functionality will raise ``ImportError`` when used.
-Code to generate more “friendly” error messages, or to pre-check whether
+Code to generate more "friendly" error messages, or to pre-check whether
 zlib is available, will be removed.
 All functionality unrelated to zlib will still be usable if zlib is
 missing.
@@ -73,7 +74,8 @@ This affects the following modules, and more that depend on these
 transitively:
 
 * :mod:`shutil` (``gztar`` and ``zip`` archive formats)
-* :mod:`tarfile`, :mod:`zipfile`, :mod:`zipimport`, :mod:`zipapp` (archive compression)
+* :mod:`tarfile`, :mod:`zipfile`, :mod:`zipimport`,
+  :mod:`zipapp` (archive compression)
 * :mod:`codecs` (``zlib_codec``)
 
 ``shutil.get_archive_formats()`` will always include ``zip`` and ``gztar``
@@ -115,7 +117,9 @@ already available in all relevant contexts.
 Reference Implementation
 ========================
 
-https://github.com/python/cpython/pull/130297
+A reference implementation may be found in a pull request to the CPython
+repository, `python/cpython#130297
+<https://github.com/python/cpython/pull/130297>`_
 
 
 Future work

--- a/peps/pep-0775.rst
+++ b/peps/pep-0775.rst
@@ -26,7 +26,7 @@ Motivation
 ==========
 
 The zlib library, which powers the :mod:`!zlib` Python module,
-is available on virtually all systems.
+is available on all supported systems except WASI.
 
 Many wheels on PyPI, including the :pypi:`pip` installer, require zlib.
 Users of pip would consider CPython without zlib to be broken,

--- a/peps/pep-0775.rst
+++ b/peps/pep-0775.rst
@@ -13,13 +13,13 @@ Post-History: `23-Jan-2023 <https://discuss.python.org/t/23062>`__
 Abstract
 ========
 
-Building CPython on systems without the `zlib <https://zlib.net>`_ compression library, except WASI,
-is no longer supported.
-
-The :mod:`zlib` module is made a required part of the standard library,
-except on WASI.
-
-Builds without zlib will still be possible, but formally unsupported.
+Building CPython without the `zlib <https://zlib.net>`_ compression library
+will no be longer supported, and the :mod:`zlib` module will be required in
+the standard library.
+The only exception is `WASI <https://wasi.dev>`_, as zlib is not currently
+supported in CPython on WASI.
+Building the interpreter without zlib may still be possible,
+but formally unsupported.
 
 
 Motivation

--- a/peps/pep-0775.rst
+++ b/peps/pep-0775.rst
@@ -81,7 +81,7 @@ transitively:
 ``shutil.get_archive_formats()`` will always include ``zip`` and ``gztar``
 as registered formats, even if they are unusable due to missing ``zlib``.
 
-The ``configure`` script will issue a warning when `zlib` is not found on
+The ``configure`` script will issue a warning when ``zlib`` is not found on
 platforms other than WASI.
 
 ``test_zlib`` will fail on platforms other than WASI.

--- a/peps/pep-0775.rst
+++ b/peps/pep-0775.rst
@@ -12,7 +12,7 @@ Post-History: `23-Jan-2023 <https://discuss.python.org/t/23062>`__
 Abstract
 ========
 
-Building CPython on systems without the ``zlib`` compression library, except WASI,
+Building CPython on systems without the `zlib <https://zlib.net>`_ compression library, except WASI,
 is no longer supported.
 
 The ``zlib`` module is made a required part of the standard library,
@@ -81,7 +81,7 @@ transitively:
 ``shutil.get_archive_formats()`` will always include ``zip`` and ``gztar``
 as registered formats, even if they are unusable due to missing ``zlib``.
 
-The ``configure`` script will issue a warning when `zlib`_ is not found on
+The ``configure`` script will issue a warning when `zlib` is not found on
 platforms other than WASI.
 
 ``test_zlib`` will fail on platforms other than WASI.

--- a/peps/pep-0775.rst
+++ b/peps/pep-0775.rst
@@ -5,7 +5,7 @@ Author: Stan Ulbrych <stanulbrych@gmail.com>,
 Discussions-To: https://discuss.python.org/t/lets-make-zlib-required-rather-than-optional-to-build-cpython/23062
 Status: Draft
 Type: Standards Track
-Created: 20-Feb-2025
+Created: 24-Feb-2025
 Python-Version: 3.14
 Post-History: `23-Jan-2023 <https://discuss.python.org/t/23062>`__
 
@@ -15,31 +15,29 @@ Abstract
 Building CPython on systems without the `zlib <https://zlib.net>`_ compression library, except WASI,
 is no longer supported.
 
-The ``zlib`` module is made a required part of the standard library,
+The :mod:`zlib` module is made a required part of the standard library,
 except on WASI.
 
-Builds without ``zlib`` will still be possible, but formally unsupported.
+Builds without zlib will still be possible, but formally unsupported.
 
 
 Motivation
 ==========
 
-The ``zlib`` library, which powers the ``zlib`` Python module,
+The zlib library, which powers the :mod:`!zlib` Python module,
 is available on virtually all systems.
 
-Many wheels on PyPI, including the `pip`_ installer, require ``zlib``.
-Users of *pip* would consider CPython without ``zlib`` to be broken,
-but mostly don't notice because all major builds of CPython include ``zlib``.
-
-.. _pip: https://pypi.org/project/pip/
+Many wheels on PyPI, including the :pypi:`pip` installer, require zlib.
+Users of pip would consider CPython without zlib to be broken,
+but mostly don't notice because all major builds of CPython include zlib.
 
 CPython developers don't really notice either. It turns out that at the time
-of this writing, at least one CPython test fails without ``zlib`` (the “skip”
+of writing, at least one CPython test fails without zlib (the "skip"
 decorator in ``test_peg_generator.test_c_parser`` is applied too late),
 but our CI didn't catch this.
 
 This PEP treats this as an issue in documentation and messaging.
-In practice, we already don't support building CPython without ``zlib``; we
+In practice, we already don't support building CPython without zlib; we
 should just say so.
 
 
@@ -52,11 +50,11 @@ Therefore, we don't *remove* support for zlib-less systems; we mark them
 unsupported and invite affected users to do their own testing, or to share
 use cases that can make us reconsider this decision.
 
-``zlib`` is not yet used by default on the WASI platform -- mostly because
+zlib is not yet used by default on the WASI platform -- mostly because
 adding it hasn't yet been a priority there. (Note that `Pyodide`_, the main
-“real-world” CPython distribution for WASI, does include ``zlib``.)
+"real-world" CPython distribution for WASI, does include zlib.)
 We take this as an opportunity to  continue testing a platform without
-``zlib``, so that we don't unintentionally break unsupported builds yet.
+zlib, so that we don't unintentionally break unsupported builds yet.
 
 .. _Pyodide: https://pyodide.org
 
@@ -64,24 +62,24 @@ We take this as an opportunity to  continue testing a platform without
 Specification
 =============
 
-In standard library modules that use ``zlib`` for optional functionality,
+In standard library modules that use zlib for optional functionality,
 that functionality will raise ``ImportError`` when used.
 Code to generate more “friendly” error messages, or to pre-check whether
-``zlib`` is available, will be removed.
-All non-``zlib``-related functionality will still be usable if ``zlib`` is
+zlib is available, will be removed.
+All functionality unrelated to zlib will still be usable if zlib is
 missing.
 
 This affects the following modules, and more that depend on these
 transitively:
 
-* ``shutil`` (``gztar`` and ``zip`` archive formats)
-* ``tarfile``, ``zipfile``, ``zipimport``, ``zipapp`` (archive compression)
-* ``codecs`` (``zlib_codec``)
+* :mod:`shutil` (``gztar`` and ``zip`` archive formats)
+* :mod:`tarfile`, :mod:`zipfile`, :mod:`zipimport`, :mod:`zipapp` (archive compression)
+* :mod:`codecs` (``zlib_codec``)
 
 ``shutil.get_archive_formats()`` will always include ``zip`` and ``gztar``
-as registered formats, even if they are unusable due to missing ``zlib``.
+as registered formats, even if they are unusable due to missing zlib.
 
-The ``configure`` script will issue a warning when ``zlib`` is not found on
+The ``configure`` script will issue a warning when zlib is not found on
 platforms other than WASI.
 
 ``test_zlib`` will fail on platforms other than WASI.
@@ -89,7 +87,7 @@ All other tests will continue to be skipped -- that is, uses of
 ``@test.support.requires_zlib`` will be kept in place -- for the benefit
 of WASI, unsupported builds, and any possible reverts.
 
-PEP 11 will be adjusted to mark "Systems without zlib, except WASI" as
+:pep:`11` will be adjusted to mark "Systems without zlib, except WASI" as
 unsupported.
 
 
@@ -97,7 +95,7 @@ Backwards Compatibility
 =======================
 
 In practice, nothing major changes, except in error cases -- for example,
-attempts to use tar compression withoutt ``zlib`` available will raise
+attempts to use tar compression without zlib available will raise
 ``ImportError`` and not ``CompressionError``.
 
 
@@ -110,7 +108,7 @@ None known.
 How to Teach This
 =================
 
-We don't expect that any instructions will need to change, as ``zlib`` is
+We don't expect that any instructions will need to change, as zlib is
 already available in all relevant contexts.
 
 
@@ -123,8 +121,8 @@ https://github.com/python/cpython/pull/130297
 Future work
 ===========
 
-In the future, if no use cases for ``zlib``-less  builds are found,
-``zlib`` may be made fully required.
+In the future, if no use cases for zlib-less builds are found,
+zlib may be made fully required.
 The main changes needed for that would be making the ``configure`` script
 raise a hard error, and removing ``@test.support.requires_zlib``.
 

--- a/peps/pep-0775.rst
+++ b/peps/pep-0775.rst
@@ -1,0 +1,134 @@
+PEP: 775
+Title: Make zlib required to build Python
+Author: Stan Ulbrych <stanulbrych@gmail.com>,
+        Petr Viktorin <encukou@gmail.com>
+Discussions-To: https://discuss.python.org/t/lets-make-zlib-required-rather-than-optional-to-build-cpython/23062
+Status: Draft
+Type: Standards Track
+Created: 20-Feb-2025
+Python-Version: 3.14
+Post-History: `23-Jan-2023 <https://discuss.python.org/t/23062>`__
+
+Abstract
+========
+
+Building CPython on systems without the ``zlib`` compression library, except WASI,
+is no longer supported.
+
+The ``zlib`` module is made a required part of the standard library,
+except on WASI.
+
+Builds without ``zlib`` will still be possible, but formally unsupported.
+
+
+Motivation
+==========
+
+The ``zlib`` library, which powers the ``zlib`` Python module,
+is available on virtually all systems.
+
+Many wheels on PyPI, including the `pip`_ installer, require ``zlib``.
+Users of *pip* would consider CPython without ``zlib`` to be broken,
+but mostly don't notice because all major builds of CPython include ``zlib``.
+
+.. _pip: https://pypi.org/project/pip/
+
+CPython developers don't really notice either. It turns out that at the time
+of this writing, at least one CPython test fails without ``zlib`` (the “skip”
+decorator in ``test_peg_generator.test_c_parser`` is applied too late),
+but our CI didn't catch this.
+
+This PEP treats this as an issue in documentation and messaging.
+In practice, we already don't support building CPython without ``zlib``; we
+should just say so.
+
+
+Rationale
+=========
+
+There are possible use cases for zlib-less builds, such as embedding and
+bootstrapping, as well as unforeseen ones.
+Therefore, we don't *remove* support for zlib-less systems; we mark them
+unsupported and invite affected users to do their own testing, or to share
+use cases that can make us reconsider this decision.
+
+``zlib`` is not yet used by default on the WASI platform -- mostly because
+adding it hasn't yet been a priority there. (Note that `Pyodide`_, the main
+“real-world” CPython distribution for WASI, does include ``zlib``.)
+We take this as an opportunity to  continue testing a platform without
+``zlib``, so that we don't unintentionally break unsupported builds yet.
+
+
+Specification
+=============
+
+In standard library modules that use ``zlib`` for optional functionality,
+that functionality will raise ``ImportError`` when used.
+Code to generate more “friendly” error messages, or to pre-check whether
+``zlib`` is available, will be removed.
+All non-``zlib``-related functionality will still be usable if ``zlib`` is
+missing.
+
+This affects the following modules, and more that depend on these
+transitively:
+
+* ``shutil`` (``gztar`` and ``zip`` archive formats)
+* ``tarfile``, ``zipfile``, ``zipimport``, ``zipapp`` (archive compression)
+* ``codecs`` (``zlib_codec``)
+
+``shutil.get_archive_formats()`` will always include ``zip`` and ``gztar``
+as registered formats, even if they are unusable due to missing ``zlib``.
+
+The ``configure`` script will issue a warning when `zlib`_ is not found on
+platforms other than WASI.
+
+``test_zlib`` will fail on platforms other than WASI.
+All other tests will continue to be skipped -- that is, uses of
+``@test.support.requires_zlib`` will be kept in place -- for the benefit
+of WASI, unsupported builds, and any possible reverts.
+
+PEP 11 will be adjusted to mark "Systems without zlib, except WASI" as
+unsupported.
+
+
+Backwards Compatibility
+=======================
+
+In practice, nothing major changes, except in error cases -- for example,
+attempts to use tar compression withoutt ``zlib`` available will raise
+``ImportError`` and not ``CompressionError``.
+
+
+Security Implications
+=====================
+
+None known.
+
+
+How to Teach This
+=================
+
+We don't expect that any instructions will need to change, as ``zlib`` is
+already available in all relevant contexts.
+
+
+Reference Implementation
+========================
+
+https://github.com/python/cpython/pull/130297
+
+
+Future work
+===========
+
+In the future, if no use cases for ``zlib``-less  builds are found,
+``zlib`` may be made fully required.
+The main changes needed for that would be making the ``configure`` script
+raise a hard error, and removing ``@test.support.requires_zlib``.
+
+
+Copyright
+=========
+
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.

--- a/peps/pep-0775.rst
+++ b/peps/pep-0775.rst
@@ -1,5 +1,5 @@
 PEP: 775
-Title: Make zlib required to build Python
+Title: Make zlib required to build CPython
 Author: Gregory P. Smith <greg@krypto.org>,
         Stan Ulbrych <stanulbrych@gmail.com>,
         Petr Viktorin <encukou@gmail.com>

--- a/peps/pep-0775.rst
+++ b/peps/pep-0775.rst
@@ -1,6 +1,7 @@
 PEP: 775
 Title: Make zlib required to build Python
-Author: Stan Ulbrych <stanulbrych@gmail.com>,
+Author: Gregory P. Smith <greg@krypto.org>,
+        Stan Ulbrych <stanulbrych@gmail.com>,
         Petr Viktorin <encukou@gmail.com>
 Discussions-To: https://discuss.python.org/t/23062
 Status: Draft

--- a/peps/pep-0775.rst
+++ b/peps/pep-0775.rst
@@ -58,6 +58,8 @@ adding it hasn't yet been a priority there. (Note that `Pyodide`_, the main
 We take this as an opportunity to  continue testing a platform without
 ``zlib``, so that we don't unintentionally break unsupported builds yet.
 
+.. _Pyodide: https://pyodide.org
+
 
 Specification
 =============


### PR DESCRIPTION
<!--
You can use the following checklist when double-checking your PEP,
and you can help complete some of it yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about anything, just leave it blank and we'll take a look.

If your PEP is not Standards Track, remove the corresponding section.
-->

## Basic requirements (all PEP Types)

* [x] Read and followed [PEP 1](https://peps.python.org/1) & [PEP 12](https://peps.python.org/12)
* [x] File created from the [latest PEP template](https://github.com/python/peps/blob/main/peps/pep-0012/pep-NNNN.rst?plain=1)
* [x] PEP has next available number, & set in filename (``pep-NNNN.rst``), PR title (``PEP 123: <Title of PEP>``) and ``PEP`` header
* [x] Title clearly, accurately and concisely describes the content in 79 characters or less
* [x] Core dev/PEP editor listed as ``Author`` or ``Sponsor``, and formally confirmed their approval
* [x] ``Author``, ``Status`` (``Draft``), ``Type`` and ``Created`` headers filled out correctly
* [x] ``PEP-Delegate``, ``Topic``, ``Requires`` and ``Replaces`` headers completed if appropriate
* [x] Required sections included
    * [x] Abstract (first section)
    * [x] Copyright (last section; exact wording from template required)
* [x] Code is well-formatted (PEP 7/PEP 8) and is in [code blocks, with the right lexer names](https://peps.python.org/pep-0012/#literal-blocks) if non-Python
* [ ] PEP builds with no warnings, pre-commit checks pass and content displays as intended in the rendered HTML
* [x] Authors/sponsor added to ``.github/CODEOWNERS`` for the PEP


## Standards Track requirements

* [x] PEP topic [discussed in a suitable venue](https://peps.python.org/pep-0001/#start-with-an-idea-for-python) with general agreement that a PEP is appropriate
* [x] ``Python-Version`` set to valid (pre-beta) future Python version, if relevant
* [ ] Right before or after initial merging, [PEP discussion thread](https://peps.python.org/pep-0001/#discussing-a-pep) created and linked to in ``Discussions-To`` and ``Post-History``


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4281.org.readthedocs.build/pep-0775/

<!-- readthedocs-preview pep-previews end -->