### PR TITLE
PEP 518: Do not mention wheel in default [build-system] requires

### DIFF
--- a/peps/pep-0518.rst
+++ b/peps/pep-0518.rst
@@ -164,9 +164,9 @@ the ``pyproject.toml`` file will be::
 
   [build-system]
   # Minimum requirements for the build system to execute.
-  requires = ["setuptools", "wheel"]  # PEP 508 specifications.
+  requires = ["setuptools"]  # PEP 508 specifications.
 
-Because the use of setuptools and wheel are so expansive in the
+Because the use of setuptools is so expansive in the
 community at the moment, build tools are expected to use the example
 configuration file above as their default semantics when a
 ``pyproject.toml`` file is not present.


### PR DESCRIPTION
It was never necessary. In the past, setuptools would pull it in through the PEP 517 hook, only when building the wheels. During PyCon 2024, though, wheel moved into the setuptools' codebase and so it's always bundled now, in the modern versions.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

cc @webknjaz, whose rationale I copied to the commit message.

~This is a change to an accepted/final PEP and is not editorial, but reflects the reality. Is Steering Council approval necessary?~

(Edited by @ncoghlan: I think this *is* an editorial change, since it's just fixing a bug in the example config rather than changing anything in the specification. I have merged it on that basis)

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4603.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->