### PR TITLE
PEP 779: Mark as Final

### DIFF
--- a/peps/pep-0779.rst
+++ b/peps/pep-0779.rst
@@ -4,7 +4,7 @@ Author: Thomas Wouters <thomas@python.org>,
         Matt Page <mpage at python.org>,
         Sam Gross <colesbury at gmail.com>
 Discussions-To: https://discuss.python.org/t/84319
-Status: Accepted
+Status: Final
 Type: Standards Track
 Created: 13-Mar-2025
 Python-Version: 3.14


### PR DESCRIPTION
* [X] Final implementation has been merged (including tests and docs)
* [X] PEP matches the final implementation
* [X] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [X] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [X] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [ ] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

cc @Yhg1s @mpage @colesbury @hugovk 

I can't see any appropriate documentation to link to, as this is more of a 'policy' PEP, so I haven't added a `canonical-doc` directive. Please let me know if there's something that should be linked to otherwise!

A