### PR TITLE
PEP 790: 3.15.0a2 was released on 2025-11-19

### DIFF
--- a/peps/pep-0790.rst
+++ b/peps/pep-0790.rst
@@ -37,10 +37,10 @@ Actual:
 
 - 3.15 development begins: Wednesday, 2025-05-07
 - 3.15.0 alpha 1: Tuesday, 2025-10-14
+- 3.15.0 alpha 2: Wednesday, 2025-11-19
 
 Expected:
 
-- 3.15.0 alpha 2: Tuesday, 2025-11-18
 - 3.15.0 alpha 3: Tuesday, 2025-12-16
 - 3.15.0 alpha 4: Tuesday, 2026-01-13
 - 3.15.0 alpha 5: Tuesday, 2026-02-10

--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3532,8 +3532,8 @@ date = 2025-10-14
 
 [[release."3.15"]]
 stage = "3.15.0 alpha 2"
-state = "expected"
-date = 2025-11-18
+state = "actual"
+date = 2025-11-19
 
 [[release."3.15"]]
 stage = "3.15.0 alpha 3"


### PR DESCRIPTION
1. Updated the TOML manually, ran `make regen-all`, and it automatically updated the PEP, _including updating the day name_ :) 🎉 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4712.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->