### PR TITLE
PEP 12: Allow Pending as Post-History

### DIFF
--- a/check-peps.py
+++ b/check-peps.py
@@ -401,7 +401,7 @@ def _validate_python_version(line_num: int, line: str) -> MessageIterator:
 def _validate_post_history(line_num: int, body: str) -> MessageIterator:
     """'Post-History' must be '`DD-mmm-YYYY <Thread URL>`__, …' or `DD-mmm-YYYY`"""
 
-    if body == "":
+    if body in ("", "Pending"):
         return
 
     for offset, line in enumerate(body.removesuffix(",").split("\n"), start=line_num):
@@ -414,7 +414,7 @@ def _validate_post_history(line_num: int, body: str) -> MessageIterator:
                 yield from _date(offset, post_date, "Post-History")
                 yield from _thread(offset, post_url, "Post-History")
             else:
-                yield offset, "post line must be a date or both start with “`” and end with “>`__”"
+                yield offset, "post line must be a date or both start with “`” and end with “>`__”, or 'Pending'"
 
 
 def _validate_resolution(line_num: int, line: str) -> MessageIterator:

--- a/pep_sphinx_extensions/tests/pep_lint/test_post_url.py
+++ b/pep_sphinx_extensions/tests/pep_lint/test_post_url.py
@@ -61,6 +61,7 @@ def test_validate_discussions_to_invalid_list_domain(line: str):
     "body",
     [
         "",
+        "Pending",
         (
             "01-Jan-2001, 02-Feb-2002,\n              "
             "03-Mar-2003, 04-Apr-2004,\n              "
@@ -90,7 +91,7 @@ def test_validate_post_history_valid(body: str):
 def test_validate_post_history_unbalanced_link(body: str):
     warnings = [warning for (_, warning) in check_peps._validate_post_history(1, body)]
     assert warnings == [
-        "post line must be a date or both start with “`” and end with “>`__”"
+        "post line must be a date or both start with “`” and end with “>`__”, or 'Pending'"
     ], warnings
 
 

--- a/peps/pep-0012.rst
+++ b/peps/pep-0012.rst
@@ -119,7 +119,7 @@ directions below.
 - Add a Topic header if the PEP belongs under one shown at the :ref:`topic-index`.
   Most PEPs don't.
 
-- Leave Post-History alone for now; you'll add dates and corresponding links
+- Post-History can be 'Pending' for now; you'll add dates and corresponding links
   to this header each time you post your PEP to the designated discussion forum
   (and update the Discussions-To header with said link, as above).
   For each thread, use the date (in the ``dd-mmm-yyy`` format) as the

--- a/peps/pep-0012/pep-NNNN.rst
+++ b/peps/pep-0012/pep-NNNN.rst
@@ -10,7 +10,7 @@ Topic: <Governance | Packaging | Release | Typing>
 Requires: <pep numbers>
 Created: <date created on, in dd-mmm-yyyy format>
 Python-Version: <version number>
-Post-History: <REQUIRED: dates, in dd-mmm-yyyy format, and corresponding links to PEP discussion threads>
+Post-History: Pending
 Replaces: <pep number>
 Superseded-By: <pep number>
 Resolution: <url>


### PR DESCRIPTION
Follow on from https://github.com/python/peps/pull/4361 which allowed "Discussions-To: Pending".

It would be handy to also put "Post-History: Pending" as a placeholder for the initial draft.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4670.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->