### PR TITLE
PEP 787: Postpone to Python 3.15

### DIFF
--- a/peps/pep-0787.rst
+++ b/peps/pep-0787.rst
@@ -6,7 +6,7 @@ Status: Draft
 Type: Standards Track
 Requires: 750
 Created: 13-Apr-2025
-Python-Version: 3.14
+Python-Version: 3.15
 Post-History: `14-Apr-2025 <https://discuss.python.org/t/pep-787-safer-subprocess-usage-using-t-strings/88311>`__
 
 Abstract


### PR DESCRIPTION
Change python version to target 3.15 instead of 3.14

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4381.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->