### PR TITLE
PEP 685: Mark as Final

### DIFF
--- a/peps/pep-0685.rst
+++ b/peps/pep-0685.rst
@@ -3,7 +3,7 @@ Title: Comparison of extra names for optional distribution dependencies
 Author: Brett Cannon <brett@python.org>
 PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/14141
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Packaging
 Created: 08-Mar-2022


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [X] Final implementation has been merged (including tests and docs)
* [X] PEP matches the final implementation
* [X] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [X] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [X] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [X] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4470.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->