### PR TITLE
PEP 101: Remove three manual steps to edit python.org pages

### DIFF
--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -646,22 +646,6 @@ permissions.
 
       curl -X PURGE https://www.python.org/downloads/release/python-XXX/
 
-- If this is a **final** release:
-
-  - For 3.X.Y, edit all the previous X.Y releases' page(s) to
-    point to the new release.  This includes the content field of the
-    ``Downloads -> Releases`` entry for the release::
-
-      Note: Python 3.x.(y-1) has been superseded by
-      `Python 3.x.y </downloads/release/python-3xy/>`_.
-
-    And, for those releases having separate release page entries
-    (phasing these out?), update those pages as well,
-    e.g. ``download/releases/3.x.y``::
-
-      Note: Python 3.x.(y-1) has been superseded by
-      `Python 3.x.y </download/releases/3.x.y/>`_.
-
 - Write the announcement on `discuss.python.org`_.  This is the
   fuzzy bit because not much can be automated.  You can use an earlier
   announcement as a template, but edit it for content!


### PR DESCRIPTION
I added a https://python.org/downloads/latest/prerelease redirect (https://github.com/python/pythondotorg/pull/2823) so RMs no longer need to manually edit https://www.python.org/download/pre-releases/ for every pre-release and .0 final.

I also changed https://www.python.org/doc/versions/ to be generated from the releases in the CMS (https://github.com/python/pythondotorg/pull/2813), so it's no longer a static CMS page that RMs forget to manually edit for every non-pre-release.

(The old static one is at https://www.python.org/doc/versions-old/ for now, will unpublish later.)

Related release-tools PR: https://github.com/python/release-tools/pull/308

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4717.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->