### PR TITLE
PEP 387: Fix broken TIOBE link

### DIFF
--- a/peps/pep-0387.rst
+++ b/peps/pep-0387.rst
@@ -219,7 +219,7 @@ References
 
 .. [#tiobe] TIOBE Programming Community Index
 
-   http://www.tiobe.com/index.php/content/paperinfo/tpci/index.html
+   https://www.tiobe.com/tiobe-index/
 
 .. [#warnings] The warnings module
 


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

Link to TIOBE programming community index in PEP 387: Backwards Compatability Policy, was dead.
Updated with the new link.