### PR TITLE
PEP 516: Fix Sphinx warnings

### DIFF
--- a/peps/pep-0516.rst
+++ b/peps/pep-0516.rst
@@ -451,12 +451,6 @@ References
 .. [#flit] flit, a simple way to put packages in PyPI
    (http://flit.readthedocs.org/en/latest/)
 
-.. [#pypi] PyPI, the Python Package Index
-   (https://pypi.python.org/)
-
-.. [#shellvars] Shellvars, an implementation of shell variable rules for Python.
-   (https://github.com/testing-cabal/shellvars)
-
 .. [#thread] The kick-off thread.
    (https://mail.python.org/pipermail/distutils-sig/2015-October/026925.html)
 


### PR DESCRIPTION
Ref: #4087 

I have verified that PEP 516 generates no warnings on Sphinx v8.1.3.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4809.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->