### PR TITLE
PEP 751: address some minor user feedback

### DIFF
--- a/peps/pep-0751.rst
+++ b/peps/pep-0751.rst
@@ -229,7 +229,9 @@ consistent order. Usage of inline tables SHOULD also be kept consistent.
 - **Type**: Array of strings
 - **Required?**: no; defaults to ``[]``
 - **Inspiration**: :ref:`packaging:pyproject-tool-table`
-- The list of :ref:`packaging:dependency-groups` supported by this lock file.
+- The list of :ref:`packaging:dependency-groups` publicly supported by this lock
+  file (i.e. dependency groups users are expected to be able to specify via a
+  tool's UI).
 - Lockers MAY choose to not support writing lock files that support extras and
   dependency groups (i.e. tools may only support exporting a single-use lock
   file).
@@ -906,6 +908,13 @@ Installation
 The following outlines the steps to be taken to install from a lock file
 (while the requirements are prescriptive, the general steps and order are
 a suggestion):
+
+#. Gather the extras and dependency groups to install and set ``extras`` and
+   ``dependency_groups`` for marker evaluation, respectively.
+
+   #. ``extras`` SHOULD be set to the empty set by default.
+   #. ``dependency_groups`` SHOULD be the set created from ``default-groups`` by
+      default.
 
 #. Check if the metadata version specified by ``lock-version`` is supported;
    an error or warning MUST be raised as appropriate.


### PR DESCRIPTION
Made it explicit that `dependency-groups` represents the groups users are expected to be able to set via a tool's UI. Also made clear what `extras` and `dependency_groups` should be set to by default.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4330.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->