### PR TITLE
PEP 802: Amend wording of single-token rejected alternative

### DIFF
--- a/peps/pep-0802.rst
+++ b/peps/pep-0802.rst
@@ -145,7 +145,7 @@ Backwards Compatibility
 Code that relies on the ``repr()`` or ``str()`` of the empty set
 will no longer work, because the representation will change.
 
-There will be no other backwards incompatibile changes,
+There will be no other backwards incompatible changes,
 all current constructors for the empty set will continue to work,
 and the behaviour of the :py:class:`set` type will remain unchanged.
 
@@ -168,7 +168,7 @@ How to Teach This
 All users can be taught that ``{/}`` is the new spelling for ``set()``,
 and that it is equivalent in all other ways.
 To help reinforce this, we will update the documentation to use ``{/}``
-instead of ``set()``, including the tutorial, standard libary modules,
+instead of ``set()``, including the tutorial, standard library modules,
 and the Python Language Reference.
 
 For new users, sets can be introduced through syntax, noting that the four
@@ -246,7 +246,7 @@ This removes agency from the learner.
 Especially when using a programming language that can execute arbitrary code,
 it is important that users understand what the code they are writing does.
 
-In the authors' opinion, it would be a misttep to promote ``{*()}``
+In the authors' opinion, it would be a misstep to promote ``{*()}``
 as the syntax for an empty set.
 It resulted as a side-effect of :pep:`448`, rather than an intentional attempt
 to design a syntax that is easy to teach, understand, and explain.
@@ -261,7 +261,7 @@ The authors prefer ``{/}`` due to the resemblance to :math:`\emptyset`.
 Use the ``(/)`` syntax
 ----------------------
 
-This notation has been suggested as a better visual resemlence of
+This notation has been suggested as a better visual resemblance of
 the empty set symbol (e.g. U+2205 ∅ EMPTY SET).
 However, it is a complete departure from the regular set syntax.
 To the authors, any of the proposed notations with curly brackets
@@ -293,7 +293,7 @@ to create a new token for this construct.
 This would require ``'{/}'`` to be written literally,
 with no whitespace between the characters.
 
-We insted chose to allow whitespace between the brackets and the slash,
+We instead chose to allow whitespace between the brackets and the slash,
 treating ``{``, ``/``, and ``}`` as three distinct tokens,
 as we cannot see any reason to prevent it.
 However, we expect that the vast majority of uses will not include whitespace.

--- a/peps/pep-0802.rst
+++ b/peps/pep-0802.rst
@@ -288,12 +288,11 @@ for all empty collections.
 Create and use a new token for ``'{/}'``
 ----------------------------------------
 
-There have been `previous proposals <https://discuss.python.org/t/73235/66>`__
-to create a new token for this construct.
-This would require ``'{/}'`` to be written literally,
-with no whitespace between the characters.
+There have been `previous discussions <https://discuss.python.org/t/73235/66>`__
+on whether to create a new token for this construct. This would require
+``'{/}'`` to be written literally, with no whitespace between the characters.
 
-We instead chose to allow whitespace between the braces and the slash,
+We choose to allow whitespace between the braces and the slash,
 treating ``{``, ``/``, and ``}`` as three distinct tokens,
 as we cannot see any reason to prevent it.
 However, we expect that the vast majority of uses will not include whitespace.

--- a/peps/pep-0802.rst
+++ b/peps/pep-0802.rst
@@ -264,7 +264,7 @@ Use the ``(/)`` syntax
 This notation has been suggested as a better visual resemblance of
 the empty set symbol (e.g. U+2205 ∅ EMPTY SET).
 However, it is a complete departure from the regular set syntax.
-To the authors, any of the proposed notations with curly brackets
+To the authors, any of the proposed notations with curly braces
 are better than this proposal, as they are more consistent with the
 current (since Python 3.0) set notation.
 
@@ -293,7 +293,7 @@ to create a new token for this construct.
 This would require ``'{/}'`` to be written literally,
 with no whitespace between the characters.
 
-We instead chose to allow whitespace between the brackets and the slash,
+We instead chose to allow whitespace between the braces and the slash,
 treating ``{``, ``/``, and ``}`` as three distinct tokens,
 as we cannot see any reason to prevent it.
 However, we expect that the vast majority of uses will not include whitespace.


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

## Summary

I love that my discussion post made it into the PEP, but a slight change of characterisation is needed: 

I *discussed* whether `{/}` should be added as a single token or three separate ones. I didn't *propose* it. I'm in favour of allowing spaces. 😅

I love this PEP btw.

## Commits

- 74d11ba2: Typos
- 35163bec: Change 'bracket' to 'brace' for `{` and `}`. Do cherry pick this out it it's insulting pedantry
- 4788b162: Main commit amending the wording referring to my post

Thanks!

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4938.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->