### PR TITLE
PEP 743: Remove redundant section and use correct replacement for _Py_T_OBJECT

### DIFF
--- a/peps/pep-0743.rst
+++ b/peps/pep-0743.rst
@@ -110,13 +110,6 @@ known issues at once, rather than do codebase-wide sweeps for a single kind of
 issue, so that we avoid multiple renames of the same function.
 
 
-Adding the ``Py`` prefix
-------------------------
-
-An opt-in macro allows us to omit definitions that could clash with
-third-party libraries.
-
-
 Specification
 =============
 
@@ -255,7 +248,7 @@ The following API will be omitted with ``Py_OMIT_LEGACY_API`` set:
   ``_PyThreadState_UncheckedGet()``     ``PyThreadState_GetUnchecked()``
   ``_PyUnicode_AsString()``             ``PyUnicode_AsUTF8()``
   ``_Py_HashPointer()``                 ``Py_HashPointer()``
-  ``_Py_T_OBJECT``                      ``Py_T_OBJECT_EX``
+  ``_Py_T_OBJECT``                      (``tp_getset``; docs to be written)
   ``_Py_WRITE_RESTRICTED``              (no longer needed)
   ====================================  ==============================
 


### PR DESCRIPTION
Thanks to Serhiy for finding these in https://github.com/capi-workgroup/decisions/issues/49#issuecomment-3423113214

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4663.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->