### PR TITLE
PEP 794: Weaken the suggestion to use a project's name when `Import-Name` isn't set

### DIFF
--- a/peps/pep-0794.rst
+++ b/peps/pep-0794.rst
@@ -178,26 +178,27 @@ installed. This is a "MAY" and not a "SHOULD" due to some users purposefully
 overwriting import names when installation is done in multiple steps (e.g.
 using different installers with the same environment).
 
-Tools MAY leave ``Import-Name`` and ``Import-Namespace`` out of the core
-metadata for a project. In that instance, tools consuming such metadata SHOULD
-assume that when the core metadata is 2.5 or newer, the normalized project name,
-when converted to an import name, would be an entry in ``Import-Name`` (i.e.
-``-`` replaced with ``_`` in the normalized project name). This is deemed
-reasonable as this will only occur for projects that make a new release once
-their build back-end supports core metadata 2.5 or newer as proposed by this
-PEP.
-
-Projects MAY set ``import-names`` or ``import-namespaces`` -- as well as
-``Import-Name`` or ``Import-Namespace``, respectively -- to the normalized
-import name of the project to explicitly declare that the project's name
-is also the import name.
-
 Projects MAY set ``import-names`` an empty array and not set
 ``import-namespaces`` at all in a :file:`pyproject.toml` file (e.g.
 ``import-names = []``). To match this, projects MAY have an empty
 ``Import-Name`` field in their metadata. This represents a project with NO
 import names, public or private (i.e. there are no Python modules of any kind
 in the distribution file).
+
+Since projects MAY have no ``Import-Name`` metadata (either because the project
+uses an older metadata version, or because it didn't specify any), then tools
+have no information about what names the project provides. However, in practice
+the majority of projects have their project name match what their import name
+would be. As such, it is a reasonable assumption to make that a project name
+that is normalized in some way to an import name (e.g.
+``packaging.utils.canonicalize_name(name, validate=True).replace("-", "_")``)
+can be used if some answer is needed.
+
+Projects MAY set ``import-names`` or ``import-namespaces`` -- as well as
+``Import-Name`` or ``Import-Namespace``, respectively -- to an import name that
+matches the project name (normalized or not) to explicitly declare that the
+project's name is also the import name.
+
 
 
 Examples


### PR DESCRIPTION

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4576.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->