### PR TITLE
Infra: Make PEP abstract extration more robust

### DIFF
--- a/pep_sphinx_extensions/generate_rss.py
+++ b/pep_sphinx_extensions/generate_rss.py
@@ -59,10 +59,14 @@ def pep_abstract(document: nodes.document) -> str:
         if title_node is None:
             continue
 
+        para_node = None
         if title_node.astext() == "Abstract":
-            return node.next_node(nodes.paragraph).astext().strip().replace("\n", " ")
+            para_node = node.next_node(nodes.paragraph)
         elif title_node.astext() == "Introduction":
-            introduction = node.next_node(nodes.paragraph).astext().strip().replace("\n", " ")
+            para_node = node.next_node(nodes.paragraph)
+
+        if para_node:
+            introduction = para_node.astext().strip().replace("\n", " ")
 
     return introduction
 

--- a/pep_sphinx_extensions/generate_rss.py
+++ b/pep_sphinx_extensions/generate_rss.py
@@ -59,14 +59,12 @@ def pep_abstract(document: nodes.document) -> str:
         if title_node is None:
             continue
 
-        para_node = None
         if title_node.astext() == "Abstract":
-            para_node = node.next_node(nodes.paragraph)
-        elif title_node.astext() == "Introduction":
-            para_node = node.next_node(nodes.paragraph)
-
-        if para_node:
-            introduction = para_node.astext().strip().replace("\n", " ")
+            if (para_node := node.next_node(nodes.paragraph)) is not None:
+                return para_node.astext().strip().replace("\n", " ")
+            return ""
+        if title_node.astext() == "Introduction":
+            introduction = node.next_node(nodes.paragraph).astext().strip().replace("\n", " ")
 
     return introduction
 


### PR DESCRIPTION
This eliminates an AttributeError during PEP editing, if the PEP being edited has an Abstract or Introduction section but with no interior content (i.e. paragraphs) yet.

In practice this should have no effect on actual
RSS feeds, since merged PEPs should always have a proper abstract. However, this prevents a confusing error from bubbling up during local editing.

See #4355.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4356.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->