### PR TITLE
PEP 745: 3.14.0a6 was released on 2024-03-14 (π day)

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -41,10 +41,10 @@ Actual:
 - 3.14.0 alpha 3: Tuesday, 2024-12-17
 - 3.14.0 alpha 4: Tuesday, 2025-01-14
 - 3.14.0 alpha 5: Tuesday, 2025-02-11
+- 3.14.0 alpha 6: Friday, 2025-03-14
 
 Expected:
 
-- 3.14.0 alpha 6: Friday, 2025-03-14
 - 3.14.0 alpha 7: Tuesday, 2025-04-08
 - 3.14.0 beta 1: Tuesday, 2025-05-06
   (No new features beyond this point.)


### PR DESCRIPTION
* https://discuss.python.org/t/python-3-14-0-alpha-6/84513
* https://www.python.org/downloads/release/python-3140a6/

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4303.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->