### PR TITLE
PEP 800: Note that ty now supports ``@disjoint_base``

### DIFF
--- a/peps/pep-0800.rst
+++ b/peps/pep-0800.rst
@@ -372,7 +372,7 @@ Reference Implementation
 ========================
 
 The runtime implementation of the ``@disjoint_base`` decorator is available in
-typing-extensions 4.15.0.
+`typing-extensions 4.15.0 <https://pypi.org/project/typing-extensions/4.15.0/>`__.
 `python/mypy#19678 <https://github.com/python/mypy/pull/19678>`__
 implements support for disjoint bases in mypy and in the stubtest tool.
 `astral-sh/ruff#20084 <https://github.com/astral-sh/ruff/pull/20084>`__


### PR DESCRIPTION
See:
- https://github.com/astral-sh/ruff/pull/20084


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4560.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->