### PR TITLE
Infra: bump Sphinx to 9.0+, limit docutils to <0.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,6 @@ htmllive: _ensure-sphinx-autobuild html
 .PHONY: dirhtml
 dirhtml: BUILDER = dirhtml
 dirhtml: html
-	mv $(BUILDDIR)/404/index.html $(BUILDDIR)/404.html
 
 ## search         to rebuild the search index
 .PHONY: search

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ htmllive: _ensure-sphinx-autobuild html
 .PHONY: dirhtml
 dirhtml: BUILDER = dirhtml
 dirhtml: html
+	mv $(BUILDDIR)/404/index.html $(BUILDDIR)/404.html
 
 ## search         to rebuild the search index
 .PHONY: search

--- a/pep_sphinx_extensions/pep_processor/html/pep_html_builder.py
+++ b/pep_sphinx_extensions/pep_processor/html/pep_html_builder.py
@@ -48,4 +48,4 @@ class DirectoryBuilder(FileBuilder):
     # sync all overwritten things from DirectoryHTMLBuilder
     name = DirectoryHTMLBuilder.name
     get_target_uri = DirectoryHTMLBuilder.get_target_uri
-    get_outfilename = DirectoryHTMLBuilder.get_output_path
+    get_output_path = DirectoryHTMLBuilder.get_output_path

--- a/pep_sphinx_extensions/pep_processor/html/pep_html_builder.py
+++ b/pep_sphinx_extensions/pep_processor/html/pep_html_builder.py
@@ -48,4 +48,4 @@ class DirectoryBuilder(FileBuilder):
     # sync all overwritten things from DirectoryHTMLBuilder
     name = DirectoryHTMLBuilder.name
     get_target_uri = DirectoryHTMLBuilder.get_target_uri
-    get_outfilename = DirectoryHTMLBuilder.get_outfilename
+    get_outfilename = DirectoryHTMLBuilder.get_output_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,9 @@
 # Sphinx requires >= 2.17. JSON5 support added in 2.19, `lazy` highlight added in 2.21
 pygments >= 2.21
 
-# Sphinx 6.1.0 broke copying images in parallel builds; fixed in 6.1.2
-# See https://github.com/sphinx-doc/sphinx/pull/11100
-Sphinx >= 5.1.1, != 6.1.0, != 6.1.1, < 8.1.0
-docutils >= 0.19.0
+Sphinx >= 8.2
+# 0.22 causes build errors, see https://github.com/python/peps/issues/4924
+docutils < 0.22
 sphinx-notfound-page >= 1.0.2
 # For search
 pagefind[bin] >= 1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,9 @@
 # https://github.com/pygments/pygments/discussions/3145
 pygments @ git+https://github.com/pygments/pygments@2cad2642058441b59782a6a18f03c98c42d081f1
 
-# Sphinx 6.1.0 broke copying images in parallel builds; fixed in 6.1.2
-# See https://github.com/sphinx-doc/sphinx/pull/11100
-Sphinx >= 5.1.1, != 6.1.0, != 6.1.1, < 8.1.0
-docutils >= 0.19.0
+Sphinx >= 8.2
+# 0.22 causes build errors, see https://github.com/python/peps/issues/4924
+docutils < 0.22
 sphinx-notfound-page >= 1.0.2
 # For search
 pagefind[bin] >= 1.5.0


### PR DESCRIPTION
~~Blocked by: #4908, #4906~~
Closes: #4087 

Bump Sphinx to 9.0+ (9.2 at the moment). `docutils` is upper-limited because of build errors listed in #4924.


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4926.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->