### PR TITLE
PEP 101: Generalize Android wording to include other platforms

### DIFF
--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -298,7 +298,7 @@ and guides you to perform some manual steps.
   - Create the documentation tar and zip files.
   - Check the source tarball to make sure a completely clean, virgin build
     passes the regression test.
-  - Build and test the Android binaries (if Python 3.14 or later).
+  - Build and test the binaries for platforms which don't require an expert.
 
   The resulting artifacts will be attached to the summary page of the GitHub
   workflow. Once the source tarball is available, download and unpack it to make


### PR DESCRIPTION
Automated iOS releases were added in https://github.com/python/release-tools/pull/365, and there may be other platforms in the future, so I've replaced the reference to Android with a more general statement.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4927.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->