### PR TITLE
Infra: Fix margin clipping in the print CSS

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -152,7 +152,7 @@
 
     section#pep-page-section > article {
         float: none;
-        max-width: 17.5cm;
+        max-width: 100%;
         width: auto;
         margin: 0;
         padding: 0;


### PR DESCRIPTION
Print CSS was added in https://github.com/python/peps/pull/3486.

The left side is being clipped:

<img width="470" height="661" alt="image" src="https://github.com/user-attachments/assets/17ce473b-92a8-4d02-84cc-5f72a5d46f67" />

With this PR:

<img width="473" height="660" alt="image" src="https://github.com/user-attachments/assets/06863d78-fc92-4910-8e0d-c1d12b4e624b" />

cc @srittau 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4742.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->