### PR TITLE
PEP 596: Mark Python 3.9 as end-of-life in python-releases.toml

### DIFF
--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -2511,14 +2511,14 @@ note = "final security release"
 
 [metadata."3.9"]
 pep = 596
-status = "security"
+status = "end-of-life"
 branch = "3.9"
 release-manager = "Łukasz Langa"
 start-of-development = 2019-06-04
 feature-freeze = 2020-05-18
 first-release = 2020-10-05
 end-of-bugfix = 2022-05-17
-end-of-life = 2025-10-01
+end-of-life = 2025-10-31
 
 [[release."3.9"]]
 stage = "3.9.0 alpha 1"


### PR DESCRIPTION
Follow on from https://github.com/python/peps/pull/4331.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4694.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->