### PR TITLE
PEP 672: Note that mentioning Unicode specs doesn't mean we follow them

### DIFF
--- a/peps/pep-0672.rst
+++ b/peps/pep-0672.rst
@@ -41,6 +41,7 @@ or recommendations: it is rather a list of things to keep in mind.
 This document is specific to Python.
 For general security considerations in Unicode text and source code,
 see Unicode technical reports [tr36]_, [tr39]_, and [tr55]_.
+(Note that Python does not necessarily conform to these specifications.)
 
 
 Acknowledgement


### PR DESCRIPTION
I intended these to be *further reading*, but since they're specifications, people might assume that Python is conformant. It is not. (Formally, we don't even pass the [very first point](https://www.unicode.org/reports/tr55/#Conformance) of TR55's checklist -- *“An implementation claiming conformance to this specification shall identify the version of this specification.”*)

@miketheman, does this clear things up?

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4460.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->