### PR TITLE
PEP 747: More precise discussion of subtyping

### DIFF
--- a/peps/pep-0747.rst
+++ b/peps/pep-0747.rst
@@ -311,15 +311,15 @@ Assignability
   t1: TypeForm[int | str] = get_type_form()  # OK
   t2: TypeForm[str] = get_type_form()  # Error
 
-``type[T]`` is a subtype of ``TypeForm[T]``, which means that ``type[B]`` is
-assignable to ``TypeForm[A]`` if ``B`` is assignable to ``A``::
+Given two fully static types ``T1`` and ``T2``, ``type[T1]`` is a subtype of ``TypeForm[T2]``
+if ``T1`` is a subtype of ``T2``::
 
   def get_type() -> type[int]: ...
 
   t3: TypeForm[int | str] = get_type()  # OK
   t4: TypeForm[str] = get_type()  # Error
 
-``TypeForm`` is a subtype of ``object`` and is assumed to have all of the
+Any specialization of ``TypeForm`` is a subtype of ``object`` and is assumed to have all of the
 attributes and methods of ``object``.
 
 


### PR DESCRIPTION
These paragraphs don't properly reflect the notion of "subtyping" in [the spec](https://typing.python.org/en/latest/spec/concepts.html). I reworded them to align more explicitly with the way assignability and subtyping are defined in the spec.

In particular, the subtyping relation exists only for fully static types. This makes the statement "TypeForm is a subtype of object" suspect: TypeForm by itself is TypeForm[Any], which is not a fully static type and therefore doesn't participate in subtyping.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4465.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->