### PR TITLE
PEP 387: Update language around discussion venues, part 2

### DIFF
--- a/peps/pep-0387.rst
+++ b/peps/pep-0387.rst
@@ -150,7 +150,7 @@ several releases:
    Depending on the degree of incompatibility, this could be on
    `Discourse <https://discuss.python.org/>`__,
    the `issue tracker <https://github.com/python/cpython/issues/>`__,
-   or the appropriate workgroup or SIG.
+   or in an appropriate workgroup or SIG.
    If the discussion reaches consensus a :pep:`PEP <1>` or
    similar document may be written.
    Hopefully users of the affected API will pipe up to comment.


### PR DESCRIPTION
Follow on from https://github.com/python/peps/pull/4769.

Not all deprecations needs a PEP, so rather than pointing people to PEP process, point to some of the example venues for discussion, with links. Replace the mailing lists with Discourse, and include WGs.

Keep the PEP link for when a PEP is needed.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4770.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->