### PR TITLE
PEP 788: Fix incorrect call to `free`

### DIFF
--- a/peps/pep-0788.rst
+++ b/peps/pep-0788.rst
@@ -553,7 +553,6 @@ With this PEP, you would implement it like this:
             return -1;
         }
         int res = PyFile_WriteString(to_write, file);
-        free(to_write);
         if (res < 0) {
             PyErr_Print();
         }


### PR DESCRIPTION
* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

This typo was noted here: https://github.com/python/steering-council/issues/316#issuecomment-3602982772

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4725.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->