### PR TITLE
PEP 779: Mark as Accepted

### DIFF
--- a/peps/pep-0779.rst
+++ b/peps/pep-0779.rst
@@ -11,6 +11,11 @@ Python-Version: 3.14
 Post-History: `13-Mar-2025 <https://discuss.python.org/t/84319>`__
 Resolution: `16-Jun-2025 <https://discuss.python.org/t/84319/123>`__
 
+.. note::
+   The Steering Council accepts PEP 779 with a non-exhaustive list of
+   requirements to be addressed during phase II. See the `acceptance
+   <https://discuss.python.org/t/84319/123>`__ for details.
+
 Abstract
 ========
 

--- a/peps/pep-0779.rst
+++ b/peps/pep-0779.rst
@@ -4,11 +4,12 @@ Author: Thomas Wouters <thomas@python.org>,
         Matt Page <mpage at python.org>,
         Sam Gross <colesbury at gmail.com>
 Discussions-To: https://discuss.python.org/t/84319
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Created: 13-Mar-2025
 Python-Version: 3.14
 Post-History: `13-Mar-2025 <https://discuss.python.org/t/84319>`__
+Resolution: `16-Jun-2025 <https://discuss.python.org/t/84319/123>`__
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [x] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date

Suggestions welcome for the acceptance note.
