### PR TITLE
PEP 11: Restore Emscripten to Tier 3

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -128,6 +128,7 @@ powerpc64le-unknown-linux-gnu    glibc, clang                Victor Stinner
 
                                  glibc, gcc                  Victor Stinner
 s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
+wasm32-unknown-emscripten        emcc                        Russell Keith-Magee
 x86_64-linux-android                                         Russell Keith-Magee, Petr Viktorin
 x86_64-unknown-freebsd           BSD libc, clang             Victor Stinner
 ================================ =========================== ========


### PR DESCRIPTION
With the restoration of an [Emscripten buildbot](https://buildbot.python.org/#/builders/1810), plus python/cpython#136230 and python/steering-council#256, we are now in a position to formally restore Emscripten to Tier 3.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4490.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->