### PR TITLE
Normalize Pablo's name across all PEPs

### DIFF
--- a/peps/pep-0570.rst
+++ b/peps/pep-0570.rst
@@ -1,7 +1,7 @@
 PEP: 570
 Title: Python Positional-Only Parameters
 Author: Larry Hastings <larry@hastings.org>,
-        Pablo Galindo <pablogsal@python.org>,
+        Pablo Galindo Salgado <pablogsal@python.org>,
         Mario Corchero <mariocj89@gmail.com>,
         Eric N. Vander Weele <ericvw@gmail.com>
 BDFL-Delegate: Guido van Rossum <guido@python.org>

--- a/peps/pep-0617.rst
+++ b/peps/pep-0617.rst
@@ -1,7 +1,7 @@
 PEP: 617
 Title: New PEG parser for CPython
 Author: Guido van Rossum <guido@python.org>,
-        Pablo Galindo <pablogsal@python.org>,
+        Pablo Galindo Salgado <pablogsal@python.org>,
         Lysandros Nikolaou <lisandrosnik@gmail.com>
 Discussions-To: python-dev@python.org
 Status: Final

--- a/peps/pep-0626.rst
+++ b/peps/pep-0626.rst
@@ -1,7 +1,7 @@
 PEP: 626
 Title: Precise line numbers for debugging and other tools.
 Author: Mark Shannon <mark@hotpy.org>
-BDFL-Delegate: Pablo Galindo <pablogsal@python.org>
+BDFL-Delegate: Pablo Galindo Salgado <pablogsal@python.org>
 Status: Final
 Type: Standards Track
 Created: 15-Jul-2020

--- a/peps/pep-0641.rst
+++ b/peps/pep-0641.rst
@@ -3,7 +3,7 @@ Title: Using an underscore in the version portion of Python 3.10 compatibility t
 Author: Brett Cannon <brett@python.org>,
         Steve Dower <steve.dower@python.org>,
         Barry Warsaw <barry@python.org>
-PEP-Delegate: Pablo Galindo <pablogsal@python.org>
+PEP-Delegate: Pablo Galindo Salgado <pablogsal@python.org>
 Discussions-To: https://discuss.python.org/t/pep-641-using-an-underscore-in-the-version-portion-of-python-3-10-compatibility-tags/5513
 Status: Rejected
 Type: Standards Track

--- a/peps/pep-0648.rst
+++ b/peps/pep-0648.rst
@@ -1,7 +1,7 @@
 PEP: 648
 Title: Extensible customizations of the interpreter at startup
 Author: Mario Corchero <mariocj89@gmail.com>
-Sponsor: Pablo Galindo
+Sponsor: Pablo Galindo Salgado
 Discussions-To: https://discuss.python.org/t/pep-648-extensible-customizations-of-the-interpreter-at-startup/6403
 Status: Rejected
 Type: Standards Track

--- a/peps/pep-0657.rst
+++ b/peps/pep-0657.rst
@@ -1,6 +1,6 @@
 PEP: 657
 Title: Include Fine Grained Error Locations in Tracebacks
-Author: Pablo Galindo <pablogsal@python.org>,
+Author: Pablo Galindo Salgado <pablogsal@python.org>,
         Batuhan Taskaya <batuhan@python.org>,
         Ammar Askar <ammar@ammaraskar.com>
 Discussions-To: https://discuss.python.org/t/pep-657-include-fine-grained-error-locations-in-tracebacks/8629

--- a/peps/pep-0701.rst
+++ b/peps/pep-0701.rst
@@ -1,6 +1,6 @@
 PEP: 701
 Title: Syntactic formalization of f-strings
-Author: Pablo Galindo <pablogsal@python.org>,
+Author: Pablo Galindo Salgado <pablogsal@python.org>,
         Batuhan Taskaya <batuhan@python.org>,
         Lysandros Nikolaou <lisandrosnik@gmail.com>,
         Marta Gómez Macías <cyberwitch@google.com>

--- a/peps/pep-0705.rst
+++ b/peps/pep-0705.rst
@@ -1,7 +1,7 @@
 PEP: 705
 Title: TypedDict: Read-only items
 Author: Alice Purcell <alicederyn@gmail.com>
-Sponsor: Pablo Galindo <pablogsal@gmail.com>
+Sponsor: Pablo Galindo Salgado <pablogsal@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-705-read-only-typeddict-items/37867
 Status: Final
 Type: Standards Track

--- a/peps/pep-0758.rst
+++ b/peps/pep-0758.rst
@@ -1,6 +1,6 @@
 PEP: 758
 Title: Allow ``except`` and ``except*`` expressions without parentheses
-Author: Pablo Galindo <pablogsal@python.org>, Brett Cannon <brett@python.org>
+Author: Pablo Galindo Salgado <pablogsal@python.org>, Brett Cannon <brett@python.org>
 Status: Final
 Type: Standards Track
 Created: 30-Sep-2024

--- a/peps/pep-0760.rst
+++ b/peps/pep-0760.rst
@@ -1,6 +1,6 @@
 PEP: 760
 Title: No More Bare Excepts
-Author: Pablo Galindo <pablogsal@python.org>, Brett Cannon <brett@python.org>
+Author: Pablo Galindo Salgado <pablogsal@python.org>, Brett Cannon <brett@python.org>
 Status: Withdrawn
 Type: Standards Track
 Created: 02-Oct-2024

--- a/peps/pep-0799.rst
+++ b/peps/pep-0799.rst
@@ -1,6 +1,6 @@
 PEP: 799
 Title: A dedicated ``profiling`` package for organizing Python profiling tools
-Author: Pablo Galindo <pablogsal@python.org>,
+Author: Pablo Galindo Salgado <pablogsal@python.org>,
         László Kiss Kollár <kiss.kollar.laszlo@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-799-a-dedicated-profilers-package-for-organizing-python-profiling-tool/100898
 Status: Accepted

--- a/peps/pep-0810.rst
+++ b/peps/pep-0810.rst
@@ -1,6 +1,6 @@
 PEP: 810
 Title: Explicit lazy imports
-Author: Pablo Galindo <pablogsal@python.org>,
+Author: Pablo Galindo Salgado <pablogsal@python.org>,
         Germán Méndez Bravo <german.mb@gmail.com>,
         Thomas Wouters <thomas@python.org>,
         Dino Viehland <dinoviehland@gmail.com>,


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [ ] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

Pablo has accidentally left off part of his last name due to habits formed from his days as an Academic. This PR fixes this in all places but the voter roll entries in the 81NN PEPs.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4689.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->