### PR TITLE
PEP 798: Small Typo Fix

### DIFF
--- a/peps/pep-0798.rst
+++ b/peps/pep-0798.rst
@@ -88,7 +88,7 @@ an additional alternative::
     [*it for it in its]  # list with the concatenation of iterables in 'its'
     {*it for it in its}  # set with the union of iterables in 'its'
     {**d for d in dicts} # dict with the combination of dicts in 'dicts'
-    (*it for it in its)  # generator of the concatenation of iterables in 'its'   (*it for it in its)
+    (*it for it in its)  # generator of the concatenation of iterables in 'its'
 
 This proposal also extends to asynchronous comprehensions and generator
 expressions, such that, for example, ``(*ait async for ait in aits())`` is


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

Fixes a small typo in PEP 798, a duplicate piece of code in an early example box.

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4500.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->