### PR TITLE
PEP 790: 3.15.0a1 was released on 2025-10-14

### DIFF
--- a/peps/pep-0790.rst
+++ b/peps/pep-0790.rst
@@ -34,10 +34,10 @@ release cadence between feature versions, as defined by :pep:`602`.
 Actual:
 
 - 3.15 development begins: Wednesday, 2025-05-07
+- 3.15.0 alpha 1: Tuesday, 2025-10-14
 
 Expected:
 
-- 3.15.0 alpha 1: Tuesday, 2025-10-14
 - 3.15.0 alpha 2: Tuesday, 2025-11-18
 - 3.15.0 alpha 3: Tuesday, 2025-12-16
 - 3.15.0 alpha 4: Tuesday, 2026-01-13


### PR DESCRIPTION
https://discuss.python.org/t/python-3-15-alpha-1/104358/1

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4658.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->