### PR TITLE
Remove eliben and doerwalter from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -149,7 +149,7 @@ peps/pep-0289.rst  @rhettinger
 peps/pep-0290.rst  @rhettinger
 # peps/pep-0291.rst
 peps/pep-0292.rst  @warsaw
-peps/pep-0293.rst  @doerwalter
+peps/pep-0293.rst
 # peps/pep-0294.rst
 # peps/pep-0295.rst
 # peps/pep-0296.rst
@@ -262,10 +262,10 @@ peps/pep-0404.rst  @warsaw
 # peps/pep-0405.rst
 peps/pep-0406.rst  @ncoghlan
 peps/pep-0407.rst  @pitrou @birkenfeld @warsaw
-peps/pep-0408.rst  @ncoghlan @eliben
+peps/pep-0408.rst  @ncoghlan
 peps/pep-0409.rst  @ethanfurman
 peps/pep-0410.rst  @vstinner
-peps/pep-0411.rst  @ncoghlan @eliben
+peps/pep-0411.rst  @ncoghlan
 peps/pep-0412.rst  @markshannon
 peps/pep-0413.rst  @ncoghlan
 peps/pep-0414.rst  @mitsuhiko @ncoghlan
@@ -292,7 +292,7 @@ peps/pep-0432.rst  @ncoghlan @vstinner @ericsnowcurrently
 peps/pep-0433.rst  @vstinner
 peps/pep-0433/     @vstinner
 peps/pep-0434.rst  @terryjreedy
-peps/pep-0435.rst  @warsaw @eliben @ethanfurman
+peps/pep-0435.rst  @warsaw @ethanfurman
 peps/pep-0436.rst  @larryhastings
 # peps/pep-0437.rst
 # peps/pep-0438.rst

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -149,7 +149,7 @@ peps/pep-0289.rst  @rhettinger
 peps/pep-0290.rst  @rhettinger
 # peps/pep-0291.rst
 peps/pep-0292.rst  @warsaw
-peps/pep-0293.rst
+# peps/pep-0293.rst
 # peps/pep-0294.rst
 # peps/pep-0295.rst
 # peps/pep-0296.rst


### PR DESCRIPTION
eliben and doerwalter left the core team in 2020 and 2021 respectively: 

https://devguide.python.org/core-developers/developer-log/

They are no longer members of the https://github.com/python organisation so we need to update https://github.com/python/peps/blob/main/.github/CODEOWNERS:

<img width="645" alt="image" src="https://github.com/user-attachments/assets/c4959948-e906-4bb5-927b-4541b11b4554" />





<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4282.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->