### PR TITLE
PEP 12: Allow "Pending" as Discussions-To

### DIFF
--- a/check-peps.py
+++ b/check-peps.py
@@ -303,6 +303,8 @@ def _validate_discussions_to(line_num: int, line: str) -> MessageIterator:
     """'Discussions-To' must be a thread URL"""
 
     yield from _thread(line_num, line, "Discussions-To", discussions_to=True)
+    if line == "TBA":
+        return
     if line.startswith("https://"):
         return
     for suffix in "@python.org", "@googlegroups.com":
@@ -311,7 +313,7 @@ def _validate_discussions_to(line_num: int, line: str) -> MessageIterator:
             if re.fullmatch(r"[\w\-]+", remainder) is None:
                 yield line_num, "Discussions-To must be a valid mailing list"
             return
-    yield line_num, "Discussions-To must be a valid thread URL or mailing list"
+    yield line_num, "Discussions-To must be 'TBA', a valid thread URL or mailing list"
 
 
 def _validate_status(line_num: int, line: str) -> MessageIterator:

--- a/check-peps.py
+++ b/check-peps.py
@@ -303,7 +303,7 @@ def _validate_discussions_to(line_num: int, line: str) -> MessageIterator:
     """'Discussions-To' must be a thread URL"""
 
     yield from _thread(line_num, line, "Discussions-To", discussions_to=True)
-    if line == "TBA":
+    if line == "Pending":
         return
     if line.startswith("https://"):
         return
@@ -313,7 +313,7 @@ def _validate_discussions_to(line_num: int, line: str) -> MessageIterator:
             if re.fullmatch(r"[\w\-]+", remainder) is None:
                 yield line_num, "Discussions-To must be a valid mailing list"
             return
-    yield line_num, "Discussions-To must be 'TBA', a valid thread URL or mailing list"
+    yield line_num, "Discussions-To must be a valid thread URL, mailing list, or 'Pending'"
 
 
 def _validate_status(line_num: int, line: str) -> MessageIterator:

--- a/pep_sphinx_extensions/tests/pep_lint/test_pep_lint.py
+++ b/pep_sphinx_extensions/tests/pep_lint/test_pep_lint.py
@@ -37,7 +37,7 @@ def test_with_fake_pep():
         (14, "Topic must be for a valid sub-index"),
         (14, "Topic must be sorted lexicographically"),
         (16, "PEP references must be separated by comma-spaces (', ')"),
-        (17, "Discussions-To must be 'TBA', a valid thread URL or mailing list"),
+        (17, "Discussions-To must be a valid thread URL, mailing list, or 'Pending'"),
         (18, "Post-History must be a 'DD-mmm-YYYY' date: '2-Feb-2000'"),
         (18, "Post-History must be a valid thread URL"),
         (19, "Post-History must be a 'DD-mmm-YYYY' date: '3-Mar-2001'"),

--- a/pep_sphinx_extensions/tests/pep_lint/test_pep_lint.py
+++ b/pep_sphinx_extensions/tests/pep_lint/test_pep_lint.py
@@ -37,7 +37,7 @@ def test_with_fake_pep():
         (14, "Topic must be for a valid sub-index"),
         (14, "Topic must be sorted lexicographically"),
         (16, "PEP references must be separated by comma-spaces (', ')"),
-        (17, "Discussions-To must be a valid thread URL or mailing list"),
+        (17, "Discussions-To must be 'TBA', a valid thread URL or mailing list"),
         (18, "Post-History must be a 'DD-mmm-YYYY' date: '2-Feb-2000'"),
         (18, "Post-History must be a valid thread URL"),
         (19, "Post-History must be a 'DD-mmm-YYYY' date: '3-Mar-2001'"),

--- a/pep_sphinx_extensions/tests/pep_lint/test_post_url.py
+++ b/pep_sphinx_extensions/tests/pep_lint/test_post_url.py
@@ -53,7 +53,7 @@ def test_validate_discussions_to_invalid_list_domain(line: str):
         warning for (_, warning) in check_peps._validate_discussions_to(1, line)
     ]
     assert warnings == [
-        "Discussions-To must be 'TBA', a valid thread URL or mailing list"
+        "Discussions-To must be a valid thread URL, mailing list, or 'Pending'"
     ], warnings
 
 

