### PR TITLE
PEP 747: Link to mypy reference implementation

### DIFF
--- a/peps/pep-0747.rst
+++ b/peps/pep-0747.rst
@@ -516,11 +516,13 @@ Reference Implementation
 
 Pyright (version 1.1.379) provides a reference implementation for ``TypeForm``.
 
-Mypy contributors also `plan to implement <https://github.com/python/mypy/issues/9773>`__
-support for ``TypeForm``.
+Mypy (`commit 1b7e71`_; Nov 3, 2025) provides
+a reference implementation for ``TypeForm``.
 
 A reference implementation of the runtime component is provided in the
 ``typing_extensions`` module.
+
+.. _commit 1b7e71: https://github.com/python/mypy/commit/1b7e717ecc56cd13d76bc110a1db2796e8b3c918
 
 
 Rejected Ideas


### PR DESCRIPTION
* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4700.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->