### PR TITLE
PEP 758: Mark as Accepted

### DIFF
--- a/peps/pep-0758.rst
+++ b/peps/pep-0758.rst
@@ -2,11 +2,12 @@ PEP: 758
 Title: Allow ``except`` and ``except*`` expressions without parentheses
 Author: Pablo Galindo <pablogsal@python.org>, Brett Cannon <brett@python.org>
 PEP-Delegate: TBD
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Created: 30-Sep-2024
 Python-Version: 3.14
 Post-History: `02-Oct-2024 <https://discuss.python.org/t/66453>`__
+Resolution: https://discuss.python.org/t/pep-758-allow-except-and-except-expressions-without-parentheses/66453/63
 
 Abstract
 ========

--- a/peps/pep-0758.rst
+++ b/peps/pep-0758.rst
@@ -7,7 +7,7 @@ Type: Standards Track
 Created: 30-Sep-2024
 Python-Version: 3.14
 Post-History: `02-Oct-2024 <https://discuss.python.org/t/66453>`__
-Resolution: https://discuss.python.org/t/pep-758-allow-except-and-except-expressions-without-parentheses/66453/63
+Resolution: `14-Mar-2025 <https://discuss.python.org/t/66453/63>`__
 
 Abstract
 ========

--- a/peps/pep-0758.rst
+++ b/peps/pep-0758.rst
@@ -1,7 +1,6 @@
 PEP: 758
 Title: Allow ``except`` and ``except*`` expressions without parentheses
 Author: Pablo Galindo <pablogsal@python.org>, Brett Cannon <brett@python.org>
-PEP-Delegate: TBD
 Status: Accepted
 Type: Standards Track
 Created: 30-Sep-2024

--- a/peps/pep-0758.rst
+++ b/peps/pep-0758.rst
@@ -57,7 +57,7 @@ The same change would apply to ``except*`` expressions. For example:
     except* ExceptionA, ExceptionB, ExceptionC:
         ...
 
-When using the ``as`` clause to capture the exception instance paretheses must
+When using the ``as`` clause to capture the exception instance parentheses must
 be used as before. Some users have expressed that they would find it confusing not
 to require parentheses as it would be unclear what exactly is being assigned to
 the target since in other parts of the language multiple ``as`` clauses can be used


### PR DESCRIPTION
- [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the Discussions-To thread
- [x]  Pull request title in appropriate format (PEP 123: Mark as Accepted)
- [x]  `Status` changed to `Accepted`/`Rejected`
- [x]  `Resolution` link points directly to SC/PEP Delegate official acceptance/rejected post
- [x]  Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
- [x]  `Discussions-To`, `Post-History` and `Python-Version` up to date

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4304.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->