### PR TITLE
PEP 9999: Immutable variables with const keyword

### DIFF
--- a/peps/pep-0812.rst
+++ b/peps/pep-0812.rst
@@ -5,23 +5,21 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 31-Oct-2025
+Python-Version: 3.15
+Post-History: Pending
+Discussions-To: Pending
 
 Abstract
 ========
 
-Today, python variables are wonderfully mutable - this is a super power of the language. However, in larger codebases, or more complex implementations, there is often a need to mark a variable as immutable. This is useful in two major ways, the first of which is general to programming, and not specific to python - assurances of objects staying identical for their lifetimes is a powerful hint to both the programmer, and the compiler. Potential compiler opitmizations aside, ``const`` hints ignal to programmers that the original author of the code intended this object not to change, which, like c++'s ``const`` corectness ideas, promotes safety and readability. Potential general programming benefits aside, a far more specific python "Gotcha", is mutable defaults.
+Today, Python variables are wonderfully mutable - this is a super power of the language. However, in larger codebases, or more complex implementations, there is often a need to mark a variable as immutable. This is useful in two major ways. First, general to programming and not specific to Python, assurances of objects staying identical for their lifetimes is a powerful hint to both the programmer and the compiler. Potential compiler optimizations aside, ``const`` hints signal to programmers that the original author of the code intended this object not to change, which, like C++'s ``const`` correctness ideas, promotes safety and readability.
 
-This PEP proposes a ``const`` keyword that can be inserted in function arguments, defaults, and in scopes that declares an object as immutable.
-
-Proposal
-========
-
-A ``const`` keyword that applies to functions, class attributes, and variables.
+Second, a far more specific Python "Gotcha" is mutable defaults. This PEP proposes a ``const`` keyword that can be inserted in function arguments, defaults, class attributes, and scopes to declare an object as immutable, forbidding both rebinding and mutation.
 
 Motivation
 ==========
 
