### PR TITLE
PEP 787: Add discussion-to

### DIFF
--- a/peps/pep-0787.rst
+++ b/peps/pep-0787.rst
@@ -1,12 +1,13 @@
 PEP: 787
 Title: Safer subprocess usage using t-strings
 Author: Nick Humrich <nick@humrich.us>, Alyssa Coghlan <ncoghlan@gmail.com>
-Discussions-To: Pending
+Discussions-To: https://discuss.python.org/t/pep-787-safer-subprocess-usage-using-t-strings/88311
 Status: Draft
 Type: Standards Track
 Requires: 750
 Created: 13-Apr-2025
 Python-Version: 3.14
+Post-History: `14-Apr-2025 <https://discuss.python.org/t/pep-787-safer-subprocess-usage-using-t-strings/88311>`__
 
 Abstract
 ========


### PR DESCRIPTION
Adds the discussion-to and post-history to PEP 787

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4373.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->