### PR TITLE
PEP 751: drop the requirement that installers default to not installing any extras or dependency groups

### DIFF
--- a/peps/pep-0751.rst
+++ b/peps/pep-0751.rst
@@ -729,8 +729,8 @@ do for *containers*". There are no backwards-compatibility concerns as strings
 are containers themselves.
 
 Fourth, a tool MUST raise an error if an extra or dependency group is specified
-in a marker expression that does not exist in ``packages.extras`` and
-``packages.dependency-groups``, respectively.
+in a marker expression that does not exist in ``extras`` and
+``dependency-groups``, respectively.
 
 These changes, along with ``packages.extras``/ ``packages.dependency-groups``
 and marker expressions' Boolean logic support, allow for expressing arbitrary,
@@ -751,12 +751,10 @@ installed when:
 The same flexibility applies to dependency groups.
 
 How users tell a tool what extras and/or dependency groups they want installed
-is up to the tool. Tools MUST default to no extras or dependency groups being
-requested by the user if no extras or dependency groups are requested.
-Installers MUST support the marker expression syntax additions as
-proposed by this PEP. Lockers MAY support writing lock files that utilize the
-proposed marker expression syntax additions (i.e. lockers can choose to only
-support writing single-use lock files).
+is up to the tool. Installers MUST support the marker expression syntax
+additions as proposed by this PEP. Lockers MAY support writing lock files that
+utilize the proposed marker expression syntax additions (i.e. lockers can choose
+to only support writing single-use lock files).
 
 
 -------

--- a/peps/pep-0751.rst
+++ b/peps/pep-0751.rst
@@ -729,7 +729,7 @@ do for *containers*". There are no backwards-compatibility concerns as strings
 are containers themselves.
 
 Fourth, a tool MUST raise an error if an extra or dependency group is specified
-in a marker expression that does not exist in ``extras`` and
+in a marker expression that does not exist in ``extras`` or
 ``dependency-groups``, respectively.
 
 These changes, along with ``packages.extras``/ ``packages.dependency-groups``


### PR DESCRIPTION
This change is based on feedback from Poetry.

Also fix some typos.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [ ] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4300.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->