### PR TITLE
PEP 750: Mark as Final

### DIFF
--- a/peps/pep-0750.rst
+++ b/peps/pep-0750.rst
@@ -17,7 +17,7 @@ Post-History: `09-Aug-2024 <https://discuss.python.org/t/60408>`__,
               `18-Nov-2024 <https://discuss.python.org/t/71594>`__,
 Resolution: `10-Apr-2025 <https://discuss.python.org/t/71594/130>`__
 
-.. canonical-doc:: ref:`python:template-strings`
+.. canonical-doc:: ref:`py3.14:template-strings`
 
 
 Abstract

--- a/peps/pep-0750.rst
+++ b/peps/pep-0750.rst
@@ -7,7 +7,7 @@ Author: Jim Baker <jim.baker@python.org>,
         Lysandros Nikolaou <lisandrosnik@gmail.com>,
         Dave Peck <davepeck@davepeck.org>
 Discussions-To: https://discuss.python.org/t/71594
-Status: Accepted
+Status: Final
 Type: Standards Track
 Created: 08-Jul-2024
 Python-Version: 3.14
@@ -16,6 +16,8 @@ Post-History: `09-Aug-2024 <https://discuss.python.org/t/60408>`__,
               `21-Oct-2024 <https://discuss.python.org/t/60408/226>`__,
               `18-Nov-2024 <https://discuss.python.org/t/71594>`__,
 Resolution: `10-Apr-2025 <https://discuss.python.org/t/71594/130>`__
+
+.. canonical-doc: ref:`python:template-strings`
 
 Abstract
 ========

--- a/peps/pep-0750.rst
+++ b/peps/pep-0750.rst
@@ -17,7 +17,8 @@ Post-History: `09-Aug-2024 <https://discuss.python.org/t/60408>`__,
               `18-Nov-2024 <https://discuss.python.org/t/71594>`__,
 Resolution: `10-Apr-2025 <https://discuss.python.org/t/71594/130>`__
 
-.. canonical-doc: ref:`python:template-strings`
+.. canonical-doc:: ref:`python:template-strings`
+
 
 Abstract
 ========

--- a/peps/pep-0750.rst
+++ b/peps/pep-0750.rst
@@ -17,7 +17,7 @@ Post-History: `09-Aug-2024 <https://discuss.python.org/t/60408>`__,
               `18-Nov-2024 <https://discuss.python.org/t/71594>`__,
 Resolution: `10-Apr-2025 <https://discuss.python.org/t/71594/130>`__
 
-.. canonical-doc:: ref:`py3.14:template-strings`
+.. canonical-doc:: :ref:`py3.14:template-strings`
 
 
 Abstract


### PR DESCRIPTION
Part of https://github.com/python/peps/issues/4437

- [x] Final implementation has been merged (including tests and docs)
- [x] PEP matches the final implementation
- [x] Any substantial changes since the accepted version approved by the SC/PEP delegate
- [x] Pull request title in appropriate format (PEP 123: Mark as Final)
- [x] Status changed to Final (and Python-Version is correct)
- [x] Canonical docs/spec linked with a canonical-doc directive (or canonical-pypa-spec for packaging PEPs, or canonical-typing-spec for typing PEPs)

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4551.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->