### PR TITLE
PEP 725: Fix Sphinx reference warning

### DIFF
--- a/peps/pep-0725.rst
+++ b/peps/pep-0725.rst
@@ -663,9 +663,9 @@ References
 .. [#pypackaging-native-cross] pypackaging-native: "Cross compilation"
    https://pypackaging-native.github.io/key-issues/cross_compilation/
 
-.. [#pkgconfig-and-ctypes-findlibrary] The "``pkgconfig`` specification as an
-   alternative to ``ctypes.util.find_library``" thread (2023, Discourse):
-   https://discuss.python.org/t/pkgconfig-specification-as-an-alternative-to-ctypes-util-find-library/31379
+* The "``pkgconfig`` specification as an
+  alternative to ``ctypes.util.find_library``" thread (2023, Discourse):
+  https://discuss.python.org/t/pkgconfig-specification-as-an-alternative-to-ctypes-util-find-library/31379
 
 
 Copyright


### PR DESCRIPTION
For https://github.com/python/peps/issues/4087.

The definition was added in the initial commit  https://github.com/python/peps/commit/bd0a5d82bad14332a1bdc4b28cef95b2b495a4af but never referred to from the text.

This changes it to a bullet point.

Alternatively, we could delete it.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4440.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->