-To elaborate on the cases above, consider the following code::
+Consider the following code::
 
     def add_item_to_cart(item, cart=[]):
         """
@@ -31,9 +29,9 @@ To elaborate on the cases above, consider the following code::
         cart.append(item)
         return cart
 
-cart is evaluated *once* when the function is defined - this means that a second caller appending to the cart is going to see the first item, and so forth, - a common mistake.
+In this standard example, ``cart`` is evaluated *once* when the function is defined. This means that a second caller appending to the cart is going to see the first item, and so forth—a common mistake.
 
-Or::
+Another example involves accidentally mutating data that should be a snapshot::
 
     def analyze_latest_scores(current_scores):
         original_order = current_scores
@@ -43,70 +41,69 @@ Or::
             "first_entry": original_order[0]
         }
 
-It looks like we are saving a snapshot of the data as it came in... but .sort() modifies the list *in-place*. Because 'original_order' is just a reference to 'current_scores', the returned "first_entry" field is will be the top score, not the first entry!
+It looks like we are saving a snapshot of the data as it came in, but ``.sort()`` modifies the list *in-place*. Because ``original_order`` is just a reference to ``current_scores``, the returned "first_entry" field will be the top score, not the first entry.
 
-And, aside from these edge cases of mutability, just general readability and safety added to python.
+Beyond these edge cases of mutability, a ``const`` keyword adds general readability and safety to Python.
 
-What does ``const`` mean?
-=========================
+Rationale
+=========
 
-There are two tiers of ``const``-ness - this proposal pushes for the strictest version of it.
+The inclusion of ``const`` provides significant benefits in both tooling and language semantics.
 
-Less restrictive - ``const`` only forbids rebinding
----------------------------------------------------
+Compiler Benefits
+-----------------
 
-In this variant of ``const``, we limit it to mean rebinding. It is closer spiritually to "final" in certain other languages.
+Globals Optimization
+''''''''''''''''''''
 
-.. code-block:: python
+If the compiler knows a global is ``const``, it can bake its value directly into the bytecode of functions that use it, rather than emitting ``LOAD_GLOBAL`` instructions.
+
+Consider the following standard Python code::
+
+    DEBUG = False
+    def foo():
+        if DEBUG:
+            ...
+        if DEBUG:
+            ...
+
+Currently, this results in repeated ``LOAD_GLOBAL`` instructions and runtime checks. With a ``const`` global, the compiler can store the value once, skip the ``LOAD_GLOBAL`` opcodes, and potentially use static analysis to identify and remove the dead branches entirely.
+
+Class Safety and MRO Optimization
+'''''''''''''''''''''''''''''''''
+
+If a class method is marked ``const``, the compiler guarantees it will never be overridden by a subclass or shadowed by an instance attribute. When calling ``my_obj.const_method()``, the compiler does not need to check the instance dictionary or walk the Method Resolution Order (MRO). It can compile a direct call to that exact function object.
+
+JIT Guard Reduction
+'''''''''''''''''''
+
+JIT compilers that rely on guards (such as CPython's JIT, torchdynamo, etc.) can emit fewer guards, as the invariants provided by ``const`` reduce the number of state changes that need monitoring.
+
+Non-Compiler Benefits
+---------------------
+
+*   **Readability**: Code becomes cleaner and easier to reason about.
+*   **Invariants**: Provides stronger invariants at the language level, reducing classes of bugs related to accidental mutation.
+
+Specification
+=============
+
+This proposal pushes for the strictest version of ``const``-ness: forbidding both rebinding and direct mutation.
+
+Syntax and Semantics
+--------------------
+
+Variables marked as ``const`` cannot be updated, and raise an exception upon update attempts.
+
+Rebinding is forbidden::
 
     const x = []
     x = {}  # Fails, no rebinding allowed, raises
 
-However::
-
-    const x = []
-    x.append(1)  # Sound, allowed, as the name `x` stays the same type and object, it merely got mutated
-
-In this case, theres not much to do with function arguments, except catch shadowing as an exception.
-In this case, the mutable default problem presented above is not resolved.
-
-More restrictive - ``const`` forbids direct mutation
-----------------------------------------------------
-
-.. code-block:: python
-
-    const x = []
-    x = {}  # Fails, no rebinding allowed, raises
-
-And::
+Mutation is forbidden::
 
     const x = []
     x.append(1)  # Fails, modifying the object declared as const, illegal
-
-And::
-
-    class MyWidget:
-        x: int
-
-        def update(self, x):
-            self.x = x
-
-    m = MyWidget()
-    m.update(1)  # 1, sound
-    m.update(2)  # 2, sound
-    const n = MyWidget()
-    n.update(1)  # Fails, updating a const
-
-Variables marked as ``const`` cannot be updated, and raise upon updated
-
-Usage
-=====
-
-There are three primary uses of the ``const`` keyword proposed here:
-
-* On function arguments
-* On attributes and fields classes
-* On variables
 
 Function Arguments
 ------------------
@@ -119,21 +116,13 @@ Key behaviors include:
 *   **Transitive Constness**: A ``const`` argument can only be passed to other functions that also expect it as ``const``. You cannot erase "constness" once it is applied.
 *   **Explicit Copying**: It can be copied out to a non-``const`` variable. This is the proposed analogue to C++'s ``const_cast``; the only way to "un-const" something is via a copy.
 
-Reassignment and Shadowing
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-
-Shadowing or reassigning a ``const`` name is treated as an exception.
-
-.. code-block:: python
+Shadowing or reassigning a ``const`` name is treated as an exception::
 
    def foo(const bar, baz):
        bar = 3  # Fails, raises on reassignment/shadowing
        return bar * baz
 
-When passing a ``const`` variable to another function, the receiving function's arguments must also be marked ``const``.
-
-.. code-block:: python
+When passing a ``const`` variable to another function, the receiving function's arguments must also be marked ``const``::
 
    # Standard function with mutable arguments
    def boo(bat, man):
@@ -147,9 +136,7 @@ When passing a ``const`` variable to another function, the receiving function's 
 Class Attributes and Fields
 ---------------------------
 
-Marking an attribute as ``const`` makes it writable only at ``__init__`` time (or assignable via a default value). It is illegal to modify a ``const`` attribute after initialization.
-
-.. code-block:: python
+Marking an attribute as ``const`` makes it writable only at ``__init__`` time (or assignable via a default value). It is illegal to modify a ``const`` attribute after initialization::
 
    class MyWidget:
        const x: int
@@ -160,98 +147,56 @@ Marking an attribute as ``const`` makes it writable only at ``__init__`` time (o
 Variables
 ---------
 
-As covered in previous sections, both local and global variables can be declared ``const``. This enforces the renaming and update semantics described above.
+Both local and global variables can be declared ``const``. This enforces the renaming and update semantics described above. Critically, these variables can only be passed to functions where the corresponding argument is also marked ``const``.
 
-Critically, these variables can only be passed to functions where the corresponding argument is also marked ``const``.
+Backwards Compatibility
+=======================
 
-Benefits
-========
+This proposal should be generally sound regarding backwards compatibility, except for cases where ``const`` is currently used as a variable name. This will become a ``SyntaxError``, which can be detected statically (via linting) and is relatively trivial to fix in existing codebases.
 
-Compiler Benefits
------------------
+Security Implications
+=====================
 
-Globals Optimization
-^^^^^^^^^^^^^^^^^^^^
+Introducing strict immutability may enhance security by preventing certain classes of injection or state-tampering attacks where mutable shared state is exploited. No negative security implications are immediately foreseen, though the implementation of "frozen" objects must ensure that standard Python sandboxing or restricted execution environments cannot bypass constness.
 
-If the compiler knows a global is ``const``, it can bake its value directly into the bytecode of functions that use it, rather than emitting ``LOAD_GLOBAL`` instructions.
+How to Teach This
+=================
 
-Consider the following standard Python code:
+[Placeholder: Instructions for teaching this feature to new and experienced Python users.]
+
+Reference Implementation
+========================
+
+The implementation is planned in phases (WIP):
+
+*   **Phase 1 (Rebinding):** Implementing standard "final" behavior. Bytecodes used for assignment (``STORE_FAST``, etc.) will be extended to look up const tagging and fail if necessary.
+*   **Phase 2 (Frozen Objects):** New bytecodes that set flags propagating the constness of the object to the underlying implementation. This will start with builtin types (``PyList``, ``PyDict``) and explore intercessions into functions like ``PyList_Append`` to respect the constness of the object.
+*   **Phase 3 (Viral Constness):** Implementing the transitive nature of const in function calls.
+
+Rejected Ideas
+==============
+
+Less restrictive ``const`` (rebinding only)
+-------------------------------------------
+
+A variant of ``const`` was considered that only forbids rebinding, similar to "final" in Java or ``const`` in JavaScript.
 
 .. code-block:: python
 
-   DEBUG = False
-   def foo():
-       if DEBUG:
-           ...
-       if DEBUG:
-           ...
+    const x = []
+    x = {}  # Fails, no rebinding allowed, raises
+    x.append(1)  # Allowed, as the name `x` stays the same object
 
-Currently, this results in repeated ``LOAD_GLOBAL`` instructions and runtime checks:
+This was rejected because it does not resolve the mutable default problem presented in the Motivation, nor does it provide the strong invariants required for the proposed compiler optimizations.
 
-.. code-block:: text
-
-   Disassembly of <code object foo at 0x561367afd590, file "example.py", line 2>:
-     2           RESUME                   0
-
-     3           LOAD_GLOBAL              0 (DEBUG)
-                 TO_BOOL
-                 POP_JUMP_IF_FALSE        1 (to L1)
-
-     4           NOP
-
-     5   L1:     LOAD_GLOBAL              0 (DEBUG)
-                 TO_BOOL
-                 POP_JUMP_IF_FALSE        1 (to L2)
-
-     6           RETURN_CONST             0 (None)
-
-     5   L2:     RETURN_CONST             0 (None)
-
-With a ``const`` global, the compiler can store the value once, skip the ``LOAD_GLOBAL`` opcodes, and potentially use static analysis to identify and remove the dead branches entirely.
-
-Class Safety and MRO Optimization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If a class method is marked ``const``, the compiler guarantees it will never be overridden by a subclass or shadowed by an instance attribute.
-
-When calling ``my_obj.const_method()``, the compiler does not need to check the instance dictionary or walk the Method Resolution Order (MRO). It can compile a direct call to that exact function object.
-
-JIT Guard Reduction
-~~~~~~~~~~~~~~~~~~~
-JIT compilers that rely on guards (such as CPython's JIT, torchdynamo, etc.) can emit fewer guards, as the invariants provided by ``const`` reduce the number of state changes that need monitoring.
-
-Non-Compiler Benefits
----------------------
-
-*   **Readability**: Code becomes cleaner and easier to reason about.
-*   **Invariants**: Provides stronger invariants at the language level, reducing classes of bugs related to accidental mutation.
-
-
-Back-compat
+Open Issues
 ===========
 
-Should be entirely sound - except for cases where someone is using ``const`` as a variable name. This should become a SyntaxError, which should be relatively trivial to fix, and can be detected entirely statically (linting, etc).
+*   **Viral Constness Implementation**: strictly enforcing transitive constness may incur a type check on every function call with const keywords in it, which may be prohibitively expensive or complex to implement efficiently.
+*   **Phase 2 Scope**: The extent to which "frozen" objects can be implemented across all C-extension types remains an open question.
 
+Copyright
+=========
 
-Implementation / Open questions 
-===============================
-
-Note - this section needs further exploration and is a WIP. 
-
-Basics
-------
-The implementation would require adding const to the python grammar, updating the ast, and all other language level structures that handle keywords.
-
-Less restrictive / phase 1
---------------------------
-The first phase, rebinding, (or, breaking rebinding, aka, the final keyword like work described above) - seems relatively straightforward. Bytecodes used for assignment (store_fast, etc) - would be extended to look up our const tagging and fail according to the descriptions above.   
-
-
-Frozen objects / phase 2
-------------------------
-For the second phase, more akin to a frozen object, we would need to come up with new bytecodes that set flags that propagate the constness of the object to the underlying implementation. I think we would start with builtin types (PyList, PyDict) and start exploring intercessions into functions like PyList_Append to respect the constness of the object.
-
-
-Viral constness / phase 3
--------------------------
-Viral constness seems tricky to implement, as it would incur a type check on every function call with const keywords in it. 
-
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.


### PR DESCRIPTION
<!--
You can use the following checklist when double-checking your PEP,
and you can help complete some of it yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about anything, just leave it blank and we'll take a look.

If your PEP is not Standards Track, remove the corresponding section.
-->

## Basic requirements (all PEP Types)

* [X] Read and followed [PEP 1](https://peps.python.org/1) & [PEP 12](https://peps.python.org/12)
* [X] File created from the [latest PEP template](https://github.com/python/peps/blob/main/peps/pep-0012/pep-NNNN.rst?plain=1)
* [X] PEP has next available number, & set in filename (``pep-NNNN.rst``), PR title (``PEP 123: <Title of PEP>``) and ``PEP`` header
* [X] Title clearly, accurately and concisely describes the content in 79 characters or less
* [?] Core dev/PEP editor listed as ``Author`` or ``Sponsor``, and formally confirmed their approval
* [?] ``Author``, ``Status`` (``Draft``), ``Type`` and ``Created`` headers filled out correctly
* [?] ``PEP-Delegate``, ``Topic``, ``Requires`` and ``Replaces`` headers completed if appropriate
* [X] Required sections included
    * [X] Abstract (first section)
    * [X] Copyright (last section; exact wording from template required)
* [X] Code is well-formatted (PEP 7/PEP 8) and is in [code blocks, with the right lexer names](https://peps.python.org/pep-0012/#literal-blocks) if non-Python
* [TBD] PEP builds with no warnings, pre-commit checks pass and content displays as intended in the rendered HTML
* [?] Authors/sponsor added to ``.github/CODEOWNERS`` for the PEP


## Standards Track requirements

* [ ] PEP topic [discussed in a suitable venue](https://peps.python.org/pep-0001/#start-with-an-idea-for-python) with general agreement that a PEP is appropriate
* [ ] [Suggested sections](https://peps.python.org/pep-0012/#suggested-sections) included (unless not applicable)
    * [ ] Motivation
    * [ ] Rationale
    * [ ] Specification
    * [ ] Backwards Compatibility
    * [ ] Security Implications
    * [ ] How to Teach This
    * [ ] Reference Implementation
    * [ ] Rejected Ideas
    * [ ] Open Issues
* [ ] ``Python-Version`` set to valid (pre-beta) future Python version, if relevant
* [ ] Any project stated in the PEP as supporting/endorsing/benefiting from the PEP formally confirmed such
* [ ] Right before or after initial merging, [PEP discussion thread](https://peps.python.org/pep-0001/#discussing-a-pep) created and linked to in ``Discussions-To`` and ``Post-History``


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4682.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->