### PR TITLE
Infra: Only add preview links for PRs to ``python/peps``

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   documentation-links:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == 'python/peps'
+    if: github.event.repository.fork == false
     steps:
       - uses: readthedocs/actions/preview@v1
         with:

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   documentation-links:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == 'python/peps'
     steps:
       - uses: readthedocs/actions/preview@v1
         with:


### PR DESCRIPTION
<!--
This template is for an infra or meta change not belonging to another category.
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

If you make a fork, and then a coauthor makes a PR to that fork, a non-working docs link will get generated. This should fix this by making sure it's only being added to PRs to this repository, and not PRs to forks.

Example: https://github.com/henryiii/peps/pull/1

~~Though I need to try to test this in my fork to make sure, `pull_request_target` can be tricky.~~ I think I have to test it by PR'ing into this branch on my fork. Edit: yes, it's working: https://github.com/henryiii/peps/pull/2


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4399.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->