### PR TITLE
PEPs 596, 619, 664, 693, 719, 745: Update release dates

### DIFF
--- a/peps/pep-0596.rst
+++ b/peps/pep-0596.rst
@@ -96,14 +96,15 @@ Provided irregularly on an "as-needed" basis until October 2025.
 - 3.9.19: Tuesday, 2024-03-19
 - 3.9.20: Friday, 2024-09-06
 - 3.9.21: Tuesday, 2024-12-03
+- 3.9.22: Tuesday, 2025-04-08
 
 
 3.9 Lifespan
 ------------
 
-3.9 will receive bugfix updates approximately every 2 months for
+3.9 received bugfix updates approximately every 2 months for
 approximately 18 months.  Some time after the release of 3.10.0 final,
-the ninth and final 3.9 bugfix update will be released.  After that,
+the ninth and final 3.9 bugfix update was released.  After that,
 it is expected that security updates (source only) will be released
 until 5 years after the release of 3.9 final, so until approximately
 October 2025.

--- a/peps/pep-0619.rst
+++ b/peps/pep-0619.rst
@@ -84,13 +84,14 @@ Provided irregularly on an "as-needed" basis until October 2026.
 - 3.10.14: Tuesday, 2024-03-19
 - 3.10.15: Saturday, 2024-09-07
 - 3.10.16: Tuesday, 2024-12-03
+- 3.10.17: Tuesday, 2025-04-08
 
 3.10 Lifespan
 -------------
 
-3.10 will receive bugfix updates approximately every 2 months for
+3.10 received bugfix updates approximately every 2 months for
 approximately 18 months.  Some time after the release of 3.11.0 final,
-the 11th and final 3.10 bugfix update will be released.  After that,
+the 11th and final 3.10 bugfix update was released.  After that,
 it is expected that security updates (source only) will be released
 until 5 years after the release of 3.10 final, so until approximately
 October 2026.

--- a/peps/pep-0664.rst
+++ b/peps/pep-0664.rst
@@ -81,13 +81,14 @@ Provided irregularly on an "as-needed" basis until October 2027.
 
 - 3.11.10: Saturday, 2024-09-07
 - 3.11.11: Tuesday, 2024-12-03
+- 3.11.12: Tuesday, 2025-04-08
 
 3.11 Lifespan
 -------------
 
-3.11 will receive bugfix updates approximately every 2 months for
+3.11 received bugfix updates approximately every 2 months for
 approximately 18 months.  Some time after the release of 3.12.0 final,
-the ninth and final 3.11 bugfix update will be released.  After that,
+the ninth and final 3.11 bugfix update was released.  After that,
 it is expected that security updates (source only) will be released
 until 5 years after the release of 3.11.0 final, so until approximately
 October 2027.

--- a/peps/pep-0693.rst
+++ b/peps/pep-0693.rst
@@ -66,10 +66,7 @@ Actual:
 - 3.12.7: Tuesday, 2024-10-01
 - 3.12.8: Tuesday, 2024-12-03
 - 3.12.9: Tuesday, 2025-02-04
-
-Expected:
-
-- 3.12.10: Tuesday, 2025-04-08
+- 3.12.10: Tuesday, 2025-04-08 (final regular bugfix release with binary installers)
 
 Source-only security fix releases
 ---------------------------------
@@ -79,9 +76,9 @@ Provided irregularly on an as-needed basis until October 2028.
 3.12 Lifespan
 -------------
 
-3.12 will receive bugfix updates approximately every 2 months for
+3.12 received bugfix updates approximately every 2 months for
 approximately 18 months.  Some time after the release of 3.13.0 final,
-the tenth and final 3.12 bugfix update will be released.  After that,
+the tenth and final 3.12 bugfix update was released.  After that,
 it is expected that security updates (source only) will be released
 until 5 years after the release of 3.12.0 final, so until approximately
 October 2028.

--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -53,13 +53,13 @@ Actual:
 - 3.13.0 final: Monday, 2024-10-07
 - 3.13.1: Tuesday, 2024-12-03
 - 3.13.2: Tuesday, 2025-02-04
+- 3.13.3: Tuesday, 2025-04-08
 
 Bugfix releases
 ---------------
 
 Expected:
 
-- 3.13.3: Tuesday, 2025-04-08
 - 3.13.4: Tuesday, 2025-06-03
 - 3.13.5: Tuesday, 2025-08-05
 - 3.13.6: Tuesday, 2025-10-07

--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -42,10 +42,10 @@ Actual:
 - 3.14.0 alpha 4: Tuesday, 2025-01-14
 - 3.14.0 alpha 5: Tuesday, 2025-02-11
 - 3.14.0 alpha 6: Friday, 2025-03-14
+- 3.14.0 alpha 7: Tuesday, 2025-04-08
 
 Expected:
 
-- 3.14.0 alpha 7: Tuesday, 2025-04-08
 - 3.14.0 beta 1: Tuesday, 2025-05-06
   (No new features beyond this point.)
 - 3.14.0 beta 2: Tuesday, 2025-05-27


### PR DESCRIPTION
Releases of 3.9-3.14:

* https://discuss.python.org/t/python-3-14-0a7-3-13-3-3-12-10-3-11-12-3-10-17-and-3-9-22-are-now-available/87580