### PR TITLE
PEP 745: Add planned bugfix releases for Python 3.14

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -53,9 +53,9 @@ Actual:
 - 3.14.0 candidate 3: Thursday, 2025-09-18
 - 3.14.0 final: Tuesday, 2025-10-07
 
-Expected:
-
 Subsequent bugfix releases every two months.
+
+Expected:
 
 - 3.14.1: Tuesday, 2025-12-02
 - 3.14.2: Tuesday, 2026-02-03


### PR DESCRIPTION
Same day as remaining 3.13 bugfix releases (up to 2026-10-06), and the remainder on the first Tuesdays of even months.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4691.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->