### PR TITLE
PEP 719, 745: 3.13.11 and 3.14.2 were released on 5 Dec 2025

### DIFF
--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -74,14 +74,15 @@ Actual:
 - 3.13.8: Tuesday, 2025-10-07
 - 3.13.9: Tuesday, 2025-10-14
 - 3.13.10: Tuesday, 2025-12-02
+- 3.13.11: Friday, 2025-12-05
 
 Expected:
 
-- 3.13.11: Tuesday, 2026-02-03
-- 3.13.12: Tuesday, 2026-04-07
-- 3.13.13: Tuesday, 2026-06-09
-- 3.13.14: Tuesday, 2026-08-04
-- 3.13.15: Tuesday, 2026-10-06
+- 3.13.12: Tuesday, 2026-02-03
+- 3.13.13: Tuesday, 2026-04-07
+- 3.13.14: Tuesday, 2026-06-09
+- 3.13.15: Tuesday, 2026-08-04
+- 3.13.16: Tuesday, 2026-10-06
   (Final regular bugfix release with binary installers)
 
 .. release schedule: ends

--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -65,20 +65,21 @@ Bugfix releases
 Actual:
 
 - 3.14.1: Tuesday, 2025-12-02
+- 3.14.2: Friday, 2025-12-05
 
 Expected:
 
-- 3.14.2: Tuesday, 2026-02-03
-- 3.14.3: Tuesday, 2026-04-07
-- 3.14.4: Tuesday, 2026-06-09
-- 3.14.5: Tuesday, 2026-08-04
-- 3.14.6: Tuesday, 2026-10-06
-- 3.14.7: Tuesday, 2026-12-01
-- 3.14.8: Tuesday, 2027-02-02
-- 3.14.9: Tuesday, 2027-04-06
-- 3.14.10: Tuesday, 2027-06-01
-- 3.14.11: Tuesday, 2027-08-03
-- 3.14.12: Tuesday, 2027-10-05
+- 3.14.3: Tuesday, 2026-02-03
+- 3.14.4: Tuesday, 2026-04-07
+- 3.14.5: Tuesday, 2026-06-09
+- 3.14.6: Tuesday, 2026-08-04
+- 3.14.7: Tuesday, 2026-10-06
+- 3.14.8: Tuesday, 2026-12-01
+- 3.14.9: Tuesday, 2027-02-02
+- 3.14.10: Tuesday, 2027-04-06
+- 3.14.11: Tuesday, 2027-06-01
+- 3.14.12: Tuesday, 2027-08-03
+- 3.14.13: Tuesday, 2027-10-05
   (Final regular bugfix release with binary installers)
 
 .. release schedule: ends

--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3346,26 +3346,31 @@ date = 2025-12-02
 
 [[release."3.13"]]
 stage = "3.13.11"
-state = "expected"
-date = 2026-02-03
+state = "actual"
+date = 2025-12-05
 
 [[release."3.13"]]
 stage = "3.13.12"
 state = "expected"
-date = 2026-04-07
+date = 2026-02-03
 
 [[release."3.13"]]
 stage = "3.13.13"
 state = "expected"
-date = 2026-06-09
+date = 2026-04-07
 
 [[release."3.13"]]
 stage = "3.13.14"
 state = "expected"
-date = 2026-08-04
+date = 2026-06-09
 
 [[release."3.13"]]
 stage = "3.13.15"
+state = "expected"
+date = 2026-08-04
+
+[[release."3.13"]]
+stage = "3.13.16"
 state = "expected"
 date = 2026-10-06
 
@@ -3464,56 +3469,61 @@ date = 2025-12-02
 
 [[release."3.14"]]
 stage = "3.14.2"
-state = "expected"
-date = 2026-02-03
+state = "actual"
+date = 2025-12-05
 
 [[release."3.14"]]
 stage = "3.14.3"
 state = "expected"
-date = 2026-04-07
+date = 2026-02-03
 
 [[release."3.14"]]
 stage = "3.14.4"
 state = "expected"
-date = 2026-06-09
+date = 2026-04-07
 
 [[release."3.14"]]
 stage = "3.14.5"
 state = "expected"
-date = 2026-08-04
+date = 2026-06-09
 
 [[release."3.14"]]
 stage = "3.14.6"
 state = "expected"
-date = 2026-10-06
+date = 2026-08-04
 
 [[release."3.14"]]
 stage = "3.14.7"
 state = "expected"
-date = 2026-12-01
+date = 2026-10-06
 
 [[release."3.14"]]
 stage = "3.14.8"
 state = "expected"
-date = 2027-02-02
+date = 2026-12-01
 
 [[release."3.14"]]
 stage = "3.14.9"
 state = "expected"
-date = 2027-04-06
+date = 2027-02-02
 
 [[release."3.14"]]
 stage = "3.14.10"
 state = "expected"
-date = 2027-06-01
+date = 2027-04-06
 
 [[release."3.14"]]
 stage = "3.14.11"
 state = "expected"
-date = 2027-08-03
+date = 2027-06-01
 
 [[release."3.14"]]
 stage = "3.14.12"
+state = "expected"
+date = 2027-08-03
+
+[[release."3.14"]]
+stage = "3.14.13"
 state = "expected"
 date = 2027-10-05
 


### PR DESCRIPTION
https://discuss.python.org/t/python-3-14-2-and-3-13-11-are-now-available/105214

A

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4731.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->