### PR TITLE
PEP 11: Remove Emscripten from No-longer-supported platforms

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -368,10 +368,6 @@ No-longer-supported platforms
   | Unsupported in:   Python 3.7
   | Code removed in:  Python 3.7
 
-* | Name:             wasm32-unknown-emscripten
-  | Unsupported in:   Python 3.13
-  | Code removed in:  Unknown
-
 
 Discussions
 ===========


### PR DESCRIPTION
Emscripten is no longer getting removed!

Follow-up for #4490 (commit 25cec5d07e93f7de4f42b930ec25c8d4ffbfa95b)

cc @freakboy3742 @AA-Turner

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4491.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->