### PR TITLE
PEP 827: Add missing `positional`

### DIFF
--- a/peps/pep-0827.rst
+++ b/peps/pep-0827.rst
@@ -379,7 +379,7 @@ We introduce a ``Param`` type that contains all the information about a function
     class Param[N: str | None, T, Q: ParamQuals = typing.Never]:
         pass
 
-    ParamQuals = typing.Literal["*", "**", "default", "keyword"]
+    ParamQuals = typing.Literal["*", "**", "default", "keyword", "positional"]
 
     type PosParam[N: str | None, T] = Param[N, T, Literal["positional"]]
     type PosDefaultParam[N: str | None, T] = Param[N, T, Literal["positional", "default"]]


### PR DESCRIPTION
PEP 827:  Fix typo in class Param

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4881.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->