### PR TITLE
PEP 772: Updates based on conversations at PyCon

### DIFF
--- a/peps/pep-0772.rst
+++ b/peps/pep-0772.rst
@@ -415,20 +415,21 @@ this relationship would be figured out by the inaugural Council.
 
 .. _appendix_a:
 
-=========================================
-Appendix A: Approval process for this PEP
-=========================================
+================================
+Appendix A: PEP approval process
+================================
 
-This PEP would likely require an atypical process for approval given that it
-requires changes to PyPA's governance (which involves a PyPA-committers vote)
-and it requires the Python Steering Council to change their delegations.
+This PEP likely requires an atypical approval process, given the parties that must agree.  To that
+end, the authors will submit this PEP
 
-To that end, the process for approval for this PEP will be:
+#. for a vote with the PSF Board, which must approve the linking of Packaging Council Electors to
+   the PSF Membership, and the deactivation of the Packaging Workgroup
+#. for a vote on the pypa-committers mailing list, in accordance with the process outlined in
+   :pep:`609`
+#. for formal approval by the Python Steering Council
 
-* Submit this PEP for a vote on the pypa-committers mailing list, in accordance
-  with the process outlined in :pep:`609`.
-* Submit this PEP for the Python Steering Council's comments and approval.
-* Reconcile any outstanding variances in text and repeat, if necessary.
+We will reconcile and update the PEP as necessary based on recommendations, comments, and feedback,
+and iterate until we gain all necessary approvals.
 
 .. _appendix_b:
 


### PR DESCRIPTION
* Align PPC Electors with PSF voting members as described in the PSF bylaws.  Rather than the previous categories, this approach is generally deemed to be both equitable and workable.
* Update the mechanics and timeline of PPC elections, into three phases: self-selection of Electors, nominations of Council members, voting
* Remove the language around initial membership and adding a new member, as these are no longer necessary.
* Add language about the call for deanonymization of ballots in cases where foul play is suspected.
* Clarify the PSC's role in approving changes to this PEP, and responsibilities in certain corner cases of the election process.
* Explicitly disallow PSC members from concurrently serving on the PPC.
* Clarify language around the expectation of the PSC and PSF to adjust existing standing delegations
* Unify language around "Packaging Council Electors" rather than "voting members"
* Added an acknowledgments section
* Various spelling, grammar, and wording fixes

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4429.org.readthedocs.build/pep-0772/

<!-- readthedocs-preview pep-previews end -->