### PR TITLE
PEP 784: Mark as Final

### DIFF
--- a/peps/pep-0784.rst
+++ b/peps/pep-0784.rst
@@ -3,7 +3,7 @@ Title: Adding Zstandard to the standard library
 Author: Emma Harper Smith <emma@python.org>
 Sponsor: Gregory P. Smith <greg@krypto.org>
 Discussions-To: https://discuss.python.org/t/87377
-Status: Accepted
+Status: Final
 Type: Standards Track
 Created: 06-Apr-2025
 Python-Version: 3.14

--- a/peps/pep-0784.rst
+++ b/peps/pep-0784.rst
@@ -12,6 +12,9 @@ Post-History:
 Resolution: `25-Apr-2025 <https://discuss.python.org/t/87377/138>`__
 
 
+.. canonical-doc:: :mod:`compression.zstd`
+
+
 Abstract
 ========
 


### PR DESCRIPTION
* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [x] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4436.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->