### PR TITLE
PEP 790: 3.15.0a4 was released on 2025-01-13

### DIFF
--- a/peps/pep-0790.rst
+++ b/peps/pep-0790.rst
@@ -39,10 +39,10 @@ Actual:
 - 3.15.0 alpha 1: Tuesday, 2025-10-14
 - 3.15.0 alpha 2: Wednesday, 2025-11-19
 - 3.15.0 alpha 3: Tuesday, 2025-12-16
+- 3.15.0 alpha 4: Tuesday, 2026-01-13
 
 Expected:
 
-- 3.15.0 alpha 4: Tuesday, 2026-01-13
 - 3.15.0 alpha 5: Tuesday, 2026-02-10
 - 3.15.0 alpha 6: Tuesday, 2026-03-10
 - 3.15.0 alpha 7: Tuesday, 2026-04-07

--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3557,7 +3557,7 @@ date = 2025-12-16
 
 [[release."3.15"]]
 stage = "3.15.0 alpha 4"
-state = "expected"
+state = "actual"
 date = 2026-01-13
 
 [[release."3.15"]]


### PR DESCRIPTION
https://discuss.python.org/t/python-3-15-0-alpha-4/105706

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4778.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->