### PR TITLE
PEP 8: Add an exmple for blank lines between groups of imports

### DIFF
--- a/peps/pep-0008.rst
+++ b/peps/pep-0008.rst
@@ -382,7 +382,17 @@ Imports
   2. Related third party imports.
   3. Local application/library specific imports.
 
-  You should put a blank line between each group of imports.
+  You should put a blank line between each group of imports:
+
+  .. code-block::
+     :class: good
+
+     import os
+     import sys
+
+     import mypkg.sibling
+     from mypkg import sibling
+     from mypkg.sibling import example
 
 - Absolute imports are recommended, as they are usually more readable
   and tend to be better behaved (or at least give better error


### PR DESCRIPTION
PEP 8 mentions that a white line should be included between import types, but does not provide an example for it. People quickly browsing the documentation might overlook this detail. Adding an example ensures readers visualize this recommendation.

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4433.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->