### PR TITLE
PEP 798: Fixes and Clarifications from Discourse Thread

### DIFF
--- a/peps/pep-0798.rst
+++ b/peps/pep-0798.rst
@@ -746,45 +746,65 @@ to what is already available in Python, but support for using unpacking syntax
 within comprehensions is rare.  This section provides a brief summary of
 support for similar syntax in a few other languages.
 
-Many languages that support comprehensions support double loops::
+Many languages that support comprehensions support double loops:
+
+.. code:: python
 
     # python
     [x for xs in [[1,2,3], [], [4,5]] for x in xs * 2]
 
+.. code:: haskell
+
     -- haskell
     [x | xs <- [[1,2,3], [], [4,5]], x <- xs ++ xs]
 
+.. code:: julia
+
     # julia
     [x for xs in [[1,2,3], [], [4,5]] for x in [xs; xs]]
+
+.. code:: clojure
 
     ; clojure
     (for [xs [[1 2 3] [] [4 5]] x (concat xs xs)] x)
 
 Several other languages (even those without comprehensions) support these
 operations via a built-in function/method to support flattening of nested
-structures::
+structures:
+
+.. code:: python
 
     # python
     list(itertools.chain(*(xs*2 for xs in [[1,2,3], [], [4,5]])))
 
+.. code:: javascript
+
     // Javascript
     [[1,2,3], [], [4,5]].flatMap(xs => [...xs, ...xs])
 
+.. code:: haskell
+
     -- haskell
     concat (map (\x -> x ++ x) [[1,2,3], [], [4,5]])
+
+.. code:: ruby
 
     # ruby
     [[1, 2, 3], [], [4, 5]].flat_map {|e| e * 2}
 
 However, languages that support both comprehension and unpacking do not tend to
 allow unpacking within a comprehension.  For example, the following expression
-in Julia currently leads to a syntax error::
+in Julia currently leads to a syntax error:
+
+.. code:: julia
 
     [xs... for xs in [[1,2,3], [], [4,5]]]
 
 As one counterexample, support for a similar syntax was recently added to `Civet
 <https://civet.dev/>`_.  For example, the following is a valid comprehension in
-Civet, making use of Javascript's ``...`` syntax for unpacking::
+Civet, making use of Javascript's ``...`` syntax for unpacking:
+
+.. code:: javascript
 
     for xs of [[1,2,3], [], [4,5]] then ...(xs++xs)
 

--- a/peps/pep-0798.rst
+++ b/peps/pep-0798.rst
@@ -217,7 +217,9 @@ generator::
         for x in it:
             yield from expr
 
-Since ``yield from`` is not allowed inside of async generators, the equivalent
+Since ``yield from`` is not allowed inside of async generators (see the section
+of :pep:`525` on `Asynchronous yield from
+<https://peps.python.org/pep-0525/#asynchronous-yield-from>`__), the equivalent
 for ``(*expr async for x in ait())``, is more like the following (though of
 course this new form should not define or reference the looping variable
 ``i``)::

--- a/peps/pep-0798.rst
+++ b/peps/pep-0798.rst
@@ -580,15 +580,16 @@ expressions that involve unpacking::
             yield from expr
     g = generator()
 
-We can then generalize from these specific examples to the idea that,
-wherever a non-starred comprehension/genexp would use an operator that
-adds a single element to a collection, the starred would instead use
-an operator that adds multiple elements to that collection.
+We can then generalize from these specific examples to the idea that, wherever
+a non-starred comprehension/genexp would use an operator that adds a single
+element to a collection, the starred would instead use an operator that adds
+multiple elements to that collection.
 
 Alternatively, we don't need to think of the two ideas as separate; instead,
 with the new syntax, we can think of ``out = [...x... for x in it]`` as
-equivalent to the following code [#pep798-guido]_, regardless of whether or not
-``...x...`` uses ``*``::
+equivalent to the following code [#pep798-guido]_ (where ``...x...`` is a
+stand-in for an arbitrary expression), regardless of whether or not ``...x...``
+uses ``*``::
 
     out = []
     for x in it:

--- a/peps/pep-0798.rst
+++ b/peps/pep-0798.rst
@@ -559,7 +559,8 @@ by a similar analogy::
     for x in it:
         out[k_expr] = v_expr
 
-    # equivalent to out = {**expr for x in it}
+    # equivalent to out = {**expr for x in it}, provided that expr evaluates to
+    # a mapping that can be unpacked with **
     out = {}
     for x in it:
         out.update(expr)
@@ -597,7 +598,7 @@ Similarly, we can think of ``out = {...x... for x in it}`` as equivalent to the
 following code, regardless of whether or not ``...x...`` uses ``*`` or ``**``
 or ``:``::
 
-    out = set()
+    out = set()  # or out = {}
     for x in it:
         out.update({...x...})
 

--- a/peps/pep-0798.rst
+++ b/peps/pep-0798.rst
@@ -218,11 +218,9 @@ generator::
             yield from expr
 
 Since ``yield from`` is not allowed inside of async generators (see the section
-of :pep:`525` on `Asynchronous yield from
-<https://peps.python.org/pep-0525/#asynchronous-yield-from>`__), the equivalent
-for ``(*expr async for x in ait())`` is more like the following (though of
-course this new form should not define or reference the looping variable
-``i``)::
+of :pep:`525` on Asynchronous ``yield from``), the equivalent for ``(*expr
+async for x in ait())`` is more like the following (though of course this new
+form should not define or reference the looping variable ``i``)::
 
     async def generator():
         async for x in ait():

--- a/peps/pep-0798.rst
+++ b/peps/pep-0798.rst
@@ -220,7 +220,7 @@ generator::
 Since ``yield from`` is not allowed inside of async generators (see the section
 of :pep:`525` on `Asynchronous yield from
 <https://peps.python.org/pep-0525/#asynchronous-yield-from>`__), the equivalent
-for ``(*expr async for x in ait())``, is more like the following (though of
+for ``(*expr async for x in ait())`` is more like the following (though of
 course this new form should not define or reference the looping variable
 ``i``)::
 

--- a/peps/pep-0798.rst
+++ b/peps/pep-0798.rst
@@ -587,9 +587,8 @@ multiple elements to that collection.
 
 Alternatively, we don't need to think of the two ideas as separate; instead,
 with the new syntax, we can think of ``out = [...x... for x in it]`` as
-equivalent to the following code [#pep798-guido]_ (where ``...x...`` is a
-stand-in for an arbitrary expression), regardless of whether or not ``...x...``
-uses ``*``::
+equivalent to the following [#pep798-guido]_ (where ``...x...`` is a stand-in
+for arbitrary code), regardless of whether or not ``...x...`` uses ``*``::
 
     out = []
     for x in it:


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

This PR represents a few small wording changes for PEP 798 (primarily in the "How to Teach This" section) based on discussion from the Discourse thread, attempting to fix some correctness issues and to clarify some points.  It also fixes syntax highlighting for the examples from other languages.

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4518.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->