### PR TITLE
Infra: Update pygments to 2.19.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Requirements for building PEPs with Sphinx
-Pygments >= 2.19.0
+# Sphinx requires >= 2.17. JSON5 support added in 2.19
+Pygments >= 2.19
 # Sphinx 6.1.0 broke copying images in parallel builds; fixed in 6.1.2
 # See https://github.com/sphinx-doc/sphinx/pull/11100
 Sphinx >= 5.1.1, != 6.1.0, != 6.1.1, < 8.1.0


### PR DESCRIPTION
For our upcoming PEP, we want to use JSON5 code blocks, which was added to pygments in 2.19.

<!--
This template is for an infra or meta change not belonging to another category.
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4730.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->