### PR TITLE
PEP 776: RPATH is fully supported as of Emscripten 4.0.8

### DIFF
--- a/peps/pep-0776.rst
+++ b/peps/pep-0776.rst
@@ -305,31 +305,6 @@ In the long term, we hope to implement stack switching ``stdin`` devices, but
 that is out of scope for this PEP.
 
 
-Missing RPATH Support
----------------------
-
-An important limitation of the Emscripten dynamic loader is that it does not
-currently have RPATH support. Pyodide's present workaround is as follows:
-``auditwheel-emscripten`` places shared library dependencies that are vendored
-into a package in a ``${package}.libs`` folder, following auditwheel's
-convention. Pyodide patches the dynamic loader to treat this ``${package}.libs``
-folder as if it were on the RPATH of all of the dynamic libraries in the wheel.
-
-In Emscripten 4.0.5, we have updated the shared object file format, ``wasm-ld``
-and ``emcc`` to accept an ``-rpath`` flag. We are still working on updating the
-dynamic loader to respect the rpath, but we expect this will be finished soon.
-Pyodide will then switch to using the RPATH and drop the patch on the dynamic
-loader.
-
-Emscripten Python currently uses the unpatched dynamic loader and so cannot load
-extension modules that depend on vendored dynamic libraries via DT_NEEDED.
-Extension modules can load dynamic libraries via DT_NEEDED if they are in the
-system ``lib`` directory. We will wait to resolve this until we have fixed the
-Emscripten dynamic loader upstream. When Emscripten Python is built with a
-compatible version of Emscripten, it will automatically pick up support for
-wheels with vendored dynamic libraries.
-
-
 Traps and Uncaught Exceptions
 -----------------------------
 


### PR DESCRIPTION
There is some more work to be done to teach CMake and other build systems that Emscripten supports RPATH. But those are packaging problems. I think this section can be deleted.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4423.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->