### PR TITLE
PEP 763: Mark as Withdrawn

### DIFF
--- a/peps/pep-0763.rst
+++ b/peps/pep-0763.rst
@@ -12,6 +12,18 @@ Created: 24-Oct-2024
 Post-History: `09-Jul-2022 <https://discuss.python.org/t/17227>`__,
               `01-Oct-2024 <https://discuss.python.org/t/66351>`__,
               `28-Oct-2024 <https://discuss.python.org/t/69487>`__
+Resolution: `21-Sep-2025 <https://discuss.python.org/t/69487/38>`__
+
+
+PEP Withdrawal
+==============
+
+This PEP has been withdrawn as of 22-Sep-2025.
+
+During discussion of the PEP, it became clear that a PEP is not necessarily
+the appropriate venue for changes to PyPI's deletion policy, as
+PyPI's usage policies are not presently (or necessarily should) be part of the
+PEP process.
 
 Abstract
 ========

--- a/peps/pep-0763.rst
+++ b/peps/pep-0763.rst
@@ -5,7 +5,7 @@ Author: William Woodruff <william@yossarian.net>,
 Sponsor: Donald Stufft <donald@stufft.io>
 PEP-Delegate: Donald Stufft <donald@stufft.io>
 Discussions-To: https://discuss.python.org/t/69487
-Status: Draft
+Status: Withdrawn
 Type: Standards Track
 Topic: Packaging
 Created: 24-Oct-2024


### PR DESCRIPTION
As the PEP's author, I'm marking PEP 763 as withdrawn -- I think that the overall approach defined in this PEP makes sense, but I don't think there's a clear route to acceptance here that can surmount procedural problems with this being a PEP versus a matter of PyPI policy (like account management, AUPs, malware, quotas, etc.).

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4601.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->