### PR TITLE
PEP 101: Remove DE tasks

### DIFF
--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -134,7 +134,6 @@ release.  The roles and their current experts are:
 
 * WE = Windows - Steve Dower <steve.dower@python.org>
 * ME = Mac - Ned Deily <nad@python.org> (US)
-* DE = Docs - Julien Palard <julien@python.org> (Central Europe)
 
 .. note:: It is highly recommended that the RM contact the Experts the day
   before the release.  Because the world is round and everyone lives
@@ -388,8 +387,6 @@ and guides you to perform some manual steps.
     ``docs.nyc1.psf.io``. Make sure the files are in group ``docs`` and are
     group-writeable.
 
-  - Let the DE check if the docs are built and work all right.
-
   - Note both the documentation and downloads are behind a caching CDN. If
     you change archives after downloading them through the website, you'll
     need to purge the stale data in the CDN like this::
@@ -421,8 +418,6 @@ and guides you to perform some manual steps.
    - Have you gotten the green light from the WE?
 
    - Have you gotten the green light from the ME?
-
-   - Have you gotten the green light from the DE?
 
 If green, it's time to merge the release engineering branch back into
 the main repo.


### PR DESCRIPTION
Since https://github.com/python/release-tools/pull/71 the docs have been automatically built in the CI and there's no manual tasks for the Docs Expert as part of PEP 101.

cc @JulienPalard 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4574.org.readthedocs.build/pep-0101/

<!-- readthedocs-preview pep-previews end -->