### PR TITLE
PEP 743: Omit ``PyList_GET_ITEM``

### DIFF
--- a/peps/pep-0743.rst
+++ b/peps/pep-0743.rst
@@ -212,6 +212,7 @@ The following API will be omitted with ``Py_COMPAT_API_VERSION`` set to
   ``PyDict_GetItemString()``            ``PyDict_GetItemStringRef()``
   ``PyImport_AddModule()``              ``PyImport_AddModuleRef()``
   ``PyList_GetItem()``                  ``PyList_GetItemRef()``
+  ``PyList_GET_ITEM()``                 ``PyList_GetItemRef()``
   ====================================  ==============================
 
 - Omit deprecated APIs:


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

`PyList_GET_ITEM` should be treated akin to `PyList_GetItem` when it comes to free-threading considerations.
This PR matches https://github.com/python/cpython/pull/137042.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4507.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->