### PR TITLE
PEP 745: Move RC2 earlier and add RC3

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -52,7 +52,8 @@ Actual:
 
 Expected:
 
-- 3.14.0 candidate 2: Tuesday, 2025-08-26
+- 3.14.0 candidate 2: Tuesday, 2025-08-14
+- 3.14.0 candidate 3: Tuesday, 2025-09-16
 - 3.14.0 final: Tuesday, 2025-10-07
 
 Subsequent bugfix releases every two months.

--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -52,7 +52,7 @@ Actual:
 
 Expected:
 
-- 3.14.0 candidate 2: Tuesday, 2025-08-14
+- 3.14.0 candidate 2: Thursday, 2025-08-14
 - 3.14.0 candidate 3: Tuesday, 2025-09-16
 - 3.14.0 final: Tuesday, 2025-10-07
 


### PR DESCRIPTION
Because of the magic number bump:

* https://discuss.python.org/t/early-3-14-0-rc2-and-extra-rc3/102151
* https://discuss.python.org/t/heads-up-pyc-magic-number-change-in-3-14-0rc2/102095

We're planning on making an early RC2 release this Thursday, and will add an extra RC3 about midway between RC2 and final (during the core sprint).


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4544.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->