### PR TITLE
PEP 772: Update discussion link

### DIFF
--- a/peps/pep-0772.rst
+++ b/peps/pep-0772.rst
@@ -7,8 +7,8 @@ Discussions-To: https://discuss.python.org/t/pep-772-packaging-council-governanc
 Status: Draft
 Type: Process
 Topic: Governance, Packaging
-Post-History: 06-Feb-2025, 30-May-2025
 Created: 21-Jan-2025
+Post-History: 06-Feb-2025, 30-May-2025
 Replaces: 609
 
 

--- a/peps/pep-0772.rst
+++ b/peps/pep-0772.rst
@@ -7,6 +7,7 @@ Discussions-To: https://discuss.python.org/t/pep-772-packaging-council-governanc
 Status: Draft
 Type: Process
 Topic: Governance, Packaging
+Post-History: 06-Feb-2025, 30-May-2025
 Created: 21-Jan-2025
 Replaces: 609
 

--- a/peps/pep-0772.rst
+++ b/peps/pep-0772.rst
@@ -3,7 +3,7 @@ Title: Packaging Council governance process
 Author: Barry Warsaw <barry@python.org>,
         Deb Nicholson <deb@python.org>,
         Pradyun Gedam <pradyunsg@gmail.com>
-Discussions-To: https://discuss.python.org/t/pep-772-packaging-governance-process/79724
+Discussions-To: https://discuss.python.org/t/pep-772-packaging-council-governance-process-round-2/93904
 Status: Draft
 Type: Process
 Topic: Governance, Packaging


### PR DESCRIPTION
I noticed the discussion header was still referring to the original thread.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4445.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->