### PR TITLE
PEP 489: Fix syntax highlighting

### DIFF
--- a/peps/pep-0489.rst
+++ b/peps/pep-0489.rst
@@ -12,6 +12,10 @@ Python-Version: 3.5
 Post-History: 23-Aug-2013, 20-Feb-2015, 16-Apr-2015, 07-May-2015, 18-May-2015
 Resolution: https://mail.python.org/pipermail/python-dev/2015-May/140108.html
 
+.. canonical-doc:: :ref:`python:initializing-modules`.
+                   For Python 3.14+, see :ref:`py3.14:extension-modules`
+                   and :ref:`py3.14:pymoduledef`
+
 .. highlight:: c
 
 Abstract


### PR DESCRIPTION
Most of the code blocks are C, so set that as the document highlight, and use Python on blocks where needed.

Also add inline code formatting.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4456.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->