### PR TITLE
PEP 819: Disambiguate JSON parsing and make new files required

### DIFF
--- a/peps/pep-0819.rst
+++ b/peps/pep-0819.rst
@@ -235,26 +235,6 @@ JSON schema for wheel metadata has been produced.
 This schema will be updated with each revision to the wheel metadata
 specification. The schema is available in :ref:`0819-wheel-json-schema`.
 
-Handling of Integer and Float Values in JSON Package Metadata
--------------------------------------------------------------
-
-While no core metadata or wheel metadata values are currently encoded as
-integers or floats, when decoding a JSON file, integer and float values should
-be decoded as strings for both core metadata and wheel metadata. This is to
-avoid compatibility issues due to differences in precision and representation
-of integers and floats between languages and parsers. This also mitigates a
-security risk with integer parsing denial of service attacks based on
-`CVE-2020-10735 <https://github.com/advisories/GHSA-6jr7-xr67-mgxw>`__.
-
-If a future field of core metadata or wheel metadata needs to be encoded as an
-integer or float, the field MUST be decoded lazily after loading the JSON
-document. This minimizes the risks of denial of service attacks by minimizing
-the integer parsing allowed during the deserialization process.
-
-If using the Python :mod:`!json` module, parsing integers and floats as strings
-can be accomplished by setting the ``parse_int`` and ``parse_float``
-keyword arguments to :func:`json.load` or :func:`json.loads` to :class:`str`.
-
 Handling of Duplicate Keys in JSON Package Metadata
 ---------------------------------------------------
 
@@ -306,13 +286,20 @@ or ``WHEEL`` files.
 Security Implications
 =====================
 
-JSON encoded core metadata and wheel metadata have the potential for a denial
-of service attack due to the quadratic parsing time complexity of parsing of
-integers. This PEP mitigates this risk by requiring that integers and floats be
-parsed as strings, and only lazily parsed into integers or floats after the
-initial deserialization of the JSON document. With these mitigations in place,
-concerns about denial of service attacks with JSON encoded package metadata are
-considered minimal.
+Maliciously crafted JSON encoded metadata files have the potential to cause a
+denial of service attack due to the quadratic parsing time complexity of
+reading integer strings as reported in
+`CVE-2020-10735 <https://github.com/advisories/GHSA-6jr7-xr67-mgxw>`__. No
+package metadata fields are currently encoded as integers, so this risk can be
+mitigated by decoding integer values as strings when parsing JSON package
+metadata.
+
+If using the Python :mod:`!json` module, parsing integers as strings
+can be accomplished by setting the ``parse_int`` keyword argument to
+:func:`json.load` or :func:`json.loads` to :class:`str`.
+
+With this mitigation in place, concerns about denial of service attacks with
+JSON encoded package metadata are considered minimal.
 
 
 Reference Implementation


### PR DESCRIPTION
Update the PEP to clarify that integers and floats should be serialized to strings and specify that when there are duplicate keys the second key wins in a JSON object. Also make the new metadata files required.

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4773.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->