### PR TITLE
PEP 810: fix formatting

### DIFF
--- a/peps/pep-0810.rst
+++ b/peps/pep-0810.rst
@@ -1367,16 +1367,16 @@ The Python ``import`` machinery separates out finding a module and loading
 it, and the lazy import implementation could technically defer only the
 loading part. However:
 
- - Finding the module does not guarantee the import will succeed, nor even
-   that it will not raise ImportError.
- - Finding modules in packages requires that those packages are loaded, so
-   it would only help with lazy loading one level of a package hierarchy.
- - Since "finding" attributes in modules *requires* loading them, this would
-   create a hard to explain difference between
-   ``from package import module`` and ``from module import function``.
- - A significant part of the performance win is skipping the finding part
-   (which may involve filesystem searches and consulting multiple importers
-   and meta-importers).
+- Finding the module does not guarantee the import will succeed, nor even
+  that it will not raise ImportError.
+- Finding modules in packages requires that those packages are loaded, so
+  it would only help with lazy loading one level of a package hierarchy.
+- Since "finding" attributes in modules *requires* loading them, this would
+  create a hard to explain difference between
+  ``from package import module`` and ``from module import function``.
+- A significant part of the performance win is skipping the finding part
+  (which may involve filesystem searches and consulting multiple importers
+  and meta-importers).
 
 Placing the ``lazy`` keyword in the middle of from imports
 ----------------------------------------------------------


### PR DESCRIPTION
It's currently rendered as a block quote, see the ordered list above for comparison:

<img width="1306" height="908" alt="image" src="https://github.com/user-attachments/assets/b84d2019-3a0f-486b-9495-93776592b516" />

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4631.org.readthedocs.build/pep-0810/#making-lazy-imports-find-the-module-without-loading-it

<!-- readthedocs-preview pep-previews end -->