### PR TITLE
PEP 782: Set the Python version to 3.15

### DIFF
--- a/peps/pep-0782.rst
+++ b/peps/pep-0782.rst
@@ -5,7 +5,7 @@ Discussions-To: https://discuss.python.org/t/86617
 Status: Draft
 Type: Standards Track
 Created: 27-Mar-2025
-Python-Version: 3.14
+Python-Version: 3.15
 Post-History:
     `18-Feb-2025 <https://discuss.python.org/t/81182>`__
 


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4407.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->