### PR TITLE
PEP 661: Mark as Final

### DIFF
--- a/peps/pep-0661.rst
+++ b/peps/pep-0661.rst
@@ -2,13 +2,14 @@ PEP: 661
 Title: Sentinel Values
 Author: Tal Einat <tal@python.org>, Jelle Zijlstra <jelle.zijlstra@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-661-sentinel-values/9126
-Status: Accepted
+Status: Final
 Type: Standards Track
 Created: 06-Jun-2021
 Python-Version: 3.15
 Post-History: `20-May-2021 <https://discuss.python.org/t/sentinel-values-in-the-stdlib/8810>`__, `06-Jun-2021 <https://discuss.python.org/t/pep-661-sentinel-values/9126>`__
 Resolution: `23-Apr-2026 <https://discuss.python.org/t/pep-661-sentinel-values/9126/337>`__
 
+.. canonical-doc:: :external+py3.15:class:`sentinel`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

Docs:

* https://docs.python.org/3.15/whatsnew/3.15.html#whatsnew315-sentinel
* https://docs.python.org/3.15/library/functions.html#sentinel


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4940.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->