### PR TITLE
PEP 101: Instruct the Release Manager to change ``python-releases.toml``

### DIFF
--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -726,8 +726,7 @@ permissions.
   - Update the `issue tracker`_ for the new branch:
     add the new version to the versions list.
 
-  - Update `python-releases.toml <../release_management/python-releases.toml>`__
-    to reflect the new branches and versions.
+  - Update python-releases.toml_ to reflect the new branches and versions.
 
   - Create a PR to update the supported releases table on the
     `downloads page <https://www.python.org/downloads/>`__ (see
@@ -811,8 +810,7 @@ else does them.  Some of those tasks include:
 
   * https://www.python.org/downloads/release/python-336/
 
-- In `python-releases.toml <../release_management/python-releases.toml>`__,
-  set the branch status to end-of-life.
+- In python-releases.toml_, set the branch status to end-of-life.
 
 - Update or remove references to the branch in the `developer's guide
   <https://github.com/python/devguide/>`__.
@@ -884,6 +882,7 @@ This document has been placed in the public domain.
 .. _deferred-blocker: https://github.com/python/cpython/labels/deferred-blocker
 .. _discuss.python.org: https://discuss.python.org
 .. _issue tracker: https://github.com/python/cpython/issues
+.. _python-releases.toml: https://github.com/python/peps/blob/HEAD/release_management/python-releases.toml
 .. _python/cpython: https://github.com/python/cpython
 .. _python/peps: https://github.com/python/peps
 .. _python/release-tools: https://github.com/python/release-tools


### PR DESCRIPTION
* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [X] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4697.org.readthedocs.build/pep-0101/

<!-- readthedocs-preview pep-previews end -->