### PR TITLE
Mark Python 3.12 as security and 3.14 as bugfix

### DIFF
--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3066,7 +3066,7 @@ date = 2025-10-09
 
 [metadata."3.12"]
 pep = 693
-status = "bugfix"
+status = "security"
 branch = "3.12"
 release-manager = "Thomas Wouters"
 start-of-development = 2022-05-08
@@ -3368,7 +3368,7 @@ date = 2026-10-06
 
 [metadata."3.14"]
 pep = 745
-status = "prerelease"
+status = "bugfix"
 branch = "3.14"
 release-manager = "Hugo van Kemenade"
 start-of-development = 2024-05-08


### PR DESCRIPTION
Couple more followups from https://github.com/python/peps/pull/4331.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4696.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->