### PR TITLE
PEP 745: 3.14.0 was released on 7 October 2025

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -51,9 +51,6 @@ Actual:
 - 3.14.0 candidate 1: Tuesday, 2025-07-22
 - 3.14.0 candidate 2: Thursday, 2025-08-14
 - 3.14.0 candidate 3: Thursday, 2025-09-18
-
-Expected:
-
 - 3.14.0 final: Tuesday, 2025-10-07
 
 Subsequent bugfix releases every two months.


### PR DESCRIPTION
Python 3.14.0 is out: https://discuss.python.org/t/python-3-14-0-final-is-here/104210/

A