### PR TITLE
PEP 101: Stop announcing releases on MLs

### DIFF
--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -704,12 +704,6 @@ permissions.
   fuzzy bit because not much can be automated.  You can use an earlier
   announcement as a template, but edit it for content!
 
-- Once the announcement is up on Discourse, send an equivalent to the
-  following mailing lists:
-
-  * python-list@python.org
-  * python-announce@python.org
-
 - Also post the announcement to the
   `Python Insider blog <https://blog.python.org>`_.
   To add a new entry, go to
@@ -841,8 +835,6 @@ else does them.  Some of those tasks include:
 - Announce the branch retirement in the usual places:
 
   * `discuss.python.org`_
-
-  * mailing lists (python-dev, python-list, python-announcements)
 
   * Python Dev blog
 


### PR DESCRIPTION
We've been retiring mailing lists in favour of Discourse ([python-dev](https://mail.python.org/archives/list/python-dev@python.org/thread/PDRLCB6CNLQAFVGPTLXL5QV6SVQDPCCV/), [python-committers](https://mail.python.org/archives/list/python-committers@python.org/thread/WAVEXV3FAK6IFMXTVO7PRNYOY66NBP2F/), [typing-sig](https://discuss.python.org/t/move-typing-sig-to-discourse/29129), [python-ideas](https://discuss.python.org/t/archive-python-ideas-mailing-list-in-favour-of-discourse/88398), [translations](https://discuss.python.org/t/archiving-the-translation-mailing-list-in-favour-of-discourse/102280).

Let's stop sending the release announcements to the mailing lists.

I spoke with @Yhg1s at the sprint, and decided we'll mention this plan in the 3.14.0rc3 email, then do a final one with 3.14.0 final, and then we can stop sending them out entirely.

Release announcements can still be found on Discourse and the blog.

cc @savannahostrowski