### PR TITLE
PEP 725: Fix Sphinx warnings

### DIFF
--- a/peps/pep-0725.rst
+++ b/peps/pep-0725.rst
@@ -1035,6 +1035,9 @@ None at this time.
 References
 ==========
 
+* The "``pkgconfig`` specification as an alternative to ``ctypes.util.find_library``" thread (2023, Discourse):
+   https://discuss.python.org/t/pkgconfig-specification-as-an-alternative-to-ctypes-util-find-library/31379
+
 .. [#singular-vision-native-deps] The "define native requirements metadata"
    part of the "Wanting a singular packaging vision" thread (2022, Discourse):
    https://discuss.python.org/t/wanting-a-singular-packaging-tool-vision/21141/92
@@ -1050,10 +1053,6 @@ References
 
 .. [#pypackaging-native-cross] pypackaging-native: "Cross compilation"
    https://pypackaging-native.github.io/key-issues/cross_compilation/
-
-.. [#pkgconfig-and-ctypes-findlibrary] The "``pkgconfig`` specification as an
-   alternative to ``ctypes.util.find_library``" thread (2023, Discourse):
-   https://discuss.python.org/t/pkgconfig-specification-as-an-alternative-to-ctypes-util-find-library/31379
 
 
 Copyright


### PR DESCRIPTION
Ref: #4087 

The reference was not used in the document, but I found it significant enough to keep it.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4904.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->