### PR TITLE
PEP 351: Fix RST formatting that got lost in translation

### DIFF
--- a/peps/pep-0351.rst
+++ b/peps/pep-0351.rst
@@ -38,8 +38,8 @@ It is conceivable that third party objects also have similar mutable
 and immutable counterparts, and it would be useful to have a standard
 protocol for conversion of such objects.
 
-sets.Set objects expose a "protocol for automatic conversion to
-immutable" so that you can create sets.Sets of sets.Sets.  :pep:`218`
+``sets.Set`` objects expose a "protocol for automatic conversion to
+immutable" so that you can create ``sets.Set``'s of ``sets.Set``'s.  :pep:`218`
 deliberately dropped this feature from built-in sets.  This PEP
 advances that the feature is still useful and proposes a standard
 mechanism for its support.
@@ -48,22 +48,24 @@ mechanism for its support.
 Proposal
 ========
 
-It is proposed that a new built-in function called freeze() is added.
+It is proposed that a new built-in function called ``freeze()`` is added.
 
-If freeze() is passed an immutable object, as determined by hash() on
-that object not raising a TypeError, then the object is returned
+If ``freeze()`` is passed an immutable object, as determined by ``hash()`` on
+that object not raising a ``TypeError``, then the object is returned
 directly.
 
-If freeze() is passed a mutable object (i.e. hash() of that object
-raises a TypeError), then freeze() will call that object's
-__freeze__() method to get an immutable copy.  If the object does not
-have a __freeze__() method, then a TypeError is raised.
+If ``freeze()`` is passed a mutable object (i.e. ``hash()`` of that object
+raises a ``TypeError``), then ``freeze()`` will call that object's
+``__freeze__()`` method to get an immutable copy.  If the object does not
+have a ``__freeze__()`` method, then a ``TypeError`` is raised.
 
 
 Sample implementations
 ======================
 
-Here is a Python implementation of the freeze() built-in::
+Here is a Python implementation of the ``freeze()`` built-in:
+
+.. code-block:: python
 
     def freeze(obj):
         try:
@@ -73,9 +75,11 @@ Here is a Python implementation of the freeze() built-in::
             freezer = getattr(obj, '__freeze__', None)
             if freezer:
                 return freezer()
-            raise TypeError('object is not freezable')``
+            raise TypeError('object is not freezable')
 
-Here are some code samples which show the intended semantics::
+Here are some code samples which show the intended semantics:
+
+.. code-block:: python
 
     class xset(set):
         def __freeze__(self):
@@ -103,6 +107,8 @@ Here are some code samples which show the intended semantics::
     class xdict(dict):
         def __freeze__(self):
             return imdict(self)
+
+.. code-block:: python-console
 
     >>> s = set([1, 2, 3])
     >>> {s: 4}
@@ -140,9 +146,9 @@ Reference implementation
 ========================
 
 Patch 1335812_ provides the C implementation of this feature.  It adds the
-freeze() built-in, along with implementations of the __freeze__()
+``freeze()`` built-in, along with implementations of the ``__freeze__()``
 method for lists and sets.  Dictionaries are not easily freezable in
-current Python, so an implementation of dict.__freeze__() is not
+current Python, so an implementation of ``dict.__freeze__()`` is not
 provided yet.
 
 .. _1335812: http://sourceforge.net/tracker/index.php?func=detail&aid=1335812&group_id=5470&atid=305470
@@ -155,11 +161,11 @@ Open issues
 - Should dicts and sets automatically freeze their mutable keys?
 
 - Should we support "temporary freezing" (perhaps with a method called
-  __congeal__()) a la __as_temporarily_immutable__() in sets.Set?
+  ``__congeal__()``) a la ``__as_temporarily_immutable__()`` in ``sets.Set``?
 
-- For backward compatibility with sets.Set, should we support
-  __as_immutable__()?  Or should __freeze__() just be renamed to
-  __as_immutable__()?
+- For backward compatibility with ``sets.Set``, should we support
+  ``__as_immutable__()``?  Or should ``__freeze__()`` just be renamed to
+  ``__as_immutable__()``?
 
 
 Copyright


### PR DESCRIPTION
This PEP was originally in plaintext and when it got converted to reStructuredText format, the formatting became suboptimal.  Found by @larryhastings

For historical purposes, no substantive changes have been made.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4589.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->