### PR TITLE
PEP 790: 3.15.0a3 was released on 2025-12-16

### DIFF
--- a/peps/pep-0790.rst
+++ b/peps/pep-0790.rst
@@ -38,10 +38,10 @@ Actual:
 - 3.15 development begins: Wednesday, 2025-05-07
 - 3.15.0 alpha 1: Tuesday, 2025-10-14
 - 3.15.0 alpha 2: Wednesday, 2025-11-19
+- 3.15.0 alpha 3: Tuesday, 2025-12-16
 
 Expected:
 
-- 3.15.0 alpha 3: Tuesday, 2025-12-16
 - 3.15.0 alpha 4: Tuesday, 2026-01-13
 - 3.15.0 alpha 5: Tuesday, 2026-02-10
 - 3.15.0 alpha 6: Tuesday, 2026-03-10

--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3552,7 +3552,7 @@ date = 2025-11-19
 
 [[release."3.15"]]
 stage = "3.15.0 alpha 3"
-state = "expected"
+state = "actual"
 date = 2025-12-16
 
 [[release."3.15"]]


### PR DESCRIPTION
* https://discuss.python.org/t/python-3-15-0-alpha-3/105325
* https://www.python.org/downloads/release/python-3150a3/

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4755.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->