### PR TITLE
PEP 794: Mark as Accepted

### DIFF
--- a/peps/pep-0794.rst
+++ b/peps/pep-0794.rst
@@ -6,7 +6,7 @@ Status: Accepted
 Type: Standards Track
 Topic: Packaging
 Created: 05-Jun-2025
-Post-History: `02-May-2025 <https://discuss.python.org/t/90506>`__
+Post-History: `02-May-2025 <https://discuss.python.org/t/90506>`__,
               `05-Jun-2025 <https://discuss.python.org/t/94567>`__
 Resolution: `05-Sep-2025 <https://discuss.python.org/t/94567/85>`__
 


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

* [X] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [X] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [X] ``Status`` changed to ``Accepted``/``Rejected``
* [X] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [X] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [X] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4577.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->