### PR TITLE
Open typing PEPs: Retarget to 3.15

### DIFF
--- a/peps/pep-0718.rst
+++ b/peps/pep-0718.rst
@@ -7,7 +7,7 @@ Status: Draft
 Type: Standards Track
 Topic: Typing
 Created: 23-Jun-2023
-Python-Version: 3.13
+Python-Version: 3.15
 Post-History: `24-Jun-2023 <https://discuss.python.org/t/28457/>`__
 
 Abstract

--- a/peps/pep-0728.rst
+++ b/peps/pep-0728.rst
@@ -7,7 +7,7 @@ Status: Draft
 Type: Standards Track
 Topic: Typing
 Created: 12-Sep-2023
-Python-Version: 3.14
+Python-Version: 3.15
 Post-History: `09-Feb-2024 <https://discuss.python.org/t/pep-728-typeddict-with-typed-extra-items/45443>`__,
 
 

--- a/peps/pep-0746.rst
+++ b/peps/pep-0746.rst
@@ -7,7 +7,7 @@ Status: Draft
 Type: Standards Track
 Topic: Typing
 Created: 20-May-2024
-Python-Version: 3.14
+Python-Version: 3.15
 Post-History: 20-May-2024
 
 Abstract

--- a/peps/pep-0747.rst
+++ b/peps/pep-0747.rst
@@ -7,7 +7,7 @@ Status: Draft
 Type: Standards Track
 Topic: Typing
 Created: 27-May-2024
-Python-Version: 3.14
+Python-Version: 3.15
 Post-History: `19-Apr-2024 <https://discuss.python.org/t/typeform-spelling-for-a-type-annotation-object-at-runtime/51435>`__, `04-May-2024 <https://discuss.python.org/t/typeform-spelling-for-a-type-annotation-object-at-runtime/51435/7/>`__, `17-Jun-2024 <https://discuss.python.org/t/pep-747-typeexpr-type-hint-for-a-type-expression/55984>`__
 
 

--- a/peps/pep-0764.rst
+++ b/peps/pep-0764.rst
@@ -7,7 +7,7 @@ Status: Draft
 Type: Standards Track
 Topic: Typing
 Created: 25-Oct-2024
-Python-Version: 3.14
+Python-Version: 3.15
 Post-History: `29-Jan-2025 <https://discuss.python.org/t/78779>`__
 
 

--- a/peps/pep-0767.rst
+++ b/peps/pep-0767.rst
@@ -7,7 +7,7 @@ Status: Draft
 Type: Standards Track
 Topic: Typing
 Created: 18-Nov-2024
-Python-Version: 3.14
+Python-Version: 3.15
 Post-History: `09-Oct-2024 <https://discuss.python.org/t/expanding-readonly-to-normal-classes-protocols/67359>`__
 
 

--- a/peps/pep-0781.rst
+++ b/peps/pep-0781.rst
@@ -6,7 +6,7 @@ Status: Draft
 Type: Standards Track
 Topic: Typing
 Created: 24-Mar-2025
-Python-Version: 3.14
+Python-Version: 3.15
 Post-History: `11-Jan-2025 <https://discuss.python.org/t/76766>`__,
               `24-Mar-2025 <https://discuss.python.org/t/85728>`__,
 


### PR DESCRIPTION
The ship has sailed for 3.14. cc @Gobot1234 @PIG208 @adriangb @davidfstr @Viicos @Enegg @methane 

Several of these PEPs seem pretty far along and I'd encourage you to submit them to the Typing Council for a decision.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4409.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->