### PR TITLE
Link to plain text PEPs for 'Page Source'

### DIFF
--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -55,7 +55,7 @@
             {{ toc }}
             <br>
             {%- if not pagename.startswith(("pep-0000", "topic")) %}
-            <a id="source" href="https://github.com/python/peps/blob/main/peps/{{pagename}}.rst">Page Source (GitHub)</a>
+            <a id="source" href="https://github.com/python/peps/blob/main/peps/{{pagename}}.rst?plain=1">Page Source (GitHub)</a>
             {%- endif %}
         </nav>
         {%- endif %}


### PR DESCRIPTION
<!--
This template is for an infra or meta change not belonging to another category.
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->
Prior art: https://github.com/python/cpython/commit/9cbf46d9920c269fe736ed689236d00223545f73


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4561.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->