### PR TITLE
PEP 785: post-history

### DIFF
--- a/peps/pep-0785.rst
+++ b/peps/pep-0785.rst
@@ -2,10 +2,13 @@ PEP: 785
 Title: New methods for easier handling of ``ExceptionGroup``\ s
 Author: Zac Hatfield-Dodds <zac@zhd.dev>
 Sponsor: Gregory P. Smith <greg@krypto.org>
+Discussions-To: https://discuss.python.org/t/88244
 Status: Draft
 Type: Standards Track
 Created: 08-Apr-2025
 Python-Version: 3.14
+Post-History:
+  `13-Apr-2025 <https://discuss.python.org/t/88244>`__,
 
 Abstract
 ========


### PR DESCRIPTION
Per @hugovk's request in https://github.com/python/peps/pull/4357#issuecomment-2800482219 🙂 



<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4372.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->