### PR TITLE
PEP 747: Add Acknowledgements section

### DIFF
--- a/peps/pep-0747.rst
+++ b/peps/pep-0747.rst
@@ -619,6 +619,42 @@ this behavior. The example above could more simply be written as the equivalent:
    def checkcast(typx: TypeForm[T], value: object) -> T:
 
 
+Acknowledgements
+================
+
+- David Foster drafted the initial version of this PEP, drafted the
+  mypy implementation of it, and shepherded it through the PEP process.
+
+- Eric Traut provided tons of feedback throughout the design process,
+  drafted a major update to the original PEP text, and drafted the
+  pyright implementation of it.
+
+- Jelle Zijlstra provided feedback especially on early drafts of the PEP
+  and drafted the ``typing_extensions`` implementation of the
+  ``TypeExpr`` special form.
+
+- Carl Meyer and Mehdi Drissi provided valuable feedback,
+  particularly on the question of whether to allow ``type`` to be assigned
+  to ``TypeForm`` or not.
+
+- Cecil Curry (leycec) provided feedback from the perspective of
+  runtime type checkers and experimented with the in-progress ``TypeForm``
+  special form in a real-world runtime type checker (beartype).
+
+- Jukka Lehtosalo provided feedback on the mypy implementation of TypeForm,
+  helping the checking algorithm run faster and use less memory.
+
+- Michael H (mikeshardmind) proposed syntax ideas for matching specific kinds
+  of type forms.
+
+- Paul Moore advocated for several changes to the PEP to make it more
+  approachable to typing novices.
+
+- Tin Tvrtković (Tinche) and Salvo 'LtWorf' Tomaselli provided positive feedback
+  from the broader community at multiple times supporting that the PEP would
+  be useful.
+
+
 Footnotes
 =========
 


### PR DESCRIPTION
* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

---

I wanted to specially thank a number of folks who have contributed to the TypeForm PEP. 💖 **For each person that I mentioned†, please review my summary of your key contribution(s) and let me know if you'd like to modify the wording.**

This Acknowledgements section is the last major change I intend to make to this PEP before submitting it to the Typing Council for review. There are already (nearly‡) 2 implementations of the PEP available in major typecheckers and no significant further issues were discovered during the implementation process.

† Folks I mentioned in this PR, tagged for visibility:

* [x] @erictraut - Approved PR
* [x] @JelleZijlstra - Approved PR
* [x] @carljm - Approved PR
* [x] @hmc-cs-mdrissi - Hearted PR
* [x] @leycec - Hearted PR
* [ ] @JukkaL 
* [x] @mikeshardmind 
* [x] @pfmoore - Approved PR
* [x] @Tinche - Approved PR
* [x] @ltworf - Approved PR

‡ The mypy implementation is still going through PR reviews. The pyright implementation has existed for many months now.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4446.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->