### PR TITLE
Add emmatyping to `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -431,7 +431,7 @@ peps/pep-0557.rst  @ericvsmith
 peps/pep-0558.rst  @ncoghlan
 peps/pep-0559.rst  @warsaw
 peps/pep-0560.rst  @ilevkivskyi
-# peps/pep-0561.rst
+peps/pep-0561.rst  @emmatyping
 peps/pep-0562.rst  @ilevkivskyi
 peps/pep-0563.rst  @ambv
 peps/pep-0564.rst  @vstinner
@@ -636,7 +636,7 @@ peps/pep-0755.rst  @warsaw
 peps/pep-0756.rst  @vstinner
 peps/pep-0757.rst  @vstinner
 peps/pep-0758.rst  @pablogsal @brettcannon
-peps/pep-0759.rst  @warsaw
+peps/pep-0759.rst  @warsaw @emmatyping
 peps/pep-0760.rst  @pablogsal @brettcannon
 peps/pep-0761.rst  @sethmlarson @hugovk
 peps/pep-0762.rst  @pablogsal @ambv @lysnikolaou @emilyemorehouse
@@ -654,15 +654,15 @@ peps/pep-0773.rst  @zooba
 peps/pep-0774.rst  @savannahostrowski
 peps/pep-0775.rst  @encukou
 peps/pep-0776.rst  @hoodmane @ambv
-peps/pep-0777.rst  @warsaw
-peps/pep-0778.rst  @warsaw
+peps/pep-0777.rst  @warsaw @emmatyping
+peps/pep-0778.rst  @warsaw @emmatyping
 # ...
 peps/pep-0779.rst  @Yhg1s @colesbury @mpage
 peps/pep-0780.rst  @lysnikolaou
 peps/pep-0781.rst  @methane
 peps/pep-0782.rst  @vstinner
 peps/pep-0783.rst  @hoodmane @ambv
-peps/pep-0784.rst  @gpshead
+peps/pep-0784.rst  @gpshead @emmatyping
 peps/pep-0785.rst  @gpshead
 # ...
 peps/pep-0787.rst  @ncoghlan


### PR DESCRIPTION
I figured it would be a good idea to add myself as a code owner for PEPs I've authored or co-authored.