### PR TITLE
Infra: Drop support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.9"
         - "3.10"
         - "3.11"
         - "3.12"

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,5 @@
 output-format = "full"
-target-version = "py39"
+target-version = "py310"
 
 [lint]
 ignore = [

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox>=4.2
 env_list =
-    py{314, 313, 312, 311, 310, 39}
+    py{314, 313, 312, 311, 310}
 no_package = true
 
 [testenv]


### PR DESCRIPTION
It's almost EOL:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0596/


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4587.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->