### PR TITLE
PEP 831: Fix typo in JIT frame pointer explanation

### DIFF
--- a/peps/pep-0831.rst
+++ b/peps/pep-0831.rst
@@ -411,7 +411,7 @@ code is a prerequisite for the JIT to be considered production-ready.
 
 Individual JIT stencils do not need frame-pointer prologues; the entire JIT
 region can be treated as a single frameless region for unwinding purposes.
-What matters is that the JIT itself is must reserve frame pointers, so
+What matters is that the JIT itself must reserve frame pointers, so
 that the frame-pointer register (``%rbp`` on x86-64, ``x29`` on AArch64) is
 reserved and not clobbered by stencil code.  With frame pointers in the
 JIT, most unwinders can walk through JIT regions without needing to inspect


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [X] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4919.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->