### PR TITLE
Fix two missing underscores.

### DIFF
--- a/peps/pep-0630.rst
+++ b/peps/pep-0630.rst
@@ -401,7 +401,7 @@ Please refer to the `documentation
 <https://docs.python.org/3/c-api/typeobj.html>`__ of `Py_TPFLAGS_HAVE_GC
 <https://docs.python.org/3/c-api/typeobj.html#Py_TPFLAGS_HAVE_GC>`__ and
 `tp_traverse
-<https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_traverse>`
+<https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_traverse>`_
 for additional considerations.
 
 If your traverse function delegates to the ``tp_traverse`` of its base class

--- a/peps/pep-0677.rst
+++ b/peps/pep-0677.rst
@@ -427,7 +427,7 @@ The proposed new syntax can be described by these AST changes to `Parser/Python.
 
 
 Here are our proposed changes to the `Python Grammar
-<https://docs.python.org/3/reference/grammar.htm>`::
+<https://docs.python.org/3/reference/grammar.htm>`_::
 
     expression:
         | disjunction disjunction 'else' expression


### PR DESCRIPTION
Next release of sphinx-lint will spot that.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4675.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->