### PR TITLE
PEP 792: add canonical PyPUG link

### DIFF
--- a/peps/pep-0792.rst
+++ b/peps/pep-0792.rst
@@ -13,6 +13,8 @@ Post-History: `03-Feb-2025 <https://discuss.python.org/t/79356/>`__,
               `09-Jun-2025 <https://discuss.python.org/t/94978>`__,
 Resolution: `08-Jul-2025 <https://discuss.python.org/t/94978/16>`__
 
+.. canonical-pypa-spec:: :ref:`packaging:project-status-markers`
+
 Abstract
 ========
 


### PR DESCRIPTION
See https://github.com/pypa/packaging.python.org/pull/1879.