### PR TITLE
PEP 792: add Discussions-To link

### DIFF
--- a/peps/pep-0792.rst
+++ b/peps/pep-0792.rst
@@ -4,12 +4,13 @@ Author: William Woodruff <william@yossarian.net>,
         Facundo Tuesca <facundo.tuesca@trailofbits.com>,
 Sponsor: Donald Stufft <donald@stufft.io>
 PEP-Delegate: Donald Stufft <donald@stufft.io>
-Discussions-To: Pending
+Discussions-To: https://discuss.python.org/t/pep-792-project-status-markers-in-the-simple-index/94978
 Status: Draft
 Type: Standards Track
 Topic: Packaging
 Created: 21-May-2025
 Post-History: `03-Feb-2025 <https://discuss.python.org/t/79356/>`__,
+              `09-Jun-2025 <https://discuss.python.org/t/94978>`__,
 
 Abstract
 ========


### PR DESCRIPTION
Per procedure, I've opened <https://discuss.python.org/t/pep-792-project-status-markers-in-the-simple-index/94978> for this PEP's discussion.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4455.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->