### PR TITLE
PEP 376: Use correct canonical spec link

### DIFF
--- a/peps/pep-0376.rst
+++ b/peps/pep-0376.rst
@@ -9,7 +9,7 @@ Python-Version: 2.7, 3.2
 Post-History: `22-Jun-2009 <https://mail.python.org/archives/list/python-dev@python.org/thread/ILLTIOZAULMDY5CAS6GOITEYJ4HNFATQ/>`__
 
 
-.. canonical-pypa-spec:: :ref:`packaging:core-metadata`
+.. canonical-pypa-spec:: :ref:`packaging:recording-installed-packages`
 
 
 Abstract


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

Fixes #4562 


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4756.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->