### PR TITLE
PEP 734: Mark as Accepted

### DIFF
--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -8,7 +8,7 @@ Created: 06-Nov-2023
 Python-Version: 3.14
 Post-History: `14-Dec-2023 <https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/>`__,
 Replaces: 554
-Resolution: https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/36
+Resolution: `05-Jun-2025 <https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/36>`__
 
 
 .. note::

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -20,7 +20,7 @@ Resolution: `05-Jun-2025 <https://discuss.python.org/t/41147/36>`__
 
 .. note::
    This PEP was accepted with the provision that the name change
-   to ``concurrent.interpreters``.
+   to :module:`!concurrent.interpreters`.
 
 
 Abstract

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -2,13 +2,13 @@ PEP: 734
 Title: Multiple Interpreters in the Stdlib
 Author: Eric Snow <ericsnowcurrently@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147
-Status: Deferred
+Status: Accepted
 Type: Standards Track
 Created: 06-Nov-2023
-Python-Version: 3.13
+Python-Version: 3.14
 Post-History: `14-Dec-2023 <https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/>`__,
 Replaces: 554
-Resolution: https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/24
+Resolution: https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/36
 
 
 .. note::
@@ -17,6 +17,10 @@ Resolution: https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-st
    This PEP is a reduction back to the essential information.  Much of
    that extra information is still valid and useful, just not in the
    immediate context of the specific proposal here.
+
+.. note::
+   This PEP was accepted with the provision that the name change
+   to ``concurrent.interpreters``.
 
 
 Abstract

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -20,7 +20,7 @@ Resolution: `05-Jun-2025 <https://discuss.python.org/t/41147/36>`__
 
 .. note::
    This PEP was accepted with the provision that the name change
-   to :module:`!concurrent.interpreters`.
+   to :py:mod:`!concurrent.interpreters`.
 
 
 Abstract

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -8,7 +8,7 @@ Created: 06-Nov-2023
 Python-Version: 3.14
 Post-History: `14-Dec-2023 <https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/>`__,
 Replaces: 554
-Resolution: `05-Jun-2025 <https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147/36>`__
+Resolution: `05-Jun-2025 <https://discuss.python.org/t/41147/36>`__
 
 
 .. note::


### PR DESCRIPTION
This includes the provision to name the module `concurrent.interpreters`.  We are still discussing
dropping that provision and sticking with just `interpreters`, but that can be addressed
in a later change if it happens.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4451.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->