### PR TITLE
PEP 833: Update Discussions-To and Post-History

### DIFF
--- a/peps/pep-0833.rst
+++ b/peps/pep-0833.rst
@@ -9,7 +9,7 @@ Type: Standards Track
 Topic: Packaging
 Created: 21-Apr-2026
 Post-History: `13-Apr-2026 <https://discuss.python.org/t/106959>`__,
-              `21-Apr-2026 <https://discuss.python.org/t/107051>`__
+              `21-Apr-2026 <https://discuss.python.org/t/107051>`__,
 
 
 Abstract

--- a/peps/pep-0833.rst
+++ b/peps/pep-0833.rst
@@ -3,12 +3,13 @@ Title: Freezing the HTML simple repository API
 Author: William Woodruff <william@yossarian.net>
 Sponsor: Donald Stufft <donald@stufft.io>
 PEP-Delegate: Donald Stufft <donald@stufft.io>
-Discussions-To: Pending
+Discussions-To: https://discuss.python.org/t/pep-833-freezing-the-html-simple-repository-api/107051
 Status: Draft
 Type: Standards Track
 Topic: Packaging
 Created: 21-Apr-2026
-Post-History: `13-Apr-2026 <https://discuss.python.org/t/106959>`__
+Post-History: `13-Apr-2026 <https://discuss.python.org/t/106959>`__,
+              `21-Apr-2026 <https://discuss.python.org/t/107051>`__
 
 
 Abstract


### PR DESCRIPTION
Now that https://discuss.python.org/t/pep-833-freezing-the-html-simple-repository-api/107051 is open 🙂 

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4931.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->