### PR TITLE
PEP 745: Update 3.14.0 final release date

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -14,16 +14,16 @@ Abstract
 This document describes the development and release schedule for
 Python 3.14.
 
-Release Manager and Crew
+Release manager and crew
 ========================
 
-- 3.14 Release Manager: Hugo van Kemenade
+- 3.14 release manager: Hugo van Kemenade
 - Windows installers: Steve Dower
 - Mac installers: Ned Deily
 - Documentation: Julien Palard
 
 
-Release Schedule
+Release schedule
 ================
 
 3.14.0 schedule
@@ -51,10 +51,9 @@ Actual:
 - 3.14.0 candidate 1: Tuesday, 2025-07-22
 - 3.14.0 candidate 2: Thursday, 2025-08-14
 - 3.14.0 candidate 3: Thursday, 2025-09-18
+- 3.14.0 final: Tuesday, 2025-10-07
 
 Expected:
-
-- 3.14.0 final: Tuesday, 2025-10-07
 
 Subsequent bugfix releases every two months.
 


### PR DESCRIPTION
<img width="538" height="507" alt="python-3 14" src="https://github.com/user-attachments/assets/03fcefaa-7278-4179-935a-c2d688e990e3" />

https://discuss.python.org/t/python-3-14-0-final-is-here/104210/1

Plus sentence case headings like https://peps.python.org/pep-0790/ and https://devguide.python.org/documentation/style-guide/#capitalization.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4642.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->