### PR TITLE
PEP 784: Updates to timeline and RFC reference

### DIFF
--- a/peps/pep-0784.rst
+++ b/peps/pep-0784.rst
@@ -231,12 +231,14 @@ Compression module migration timeline
 Existing modules will emit a ``DeprecationWarning`` in the Python
 release following the last Python without the ``compression`` module leaving
 support. For example, if the ``compression`` namespace is introduced in 3.14,
-then the ``DeprecationWarnings`` would be emitted in 3.19, the next release
-after 3.13 reaches end of life. Following the standard deprecation timeline
-specified in :pep:`387`, in Python 3.24 the existing modules will be removed
-and code must use the ``compression`` sub-modules. The documentation for these
-modules will be updated to discuss the planned deprecation and removal
-timelines.
+then the ``DeprecationWarning``s would be emitted in 3.19, the next release
+after 3.13 reaches end of life. These warnings would begin five years after the
+introduction of ``compression`` namespace. In accordance with :pep:`387`, in
+Python 3.24, five years after the ``DeprecationWarning``s are added and ten
+years after the new ``compression`` namespace is introduced, the existing
+modules will be removed and code must use the ``compression`` sub-modules. The
+documentation for these modules will be updated to discuss the planned
+deprecation and removal timelines.
 
 
 Backwards Compatibility

--- a/peps/pep-0784.rst
+++ b/peps/pep-0784.rst
@@ -231,10 +231,10 @@ Compression module migration timeline
 Existing modules will emit a ``DeprecationWarning`` in the Python
 release following the last Python without the ``compression`` module leaving
 support. For example, if the ``compression`` namespace is introduced in 3.14,
-then the ``DeprecationWarning``s would be emitted in 3.19, the next release
+then the ``DeprecationWarnings`` would be emitted in 3.19, the next release
 after 3.13 reaches end of life. These warnings would begin five years after the
 introduction of ``compression`` namespace. In accordance with :pep:`387`, in
-Python 3.24, five years after the ``DeprecationWarning``s are added and ten
+Python 3.24, five years after the ``DeprecationWarnings`` are added and ten
 years after the new ``compression`` namespace is introduced, the existing
 modules will be removed and code must use the ``compression`` sub-modules. The
 documentation for these modules will be updated to discuss the planned

--- a/peps/pep-0784.rst
+++ b/peps/pep-0784.rst
@@ -44,7 +44,8 @@ significantly faster than LZMA.
 Zstandard has seen `widespread adoption`_ in many different areas of computing.
 The numerous hardware implementations demonstrate long-term commitment to
 Zstandard and an expectation that Zstandard will stay the *de facto* choice for
-compression for years to come. Zstandard compression is also implemented in
+compression for years to come. This is further evidenced by Zstandard's IETF
+standardization in :rfc:`8478`. Zstandard compression is also implemented in
 both the ZFS_ and Btrfs_ filesystems.
 
 Zstandard's highly efficient compression has supplanted other modern


### PR DESCRIPTION
* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

Hopefully this is a bit clearer with regards to timeline.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4352.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->