### PR TITLE
PEP 747: Explicitly define "valid type expression".

### DIFF
--- a/peps/pep-0747.rst
+++ b/peps/pep-0747.rst
@@ -183,7 +183,7 @@ expression, and it represents the type described by that type expression.
 
 ``TypeForm`` is a special form that, when used in a type expression, describes
 a set of type form objects. It accepts a single type argument, which must be a
-valid type expression. ``TypeForm[T]`` describes the set of all type form
+:ref:`valid type expression <valid-type-expressions>`. ``TypeForm[T]`` describes the set of all type form
 objects that represent the type ``T`` or types that are
 :term:`assignable to <typing:assignable>` ``T``. For example,
 ``TypeForm[str | None]`` describes the set of all type form objects
@@ -218,9 +218,7 @@ equivalent to ``TypeForm[Any]``.
 Implicit ``TypeForm`` Evaluation
 --------------------------------
 
-When a static type checker encounters an expression that follows all of the
-syntactic, semantic and contextual rules for a type expression as detailed
-in the typing spec, the evaluated type of this expression should be assignable
+When a static type checker encounters a valid type expression, the evaluated type of this expression should be assignable
 to ``TypeForm[T]`` if the type it describes is assignable to ``T``.
 
 For example, if a static type checker encounters the expression ``str | None``,
@@ -248,6 +246,11 @@ be assignable to ``TypeForm``::
 
   v5: TypeForm[set[str]] = "set[str]"  # OK
 
+.. _valid-type-expressions:
+
+Valid Type Expressions
+----------------------
+
 The typing spec defines syntactic rules for type expressions in the form of a
 :ref:`formal grammar <typing:expression-grammar>`. Semantic rules are specified
 as comments along with the grammar definition. Contextual requirements are detailed
@@ -256,8 +259,11 @@ type expressions. For example, the special form ``Self`` can be used in a
 type expression only within a class, and a type variable can be used within
 a type expression only when it is associated with a valid scope.
 
-Expressions that violate one or more of the syntactic, semantic, or contextual
-rules for type expressions should not evaluate to a ``TypeForm`` type.::
+A valid type expression is an expression that follows all of the syntactic,
+semantic, and contextual rules for a type expression.
+
+Expressions that are not valid type expressions should not evaluate to a
+``TypeForm`` type::
 
   bad1: TypeForm = tuple()  # Error: Call expression not allowed in type expression
   bad2: TypeForm = (1, 2)  # Error: Tuple expression not allowed in type expression


### PR DESCRIPTION
When I was reading the PEP, it was unclear to me whether the rule on what expressions can implicitly evaluate to TypeForm applied to the rest of the PEP. This PR suggests pulling that rule out into its own section and linking to it the first time "valid type expression" is used, to make it clear that this definition applies throughout.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4484.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->