### PR TITLE
PEP 745 & 719: Python 3.14.0rc2 and 3.13.7 were released on 2025-08-14

### DIFF
--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -63,16 +63,17 @@ Actual:
 - 3.13.4: Tuesday, 2025-06-03
 - 3.13.5: Wednesday, 2025-06-11
 - 3.13.6: Wednesday, 2025-08-06
+- 3.13.7: Thursday, 2025-08-14
 
 Expected:
 
-- 3.13.7: Tuesday, 2025-10-07
-- 3.13.8: Tuesday, 2025-12-02
-- 3.13.9: Tuesday, 2026-02-03
-- 3.13.10: Tuesday, 2026-04-07
-- 3.13.11: Tuesday, 2026-06-09
-- 3.13.12: Tuesday, 2026-08-04
-- 3.13.13: Tuesday, 2026-10-06
+- 3.13.8: Tuesday, 2025-10-07
+- 3.13.9: Tuesday, 2025-12-02
+- 3.13.10: Tuesday, 2026-02-03
+- 3.13.11: Tuesday, 2026-04-07
+- 3.13.12: Tuesday, 2026-06-09
+- 3.13.13: Tuesday, 2026-08-04
+- 3.13.14: Tuesday, 2026-10-06
 
 
 Source-only security fix releases

--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -49,10 +49,10 @@ Actual:
 - 3.14.0 beta 3: Tuesday, 2025-06-17
 - 3.14.0 beta 4: Tuesday, 2025-07-08
 - 3.14.0 candidate 1: Tuesday, 2025-07-22
+- 3.14.0 candidate 2: Thursday, 2025-08-14
 
 Expected:
 
-- 3.14.0 candidate 2: Thursday, 2025-08-14
 - 3.14.0 candidate 3: Tuesday, 2025-09-16
 - 3.14.0 final: Tuesday, 2025-10-07
 


### PR DESCRIPTION
* https://discuss.python.org/t/python-3-14-0rc2-and-3-13-7-are-go/102403
* https://www.python.org/downloads/release/python-3140rc2/
* https://www.python.org/downloads/release/python-3137/

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4546.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->