### PR TITLE
PEP 810: rename get() to resolve()

### DIFF
--- a/peps/pep-0810.rst
+++ b/peps/pep-0810.rst
@@ -368,7 +368,7 @@ Lazy modules, as well as names lazy imported from modules, are represented
 by :class:`!types.LazyImportType` instances, which are resolved to the real
 object (reified) before they can be used. This reification is usually done
 automatically (see below), but can also be done by calling the lazy object's
-``get`` method.
+``resolve`` method.
 
 Lazy import mechanism
 ---------------------
@@ -493,8 +493,8 @@ Example using ``__dict__`` from external code:
 However, calling ``globals()`` does **not** trigger reification -- it returns
 the module's dictionary, and accessing lazy objects through that dictionary
 still returns lazy proxy objects that need to be manually reified upon use. A
-lazy object can be resolved explicitly by calling the ``get`` method. Other,
-more indirect ways of accessing arbitrary globals (e.g. inspecting
+lazy object can be resolved explicitly by calling the ``resolve`` method.
+Other, more indirect ways of accessing arbitrary globals (e.g. inspecting
 ``frame.f_globals``) also do **not** reify all the objects.
 
 Example using ``globals()``:
@@ -510,8 +510,8 @@ Example using ``globals()``:
   print('json' in sys.modules)  # False - still lazy
   print(type(g['json']))  # <class 'LazyImport'>
 
-  # Explicitly reify using the get() method
-  resolved = g['json'].get()
+  # Explicitly reify using the resolve() method
+  resolved = g['json'].resolve()
 
   print(type(resolved))  # <class 'module'>
   print('json' in sys.modules)  # True - now loaded
@@ -1252,7 +1252,7 @@ Can I force reification of a lazy import without using it?
 ----------------------------------------------------------
 
 Yes, accessing a module's ``__dict__`` will reify all lazy objects in that
-module. Individual lazy objects can be resolved by calling their ``get()``
+module. Individual lazy objects can be resolved by calling their ``resolve()``
 method.
 
 What's the difference between ``globals()`` and ``mod.__dict__`` for lazy imports?


### PR DESCRIPTION
We intend for this to reflect the cost of finding, loading, and executing the lazily-imported module.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4653.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->