### PR TITLE
PEP 792: mark as accepted

### DIFF
--- a/peps/pep-0792.rst
+++ b/peps/pep-0792.rst
@@ -5,12 +5,13 @@ Author: William Woodruff <william@yossarian.net>,
 Sponsor: Donald Stufft <donald@stufft.io>
 PEP-Delegate: Donald Stufft <donald@stufft.io>
 Discussions-To: https://discuss.python.org/t/pep-792-project-status-markers-in-the-simple-index/94978
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Topic: Packaging
 Created: 21-May-2025
 Post-History: `03-Feb-2025 <https://discuss.python.org/t/79356/>`__,
               `09-Jun-2025 <https://discuss.python.org/t/94978>`__,
+Resolution: `08-Jul-2025 <https://discuss.python.org/t/94978/16>`__
 
 Abstract
 ========


### PR DESCRIPTION
Per https://discuss.python.org/t/pep-792-project-status-markers-in-the-simple-index/94978/16

I'll follow up to this with an appropriate copy of PEP 792 to the PyPA standards, which I'll then link to in this PEP like the other packaging PEPs.