### PR TITLE
PEP 728: Mark as Accepted

### DIFF
--- a/peps/pep-0728.rst
+++ b/peps/pep-0728.rst
@@ -3,12 +3,13 @@ Title: TypedDict with Typed Extra Items
 Author: Zixuan James Li <p359101898@gmail.com>
 Sponsor: Jelle Zijlstra <jelle.zijlstra@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-728-typeddict-with-typed-extra-items/45443
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Topic: Typing
 Created: 12-Sep-2023
 Python-Version: 3.15
 Post-History: `09-Feb-2024 <https://discuss.python.org/t/pep-728-typeddict-with-typed-extra-items/45443>`__,
+Resolution: `15-Aug-2025 <https://discuss.python.org/t/pep-728-typeddict-with-typed-extra-items/45443/159>`__
 
 
 Abstract


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [x] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date

Thanks for all the help!

cc @JelleZijlstra 