### PR TITLE
PEP 725: Add 2nd PEP Discussion to Post-History

### DIFF
--- a/peps/pep-0725.rst
+++ b/peps/pep-0725.rst
@@ -3,7 +3,7 @@ Title: Specifying external dependencies in pyproject.toml
 Author: Pradyun Gedam <pradyunsg@gmail.com>,
         Jaime Rodríguez-Guerra <jaime.rogue@gmail.com>,
         Ralf Gommers <ralf.gommers@gmail.com>
-Discussions-To: https://discuss.python.org/t/31888
+Discussions-To: https://discuss.python.org/t/103890
 Status: Draft
 Type: Standards Track
 Topic: Packaging

--- a/peps/pep-0725.rst
+++ b/peps/pep-0725.rst
@@ -8,7 +8,8 @@ Status: Draft
 Type: Standards Track
 Topic: Packaging
 Created: 17-Aug-2023
-Post-History: `18-Aug-2023 <https://discuss.python.org/t/31888>`__
+Post-History: `18-Aug-2023 <https://discuss.python.org/t/31888>`__,
+              `22-Sep-2025 <https://discuss.python.org/t/103890>`__,
 
 
 Abstract


### PR DESCRIPTION
* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4604.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->