### PR TITLE
PEP 695: Fix template definition in C++ example

### DIFF
--- a/peps/pep-0695.rst
+++ b/peps/pep-0695.rst
@@ -1201,7 +1201,7 @@ A default type argument can be specified using the ``=`` operator.
 .. code-block:: c++
 
     // Generic class
-    template <typename>
+    template <typename T>
     class ClassA
     {
         // Constraints are supported through compile-time assertions.


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

Changed `template <typename>` to `template <typename T>` in the C++ generic class example.

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4485.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->