### PR TITLE
PEP 751: Mark as Final

### DIFF
--- a/peps/pep-0751.rst
+++ b/peps/pep-0751.rst
@@ -1,7 +1,7 @@
 PEP: 751
 Title: A file format to record Python dependencies for installation reproducibility
 Author: Brett Cannon <brett@python.org>
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Packaging
 Created: 24-Jul-2024


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [X] Final implementation has been merged (including tests and docs)
* [X] PEP matches the final implementation
* [X] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [X] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [X] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [X] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)
