### PR TITLE
PEP 769: Mark as Rejected

### DIFF
--- a/peps/pep-0769.rst
+++ b/peps/pep-0769.rst
@@ -2,11 +2,12 @@ PEP: 769
 Title: Add a 'default' keyword argument to 'attrgetter', 'itemgetter' and 'getitem'
 Author: Facundo Batista <facundo@taniquetil.com.ar>
 Discussions-To: https://discuss.python.org/t/76419
-Status: Draft
+Status: Rejected
 Type: Standards Track
 Created: 22-Dec-2024
 Python-Version: 3.14
 Post-History: `07-Jan-2025 <https://discuss.python.org/t/76419>`__
+Resolution: `14-Mar-2025 <https://discuss.python.org/t/76419/32>`__
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [ ] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date
