### PR TITLE
PEP 694: Error responses conform to the :rfc:`9457` format.

### DIFF
--- a/peps/pep-0694.rst
+++ b/peps/pep-0694.rst
@@ -307,7 +307,7 @@ RFC 9457 defines ``type``, ``status``, ``title``, and ``details``.  The ``meta``
 extension members.
 
 ``meta``
-    The same request/response metadata structe as defined in the :ref:`publishing-session` description.
+    The same request/response metadata structure as defined in the :ref:`publishing-session` description.
 
 ``errors``
     An array of specific errors, each of which contains a ``source`` key, which is a string that


### PR DESCRIPTION
As per suggestion: https://discuss.python.org/t/pep-694-pypi-upload-api-2-0-round-2/101483/32

@woodruffw for review.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4733.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->