### PR TITLE
PEP 728: Fix minor issues with examples

### DIFF
--- a/peps/pep-0728.rst
+++ b/peps/pep-0728.rst
@@ -215,7 +215,7 @@ the ``extra_items`` argument::
 
 ``extra_items`` is inherited through subclassing::
 
-    class MovieBase(TypedDict, extra_items=int | None):
+    class MovieBase(TypedDict, extra_items=ReadOnly[int | None]):
         name: str
 
     class Movie(MovieBase):
@@ -380,6 +380,7 @@ unless it is declared to be ``ReadOnly`` in the superclass::
         pass
 
     class Child(Parent, extra_items=int): # Not OK. Like any other TypedDict item, extra_items's type cannot be changed
+        pass
 
 Second, ``extra_items=T`` effectively defines the value type of any unnamed
 items accepted to the TypedDict and marks them as non-required. Thus, the above


### PR DESCRIPTION
Jukka pointed out the incorrect use of extra_items here:
  https://discuss.python.org/t/pep-728-typeddict-with-typed-extra-items/45443/157

Also fixed a minor issue with a class missing its body.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [ ] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4475.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->