### PR TITLE
PEP 810: Update decisions on with blocks and __dict__ reification

### DIFF
--- a/peps/pep-0810.rst
+++ b/peps/pep-0810.rst
@@ -1233,36 +1233,6 @@ Can I force reification of a lazy import without using it?
 Yes, individual lazy objects can be resolved by calling their ``resolve()``
 method.
 
-What's the difference between ``globals()`` and ``mod.__dict__`` for lazy imports?
-----------------------------------------------------------------------------------
-
-Both ``globals()`` and ``mod.__dict__`` return the module's dictionary without
-reifying lazy imports. Accessing lazy objects through either will yield lazy
-proxy objects. This provides a consistent low-level API for introspection:
-
-.. code-block:: python
-
-  # In your module:
-  lazy import json
-
-  g = globals()
-  print(type(g['json']))  # <class 'LazyImport'>
-
-  d = __dict__
-  print(type(d['json']))  # <class 'LazyImport'>
-
-  # From external code:
-  import sys
-  mod = sys.modules['your_module']
-  d = mod.__dict__
-  print(type(d['json']))  # <class 'LazyImport'>
-
-Both ``globals()`` and ``__dict__`` expose the raw namespace view without
-implicit side effects. This symmetry makes the behavior predictable: accessing
-the namespace dictionary never triggers imports. If you need to ensure an
-import is resolved, call the ``resolve()`` method explicitly or access the
-attribute directly (e.g., ``json.dumps``).
-
 Why not use ``importlib.util.LazyLoader`` instead?
 --------------------------------------------------
 
@@ -1664,13 +1634,6 @@ aligning with Python's "consenting adults" philosophy. For genuinely problematic
 cases like ``with suppress(ImportError): lazy import foo``, static analysis
 tools and linters are better suited to catch these patterns than hard language
 restrictions.
-
-Additionally, forbidding explicit ``lazy import`` in ``with`` blocks would
-create complex rules for how the global lazy imports flag should behave,
-leading to confusing inconsistencies between explicit and implicit laziness. By
-allowing ``lazy import`` in ``with`` blocks, the rule is simple: the global
-flag affects all module-level imports except those in ``try`` blocks and wild
-card imports, matching exactly what's allowed with explicit syntax.
 
 Forcing eager imports in ``with`` blocks under the global flag
 ---------------------------------------------------------------


### PR DESCRIPTION
This commit updates PEP 810 based on team discussion and feedback:

1. Allow lazy imports inside with blocks
   - Removed with blocks from syntax restrictions
   - Added rejected ideas section explaining why restriction was considered

2. __dict__ does not automatically reify lazy imports
   - Both `globals()` and `__dict__` return raw dictionary without reification
   - Updated reification section, FAQ, and rejected ideas

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4656.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->