### PR TITLE
PEP 750: Mark as Accepted

### DIFF
--- a/peps/pep-0750.rst
+++ b/peps/pep-0750.rst
@@ -7,7 +7,7 @@ Author: Jim Baker <jim.baker@python.org>,
         Lysandros Nikolaou <lisandrosnik@gmail.com>,
         Dave Peck <davepeck@davepeck.org>
 Discussions-To: https://discuss.python.org/t/71594
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Created: 08-Jul-2024
 Python-Version: 3.14
@@ -15,6 +15,7 @@ Post-History: `09-Aug-2024 <https://discuss.python.org/t/60408>`__,
               `17-Oct-2024 <https://discuss.python.org/t/60408/201>`__,
               `21-Oct-2024 <https://discuss.python.org/t/60408/226>`__,
               `18-Nov-2024 <https://discuss.python.org/t/71594>`__,
+Resolution: `10-Apr-2025 <https://discuss.python.org/t/71594/130>`__
 
 Abstract
 ========


### PR DESCRIPTION
* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [x] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date

cc @davepeck @lysnikolaou 

A