### PR TITLE
Infra: Only remove contents node from PEP ToCs

### DIFF
--- a/pep_sphinx_extensions/pep_processor/html/pep_html_builder.py
+++ b/pep_sphinx_extensions/pep_processor/html/pep_html_builder.py
@@ -33,7 +33,8 @@ class FileBuilder(StandaloneHTMLBuilder):
         toc_tree = self.env.tocs[docname].deepcopy()
         if len(toc_tree) and len(toc_tree[0]) > 1:
             toc_tree = toc_tree[0][1]  # don't include document title
-            del toc_tree[0]  # remove contents node
+            if docname.startswith("pep-"):
+                del toc_tree[0]  # remove contents node from PEPs
             for node in toc_tree.findall(nodes.reference):
                 node["refuri"] = node["anchorname"] or '#'  # fix targets
             toc = self.render_partial(toc_tree)["fragment"]


### PR DESCRIPTION
We remove the first item in the table of contents, which is the contents node.

But we shouldn't do that for non-PEP pages such as the API page which is missing the first `peps.json` and shows the others:

Before: https://peps.python.org/api/


<img width="293" height="213" alt="image" src="https://github.com/user-attachments/assets/c2b2f71a-c569-4f23-bdbb-7361bf764c67" />

After: https://pep-previews--4784.org.readthedocs.build/api/

<img width="295" height="242" alt="image" src="https://github.com/user-attachments/assets/8eb434df-1c2b-4ccc-89e8-5695acf69de8" />


