### PR TITLE
PEP 747: Clarify that TypeForm(T) is always a TypeForm[T]

### DIFF
--- a/peps/pep-0747.rst
+++ b/peps/pep-0747.rst
@@ -289,10 +289,12 @@ Type checkers should validate that this argument is a valid type expression::
    x1 = TypeForm(str | None)
    reveal_type(v1)  # Revealed type is "TypeForm[str | None]"
 
-   x2 = TypeForm("list[int]")
+   x2 = TypeForm('list[int]')
    revealed_type(v2)  # Revealed type is "TypeForm[list[int]]"
 
    x3 = TypeForm('type(1)')  # Error: invalid type expression
+
+The static type of a ``TypeForm(T)`` is ``TypeForm[T]``.
 
 At runtime the ``TypeForm(...)`` callable simply returns the value passed to it.
 


### PR DESCRIPTION
* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

---

Integrates [feedback from Jukka](https://discuss.python.org/t/pep-747-typeexpr-type-hint-for-a-type-expression/55984/95) (a Typing Council member) received immediately before Typing Council [acceptance](https://discuss.python.org/t/pep-747-typeexpr-type-hint-for-a-type-expression/55984/96) of the PEP.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4736.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->