### PR TITLE
PEP 798: Mark as Accepted

### DIFF
--- a/peps/pep-0798.rst
+++ b/peps/pep-0798.rst
@@ -13,6 +13,26 @@ Post-History:
   `19-Jul-2025 <https://discuss.python.org/t/pep-798-unpacking-in-comprehensions/99435>`__,
 Resolution: `03-Nov-2025 <https://discuss.python.org/t/pep-798-unpacking-in-comprehensions/99435/60>`__
 
+.. note::
+   The Steering Council accepts this PEP with one modification: we require that
+   both synchronous and asynchronous generator expressions use explicit loops
+   rather than yield from for unpacking operations.
+
+   The Steering Council believes that simplicity and consistency are paramount
+   here. The delegation behaviour provided by ``yield from`` adds semantic
+   complexity for advanced use cases involving ``.send(),`` ``.throw()``, and
+   ``.close()`` that are rarely relevant when writing comprehensions. We don’t
+   believe that developers writing comprehensions should have to think about
+   the differences between sync and async generator semantics or about generator
+   delegation protocols. We firmly believe that the mental model should be as
+   simple as possible and as symmetric as possible between all kinds of
+   comprehensions. The straightforward semantics of explicit loops provide a
+   uniform mental model that works the same way regardless of context, and also
+   provides better parity with the function-like versions, such as
+   ``itertools.chain.from_iterable``. For the rare cases where someone actually
+   needs delegation behaviour, the Steering Council believes they should use an
+   explicit generator function with ``yield from`` rather than a comprehension.
+
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [x] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date

@adqm @edemaine 

We forgot to mark this as accepted.

I added the modification required by the SC at https://discuss.python.org/t/pep-798-unpacking-in-comprehensions/99435/60 as a note.

Perhaps just the first paragraph is enough?


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4753.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->