### PR TITLE
PEP 583: Fix Sphinx warnings

### DIFF
--- a/peps/pep-0583.rst
+++ b/peps/pep-0583.rst
@@ -312,7 +312,7 @@ implementers.
 A happens-before race that's not a sequentially-consistent race
 ---------------------------------------------------------------
 
-From the POPL paper about the Java memory model [#JMM-popl].
+From the POPL paper about the Java memory model [#JMM-popl]_.
 
     Initially, ``x == y == 0``.
 
@@ -364,7 +364,7 @@ machinery you need to prove it.
 Self-justifying values
 ----------------------
 
-Also from the POPL paper about the Java memory model [#JMM-popl].
+Also from the POPL paper about the Java memory model [#JMM-popl]_.
 
     Initially, ``x == y == 0``.
 
@@ -552,7 +552,7 @@ that, and Python may not need those security guarantees anyway.
 Restrict reorderings instead of defining happens-before
 --------------------------------------------------------
 
-The .NET [#CLR-msdn] and x86 [#x86-model] memory models are based on
+The .NET [#CLR-msdn]_ and x86 [#x86-model]_ memory models are based on
 defining which reorderings compilers may allow.  I think that it's
 easier to program to a happens-before model than to reason about all
 of the possible reorderings of a program, and it's easier to insert
@@ -772,6 +772,18 @@ Jython.
 
 References
 ==========
+* Alternatives to SC, a thread on the cpp-threads mailing list,
+   which includes lots of good examples.
+   (http://www.decadentplace.org.uk/pipermail/cpp-threads/2007-January/001287.html)
+
+* python-safethread, a patch by Adam Olsen for CPython
+   that removes the GIL and statically guarantees that all objects
+   shared between threads are consistently
+   locked. (http://code.google.com/p/python-safethread/)
+* N2480: A Less Formal Explanation of the
+   Proposed C++ Concurrency Memory Model, Hans Boehm
+   (http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2480.html)
+
 
 .. _Java Memory Model: http://java.sun.com/docs/books/jls/third_edition/html/memory.html
 
@@ -783,10 +795,6 @@ References
    is an excellent introduction to memory models in general and has
    lots of examples of compiler/processor optimizations and the
    strange program behaviors they can produce.
-
-.. [#Cpp0x-memory-model] N2480: A Less Formal Explanation of the
-   Proposed C++ Concurrency Memory Model, Hans Boehm
-   (http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2480.html)
 
 .. [#CLR-msdn] Memory Models: Understand the Impact of Low-Lock
    Techniques in Multithreaded Apps, Vance Morrison
@@ -803,15 +811,6 @@ References
    (http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2427.html)
 
 .. [#slots] __slots__ (http://docs.python.org/ref/slots.html)
-
-.. [#] Alternatives to SC, a thread on the cpp-threads mailing list,
-   which includes lots of good examples.
-   (http://www.decadentplace.org.uk/pipermail/cpp-threads/2007-January/001287.html)
-
-.. [#safethread] python-safethread, a patch by Adam Olsen for CPython
-   that removes the GIL and statically guarantees that all objects
-   shared between threads are consistently
-   locked. (http://code.google.com/p/python-safethread/)
 
 
 Acknowledgements


### PR DESCRIPTION
Ref: #4087 

The search for changes removing the references was done with: `git log --follow -S "<ref.footnote>" -p -- peps/pep-0583.rst`. 

I have verified that PEP 583 generates no warnings on Sphinx v8.1.3.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4808.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->