### PR TITLE
PEP 745: 3.14.0rc1 was released on 2025-07-22

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -48,10 +48,10 @@ Actual:
 - 3.14.0 beta 2: Monday, 2025-05-26
 - 3.14.0 beta 3: Tuesday, 2025-06-17
 - 3.14.0 beta 4: Tuesday, 2025-07-08
+- 3.14.0 candidate 1: Tuesday, 2025-07-22
 
 Expected:
 
-- 3.14.0 candidate 1: Tuesday, 2025-07-22
 - 3.14.0 candidate 2: Tuesday, 2025-08-26
 - 3.14.0 final: Tuesday, 2025-10-07
 


### PR DESCRIPTION
Happy Pi Approximation Day!

https://discuss.python.org/t/python-3-14-release-candidate-1-is-go/99754
https://www.python.org/downloads/release/python-3140rc1/

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4506.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->