### PR TITLE
PEP 747: Fix Sphinx warnings

### DIFF
--- a/peps/pep-0747.rst
+++ b/peps/pep-0747.rst
@@ -670,21 +670,9 @@ Acknowledgements
 Footnotes
 =========
 
-.. [#type_t]
-   :ref:`Type[T] <typing:type-brackets>` spells a class object
-
-.. [#TypeIs]
-   :ref:`TypeIs[T] <typing:typeis>` is similar to bool
-
 .. [#DataclassInitVar]
    ``dataclass.make_dataclass`` allows the type qualifier ``InitVar[...]``,
    so ``TypeForm`` cannot be used in this case.
-
-.. [#forward_ref_normalization]
-   Special forms normalize string arguments to ``ForwardRef`` instances
-   at runtime using internal helper functions in the ``typing`` module.
-   Runtime type checkers may wish to implement similar functions when
-   working with string-based forward references.
 
 .. [#quoted_less_common]
    Quoted annotations are expected to become less common starting in Python


### PR DESCRIPTION
Ref: #4087 

There were 3 references Sphinx 8.1+ was warning about:

- `#type_t` reference was introduced in #3929, but was not used in the document text,  ~~converted to a bullet point~~ removed it.
- `#TypeIs` reference was converted from `#TypeIsPep` in #3929, but it is now linked in code via a `typing` reference, removed
- `#forward_ref_normalization` reference usage was removed in #3929, but the reference was left behind. Since it makes little sense without the usage, removed


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4908.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->