### PR TITLE
PEP 755: Address feedback, round 2

### DIFF
--- a/peps/pep-0755.rst
+++ b/peps/pep-0755.rst
@@ -154,8 +154,9 @@ Grant Ownership
 ---------------
 
 The owner of a grant may allow any number of other organizations to use the
-grant. The grants behave as if they were owned by the organization. The owner
-may revoke this permission at any time.
+grant. The grants behave as if they were owned by the organization, i.e. even
+the owner cannot upload packages to the namespace. The owner may revoke this
+permission at any time.
 
 The owner may transfer ownership to another organization at any time without
 approval from PyPI admins. If the organization is a paid organization, the


### PR DESCRIPTION
This ambiguity came up during the [PoC](https://github.com/pypi/warehouse/pull/17691).

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4312.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->