### PR TITLE
PEP 807: add Discussions-To

### DIFF
--- a/peps/pep-0807.rst
+++ b/peps/pep-0807.rst
@@ -9,6 +9,7 @@ Type: Standards Track
 Topic: Packaging
 Created: 19-Sep-2025
 Post-History: `08-Aug-2025 <https://discuss.python.org/t/103067>`__,
+              `29-Sep-2025 <https://discuss.python.org/t/104027>`__
 
 Abstract
 ========


### PR DESCRIPTION
I've opened https://discuss.python.org/t/pep-807-index-support-for-trusted-publishing/104027 as the discussion thread for PEP 807 🙂 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4614.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->