### PR TITLE
PEP 798: Mark as Accepted

### DIFF
--- a/peps/pep-0798.rst
+++ b/peps/pep-0798.rst
@@ -110,7 +110,7 @@ number of iterables.
 
 This proposal represents a natural extension of the language, paralleling
 existing syntactic structures: where ``[x, y, z]`` creates a list from a fixed
-number of vaues, ``[item for item in items]`` creates a list from an arbitrary
+number of values, ``[item for item in items]`` creates a list from an arbitrary
 number of values; this proposal extends that notion to the construction of
 lists that involve unpacking, making ``[*item for item in items]`` analogous to
 ``[*x, *y, *z]``.
@@ -773,7 +773,7 @@ Beyond the proposal outlined above, the following were also considered:
 
    This strategy would also make unpacking in synchronous and asynchronous
    generators behave symmetrically, but it would also be more complex, enough
-   so that the cost may not be worth the benefit, particularly in the absense
+   so that the cost may not be worth the benefit, particularly in the absence
    of a compelling use case for delegation.
 
 3. Using ``yield from`` for unpacking in synchronous generator expressions, and


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [ ] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date

---------

CC: @hugovk, @JelleZijlstra 

I went through and changed the parts of the proposal affected by the SC's required modification.  Should I still include a note explaining that the version originally submitted to the SC was different and including their rationale for the change (or maybe linking to the Discourse post), or is it fine without one?


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4758.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->