### PR TITLE
PEP 503 & PEP 691: Link to PyPA specifications

### DIFF
--- a/peps/pep-0503.rst
+++ b/peps/pep-0503.rst
@@ -10,6 +10,8 @@ Created: 04-Sep-2015
 Post-History: 04-Sep-2015
 Resolution: https://mail.python.org/pipermail/distutils-sig/2015-September/026899.html
 
+.. canonical-pypa-spec:: :ref:`packaging:simple-repository-api`
+
 
 Abstract
 ========

--- a/peps/pep-0691.rst
+++ b/peps/pep-0691.rst
@@ -13,6 +13,8 @@ Created: 04-May-2022
 Post-History: `05-May-2022 <https://discuss.python.org/t/pep-691-json-based-simple-api-for-python-package-indexes/15553>`__
 Resolution: https://discuss.python.org/t/pep-691-json-based-simple-api-for-python-package-indexes/15553/70
 
+.. canonical-pypa-spec:: :ref:`packaging:simple-repository-api`
+
 
 Abstract
 ========


### PR DESCRIPTION
* Change is either:
    - [ ] To a Draft PEP
    - [ ] To an Accepted or Final PEP, with Steering Council approval
    - [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

These PEPs have long since been canonicalized in the "Simple repository API" 🙂 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4558.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->