### PR TITLE
PEP 745: 3.14.0b3 was released on 2025-06-17

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -46,10 +46,10 @@ Actual:
 - 3.14.0 beta 1: Wednesday, 2025-05-07
   (No new features beyond this point.)
 - 3.14.0 beta 2: Monday, 2025-05-26
+- 3.14.0 beta 3: Tuesday, 2025-06-17
 
 Expected:
 
-- 3.14.0 beta 3: Tuesday, 2025-06-17
 - 3.14.0 beta 4: Tuesday, 2025-07-08
 - 3.14.0 candidate 1: Tuesday, 2025-07-22
 - 3.14.0 candidate 2: Tuesday, 2025-08-26


### PR DESCRIPTION
https://discuss.python.org/t/python-3-14-0-beta-3-is-here/95843

cc @hugovk 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4471.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->