### PR TITLE
PEP 745: 3.14.0b2 was released on 2025-05-26

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -45,10 +45,10 @@ Actual:
 - 3.14.0 alpha 7: Tuesday, 2025-04-08
 - 3.14.0 beta 1: Wednesday, 2025-05-07
   (No new features beyond this point.)
+- 3.14.0 beta 2: Monday, 2025-05-26
 
 Expected:
 
-- 3.14.0 beta 2: Monday, 2025-05-26
 - 3.14.0 beta 3: Tuesday, 2025-06-17
 - 3.14.0 beta 4: Tuesday, 2025-07-08
 - 3.14.0 candidate 1: Tuesday, 2025-07-22


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4441.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->