### PR TITLE
PEP 790: Record actual date for start of 3.15 development

### DIFF
--- a/peps/pep-0790.rst
+++ b/peps/pep-0790.rst
@@ -31,9 +31,12 @@ Release schedule
 The dates below use a 17-month development period that results in a 12-month
 release cadence between feature versions, as defined by :pep:`602`.
 
+Actual:
+
+- 3.15 development begins: Wednesday, 2025-05-07
+
 Expected:
 
-- 3.15 development begins: Tuesday, 2025-05-06
 - 3.15.0 alpha 1: Tuesday, 2025-10-14
 - 3.15.0 alpha 2: Tuesday, 2025-11-18
 - 3.15.0 alpha 3: Tuesday, 2025-12-16


### PR DESCRIPTION
3.14 beta 1 was released on Wednesday 7 May: https://peps.python.org/pep-0745/#schedule

A

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4528.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->