### PR TITLE
PEP 628: Fix 'Pi is [(still)] wrong' links

### DIFF
--- a/peps/pep-0628.rst
+++ b/peps/pep-0628.rst
@@ -30,7 +30,7 @@ The idea in this PEP has been implemented in the auspiciously named
 `issue 12345`_.
 
 .. _accepted: https://bugs.python.org/issue12345#msg272287
-.. _issue 12345: http://bugs.python.org/issue12345
+.. _issue 12345: https://bugs.python.org/issue12345
 
 
 The Rationale for Tau
@@ -65,12 +65,12 @@ may be of interest:
   highlighting the problems with ``pi`` has `a page of resources`_ on the
   topic
 * For those that prefer videos to written text, `Pi is wrong!`_ and
-  `Pi is (still) wrong`_ are available on YouTube
+  `Pi is (still) wrong`_ are available.
 
-.. _Tau Manifesto: http://tauday.com/
-.. _Pi is (still) wrong: http://www.youtube.com/watch?v=jG7vhMMXagQ
-.. _Pi is wrong!: http://www.youtube.com/watch?v=IF1zcRoOVN0
-.. _a page of resources: http://www.math.utah.edu/~palais/pi.html
+.. _Tau Manifesto: https://tauday.com/
+.. _Pi is (still) wrong: https://vimeo.com/147792667
+.. _Pi is wrong!: https://www.youtube.com/watch?v=PIhNNnW1tUo
+.. _a page of resources: https://www.math.utah.edu/~palais/pi.html
 
 
 Copyright


### PR DESCRIPTION
Like https://github.com/python/cpython/issues/136122.

Vi Hart has removed intentionally removed their videos from YouTube: https://www.patreon.com/posts/vihart-channel-129842460

One is available on their Vimeo. The other is not, so use another YouTube copy. Also update other links to https.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4487.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->