### PR TITLE
PEP 804: Add link to DPO thread

### DIFF
--- a/peps/pep-0804.rst
+++ b/peps/pep-0804.rst
@@ -5,14 +5,13 @@ Author: Pradyun Gedam <pradyunsg@gmail.com>,
         Michał Górny <mgorny@quansight.com>,
         Jaime Rodríguez-Guerra <jaime.rogue@gmail.com>,
         Michael Sarahan <msarahan@gmail.com>
-Discussions-To: Pending
+Discussions-To: https://discuss.python.org/t/103891
 Status: Draft
 Type: Standards Track
 Topic: Packaging
 Requires: 725
 Created: 03-Sep-2025
-Post-History: 03-Sep-2025,
-
+Post-History: `22-Sep-2025 <https://discuss.python.org/t/103891>`__
 
 Abstract
 ========


### PR DESCRIPTION
* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4605.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->