### PR TITLE
Officially defer PEP 661

### DIFF
--- a/peps/pep-0661.rst
+++ b/peps/pep-0661.rst
@@ -2,7 +2,7 @@ PEP: 661
 Title: Sentinel Values
 Author: Tal Einat <tal@python.org>
 Discussions-To: https://discuss.python.org/t/pep-661-sentinel-values/9126
-Status: Draft
+Status: Deferred
 Type: Standards Track
 Created: 06-Jun-2021
 Post-History: `20-May-2021 <https://discuss.python.org/t/sentinel-values-in-the-stdlib/8810>`__, `06-Jun-2021 <https://discuss.python.org/t/pep-661-sentinel-values/9126>`__


### PR DESCRIPTION
Deferred for Python 3.14 based on Steering Council recommendation.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4363.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->