### PR TITLE
PEP 8107: errata

### DIFF
--- a/peps/pep-8107.rst
+++ b/peps/pep-8107.rst
@@ -175,7 +175,7 @@ Enter voter data using Email list from `Voter Roll`_ repository.
 Results
 =======
 
-Of 105 eligible voters, 74 cast ballots.
+Of 106 eligible voters, 74 cast ballots.
 
 The five winners are:
 
@@ -301,6 +301,7 @@ Active Python core developers
     Jason R. Coombs
     Jelle Zijlstra
     Jeremy Hylton
+    Jeremy Kloth
     Jesús Cea
     Joannah Nanjekye
     Julien Palard


### PR DESCRIPTION
The voter file I had locally did not match the [voter file used for the election](https://github.com/python/voters/blob/bb9e3c677d9c062caeb04ccceabe324e1fddbb72/voter-files/2025-11-28-steering-council-election.csv)

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4746.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->