### PR TITLE
PEP 768: Remove Py_MAX_SCRIPT_PATH_SIZE

### DIFF
--- a/peps/pep-0768.rst
+++ b/peps/pep-0768.rst
@@ -137,7 +137,7 @@ A new structure is added to PyThreadState to support remote debugging:
 
     typedef struct {
         int debugger_pending_call;
-        char debugger_script_path[Py_MAX_SCRIPT_PATH_SIZE];
+        char debugger_script_path[...];
     } _PyRemoteDebuggerSupport;
 
 This structure is appended to ``PyThreadState``, adding only a few fields that
@@ -147,7 +147,7 @@ provides a filesystem path to a Python source file (.py) that will be executed w
 the interpreter reaches a safe point. The path must point to a Python source file,
 not compiled Python code (.pyc) or any other format.
 
-The value for ``Py_MAX_SCRIPT_PATH_SIZE`` will be a trade-off between binary size
+The size of ``debugger_script_path`` will be a trade-off between binary size
 and how big debugging scripts' paths can be. To limit the memory overhead per
 thread we will be limiting this to 512 bytes. This size will also be provided as
 part of the debugger support structure so debuggers know how much they can


### PR DESCRIPTION
`Py_MAX_SCRIPT_PATH_SIZE` was made private in https://github.com/python/cpython/pull/138350. This adjusts the the PEP to match the implementation.

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

@pablogsal, you probably know best if this needs formal SC approval :)

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4591.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->