### PR TITLE
PEP 820: Mark Accepted

### DIFF
--- a/peps/pep-0820.rst
+++ b/peps/pep-0820.rst
@@ -2,11 +2,12 @@ PEP: 820
 Title: PySlot: Unified slot system for the C API
 Author: Petr Viktorin <encukou@gmail.com>
 Discussions-To: https://discuss.python.org/t/105552
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Created: 19-Dec-2025
 Python-Version: 3.15
 Post-History: `06-Jan-2026 <https://discuss.python.org/t/105552>`__
+Resolution: `23-Apr-2025 <https://discuss.python.org/t/105552/24>`__
 
 
 .. highlight:: c
@@ -143,7 +144,7 @@ which can be specified as C literals using macros, like this::
 
     // ...
 
-    PyObject *MyClass = PyType_FromSlots(myClass_slots, -1);
+    PyObject *MyClass = PyType_FromSlots(myClass_slots);
 
 The macros simplify hand-written literals.
 For more complex use cases, like compatibility between several Python versions,
@@ -327,6 +328,8 @@ the same effect.
 To allow changing the edge case behaviour in the (far) future,
 and to allow freedom for possible alternative implementations of the C API,
 we'll start issuing runtime deprecation warnings in these cases.
+To avoid flooding users with warnings for things that are outside of their
+control, we'll only show deprecation warnings when the new API is used.
 
 
 Specification
@@ -483,7 +486,7 @@ Each ``PyType_Slot`` in the array will be converted to
 and similar with ``PyModuleDef_Slot``.
 
 In the initial implementation, nesting depth will be limited to 5 levels.
-This restrictions may be lifted in the future.
+This restriction may be lifted in the future.
 
 
 New slot IDs
@@ -585,9 +588,10 @@ This includes nested "new-style" slots (``Py_slot_subslots``).
 Deprecation warnings
 --------------------
 
-CPython will emit runtime deprecation warnings for the following cases,
-for slots where the case is currently disallowed in documentation but allowed
-by the runtime:
+Functions that take ``PySlot`` arrays (but not functions that take
+the older ``PyType_Slot`` or ``PyModuleDef_Slot`` arrays) will emit runtime
+deprecation warnings for the following cases, for slots where the case is
+currently disallowed in documentation but allowed by the runtime:
 
 - setting a slot value to NULL:
 
@@ -738,6 +742,10 @@ for substantial input on this iteration of the proposal.
 
 Change History
 ==============
+
+* 24-Apr-2026
+  - Limit deprecation for NULL and repeated slots to the new API.
+  - PEP is accepted
 
 * `12-Mar-2026 <https://discuss.python.org/t/105552/12>`__
   - Remove unnecessary flag ``PySlot_HAS_FALLBACK``


### PR DESCRIPTION
- Mark Accepted
- Limit deprecation warnings to new API, per SC request
- Fix code example & typo
- 
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [x] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
  - PEP is changed instead
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4939.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->