### PR TITLE
PEP 11: Friendlier policy for unsupported platforms

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -166,7 +166,7 @@ general improvements, may be rejected or removed from the code base
 without a deprecation process.
 Core team members that do this intentionally are encouraged to notify people
 listed in the `Platforms experts list`_ in the CPython contributor's guide,
-to review any submitted fixes (if inobtrusive), and to consider adding
+to review any submitted fixes (if unobtrusive), and to consider adding
 configuration or extension capabilities necessary for workarounds.
 
 People interested in unsupported platforms may add themselves to the


### PR DESCRIPTION
Update PEP 11 to clarify unsupported platforms.

- We have code for unsupported platforms and that’s OK, but it doesn’t imply any promises either.
- We welcome and encourage people that support CPython on other platforms – without promising any particular level of welcoming and encouragement.

Also:
- Add concrete rules for POSIX features (so we don't “over-fit” to Linux ∩ Mac ∩ BSD)
- Encourage listing “outsider” experts in the [devguide](https://devguide.python.org/core-team/experts/#platforms), and pinging the experts

SC decision: https://github.com/encukou/peps/pull/3#pullrequestreview-3695050525
Discussion: https://discuss.python.org/t/proposed-pep-11-update-policy-for-unsupported-platforms/104986


* Change is either:
    * [ ] To a Draft PEP
    * [x] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4790.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->