### PR TITLE
PEP 768: Make sure C API names start with `Py_`

### DIFF
--- a/peps/pep-0768.rst
+++ b/peps/pep-0768.rst
@@ -135,9 +135,9 @@ A new structure is added to PyThreadState to support remote debugging:
 
 .. code-block:: C
 
-    typedef struct _remote_debugger_support {
+    typedef struct {
         int debugger_pending_call;
-        char debugger_script_path[MAX_SCRIPT_PATH_SIZE];
+        char debugger_script_path[Py_MAX_SCRIPT_PATH_SIZE];
     } _PyRemoteDebuggerSupport;
 
 This structure is appended to ``PyThreadState``, adding only a few fields that
@@ -147,7 +147,7 @@ provides a filesystem path to a Python source file (.py) that will be executed w
 the interpreter reaches a safe point. The path must point to a Python source file,
 not compiled Python code (.pyc) or any other format.
 
-The value for ``MAX_SCRIPT_PATH_SIZE`` will be a trade-off between binary size
+The value for ``Py_MAX_SCRIPT_PATH_SIZE`` will be a trade-off between binary size
 and how big debugging scripts' paths can be. To limit the memory overhead per
 thread we will be limiting this to 512 bytes. This size will also be provided as
 part of the debugger support structure so debuggers know how much they can


### PR DESCRIPTION
- Remove the struct tag
- Add `Py_` to `MAX_SCRIPT_PATH_SIZE`

As discussed in: https://discuss.python.org/t/73969/58

---

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

Not *exactly* an editorial issue, but I don't think it needs a full SC vote. @pablogsal, are you OK with approving this yourself?



<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4473.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->