### PR TITLE
PEP 751: Fix typo in `dependency_groups`

### DIFF
--- a/peps/pep-0751.rst
+++ b/peps/pep-0751.rst
@@ -805,7 +805,7 @@ operations involving sets:
       python_version ~= "surprise"
 
 
-Fourth, use of ``extras`` and ``depenendency_groups`` will be considered an
+Fourth, use of ``extras`` and ``dependency_groups`` will be considered an
 error outside of lock file (much like ``extra`` outside of
 :ref:`packaging:core-metadata`).
 


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4339.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->