### PR TITLE
PEP 745: Target 3.14.0b2 a day earlier

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -48,7 +48,7 @@ Actual:
 
 Expected:
 
-- 3.14.0 beta 2: Tuesday, 2025-05-27
+- 3.14.0 beta 2: Monday, 2025-05-26
 - 3.14.0 beta 3: Tuesday, 2025-06-17
 - 3.14.0 beta 4: Tuesday, 2025-07-08
 - 3.14.0 candidate 1: Tuesday, 2025-07-22


### PR DESCRIPTION
Target beta 2 for Monday 2025-05-26 rather than Tuesday 2025-05-27. I'm off to PyCon Italia very early on Wednesday, so this also gives an extra day of buffer in case of delays.