### PR TITLE
PEP 822: add a Rejected Idea

### DIFF
--- a/peps/pep-0822.rst
+++ b/peps/pep-0822.rst
@@ -335,11 +335,11 @@ Ruby also has `"squiggly" heredoc <https://ruby-doc.org/core-2.5.0/doc/syntax/li
 that removes indent from lines in heredoc.
 
 Perl has `"Indented Here-documents <https://perldoc.perl.org/perl5260delta#Indented-Here-documents>`__
-since Perl 5.26 too.
+since Perl 5.26 as well.
 
 Java, Julia, and Ruby uses the least-indented line to determine the amount of
 indentation to be removed.
-Swift, C#, PHP, and Perl uses the indentation of the closing triple quotes or
+Swift, C#, PHP, and Perl use the indentation of the closing triple quotes or
 closing marker.
 
 
@@ -482,7 +482,7 @@ Since closing quotes can be on the same line as content, it looks symmetrical
 to allow content right after opening quotes too.
 And it would make it easier to rewrite existing ``"""`` to d-strings.
 
-On the other hand, it increase the number of syntax rules that readers need to
+On the other hand, it increases the number of syntax rules that readers need to
 remember in order to understand how much indentation will be removed.
 
 Also, allowing content after opening quotes would not resolve the usability
@@ -491,7 +491,7 @@ issue where existing ``textwrap.dedent("""...""")`` users must write
 Julia avoids this issue by removing the first newline when starting with
 ``"""<newline>``, but this adds another syntax rule that users need to remember.
 
-Since we rejected the idea of using ``__future__ import``, we prioritized
+Since we rejected the idea of using a ``__future__`` import, we prioritized
 ease of use for users rewriting from ``textwrap.dedent()`` or those who
 wanted to use ``textwrap.dedent()`` but couldn't for some reason, over
 the ease of rewriting existing multiline string literal users to d-strings.


### PR DESCRIPTION
"Allow content after opening quotes" idea is rejected.

ref: https://discuss.python.org/t/pep-822-dedented-multiline-string-d-string/105519/100

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4795.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->