### PR TITLE
PEP 745: 3.14.0b4 was released on 2025-07-08

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -47,10 +47,10 @@ Actual:
   (No new features beyond this point.)
 - 3.14.0 beta 2: Monday, 2025-05-26
 - 3.14.0 beta 3: Tuesday, 2025-06-17
+- 3.14.0 beta 4: Tuesday, 2025-07-08
 
 Expected:
 
-- 3.14.0 beta 4: Tuesday, 2025-07-08
 - 3.14.0 candidate 1: Tuesday, 2025-07-22
 - 3.14.0 candidate 2: Tuesday, 2025-08-26
 - 3.14.0 final: Tuesday, 2025-10-07


### PR DESCRIPTION
* https://discuss.python.org/t/python-3-14-0-beta-4-is-here/98092/1
* https://www.python.org/downloads/release/python-3140b4/


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4488.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->