### PR TITLE
PEP 798: Mark as Final

### DIFF
--- a/peps/pep-0798.rst
+++ b/peps/pep-0798.rst
@@ -3,7 +3,7 @@ Title: Unpacking in Comprehensions
 Author: Adam Hartz <hz@mit.edu>, Erik Demaine <edemaine@mit.edu>
 Sponsor: Jelle Zijlstra <jelle.zijlstra at gmail.com>
 Discussions-To: https://discuss.python.org/t/99435
-Status: Accepted
+Status: Final
 Type: Standards Track
 Created: 19-Jul-2025
 Python-Version: 3.15

--- a/peps/pep-0798.rst
+++ b/peps/pep-0798.rst
@@ -11,6 +11,11 @@ Post-History: `16-Oct-2021 <https://mail.python.org/archives/list/python-ideas@p
 Resolution: `03-Nov-2025 <https://discuss.python.org/t/pep-798-unpacking-in-comprehensions/99435/60>`__
 
 
+.. canonical-doc::
+   :external+py3.15:ref:`Displays for lists, sets and dictionaries <comprehensions>`,
+   :external+py3.15:ref:`Dictionary displays <dict>`
+
+
 Abstract
 ========
 


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [ ] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

-----------

@hugovk, I'm leaving a couple of the boxes unchecked for right now, because:

* While there weren't any wording changes since the Accepted version, I'm not 100% sure we got direct feedback about the current wording from an SC member.
* I don't think the one about canonical docs is relevant here (but happy to add something if I'm wrong about that).

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4812.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->