### PR TITLE
PEP 719: Move actual bugfix releases to their own subsection

### DIFF
--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -52,14 +52,14 @@ Actual:
 - 3.13.0 candidate 3: Tuesday, 2024-10-01
 - 3.13.0 final: Monday, 2024-10-07
 
-Expected:
+Bugfix releases
+---------------
+
+Actual:
 
 - 3.13.1: Tuesday, 2024-12-03
 - 3.13.2: Tuesday, 2025-02-04
 - 3.13.3: Tuesday, 2025-04-08
-
-Bugfix releases
----------------
 
 Expected:
 

--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -51,6 +51,9 @@ Actual:
 - 3.13.0 candidate 2: Friday, 2024-09-06
 - 3.13.0 candidate 3: Tuesday, 2024-10-01
 - 3.13.0 final: Monday, 2024-10-07
+
+Expected:
+
 - 3.13.1: Tuesday, 2024-12-03
 - 3.13.2: Tuesday, 2025-02-04
 - 3.13.3: Tuesday, 2025-04-08


### PR DESCRIPTION
Currently, the expected PEPs are under the `Actual` subheading.  This PR puts them under their own `Expected` subheading, [following the form like that for 3.14.0.](https://github.com/python/peps/blob/61cfcda7f94fd9c477521918e9d60090d2cf0b40/peps/pep-0745.rst?plain=1#L36-L58)

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4425.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->