### PR TITLE
PEP 387: Update language around discussion venues

### DIFF
--- a/peps/pep-0387.rst
+++ b/peps/pep-0387.rst
@@ -146,9 +146,9 @@ Making Incompatible Changes
 Making an incompatible change is a gradual process performed over
 several releases:
 
-1. Discuss the change.  Depending on the degree of incompatibility,
-   this could be on the bug tracker, python-dev, python-list, or the
-   appropriate SIG.  A PEP or similar document may be written.
+1. :pep:`PEP 1: Start with an idea <1#start-with-an-idea-for-python>` discussion.
+   If the discussion reaches consensus that acceptance is possible a PEP or
+   similar document may be written.
    Hopefully users of the affected API will pipe up to comment.
 
 2. Add a warning to the current ``main`` branch.


### PR DESCRIPTION
Point to PEP 1, updated in #2266, for the venue list.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4769.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->