### PR TITLE
PEP 12: SVG is allowed after PEP 676

### DIFF
--- a/peps/pep-0012.rst
+++ b/peps/pep-0012.rst
@@ -601,6 +601,8 @@ processed output using the ``image`` directive:
 
 Any browser-friendly graphics format is possible; SVG or PNG are
 preferred for graphics, JPEG for photos and GIF for animations.
+Images should be optimised to reduce their file size, and should
+be legible in both light and dark mode in the browser.
 
 For accessibility and readers of the source text, you should include
 a description of the image and any key information contained within


### PR DESCRIPTION
Re: https://github.com/python/peps/pull/4740#discussion_r2609809031

Remove the outdated SVG prohibition.

SVG support was listed as one of the improvements in PEP 676:

* https://peps.python.org/pep-0676/#quality-of-life-improvements-and-resolving-issues

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4741.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->