### PR TITLE
PEP 808: backwards compatibility example update

### DIFF
--- a/peps/pep-0808.rst
+++ b/peps/pep-0808.rst
@@ -273,6 +273,9 @@ metadata.
 Backwards Compatibility
 =======================
 
+Using metadata from SDists or wheels is unaffected. The METADATA version does
+not need to be incremented.
+
 This does not affect any existing ``pyproject.toml``'s, since this was strictly
 not allowed before this PEP.
 
@@ -283,8 +286,27 @@ frontends may need to be updated to benefit from the partially static metadata.
 Some frontends and other tooling may need updating, such as schema
 validation, just like other ``pyproject.toml`` PEPs.
 
-Using metadata from SDists or wheels is unaffected. The METADATA version does
-not need to be incremented.
+Static analysis tools may require updating to handle this change. Tools should
+check the dynamic table first, like this:
+
+.. code-block::
+
+   match pyproject["project"]:
+       # New in PEP 808
+       case {my.key: value, "dynamic": dyn} if my.key in dyn:
+           print(f"Partial {my.key}: {value}")
+       case {"dynamic": dyn} if my.key in dyn:
+           print(f"Fully dynamic {my.key}")
+       case {my.key: value}:
+           print(f"Fully static {my.key}: {value}")
+       case _:
+           print(f"No metadata for {my.key}")
+
+Before this PEP, tools could reverse the order of the dynamic and static
+blocks, assuming that an entry in the project table meant it could not be
+dynamic. If they do this, they will now incorrectly assume they have all the
+metadata for a field, when they in fact only have part of it.
+
 
 Security Implications
 =====================


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)



This adds a backward compat example for static tooling based on @sirosen's comment in https://discuss.python.org/t/104883. This shows an example of how to read this in Python, along with a note about how it could have been done before in a way that would be incorrect now (only in that you wouldn't know the metadata you were computing was incomplete).

Tested which the following quickly thrown together snippet:


```python
class my:
    key = "dependencies"


def f(pyproject):
    match pyproject["project"]:
       # New in PEP 808
       case {my.key: value, "dynamic": dyn} if my.key in dyn:
           print(f"Partial {my.key}: {value}")
       case {"dynamic": dyn} if my.key in dyn:
           print(f"Fully dynamic {my.key}")
       case {my.key: value}:
           print(f"Fully static {my.key}: {value}")
       case _:
           print(f"No metadata for {my.key}")


f({"project": {"dynamic": ["dependencies"], "dependencies": ["numpy"]}})
f({"project": {"dynamic": ["dependencies"]}})
f({"project": {"dependencies": ["numpy"]}})
f({"project": {}})
```

(Marked as draft until @sirosen (and maybe @pfmoore) can verify this addresses their comments)

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4710.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->