### PR TITLE
PEP 799: clarifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -675,7 +675,6 @@ peps/pep-0793.rst  @encukou
 peps/pep-0794.rst  @brettcannon
 peps/pep-0798.rst  @JelleZijlstra
 peps/pep-0799.rst  @pablogsal
-# ...
 peps/pep-0800.rst  @JelleZijlstra
 peps/pep-0801.rst  @warsaw
 # ...

--- a/peps/pep-0799.rst
+++ b/peps/pep-0799.rst
@@ -100,8 +100,8 @@ The ``profile`` module will be deprecated starting in Python 3.15.
 
 From Python 3.15, :mod:`!profilers.tracing` will be preferred to :mod:`!cProfile` & :mod:`!profile`.
 
-The code that as the time of writing this is in :mod:`!profile.sampling`
-module no longer exist and will only exist in the :mod:`!profilers` package.
+The code that, at the time of writing, is in the :mod:`!profile.sampling`
+module will be moved to the :mod:`!profilers` package.
 
 Documentation
 =============
@@ -139,7 +139,7 @@ Top-Level ``tachyon`` Module
 
 Introducing ``import tachyon`` as a new top-level module was rejected. Grouping tachyon under
 ``profilers`` helps establish a logical structure and prevents proliferation of top-level modules
-and also minimizes the usage of global namespace as requested by the Python Steering council
+and also minimizes the usage of global namespace as requested by the Python Steering Council.
 
 Copyright
 =========


### PR DESCRIPTION
This bit wasn't too clear to me:

> The code that as the time of writing this is in `profile.sampling` module no longer exist and will only exist in the `profilers` package.

This PR suggests:

> The code that, at the time of writing, is in the `profile.sampling` module will be moved to the `profilers` package.

Is that the idea?

Alternatively:

> The code that, at the time of writing, is in the `profile.sampling` module will no longer exist and will instead only exist in the `profilers` package.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4511.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->