### PR TITLE
PEP 504: Fix Sphinx reference warnings

### DIFF
--- a/peps/pep-0504.rst
+++ b/peps/pep-0504.rst
@@ -177,7 +177,7 @@ This is reflected in regular notifications of data breaches involving personally
 identifiable information [#breaches]_, as well as with failures to take
 security considerations into account when new systems, like motor vehicles
 [#uconnect]_, are connected to the internet. It's also the case that a lot of
-the programming advice readily available on the internet [#search] simply
+the programming advice readily available on the internet [#search]_ simply
 doesn't take the mathematical arcana of computer security into account.
 Compounding these issues is the fact that defenders have to cover *all* of
 their potential vulnerabilities, as a single mistake can make it possible to
@@ -277,7 +277,7 @@ generator towards explicitly calling ``random.ensure_repeatable()``.
 Avoiding the introduction of a userspace CSPRNG
 -----------------------------------------------
 
-The original discussion of this proposal on python-ideas[#csprng]_ suggested
+The original discussion of this proposal on python-ideas [#csprng]_ suggested
 introducing a cryptographically secure pseudo-random number generator and using
 that by default, rather than defaulting to the relatively slow system random
 number generator.


### PR DESCRIPTION
For #4087.

The problematic footnotes are actually referenced, the syntax is just slightly incorrect.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4759.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->