### PR TITLE
PEP 780: Update to use sys.abi_info

### DIFF
--- a/peps/pep-0780.rst
+++ b/peps/pep-0780.rst
@@ -294,7 +294,7 @@ can be used::
 
 Note that in the absence of the features described in this PEP, early adopting
 projects have had to resort to using the fork for *all* builds of a potentially
-free threading Python interpreter; typical dependencies than look like::
+free threading Python interpreter; typical dependencies then looked like::
 
     pyyaml; python_version<"3.13"
     pyyaml-ft; python_version>="3.13"


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

This PR updates PEP 780 to make use of the new `sys.abi_info` namespace that stems from [the original PEP 780 discussion](https://discuss.python.org/t/pep-780-abi-features-as-environment-markers/86013).

Pinging @rgommers, @lysnikolaou.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4608.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->