### PR TITLE
PEP 811: Mark as Accepted

### DIFF
--- a/peps/pep-0811.rst
+++ b/peps/pep-0811.rst
@@ -3,13 +3,14 @@ Title: Defining Python Security Response Team membership and responsibilities
 Author: Seth Michael Larson <seth@python.org>
 Sponsor: Gregory P. Smith <greg@krypto.org>
 Discussions-To: https://discuss.python.org/t/104606
-Status: Draft
+Status: Accepted
 Type: Process
 Topic: Governance
 Created: 22-Oct-2025
 Post-History:
   `06-Oct-2025 <https://discuss.python.org/t/104199>`__,
   `28-Oct-2025 <https://discuss.python.org/t/104606>`__,
+Resolution: `04-Dec-2025 <https://discuss.python.org/t/104606/20>`__
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [x] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4729.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->