### PR TITLE
PEP 523: Fix Sphinx reference warnings

### DIFF
--- a/peps/pep-0523.rst
+++ b/peps/pep-0523.rst
@@ -239,11 +239,11 @@ implementing their own JITs for CPython by utilizing the proposed API.
 Other JITs
 ''''''''''
 
-It should be mentioned that the Pyston team was consulted on an
+It should be mentioned that the Pyston [#pyston]_ team was consulted on an
 earlier version of this PEP that was more JIT-specific and they were
 not interested in utilizing the changes proposed because they want
 control over memory layout they had no interest in directly supporting
-CPython itself. An informal discussion with a developer on the PyPy
+CPython itself. An informal discussion with a developer on the PyPy [#pypy]_
 team led to a similar comment.
 
 Numba [#numba]_, on the other hand, suggested that they would be


### PR DESCRIPTION
Add references to orphaned footnotes in appropriate locations.

For #4087.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4777.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->