### PR TITLE
PEP 745: Update 3.14.0rc3 release date

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -50,10 +50,10 @@ Actual:
 - 3.14.0 beta 4: Tuesday, 2025-07-08
 - 3.14.0 candidate 1: Tuesday, 2025-07-22
 - 3.14.0 candidate 2: Thursday, 2025-08-14
+- 3.14.0 candidate 3: Thursday, 2025-09-18
 
 Expected:
 
-- 3.14.0 candidate 3: Tuesday, 2025-09-16
 - 3.14.0 final: Tuesday, 2025-10-07
 
 Subsequent bugfix releases every two months.


### PR DESCRIPTION
- https://discuss.python.org/t/python-3-14-0rc3-is-go/103815
- https://www.python.org/downloads/release/python-3140rc3/

Forgot to update the day (Tue → Thu) at first, hence the force push.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4602.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->