### PR TITLE
PEP 788: Address feedback from discussion round

### DIFF
--- a/peps/pep-0788.rst
+++ b/peps/pep-0788.rst
@@ -80,7 +80,7 @@ In addition, a typical pattern among users creating non-Python threads is to
 use :c:func:`PyGILState_Ensure`, which was introduced in :pep:`311`. This has
 been very unfortunate for subinterpreters, because :c:func:`PyGILState_Ensure`
 tends to create a thread state for the main interpreter rather than the
-urrent interpreter. This leads to thread-safety issues when extensions create
+current interpreter. This leads to thread-safety issues when extensions create
 threads that interact with the Python interpreter, because assumptions about
 the GIL are incorrect.
 
@@ -328,7 +328,7 @@ Interpreter Guards
     function.
 
     If the interpreter no longer exists or cannot safely run Python code,
-    this function returns 0 without setting an exception.
+    this function returns ``0`` without setting an exception.
 
     The caller does not need to hold an :term:`attached thread state`.
 


### PR DESCRIPTION
* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

---

Rename `PyInterpreterLock` to `PyInterpreterGuard`, and also do a bunch of copyediting to improve the clarity of the proposal.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4655.org.readthedocs.build/pep-0788/

<!-- readthedocs-preview pep-previews end -->