### PR TITLE
PEP 787: defer pending PyPI library experimentation

### DIFF
--- a/peps/pep-0787.rst
+++ b/peps/pep-0787.rst
@@ -26,8 +26,8 @@ a potential opportunity to offer ``shell=True`` levels of syntactic convenience 
 subprocess invocations without all of the security and cross-platform compatibility concerns
 that arise with giving user provided text access to a full system shell.
 
-To that end, the PEP authors now plan to work on an experimental `t-string based subprocess
-invocation library <https://pypi.org/project/tstrprocess/>`__ through the Python 3.14 beta
+To that end, the PEP authors now plan to work on an experimental :pypi:`t-string
+based subprocess invocation library <tstrprocess>` through the Python 3.14 beta
 period (and beyond), before preparing a revised draft of the proposal for Python 3.15.
 
 Motivation

--- a/peps/pep-0787.rst
+++ b/peps/pep-0787.rst
@@ -2,7 +2,7 @@ PEP: 787
 Title: Safer subprocess usage using t-strings
 Author: Nick Humrich <nick@humrich.us>, Alyssa Coghlan <ncoghlan@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-787-safer-subprocess-usage-using-t-strings/88311
-Status: Draft
+Status: Deferred
 Type: Standards Track
 Requires: 750
 Created: 13-Apr-2025
@@ -17,6 +17,18 @@ providing a way to safely handle string interpolation in various contexts. This 
 proposes extending the :mod:`subprocess` and :mod:`shlex` modules to natively support t-strings, enabling
 safer and more ergonomic shell command execution with interpolated values, as well as
 serving as a reference implementation for the t-string feature to improve API ergonomics.
+
+PEP Deferral
+============
+
+During the discussions of the initial draft of the PEP, it became clear that t-strings provide
+a potential opportunity to offer ``shell=True`` levels of syntactic convenience for complex
+subprocess invocations without all of the security and cross-platform compatibility concerns
+that arise with giving user provided text access to a full system shell.
+
+To that end, the PEP authors now plan to work on an experimental `t-string based subprocess
+invocation library <https://pypi.org/project/tstrprocess/>`__ through the Python 3.14 beta
+period (and beyond), before preparing a revised draft of the proposal for Python 3.15.
 
 Motivation
 ==========


### PR DESCRIPTION
Note: requires approving review from @nhumrich before merging.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4389.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->