### PR TITLE
PEP 731: Remove Michael Droettboom from C API WG member list

### DIFF
--- a/peps/pep-0731.rst
+++ b/peps/pep-0731.rst
@@ -100,7 +100,6 @@ Members
 The members of the working group are:
 
 - Erlend Aasland
-- Michael Droettboom
 - Petr Viktorin
 - Serhiy Storchaka
 - Steve Dower


### PR DESCRIPTION
@mdboom resigned.

Thank you for your service, Michael!

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4648.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->