### PR TITLE
PEP 703: Fix Sphinx warnings

### DIFF
--- a/peps/pep-0703.rst
+++ b/peps/pep-0703.rst
@@ -1812,6 +1812,7 @@ trade-offs remain an open issue.
 
 References
 ==========
+* :pep:`683` -- Immortal Objects, Using a Fixed Refcount.
 
 .. [#yuemmwang2019] "Exploiting Parallelism Opportunities with Deep Learning Frameworks."
    Yu Emma Wang, Carole-Jean Wu, Xiaodong Wang, Kim Hazelwood, David Brooks. 2019.
@@ -1824,8 +1825,6 @@ References
 .. [#brc] "Biased reference counting: minimizing atomic operations in garbage collection".
    Jiho Choi, Thomas Shull, and Josep Torrellas. PACT 2018.
    https://dl.acm.org/doi/abs/10.1145/3243176.3243195.
-
-.. [#pep683] :pep:`683` -- Immortal Objects, Using a Fixed Refcount.
 
 .. [#tid] https://github.com/colesbury/nogil/blob/f7e45d6bfbbd48c8d5cf851c116b73b85add9fc6/Include/object.h#L428-L455.
 
@@ -1870,8 +1869,6 @@ References
    escape analysis and pass-by-value instead of reference
    counting. Recent versions of Go use a non-generational garbage
    collector. https://go.dev/blog/ismmkeynote.
-
-.. [#nogil] https://github.com/colesbury/nogil.
 
 .. [#nogil312] https://github.com/colesbury/nogil-3.12.
 


### PR DESCRIPTION
Ref: #4087 

Reference to PEP 638 was covered by ``:pep:`638` `` markup, but left it as it is an important ref for this document. 

The `#nogil` reference was replaced by `#nogil312` where it was significant, and in parts that reference it, there is a verbose GitHub link to a proper repository.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4907.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->