### PR TITLE
Expose feature freeze date in python-releases.json API

### DIFF
--- a/release_management/serialize.py
+++ b/release_management/serialize.py
@@ -44,6 +44,7 @@ def version_info(metadata: VersionMetadata, /) -> dict[str, str | int]:
         'branch': metadata.branch,
         'pep': metadata.pep,
         'status': metadata.status,
+        'feature_freeze': metadata.feature_freeze.isoformat(),
         'first_release': metadata.first_release.isoformat(),
         'end_of_life': end_of_life,
         'release_manager': metadata.release_manager,


### PR DESCRIPTION
<!--
This template is for an infra or meta change not belonging to another category.
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->
Feature freeze date is used to be point of docs translations start for a release (at least for those [using translation platform](https://python-docs-transifex-automation.readthedocs.io/new-translators.html#the-latest-version-for-translation)). Having the date would allow to base the automations on release-cycle.json file.



<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4698.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->