### PR TITLE
PEP 798: Add PEP Discussion to Post-History

### DIFF
--- a/peps/pep-0798.rst
+++ b/peps/pep-0798.rst
@@ -7,7 +7,7 @@ Status: Draft
 Type: Standards Track
 Created: 19-Jul-2025
 Python-Version: 3.15
-Post-History: `16-Oct-2021 <https://mail.python.org/archives/list/python-ideas@python.org/thread/7G732VMDWCRMWM4PKRG6ZMUKH7SUC7SH/>`__, `22-Jun-2025 <https://discuss.python.org/t/pre-pep-unpacking-in-comprehensions/96362>`__
+Post-History: `16-Oct-2021 <https://mail.python.org/archives/list/python-ideas@python.org/thread/7G732VMDWCRMWM4PKRG6ZMUKH7SUC7SH/>`__, `22-Jun-2025 <https://discuss.python.org/t/pre-pep-unpacking-in-comprehensions/96362>`__, `19-Jul-2025 <https://discuss.python.org/t/pep-798-unpacking-in-comprehensions/99435>`__
 
 
 Abstract


### PR DESCRIPTION
As we discussed, @JelleZijlstra, just a quick PR to add the PEP thread to the Post-History.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4588.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->