### PR TITLE
PEP 745: Update 3.14.0b1 release date

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -43,11 +43,11 @@ Actual:
 - 3.14.0 alpha 5: Tuesday, 2025-02-11
 - 3.14.0 alpha 6: Friday, 2025-03-14
 - 3.14.0 alpha 7: Tuesday, 2025-04-08
+- 3.14.0 beta 1: Wednesday, 2025-05-07
+  (No new features beyond this point.)
 
 Expected:
 
-- 3.14.0 beta 1: Tuesday, 2025-05-06
-  (No new features beyond this point.)
 - 3.14.0 beta 2: Tuesday, 2025-05-27
 - 3.14.0 beta 3: Tuesday, 2025-06-17
 - 3.14.0 beta 4: Tuesday, 2025-07-08


### PR DESCRIPTION
Python 3.14.0 beta 1 was released today https://www.python.org/downloads/release/python-3140b1/

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4415.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->