### PR TITLE
PEP 512: Fix Sphinx reference warnings

### DIFF
--- a/peps/pep-0512.rst
+++ b/peps/pep-0512.rst
@@ -963,38 +963,11 @@ References
 .. [#tracker-plans] Wiki page for bugs.python.org feature development
    (https://wiki.python.org/moin/TrackerDevelopmentPlanning)
 
-.. [#black-knight-sketch] The "Black Knight" sketch from "Monty Python and the Holy Grail"
-   (https://www.youtube.com/watch?v=dhRUe-gz690)
-
-.. [#bridge-of-death-sketch] The "Bridge of Death" sketch from "Monty Python and the Holy Grail"
-   (https://www.youtube.com/watch?v=cV0tCphFMr8)
-
-.. [#holy-grail] "Monty Python and the Holy Grail" sketches
-   (https://www.youtube.com/playlist?list=PL-Qryc-SVnnu1MvN3r94Y9atpaRuIoGmp)
-
-.. [#killer-rabbit-sketch] "Killer rabbit" sketch from "Monty Python and the Holy Grail"
-   (https://www.youtube.com/watch?v=Nvs5pqf-DMA&list=PL-Qryc-SVnnu1MvN3r94Y9atpaRuIoGmp&index=11)
-
-.. [#french-taunter-sketch] "French Taunter" from "Monty Python and the Holy Grail"
-   (https://www.youtube.com/watch?v=A8yjNbcKkNY&list=PL-Qryc-SVnnu1MvN3r94Y9atpaRuIoGmp&index=13)
-
-.. [#constitutional-peasants-sketch] "Constitutional Peasants" from "Monty Python and the Holy Grail"
-   (https://www.youtube.com/watch?v=JvKIWjnEPNY&list=PL-Qryc-SVnnu1MvN3r94Y9atpaRuIoGmp&index=14)
-
-.. [#ni-sketch] "Knights Who Say Ni" from "Monty Python and the Holy Grail"
-   (https://www.youtube.com/watch?v=zIV4poUZAQo&list=PL-Qryc-SVnnu1MvN3r94Y9atpaRuIoGmp&index=15)
-
 .. [#homu] Homu (http://homu.io/)
 
 .. [#zuul] Zuul (http://docs.openstack.org/infra/zuul/)
 
 .. [#travis] Travis (https://travis-ci.org/)
-
-.. [#codeship] Codeship (https://codeship.com/)
-
-.. [#coverage] coverage.py (https://pypi.python.org/pypi/coverage)
-
-.. [#coveralls] Coveralls (https://coveralls.io/)
 
 .. [#codecov] Codecov (https://codecov.io/)
 


### PR DESCRIPTION
Ref: #4087 

The search for changes removing the references was done with: `git log --follow -S "<ref.footnote>" -p -- peps/pep-0512.rst`. 

I have verified that PEP 512 generates no warnings on Sphinx v8.1.3.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4805.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->