### PR TITLE
PEP 808: add discussion link

### DIFF
--- a/peps/pep-0808.rst
+++ b/peps/pep-0808.rst
@@ -4,11 +4,13 @@ Author: Henry Schreiner <henryschreineriii@gmail.com>,
         Cristian Le <python@lecris.dev>
 Sponsor: Filipe Laíns <lains@python.org>
 PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
+Discussions-To: https://discuss.python.org/t/104883
 Status: Draft
 Type: Standards Track
 Topic: Packaging
 Created: 19-Sep-2025
-Post-History: `17-Apr-2025 <https://discuss.python.org/t/partially-dynamic-project-metadata-proposal-pre-pep/88608>`__
+Post-History: `17-Apr-2025 <https://discuss.python.org/t/88608>`__,
+              `14-Nov-2025 <https://discuss.python.org/t/104883>`__
 
 
 Abstract


### PR DESCRIPTION
This adds `Discussions-To` with a link to https://discuss.python.org/t/pep-808-partially-dynamic-project-metadata/104883, followup to https://github.com/python/peps/pull/4598.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4707.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->