### PR TITLE
PEP 3108: Fix Sphinx warnings

### DIFF
--- a/peps/pep-3108.rst
+++ b/peps/pep-3108.rst
@@ -1140,9 +1140,6 @@ References
 .. [#pil] Python Imaging Library (PIL)
     (http://www.pythonware.com/products/pil/)
 
-.. [#twisted] Twisted
-    (http://twistedmatrix.com/trac/)
-
 .. [#irix-retirement] SGI Press Release:
     End of General Availability for MIPS IRIX Products -- December 2006
     (http://www.sgi.com/support/mips_irix.html)


### PR DESCRIPTION
Ref: #4087 

The search for changes removing the references was done with: `git log --follow -S "<ref.footnote>" -p -- peps/pep-3108.rst`. 

I have verified that PEP 3108 generates no warnings on Sphinx v8.1.3.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4807.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->