### PR TITLE
PEP 772: As with PEP 13, seconding a vote of no confidence should be open for one week

### DIFF
--- a/peps/pep-0772.rst
+++ b/peps/pep-0772.rst
@@ -341,7 +341,7 @@ member, or the entire council, via a vote of no confidence.
 
 A no-confidence vote is triggered when a voting member calls for one publicly
 on an appropriate public communication channel, and another voting member
-seconds the call within two weeks.
+seconds the call within one week.
 
 The vote lasts for two weeks. Each voting member votes for or against. If at
 least two thirds of voters express a lack of confidence, then the vote


### PR DESCRIPTION


As per [this discussion on DPO](https://discuss.python.org/t/pep-772-packaging-governance-process/79724/52).  The intention is to align PEP 772 with PEP 13.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4384.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->