### PR TITLE
PEP 694: Fix Sphinx warnings

### DIFF
--- a/peps/pep-0694.rst
+++ b/peps/pep-0694.rst
@@ -1098,9 +1098,6 @@ as experience is gained operating Upload 2.0.
               <https://docs.python.org/3/library/hashlib.html#hashlib.new>`_ ``hashlib.new()`` and
               which does not require additional parameters.
 
-.. [#fn-immutable] Published files may still be yanked (i.e. :pep:`592`) or `deleted
-                   <https://pypi.org/help/#file-name-reuse>`__ as normal.
-
 
 Change History
 ==============


### PR DESCRIPTION
Ref: #4087 

The reference was not used in the document, and didn't seem like it made sense as a standalone reference.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4906.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->