### PR TITLE
Document peps.json post_history as nullable

### DIFF
--- a/peps/api/index.rst
+++ b/peps/api/index.rst
@@ -20,7 +20,7 @@ The structure of each JSON object is as follows:
        "topic": "governance" | "packaging" | "release" | "typing" | "",
        "created": string,
        "python_version": string | null,
-       "post_history": string,
+       "post_history": string | null,
        "resolution": string | null,
        "requires": string | null,
        "replaces": string | null,


### PR DESCRIPTION
PEP 160 (listed as an example) as well as other PEPs (e.g. 0 and 3) have `post_history` as null, so it probably makes sense to document it like other nullable fields.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4354.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->