### PR TITLE
PEP 734: Mark as Final

### DIFF
--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -10,6 +10,7 @@ Post-History: `14-Dec-2023 <https://discuss.python.org/t/pep-734-multiple-interp
 Replaces: 554
 Resolution: `05-Jun-2025 <https://discuss.python.org/t/41147/36>`__
 
+.. canonical-doc:: :mod:`concurrent.interpreters`
 
 .. note::
    This PEP is essentially a continuation of :pep:`554`.  That document
@@ -20,7 +21,7 @@ Resolution: `05-Jun-2025 <https://discuss.python.org/t/41147/36>`__
 
 .. note::
    This PEP was accepted with the provision that the name change
-   to :py:mod:`!concurrent.interpreters`.
+   to :mod:`concurrent.interpreters`.
 
 
 Abstract

--- a/peps/pep-0734.rst
+++ b/peps/pep-0734.rst
@@ -2,7 +2,7 @@ PEP: 734
 Title: Multiple Interpreters in the Stdlib
 Author: Eric Snow <ericsnowcurrently@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-734-multiple-interpreters-in-the-stdlib/41147
-Status: Accepted
+Status: Final
 Type: Standards Track
 Created: 06-Nov-2023
 Python-Version: 3.14


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [ ] ~Any substantial changes since the accepted version approved by the SC/PEP delegate~
* [x] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4479.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->