### PR TITLE
PEP 765: Mark as Final

### DIFF
--- a/peps/pep-0765.rst
+++ b/peps/pep-0765.rst
@@ -11,7 +11,7 @@ Post-History: `09-Nov-2024 <https://discuss.python.org/t/an-analysis-of-return-i
 Replaces: 601
 Resolution: https://discuss.python.org/t/71348/111
 
-.. canonical-doc:: https://docs.python.org/dev/reference/compound_stmts.html#finally-clause
+.. canonical-doc:: :external+py3.14:ref:`finally`
 
 Abstract
 ========

--- a/peps/pep-0765.rst
+++ b/peps/pep-0765.rst
@@ -11,6 +11,7 @@ Post-History: `09-Nov-2024 <https://discuss.python.org/t/an-analysis-of-return-i
 Replaces: 601
 Resolution: https://discuss.python.org/t/71348/111
 
+.. canonical-doc:: https://docs.python.org/dev/reference/compound_stmts.html#finally-clause
 
 Abstract
 ========

--- a/peps/pep-0765.rst
+++ b/peps/pep-0765.rst
@@ -2,7 +2,7 @@ PEP: 765
 Title: Disallow return/break/continue that exit a finally block
 Author: Irit Katriel <irit@python.org>, Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-765-disallow-return-break-continue-that-exit-a-finally-block/71348
-Status: Accepted
+Status: Final
 Type: Standards Track
 Created: 15-Nov-2024
 Python-Version: 3.14


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [x] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)
