### PR TITLE
PEP 770: Mark as Accepted

### DIFF
--- a/peps/pep-0770.rst
+++ b/peps/pep-0770.rst
@@ -4,13 +4,14 @@ Author: Seth Larson <seth@python.org>
 Sponsor: Brett Cannon <brett@python.org>
 PEP-Delegate: Brett Cannon <brett@python.org>
 Discussions-To: https://discuss.python.org/t/76308
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Topic: Packaging
 Created: 02-Jan-2025
 Post-History:
   `05-Nov-2024 <https://discuss.python.org/t/70261>`__,
   `06-Jan-2025 <https://discuss.python.org/t/76308>`__,
+Resolution: `11-Apr-2025 <https://discuss.python.org/t/76308/112>`__
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [x] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date



<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4367.org.readthedocs.build/pep-0770/

<!-- readthedocs-preview pep-previews end -->