### PR TITLE
PEP 751: Make `default-group` be `default-groups`

### DIFF
--- a/peps/pep-0751.rst
+++ b/peps/pep-0751.rst
@@ -240,20 +240,19 @@ consistent order. Usage of inline tables SHOULD also be kept consistent.
   is, in effect, multi-use even if it only looks to be single-use.
 
 
-``default-group``
-=================
+``default-groups``
+==================
 
-- **Type**: String
-- **Required?**: no
+- **Type**: Array of strings
+- **Required?**: no; defaults to ``[]``
 - **Inspiration**: Poetry_, PDM_
-- The name of a synthetic dependency group to represent what should be installed
+- The name of synthetic dependency groups to represent what should be installed
   by default (e.g. what ``project.dependencies`` implicitly represents).
 - Meant to be used in situations where ``packages.marker`` necessitates such a
   group to exist.
-- The group listed by this key SHOULD NOT be listed in ``dependency-groups`` as
-  the group is not meant to be directly exposed to users by name but instead via
-  an installer's UI.
-- This group can only be specified when ``dependency-groups`` has values.
+- The groups listed by this key SHOULD NOT be listed in ``dependency-groups`` as
+  the groups are not meant to be directly exposed to users by name but instead
+  via an installer's UI.
 
 
 ``created-by``
@@ -802,6 +801,29 @@ operations involving sets:
       python_version ~= "surprise"
 
 
+Fourth, use of ``extras`` and ``depenendency_groups`` will be considered an
+error outside of lock file (much like ``extra`` outside of
+:ref:`packaging:core-metadata`).
+
+.. code-block:: diff
+
+  diff --git a/source/specifications/dependency-specifiers.rst b/source/specifications/dependency-specifiers.rst
+  index 06897da2..2914ef66 100644
+  --- a/source/specifications/dependency-specifiers.rst
+  +++ b/source/specifications/dependency-specifiers.rst
+  @@ -235,6 +235,11 @@ no current specification for this. Regardless, outside of a context where this
+  special handling is taking place, the "extra" variable should result in an
+  error like all other unknown variables.
+
+  +The "extras" and "dependency_groups" variables are also special. They are used
+  +to specify any requested extras or dependency groups when installing from a lock
+  +file. Outside of the context of lock files, these two variables should result in
+  +an error like all other unknown variables.
+  +
+  .. list-table::
+      :header-rows: 1
+
+
 These changes, along with ``packages.extras``/ ``packages.dependency-groups``
 and marker expressions' Boolean logic support, allow for expressing arbitrary,
 exhaustive requirements for when a package should be installed based on the
@@ -1075,11 +1097,11 @@ is better or worse than the other, it just changes how much can be written down
 in a single file (which can influence how manageable).
 
 Lock files that follow this PEP can be installed by any installer that
-implements the specification. This allows users of a lock file to not not be
-tied to the locker used by the person who produced the lock file. But it is not
-the case that using a different locker will lead to the same result. This could
-be for various reasons, including using different algorithms to determine what
-to lock.
+implements the specification. This allows users of a lock file to perform an
+installation to not be tied to the locker used by the person who produced the
+lock file. But it is not the case that using a different locker will lead to the
+same result. This could be for various reasons, including using different
+algorithms to determine what to lock.
 
 
 ========================


### PR DESCRIPTION
Also clarify that using `extras` and `dependency_groups` outside of lock file is an error.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4308.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->