### PR TITLE
PEP 589: Fix indentation issue with one of the example snippets

### DIFF
--- a/peps/pep-0589.rst
+++ b/peps/pep-0589.rst
@@ -437,15 +437,15 @@ Discussion:
           x: int
           y: str
 
-       def f(a: A) -> None:
-           a['y'] = 1
+      def f(a: A) -> None:
+          a['y'] = 1
 
-       def g(b: B) -> None:
-           f(b)  # Type check error: 'B' incompatible with 'A'
+      def g(b: B) -> None:
+          f(b)  # Type check error: 'B' incompatible with 'A'
 
-       c: C = {'x': 0, 'y': 'foo'}
-       g(c)
-       c['y'] + 'bar'  # Runtime error: int + str
+      c: C = {'x': 0, 'y': 'foo'}
+      g(c)
+      c['y'] + 'bar'  # Runtime error: int + str
 
 * A TypedDict isn't consistent with any ``Dict[...]`` type, since
   dictionary types allow destructive operations, including


### PR DESCRIPTION
See the screenshot (from https://peps.python.org/pep-0589/#type-consistency):
![image](https://github.com/user-attachments/assets/5751f23a-5025-41f6-83f4-a90bd6240cbc)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4358.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->