### PR TITLE
PEP 771: Renamed default-optional-dependency-keys to default-extras

### DIFF
--- a/peps/pep-0771.rst
+++ b/peps/pep-0771.rst
@@ -145,12 +145,12 @@ New key in ``[project]`` metadata table
 A new key will be added to the ``[project]`` table in project metadata as
 originally defined in :pep:`621` and now defined in the `PyPA specifications
 <https://packaging.python.org/en/latest/specifications/pyproject-toml/>`_. This key will be named
-``default-optional-dependency-keys`` with the following description:
+``default-extras`` with the following description:
 
 * `TOML <https://toml.io/>`_ type: Array of strings
 * Corresponding core metadata field: ``Default-Extra``
 
-Each string in ``default-optional-dependency-keys`` must be the name of an extra
+Each string in ``default-extras`` must be the name of an extra
 defined in `optional-dependencies
 <https://packaging.python.org/en/latest/specifications/pyproject-toml/#dependencies-optional-dependencies>`_,
 and each extra in this array will be converted to a matching ``Default-Extra``
@@ -160,7 +160,7 @@ produce the example ``Default-Extra`` entries presented in the previous section 
 .. code-block:: toml
 
     [project]
-    default-optional-dependency-keys = [
+    default-extras = [
         "recommended",
     ]
 
@@ -169,7 +169,7 @@ and:
 .. code-block:: toml
 
     [project]
-    default-optional-dependency-keys = [
+    default-extras = [
         "backend1",
         "backend2",
         "backend3"
@@ -263,7 +263,7 @@ would choose to have this be included as a default extra:
 .. code-block:: toml
 
     [project]
-    default-optional-dependency-keys = [
+    default-extras = [
         "recommended"
     ]
 
@@ -286,7 +286,7 @@ extra:
 .. code-block:: toml
 
     [project]
-    default-optional-dependency-keys = [
+    default-extras = [
         "recommended"
     ]
 
@@ -327,7 +327,7 @@ for each backend or frontend, and provide a default, e.g.:
 .. code-block:: toml
 
     [project]
-    default-optional-dependency-keys = [
+    default-extras = [
         "backend1"
     ]
 
@@ -354,7 +354,7 @@ could define the following configuration:
 .. code-block:: toml
 
     [project]
-    default-optional-dependency-keys = [
+    default-extras = [
         "pyqt5"
     ]
 
@@ -406,7 +406,7 @@ This could be achieved with e.g:
 .. code-block:: toml
 
     [project]
-    default-optional-dependency-keys = [
+    default-extras = [
         "recommended"
     ]
 
@@ -438,7 +438,7 @@ configuration would solve this case:
 .. code-block:: toml
 
     [project]
-    default-optional-dependency-keys = [
+    default-extras = [
         "recommended"
     ]
 


### PR DESCRIPTION
I originally used ``default-optional-dependency-keys`` because it seemed to me like ``pyproject.toml`` avoided the terminology of extras, but @ncoghlan pointed out in https://discuss.python.org/t/pep-771-default-extras-for-python-software-packages-round-2/94905/2 that the [specification](https://packaging.python.org/en/latest/specifications/pyproject-toml/#dependencies-optional-dependencies) for optional dependencies in ``pyproject.toml`` uses the term ``extra`` to refer to the optional dependency keys, which means we can use ``default-extras`` instead of ``default-optional-dependency-keys`` (which is a name that a lot of people have complained about). Since this change is a no-brainer and there have not been any objections since it was suggested, I am making the change straight away to avoid it being brought up again by others.

FYI @DEKHTIARJonathan and @pradyunsg 