### PR TITLE
PEP 745: Add planned bugfix releases for Python 3.14 to python-releases.toml

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -57,7 +57,10 @@ Actual:
 
 .. release schedule: ends
 
-Subsequent bugfix releases every two months.
+Bugfix releases
+---------------
+
+.. release schedule: bugfix
 
 Expected:
 
@@ -73,7 +76,9 @@ Expected:
 - 3.14.10: Tuesday, 2027-06-01
 - 3.14.11: Tuesday, 2027-08-03
 - 3.14.12: Tuesday, 2027-10-05
+  (Final regular bugfix release with binary installers)
 
+.. release schedule: ends
 
 Source-only security fix releases
 ---------------------------------

--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3452,6 +3452,66 @@ stage = "3.14.0 final"
 state = "actual"
 date = 2025-10-07
 
+[[release."3.14"]]
+stage = "3.14.1"
+state = "expected"
+date = 2025-12-02
+
+[[release."3.14"]]
+stage = "3.14.2"
+state = "expected"
+date = 2026-02-03
+
+[[release."3.14"]]
+stage = "3.14.3"
+state = "expected"
+date = 2026-04-07
+
+[[release."3.14"]]
+stage = "3.14.4"
+state = "expected"
+date = 2026-06-09
+
+[[release."3.14"]]
+stage = "3.14.5"
+state = "expected"
+date = 2026-08-04
+
+[[release."3.14"]]
+stage = "3.14.6"
+state = "expected"
+date = 2026-10-06
+
+[[release."3.14"]]
+stage = "3.14.7"
+state = "expected"
+date = 2026-12-01
+
+[[release."3.14"]]
+stage = "3.14.8"
+state = "expected"
+date = 2027-02-02
+
+[[release."3.14"]]
+stage = "3.14.9"
+state = "expected"
+date = 2027-04-06
+
+[[release."3.14"]]
+stage = "3.14.10"
+state = "expected"
+date = 2027-06-01
+
+[[release."3.14"]]
+stage = "3.14.11"
+state = "expected"
+date = 2027-08-03
+
+[[release."3.14"]]
+stage = "3.14.12"
+state = "expected"
+date = 2027-10-05
+
 # -- Python 3.15 --------------------------------------------------------------
 
 [metadata."3.15"]


### PR DESCRIPTION
Follow on from https://github.com/python/peps/pull/4331.

Generate from the TOML instead of hardcoding.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4693.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->