### PR TITLE
PEP 615: Fix Sphinx warnings

### DIFF
--- a/peps/pep-0615.rst
+++ b/peps/pep-0615.rst
@@ -930,15 +930,13 @@ References
 
 Other time zone implementations:
 --------------------------------
+* ``dateutil.tz.win``: Concrete time zone implementations wrapping Windows
+    time zones
+    https://dateutil.readthedocs.io/en/stable/tzwin.html
 
 .. [#dateutil-tz]
     ``dateutil.tz``
     https://dateutil.readthedocs.io/en/stable/tz.html
-
-.. [#dateutil-tzwin]
-    ``dateutil.tz.win``: Concrete time zone implementations wrapping Windows
-    time zones
-    https://dateutil.readthedocs.io/en/stable/tzwin.html
 
 .. [#pytz]
     ``pytz``


### PR DESCRIPTION
Ref: #4087 

The reference was not used in the document, but I found it significant enough to keep it.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4905.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->