### PR TITLE
PEP 625: Mark as Final

### DIFF
--- a/peps/pep-0625.rst
+++ b/peps/pep-0625.rst
@@ -4,12 +4,14 @@ Author: Tzu-ping Chung <uranusjr@gmail.com>,
         Paul Moore <p.f.moore@gmail.com>
 PEP-Delegate: Pradyun Gedam <pradyunsg@gmail.com>
 Discussions-To: https://discuss.python.org/t/draft-pep-file-name-of-a-source-distribution/4686
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Packaging
 Created: 08-Jul-2020
 Post-History: 08-Jul-2020
 Resolution: https://discuss.python.org/t/pep-625-file-name-of-a-source-distribution/4686/159
+
+.. canonical-pypa-spec:: :ref:`packaging:source-distribution-format-sdist`
 
 Abstract
 ========


### PR DESCRIPTION
* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [x] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)
