### PR TITLE
PEP 489: Fix reference warning

### DIFF
--- a/peps/pep-0489.rst
+++ b/peps/pep-0489.rst
@@ -12,9 +12,9 @@ Python-Version: 3.5
 Post-History: 23-Aug-2013, 20-Feb-2015, 16-Apr-2015, 07-May-2015, 18-May-2015
 Resolution: https://mail.python.org/pipermail/python-dev/2015-May/140108.html
 
-.. canonical-doc:: :ref:`python:initializing-modules`.
-                   For Python 3.14+, see :ref:`py3.14:extension-modules`
-                   and :ref:`py3.14:pymoduledef`
+.. canonical-doc:: :ref:`py3.13:initializing-modules`.
+                   For Python 3.14+, see :ref:`python:extension-modules`
+                   and :ref:`python:pymoduledef`
 
 .. highlight:: c
 


### PR DESCRIPTION
* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

Required to fix the reference warning as `/3/` now points to 3.14.

A

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4641.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->