--- a/pep_sphinx_extensions/tests/pep_lint/test_post_url.py
+++ b/pep_sphinx_extensions/tests/pep_lint/test_post_url.py
@@ -5,6 +5,7 @@ import pytest
 @pytest.mark.parametrize(
     "line",
     [
+        "TBA",
         "list-name@python.org",
         "distutils-sig@python.org",
         "csv@python.org",
@@ -52,7 +53,7 @@ def test_validate_discussions_to_invalid_list_domain(line: str):
         warning for (_, warning) in check_peps._validate_discussions_to(1, line)
     ]
     assert warnings == [
-        "Discussions-To must be a valid thread URL or mailing list"
+        "Discussions-To must be 'TBA', a valid thread URL or mailing list"
     ], warnings
 
 

--- a/pep_sphinx_extensions/tests/pep_lint/test_post_url.py
+++ b/pep_sphinx_extensions/tests/pep_lint/test_post_url.py
@@ -5,7 +5,7 @@ import pytest
 @pytest.mark.parametrize(
     "line",
     [
-        "TBA",
+        "Pending",
         "list-name@python.org",
         "distutils-sig@python.org",
         "csv@python.org",

--- a/peps/pep-0012.rst
+++ b/peps/pep-0012.rst
@@ -81,7 +81,7 @@ directions below.
 - Add the direct URL of the PEP's canonical discussion thread
   (on e.g. Python-Dev, Discourse, etc) under the Discussions-To header.
   If the thread will be created after the PEP is submitted as an official
-  draft, it is okay to just list the venue name initially, but remember to
+  draft, it is okay to just write "TBA" initially, but remember to
   update the PEP with the URL as soon as the PEP is successfully merged
   to the PEPs repository and you create the corresponding discussion thread.
   See :pep:`PEP 1 <1#discussing-a-pep>` for more details.

--- a/peps/pep-0012.rst
+++ b/peps/pep-0012.rst
@@ -81,7 +81,7 @@ directions below.
 - Add the direct URL of the PEP's canonical discussion thread
   (on e.g. Python-Dev, Discourse, etc) under the Discussions-To header.
   If the thread will be created after the PEP is submitted as an official
-  draft, it is okay to just write "TBA" initially, but remember to
+  draft, it is okay to just put "Pending" initially, but remember to
   update the PEP with the URL as soon as the PEP is successfully merged
   to the PEPs repository and you create the corresponding discussion thread.
   See :pep:`PEP 1 <1#discussing-a-pep>` for more details.

--- a/peps/pep-0012/pep-NNNN.rst
+++ b/peps/pep-0012/pep-NNNN.rst
@@ -3,7 +3,7 @@ Title: <REQUIRED: pep title>
 Author: <REQUIRED: list of authors' names and optionally, email addrs>
 Sponsor: <name of sponsor>
 PEP-Delegate: <PEP delegate's name>
-Discussions-To: TBA <REQUIRED: URL of current canonical discussion thread>
+Discussions-To: Pending
 Status: <REQUIRED: Draft | Active | Accepted | Provisional | Deferred | Rejected | Withdrawn | Final | Superseded>
 Type: <REQUIRED: Standards Track | Informational | Process>
 Topic: <Governance | Packaging | Release | Typing>

--- a/peps/pep-0012/pep-NNNN.rst
+++ b/peps/pep-0012/pep-NNNN.rst
@@ -3,7 +3,7 @@ Title: <REQUIRED: pep title>
 Author: <REQUIRED: list of authors' names and optionally, email addrs>
 Sponsor: <name of sponsor>
 PEP-Delegate: <PEP delegate's name>
-Discussions-To: <REQUIRED: URL of current canonical discussion thread>
+Discussions-To: TBA <REQUIRED: URL of current canonical discussion thread>
 Status: <REQUIRED: Draft | Active | Accepted | Provisional | Deferred | Rejected | Withdrawn | Final | Superseded>
 Type: <REQUIRED: Standards Track | Informational | Process>
 Topic: <Governance | Packaging | Release | Typing>


### PR DESCRIPTION
There's often confusion about whether the discussion thread should be created before or after the draft PEP has been merged.

It's often better to merge the PEP first, and the the thread can use the https://peps.python.org/ URL instead of disseminating a temporary RTD URL that will soon be outdated and later deleted.

The linter is confusing too: "Discussions-To must be a valid thread URL or mailing list" makes some think the thread must be created first to pass, it's not obvious they can omit the field to satisfy the linter.

Finally, PEP 12 says "it is okay to just list the venue name initially" but the linter requires a thread or ML URL.

Instead, I think it may improve things if authors can write ~"Discussions-To: TBA"~ "Discussions-To: Pending" without the linter complaining. We can then merge the draft PR, they can open the thread, and then replace the ~TBA~ Pending.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4361.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->