### PR TITLE
PEP 563: Mark as Superseded

### DIFF
--- a/peps/pep-0563.rst
+++ b/peps/pep-0563.rst
@@ -2,14 +2,22 @@ PEP: 563
 Title: Postponed Evaluation of Annotations
 Author: Łukasz Langa <lukasz@python.org>
 Discussions-To: python-dev@python.org
-Status: Accepted
+Status: Superseded
 Type: Standards Track
 Topic: Typing
 Created: 08-Sep-2017
 Python-Version: 3.7
 Post-History: 01-Nov-2017, 21-Nov-2017
-Superseded-By: 649
+Superseded-By: 649, 749
 Resolution: https://mail.python.org/pipermail/python-dev/2017-December/151042.html
+
+
+Resolution
+==========
+
+The features proposed in this PEP never became the default behaviour,
+and have been replaced with deferred evaluation of annotations,
+as proposed by :pep:`649` and :pep:`749`.
 
 
 Abstract


### PR DESCRIPTION
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)

Alternative to and would close #3571, cc @JelleZijlstra.

A

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4411.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->