### PR TITLE
PEP 790: Insert extra 3.15.0 alpha 5

### DIFF
--- a/peps/pep-0790.rst
+++ b/peps/pep-0790.rst
@@ -40,12 +40,13 @@ Actual:
 - 3.15.0 alpha 2: Wednesday, 2025-11-19
 - 3.15.0 alpha 3: Tuesday, 2025-12-16
 - 3.15.0 alpha 4: Tuesday, 2026-01-13
+- 3.15.0 alpha 5: Wednesday, 2026-01-14
 
 Expected:
 
-- 3.15.0 alpha 5: Tuesday, 2026-02-10
-- 3.15.0 alpha 6: Tuesday, 2026-03-10
-- 3.15.0 alpha 7: Tuesday, 2026-04-07
+- 3.15.0 alpha 6: Tuesday, 2026-02-10
+- 3.15.0 alpha 7: Tuesday, 2026-03-10
+- 3.15.0 alpha 8: Tuesday, 2026-04-07
 - 3.15.0 beta 1: Tuesday, 2026-05-05
   (No new features beyond this point.)
 - 3.15.0 beta 2: Tuesday, 2026-05-26

--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3562,16 +3562,21 @@ date = 2026-01-13
 
 [[release."3.15"]]
 stage = "3.15.0 alpha 5"
-state = "expected"
-date = 2026-02-10
+state = "actual"
+date = 2026-01-14
 
 [[release."3.15"]]
 stage = "3.15.0 alpha 6"
 state = "expected"
-date = 2026-03-10
+date = 2026-02-10
 
 [[release."3.15"]]
 stage = "3.15.0 alpha 7"
+state = "expected"
+date = 2026-03-10
+
+[[release."3.15"]]
+stage = "3.15.0 alpha 8"
 state = "expected"
 date = 2026-04-07
 


### PR DESCRIPTION
* https://discuss.python.org/t/python-3-15-0-alpha-5-yes-another-alpha/105721
* https://www.python.org/downloads/release/python-3150a5/

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4780.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->