### PR TITLE
PEP 768: Mark as Final

### DIFF
--- a/peps/pep-0768.rst
+++ b/peps/pep-0768.rst
@@ -2,12 +2,14 @@ PEP: 768
 Title: Safe external debugger interface for CPython
 Author: Pablo Galindo Salgado <pablogsal@python.org>, Matt Wozniski <godlygeek@gmail.com>, Ivona Stojanovic <stojanovic.i@hotmail.com>
 Discussions-To: https://discuss.python.org/t/pep-768-safe-external-debugger-interface-for-cpython/73969
-Status: Accepted
+Status: Final
 Type: Standards Track
 Created: 25-Nov-2024
 Python-Version: 3.14
 Post-History: `11-Dec-2024 <https://discuss.python.org/t/pep-768-safe-external-debugger-interface-for-cpython/73969>`__
 Resolution: `17-Mar-2025 <https://discuss.python.org/t/pep-768-safe-external-debugger-interface-for-cpython/73969/57>`__
+
+.. canonical-doc:: :ref:`py3.14:remote-debugging`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [X] Final implementation has been merged (including tests and docs)
* [X] PEP matches the final implementation
* [X] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [X] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [X] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [X] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)


cc @hugovk @pablogsal 

A