### PR TITLE
PEP 734: Drop the "syncobj" parameter

### DIFF
--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -465,11 +465,9 @@ is sent (and shared) without serialization.  See `Shareable Objects`_.
 
 The module defines the following functions:
 
-* ``create_queue(maxsize=0, *, syncobj=False) -> Queue``
+* ``create_queue(maxsize=0) -> Queue``
       Create a new queue.  If the maxsize is zero or negative then the
       queue is unbounded.
-
-      "syncobj" is used as the default for ``put()`` and ``put_nowait()``.
 
 Queue Objects
 -------------


### PR DESCRIPTION
This change slipped through the cracks when I removed `syncobj` elsewhere.

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4467.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->