### PR TITLE
PEP 807: document token minting request body

### DIFF
--- a/peps/pep-0807.rst
+++ b/peps/pep-0807.rst
@@ -249,7 +249,11 @@ proceed to mint an upload credential.
 
 To mint an upload credential, the uploading client performs
 an HTTP POST request to the *token minting endpoint* obtained during
-`discovery <Trusted Publishing Discovery_>`__.
+`discovery <Trusted Publishing Discovery_>`__. The payload of the
+POST request **MUST** be a JSON object containing the following:
+
+- ``token``: a string containing the identity credential
+  obtained from the Trusted Publishing provider.
 
 On success, the server responds with a ``200 OK`` status code and a body
 containing a JSON object with the following fields:


### PR DESCRIPTION
I realized that I omitted this by accident in the original PEP draft. I've updated it to match what I originally intended to write (which matches what PyPI does currently).

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4615.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->