### PR TITLE
PEP 792: clarify index API changes

### DIFF
--- a/peps/pep-0792.rst
+++ b/peps/pep-0792.rst
@@ -178,14 +178,19 @@ Status markers in the index APIs
 
 This PEP defines version 1.4 of the index APIs.
 
+All changes to the HTML and JSON simple indices below occur at the
+per-project level, i.e. within each project's index response, rather than
+the root index response. No root index response changes are proposed by this
+PEP.
+
 HTML index
 ~~~~~~~~~~
 
 The following changes are made to the
 :ref:`simple repository API <packaging:simple-repository-api-base>`:
 
-* The index **SHALL** define the ``pypi:repository-version`` as ``1.4``.
-* The index **SHOULD** add an appropriate ``pypi:project-status`` meta tag, with
+* The per-project index **SHALL** define the ``pypi:repository-version`` as ``1.4``.
+* The per-project index **SHOULD** add an appropriate ``pypi:project-status`` meta tag, with
   a ``content`` of the project's status marker. The index **MAY** choose to omit
   the ``pypi:project-status`` meta tag if the project is marked as ``active``.
 
@@ -216,8 +221,8 @@ JSON index
 The following changes are made to the
 :ref:`JSON simple index <packaging:simple-repository-api-json>`:
 
-* The index **SHALL** define the ``meta.api-version`` as ``1.4``.
-* The index **SHOULD** include a ``project-status`` key in the JSON response,
+* The per-project index **SHALL** define the ``meta.api-version`` as ``1.4``.
+* The per-project index **SHOULD** include a ``project-status`` key in the JSON response,
   with a value of the project's status marker. The index **MAY** choose to omit
   the ``project-status`` key if the project is marked as ``active``.
 


### PR DESCRIPTION
@brettcannon points out that the current language implicitly concerns only the "project level" index responses, not the "root" response. This change hopefully clarifies that by making it explicit 🙂 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4457.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->