### PR TITLE
PEP 752: Updates including co-authoring of the PEP

### DIFF
--- a/peps/pep-0752.rst
+++ b/peps/pep-0752.rst
@@ -1,6 +1,7 @@
 PEP: 752
 Title: Implicit namespaces for package repositories
-Author: Ofek Lev <ofekmeister@gmail.com>
+Author: Ofek Lev <ofekmeister@gmail.com>,
+        Jarek Potiuk <potiuk@apache.org>
 Sponsor: Barry Warsaw <barry@python.org>
 PEP-Delegate: Dustin Ingram <di@python.org>
 Discussions-To: https://discuss.python.org/t/63192
@@ -39,6 +40,9 @@ namespace. A few examples:
   are prefixed by ``opentelemetry-`` with child prefixes in the form
   ``opentelemetry-<component>-<name>-``. The contrib packages live in a
   central repository and they are the only ones with the ability to publish.
+* `Apache Airflow <https://airflow.apache.org>`__ is a platform to programmatically
+  author, schedule and monitor workflows. It has a providers, where each
+  provider package is prefixed by ``apache-airflow-providers-``.
 
 __ https://github.com/open-telemetry/opentelemetry-python
 __ https://github.com/open-telemetry/opentelemetry-python-contrib
@@ -92,6 +96,16 @@ The `current protection`__ against typosquatting used by PyPI is to normalize
 similar characters but that is insufficient for these use cases.
 
 __ https://github.com/pypi/warehouse/blob/8615326918a180eb2652753743eac8e74f96a90b/warehouse/migrations/versions/d18d443f89f0_ultranormalize_name_function.py#L29-L42
+
+Another problem that namespacing would solve is the issue of choosing new names
+for packages following the agreed patterns of naming. Often (this is the case
+for ``Apache Airflow`` for example), there are public discussions that precede
+the decision to create a new package. The decision is based on the agreed
+name and follow the pattern of the existing packages. If more package names are
+considered during the discussion, all the names have to be reserved via ``PyPI``
+interface before the discussion is public, otherwise the names can be taken by
+other users. This is a problem that actually happened in the past as explained
+in the associated discussion.
 
 Rationale
 =========

--- a/peps/pep-0752.rst
+++ b/peps/pep-0752.rst
@@ -41,7 +41,7 @@ namespace. A few examples:
   ``opentelemetry-<component>-<name>-``. The contrib packages live in a
   central repository and they are the only ones with the ability to publish.
 * `Apache Airflow <https://airflow.apache.org>`__ is a platform to programmatically
-  author, schedule and monitor workflows. It has a providers, where each
+  author, schedule and monitor workflows. It has providers, where each
   provider package is prefixed by ``apache-airflow-providers-``.
 
 __ https://github.com/open-telemetry/opentelemetry-python

--- a/peps/pep-0752.rst
+++ b/peps/pep-0752.rst
@@ -99,7 +99,7 @@ __ https://github.com/pypi/warehouse/blob/8615326918a180eb2652753743eac8e74f96a9
 
 Another problem that namespacing would solve is the issue of choosing new names
 for packages following the agreed patterns of naming. Often (this is the case
-for ``Apache Airflow`` for example), there are public discussions that precede
+for Apache Airflow for example), there are public discussions that precede
 the decision to create a new package. The decision is based on the agreed
 name and follow the pattern of the existing packages. If more package names are
 considered during the discussion, all the names have to be reserved via ``PyPI``

--- a/peps/pep-0752.rst
+++ b/peps/pep-0752.rst
@@ -105,7 +105,7 @@ name and follow the pattern of the existing packages. If more package names are
 considered during the discussion, all the names have to be reserved via a PyPI
 interface before the discussion is public, otherwise the names can be taken by
 other users. This has happened in the past as explained
-in the associated discussion.
+in the associated `discussion <https://discuss.python.org/t/pep-752-implicit-namespaces-for-package-repositories/63192/80>`__.
 
 Rationale
 =========

--- a/peps/pep-0752.rst
+++ b/peps/pep-0752.rst
@@ -102,7 +102,7 @@ for packages following the agreed patterns of naming. Often (this is the case
 for Apache Airflow for example), there are public discussions that precede
 the decision to create a new package. The decision is based on the agreed
 name and follow the pattern of the existing packages. If more package names are
-considered during the discussion, all the names have to be reserved via ``PyPI``
+considered during the discussion, all the names have to be reserved via a PyPI
 interface before the discussion is public, otherwise the names can be taken by
 other users. This is a problem that actually happened in the past as explained
 in the associated discussion.

--- a/peps/pep-0752.rst
+++ b/peps/pep-0752.rst
@@ -104,7 +104,7 @@ the decision to create a new package. The decision is based on the agreed
 name and follow the pattern of the existing packages. If more package names are
 considered during the discussion, all the names have to be reserved via a PyPI
 interface before the discussion is public, otherwise the names can be taken by
-other users. This is a problem that actually happened in the past as explained
+other users. This has happened in the past as explained
 in the associated discussion.
 
 Rationale


### PR DESCRIPTION
The PEP-0752 is important for community driven projects - such as Apache Airflow, not only because of security risks but also because of concerns with public discussions about new names of distributions following agreed and implemented pattern.

As agreed with Ofek, I am happy to become co-author of the PEP and added more motivation explaining this case.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4292.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->