### PR TITLE
PEP 776: Remove section on synchronous loading limit

### DIFF
--- a/peps/pep-0776.rst
+++ b/peps/pep-0776.rst
@@ -347,39 +347,11 @@ In the long term, we hope to implement stack switching ``stdin`` devices, but
 that is out of scope for this PEP.
 
 
-Dynamic Libraries
------------------
-
-Main Thread Synchronous Loading Limit
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In the main browser thread, a dynamic library can only be loaded synchronously
-if it is at most 4 kilobytes. This excludes most nontrivial dynamic libraries.
-This limit is not present in Node.js and can be avoided by using a web worker. If
-stack switching is available, then it is possible to make ``dlopen()`` stack
-switch in order to instantiate a dynamic library synchronously.
-
-To avoid the synchronous loading limit, Pyodide currently preloads all dynamic
-libraries present in a wheel when installing the wheel (or on startup). This is
-a significant disadvantage with packages like SciPy that include a very large
-number of shared libraries that are expected to be only loaded on demand.
-Pyodide will implement a solution based on stack switching as it becomes more
-widely available in runtimes.
-
-Emscripten Python only loads extension module dynamic libraries when they are
-imported. This approach is simpler and more efficient when it works. The web
-example runs in a web worker and the cli runner runs in Node so neither of these
-have the synchronous loading limit. We will continue with this approach in
-Emscripten Python.
-
-In the long run, we hope to implement a stack switching ``dlopen``, but that is
-out of scope for this PEP.
-
 Missing RPATH Support
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
-Another important limitation of the Emscripten dynamic loader is that it does
-not currently have RPATH support. Pyodide's present workaround is as follows:
+An important limitation of the Emscripten dynamic loader is that it does not
+currently have RPATH support. Pyodide's present workaround is as follows:
 ``auditwheel-emscripten`` places shared library dependencies that are vendored
 into a package in a ``${package}.libs`` folder, following auditwheel's
 convention. Pyodide patches the dynamic loader to treat this ``${package}.libs``
@@ -387,9 +359,9 @@ folder as if it were on the RPATH of all of the dynamic libraries in the wheel.
 
 In Emscripten 4.0.5, we have updated the shared object file format, ``wasm-ld``
 and ``emcc`` to accept an ``-rpath`` flag. We are still working on updating the
-dynamic loader to respect the rpath, but we expect this will be finished in the
-next Emscripten release. Pyodide will then switch to using the RPATH and drop
-the patch on the dynamic loader.
+dynamic loader to respect the rpath, but we expect this will be finished soon.
+Pyodide will then switch to using the RPATH and drop the patch on the dynamic
+loader.
 
 Emscripten Python currently uses the unpatched dynamic loader and so cannot load
 extension modules that depend on vendored dynamic libraries via DT_NEEDED.


### PR DESCRIPTION
@sbc100 tells me that it was removed from Chrome in 2023: 
https://groups.google.com/a/chromium.org/g/blink-dev/c/nJw2zwaiJ2s/m/EYPgC5D3LwAJ?pli=1

Furthermore, in that thread it is stated that such a limit was never present in the first place in Firefox or Safari.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4333.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->