### PR TITLE
PEP 821: Add discuss links

### DIFF
--- a/peps/pep-0821.rst
+++ b/peps/pep-0821.rst
@@ -2,13 +2,14 @@ PEP: 821
 Title: Support for unpacking TypedDicts in Callable type hints
 Author: Daniel Sperber <github.blurry@9ox.net>
 Sponsor: Jelle Zijlstra <jelle.zijlstra@gmail.com>
-Discussions-To: Pending
+Discussions-To: https://discuss.python.org/t/105952
 Status: Draft
 Type: Standards Track
 Topic: Typing
 Created: 12-Jan-2026
 Python-Version: 3.15
-Post-History: `28-Jun-2025 <https://discuss.python.org/t/pep-idea-extend-spec-of-callable-to-accept-unpacked-typedicts-to-specify-keyword-only-parameters/96975>`__
+Post-History: `28-Jun-2025 <https://discuss.python.org/t/96975>`__,
+              `31-Jan-2026 <https://discuss.python.org/t/105952>`__
 
 Abstract
 ========


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

I've just opened the relevant discuss thread for [PEP 821](https://discuss.python.org/t/pep-821-support-for-unpacking-typeddicts-in-callable-type-hints/105952) (initial PR #4764) that needs to be adjusted.

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4800.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->