### PR TITLE
PEP 772: Add PSF Board & ED language around CoC enforcement

### DIFF
--- a/peps/pep-0772.rst
+++ b/peps/pep-0772.rst
@@ -313,6 +313,9 @@ Code of Conduct
 All Packaging Council Electors and Packaging Council members are subject to, and must abide by the
 PSF `Code of Conduct`_, its enforcement procedures, and its remedies for adjudicated violations.
 
+The Packaging Council will moderate its spaces and support PSF Code of Conduct enforcement as
+appropriate in the area.
+
 .. _electors:
 
 ==========================


### PR DESCRIPTION
The PSF Board has given its provisional approval to PEP 772, with the addition of the language in this PR around CoC enforcement.