### PR TITLE
PEP 423: Fix a Link that Leads to Scam Website on First Opening

### DIFF
--- a/peps/pep-0423.rst
+++ b/peps/pep-0423.rst
@@ -823,7 +823,7 @@ References and footnotes:
 .. _`in development official packaging documentation`:
    http://docs.python.org/dev/packaging/
 .. _`The Hitchhiker's Guide to Packaging`:
-   http://guide.python-distribute.org/specification.html#naming-specification
+   https://the-hitchhikers-guide-to-packaging.readthedocs.io/en/latest/
 
 
 Copyright


### PR DESCRIPTION
Even though typo fixes like this are advised against -- this is pretty bad because we have a scam website right here when you open it for the first time in a browser profile.  Therefore I decided to break this rule.

Fixes #4401.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4402.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->