### PR TITLE
PEP 518: Fix Sphinx warnings

### DIFF
--- a/peps/pep-0518.rst
+++ b/peps/pep-0518.rst
@@ -515,9 +515,6 @@ References
 .. [#pip] pip
    (https://pypi.python.org/pypi/pip)
 
-.. [#wheel] wheel
-   (https://pypi.python.org/pypi/wheel)
-
 .. [#toml] TOML
    (https://github.com/toml-lang/toml)
 
@@ -535,9 +532,6 @@ References
 
 .. [#pypa] PyPA
    (https://www.pypa.io)
-
-.. [#bazel] Bazel
-   (http://bazel.io/)
 
 .. [#ast_literal_eval] ``ast.literal_eval()``
    (https://docs.python.org/3/library/ast.html#ast.literal_eval)


### PR DESCRIPTION
Ref: #4087 

I have verified that PEP 518 generates no warnings on Sphinx v8.1.3.

The removed links are no longer used as references in the document.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4810.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->