### PR TITLE
PEP 1 & 12: Suggest an 'Acknowledgements' section

### DIFF
--- a/peps/pep-0001.rst
+++ b/peps/pep-0001.rst
@@ -574,10 +574,14 @@ Each PEP should have the following parts/sections:
     ready for consideration are complete and reduces people duplicating
     prior discussion.
 
-12. Footnotes -- A collection of footnotes cited in the PEP, and
+12. Acknowledgements -- Useful to thank and acknowledge people who have helped
+    develop, discuss, or draft the PEP, or for any other purpose. The section
+    can be used to recognise contributors to the work who are not co-authors.
+
+13. Footnotes -- A collection of footnotes cited in the PEP, and
     a place to list non-inline hyperlink targets.
 
-13. Copyright/license -- Each new PEP must be placed under a dual license of
+14. Copyright/license -- Each new PEP must be placed under a dual license of
     public domain and CC0-1.0-Universal_ (see this PEP for an example).
 
 

--- a/peps/pep-0012/pep-NNNN.rst
+++ b/peps/pep-0012/pep-NNNN.rst
@@ -76,6 +76,12 @@ Open Issues
 [Any points that are still being decided/discussed.]
 
 
+Acknowledgements
+================
+
+[Thank anyone who has helped with the PEP.]
+
+
 Footnotes
 =========
 


### PR DESCRIPTION
cc @python/pep-editors 

Several (98) PEPs have an *Acknowledgements* section, which is a nice way to recognise those that have helped with the PEP, or previous work that led to its development. I think it makes sense to include it as a suggested section in PEP 1 and the PEP 12 template. What do you think?

A

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4535.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->