### PR TITLE
PEP 758: Mark as Final

### DIFF
--- a/peps/pep-0758.rst
+++ b/peps/pep-0758.rst
@@ -8,6 +8,8 @@ Python-Version: 3.14
 Post-History: `02-Oct-2024 <https://discuss.python.org/t/66453>`__
 Resolution: `14-Mar-2025 <https://discuss.python.org/t/66453/63>`__
 
+.. canonical-doc:: :ref:`python:except` and :ref:`python:except_star`
+
 Abstract
 ========
 

--- a/peps/pep-0758.rst
+++ b/peps/pep-0758.rst
@@ -8,7 +8,7 @@ Python-Version: 3.14
 Post-History: `02-Oct-2024 <https://discuss.python.org/t/66453>`__
 Resolution: `14-Mar-2025 <https://discuss.python.org/t/66453/63>`__
 
-.. canonical-doc:: :ref:`python:except` and :ref:`python:except_star`
+.. canonical-doc:: :ref:`python:try`
 
 Abstract
 ========

--- a/peps/pep-0758.rst
+++ b/peps/pep-0758.rst
@@ -1,7 +1,7 @@
 PEP: 758
 Title: Allow ``except`` and ``except*`` expressions without parentheses
 Author: Pablo Galindo <pablogsal@python.org>, Brett Cannon <brett@python.org>
-Status: Accepted
+Status: Final
 Type: Standards Track
 Created: 30-Sep-2024
 Python-Version: 3.14


### PR DESCRIPTION
Part of #4437

<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [X] Final implementation has been merged (including tests and docs)
* [X] PEP matches the final implementation
* [X] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [X] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [X] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [X] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)
