### PR TITLE
PEP 696: Update pep-0696.rst to make the explanations of `Abstract` and `Motivation` section clearer

### DIFF
--- a/peps/pep-0696.rst
+++ b/peps/pep-0696.rst
@@ -44,11 +44,18 @@ Motivation
        value: T | None = None
 
    # The type argument isn't specified.
-   reveal_type(Box()) # type is Box[int]
+   reveal_type(Box())  # type is Box[int]
+
+   # The type argument is specified with '[]'.
+   reveal_type(Box[str]())  # type is Box[str]
 
    # The type argument is specified with
-   # the type inference by an assigned value
+   # the type inference by an assigned value.
    reveal_type(Box(value="Hello World!"))  # type is Box[str]
+
+   # The type argument is specified with '[]' but not with the type
+   # inference by an assigned value because '[]' is prioritized.
+   reveal_type(Box[str](value="Hello World!"))  # type is Box[str]
 
 One place this `regularly comes
 up <https://github.com/python/typing/issues/975>`__ is ``Generator``. I


### PR DESCRIPTION
I made the explanations of `Abstract` and `Motivation` section clearer.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4722.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->