### PR TITLE
PEP 101: Remove three more manual steps

### DIFF
--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -743,13 +743,6 @@ else does them.  Some of those tasks include:
 
         git push upstream --delete 3.3  # or perform from GitHub Settings page
 
-- Remove the release from the list of "Active Python Releases" on the Downloads
-  page.  To do this, `log in to the admin page <https://www.python.org/admin>`__
-  for python.org, navigate to Boxes,
-  and edit the ``downloads-active-releases`` entry.  Strip out the relevant
-  paragraph of HTML for your release.  (You'll probably have to do the ``curl -X PURGE``
-  trick to purge the cache if you want to confirm you made the change correctly.)
-
 - In python-releases.toml_, set the branch status to end-of-life.
 
 - Update or remove references to the branch in the `developer's guide


### PR DESCRIPTION
After https://github.com/python/pythondotorg/pull/2832, we no longer need to manually edit EOL releases to add retired notices, a big red banner is now automatically added:

<img width="1190" height="333" alt="image" src="https://github.com/user-attachments/assets/6a676284-e1ce-4000-bb4d-c5e1cfd5e50a" />

https://www.python.org/downloads/release/python-3925/




<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4763.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->