### PR TITLE
Infra: document `release-cycle.json` and `python-releases.json`

### DIFF
--- a/peps/api/index.rst
+++ b/peps/api/index.rst
@@ -109,7 +109,7 @@ illustrating some of the possible values for each field:
 release-cycle.json
 ------------------
 
-There is a read-only JSON document of Python releases since version 2.6
+There is a read-only JSON document of Python releases
 available at https://peps.python.org/api/release-cycle.json.
 
 Each feature version is represented as a JSON object,


### PR DESCRIPTION
Documentation for https://github.com/python/peps/pull/4331.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4702.org.readthedocs.build/api/

<!-- readthedocs-preview pep-previews end -->