### PR TITLE
PEP 790: fix reference to future version

### DIFF
--- a/peps/pep-0790.rst
+++ b/peps/pep-0790.rst
@@ -58,7 +58,7 @@ Subsequent bugfix releases every two months.
 
 * Python 3.15 will receive bugfix updates approximately every second month for
   two years.
-* Around the time of the release of 3.18.0 final, the final 3.15 bugfix update
+* Around the time of the release of 3.17.0 final, the final 3.15 bugfix update
   will be released.
 * After that, it is expected that security updates (source only) will be
   released for the next three years, until five years after the release of


### PR DESCRIPTION
Based on the annual cadence of [PEP 602](https://peps.python.org/pep-0602/), two years after 3.15.0 final means 3.17.0 final. This looks like a simple typo.

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

_(pinging @hugovk as the PEP author & 3.15 release manager)_


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4496.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->