### PR TITLE
PEP 793: Two small updates

### DIFF
--- a/peps/pep-0793.rst
+++ b/peps/pep-0793.rst
@@ -349,7 +349,8 @@ They may not have a ``NULL`` value (instead, the slot can be omitted entirely).
 Note that currently, for modules created from a *spec* (that is, using
 ``PyModule_FromDefAndSpec``), the ``PyModuleDef.m_name`` member is ignored
 and the name from the spec is used instead.
-All API proposed in this document will ignore ``Py_mod_name`` in the same way.
+All API proposed in this document creates modules from a *spec*, and it will
+ignore ``Py_mod_name`` in the same way.
 The slot will be optional, but extension authors are strongly encouraged to
 include it for the benefit of future APIs, external tooling, debugging,
 and introspection.


### PR DESCRIPTION
- `PyType_GetModuleByToken` will return a strong reference, unlike `PyType_GetModuleByDef`
- ~~Remove incorrect note that the new API creates modules from a *spec*. (The note could be updated to say *slots*, but, it isn't that important.)~~

---

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4472.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->