### PR TITLE
PEP 649: Mark as Final

### DIFF
--- a/peps/pep-0649.rst
+++ b/peps/pep-0649.rst
@@ -2,7 +2,7 @@ PEP: 649
 Title: Deferred Evaluation Of Annotations Using Descriptors
 Author: Larry Hastings <larry@hastings.org>
 Discussions-To: https://discuss.python.org/t/pep-649-deferred-evaluation-of-annotations-tentatively-accepted/21331/
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
 Created: 11-Jan-2021


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [x] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

649 is an odd one as "PEP matches the final implementation" requires also reading 749. Thoughts?

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4414.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->