### PR TITLE
PEP 782: Add canonical doc link

### DIFF
--- a/peps/pep-0782.rst
+++ b/peps/pep-0782.rst
@@ -11,6 +11,8 @@ Post-History:
 Resolution: `11-Sep-2025 <https://discuss.python.org/t/86617/15>`__
 
 
+.. canonical-doc:: the `PyBytesWriter API <https://docs.python.org/dev/c-api/bytes.html#pybyteswriter>`_
+
 .. highlight:: c
 
 

--- a/peps/pep-0782.rst
+++ b/peps/pep-0782.rst
@@ -11,7 +11,7 @@ Post-History:
 Resolution: `11-Sep-2025 <https://discuss.python.org/t/86617/15>`__
 
 
-.. canonical-doc:: the `PyBytesWriter API <https://docs.python.org/dev/c-api/bytes.html#pybyteswriter>`_
+.. canonical-doc:: the :ref:`PyBytesWriter API <py3.15:pybyteswriter>`
 
 .. highlight:: c
 


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4590.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->