### PR TITLE
PEP 728: Fix some small mistakes

### DIFF
--- a/peps/pep-0728.rst
+++ b/peps/pep-0728.rst
@@ -335,7 +335,7 @@ extra items::
         name: str
 
     def f(movie: Movie) -> None:
-        del movie["name"]  # Not OK. The value type of 'name' is 'Required[int]'
+        del movie["name"]  # Not OK. The value type of 'name' is 'Required[str]'
         del movie["year"]  # OK. The value type of 'year' is 'NotRequired[int]'
 
 Interaction with ``Unpack``


### PR DESCRIPTION
- Wrong indentation
- Sample wouldn't type check due to an unrelated problem
- Incorrect type (noticed by @sinon in https://github.com/python/typing/pull/2068).

cc @PIG208 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4554.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->