### PR TITLE
PEP 794: Clarify the default action when `Import-Name` et. al. are not specified

### DIFF
--- a/peps/pep-0794.rst
+++ b/peps/pep-0794.rst
@@ -142,7 +142,7 @@ name should also be listed appropriately in ``Import-Namespace`` and/or
 ``spam`` with multiple submodules would only list
 ``project.import-names = ["spam"]``. A project that lists ``spam.bacon.eggs``
 would also need to account for ``spam`` and ``spam.bacon`` appropriately in
-``project-names`` and ``project-namespaces``. Listing all names acts as a check
+``import-names`` and ``import-namespaces``. Listing all names acts as a check
 that the intent of the import names is as expected.
 
 Tools SHOULD raise an error when two projects that are to be installed list
@@ -151,10 +151,13 @@ projects unexpectedly shadowing another project's code. The same applies to when
 a project has an entry in ``Import-Name`` that overlaps with another project's
 ``Import-Namespace`` entries.
 
-Projects MAY leave ``Import-Name`` and ``Import-Namespace`` empty. In that
-instance, tools SHOULD assume that the normalized project name when converted to
-an import name would be an entry in ``Import-Name``
-(i.e. ``-`` substituted for ``-`` in the normalized project name).
+Projects MAY leave ``Import-Name`` and ``Import-Namespace`` out of the core
+metadata for a project. In that instance, tools SHOULD assume that when the
+core metadata is 2.5 or newer that the normalized project name when converted to
+an import name would be an entry in ``Import-Name`` (i.e. ``-`` substituted for
+``-`` in the normalized project name). This is deemed reasonable as this will
+only occur for projects that make a new release once their build back-end
+supports core metadata 2.5 or newer as proposed by this PEP.
 
 
 Examples


### PR DESCRIPTION
Also fix a couple critical typos.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4545.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->