### PR TITLE
PEP 791: Mark as Final

### DIFF
--- a/peps/pep-0791.rst
+++ b/peps/pep-0791.rst
@@ -16,6 +16,9 @@ Post-History: `12-Jul-2018 <https://mail.python.org/archives/list/python-ideas@p
 Resolution: `23-Oct-2025 <https://discuss.python.org/t/92548/154>`__
 
 
+.. canonical-doc:: `math.integer — integer-specific mathematics functions <https://docs.python.org/3.15/library/math.integer.html>`_
+
+
 Abstract
 ========
 


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [x] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date
* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4671.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->

---------------

https://pep-previews--4671.org.readthedocs.build/pep-0791/