### PR TITLE
PEP 792: mark as Final

### DIFF
--- a/peps/pep-0792.rst
+++ b/peps/pep-0792.rst
@@ -5,7 +5,7 @@ Author: William Woodruff <william@yossarian.net>,
 Sponsor: Donald Stufft <donald@stufft.io>
 PEP-Delegate: Donald Stufft <donald@stufft.io>
 Discussions-To: https://discuss.python.org/t/pep-792-project-status-markers-in-the-simple-index/94978
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Packaging
 Created: 21-May-2025


### PR DESCRIPTION
Follows https://github.com/pypi/warehouse/pull/18422, which completes the PEP's implementation by enabling it on the index APIs 🙂 