### PR TITLE
PEP 727: Mark as Withdrawn

### DIFF
--- a/peps/pep-0727.rst
+++ b/peps/pep-0727.rst
@@ -3,7 +3,7 @@ Title: Documentation in Annotated Metadata
 Author: Sebastián Ramírez <tiangolo@gmail.com>
 Sponsor: Jelle Zijlstra <jelle.zijlstra@gmail.com>
 Discussions-To: https://discuss.python.org/t/32566
-Status: Draft
+Status: Withdrawn
 Type: Standards Track
 Topic: Typing
 Created: 28-Aug-2023
@@ -17,6 +17,12 @@ Abstract
 This PEP proposes a standardized way to provide documentation strings for Python
 symbols defined with :py:class:`~typing.Annotated` using a new class
 ``typing.Doc``.
+
+PEP Withdrawal
+==============
+
+The reception of this PEP was mostly negative, with concerns raised about
+verbosity and readability. As a result, this PEP has been withdrawn.
 
 
 Motivation


### PR DESCRIPTION
@tiangolo agreed to withdraw the PEP in emails last year, but this never happened. Let's clean it up.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4408.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->