### PR TITLE
PEP 596: 2025-10-31 was a Friday

### DIFF
--- a/peps/pep-0596.rst
+++ b/peps/pep-0596.rst
@@ -99,7 +99,7 @@ Provided irregularly on an "as-needed" basis until October 2025.
 - 3.9.22: Tuesday, 2025-04-08
 - 3.9.23: Tuesday, 2025-06-03
 - 3.9.24: Thursday, 2025-10-09
-- 3.9.25: Thursday, 2025-10-31
+- 3.9.25: Friday, 2025-10-31
 
 
 3.9 Lifespan


### PR DESCRIPTION
https://discuss.python.org/t/the-final-python-3-9-security-fix-release-is-out/104666

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4692.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->