### PR TITLE
PEP 822: Target Python 3.16

### DIFF
--- a/peps/pep-0822.rst
+++ b/peps/pep-0822.rst
@@ -5,7 +5,7 @@ Discussions-To: https://discuss.python.org/t/105519
 Status: Draft
 Type: Standards Track
 Created: 05-Jan-2026
-Python-Version: 3.15
+Python-Version: 3.16
 Post-History: `05-Jan-2026 <https://discuss.python.org/t/105519>`__,
 
 


### PR DESCRIPTION
Re:
* https://github.com/python/steering-council/issues/336#issuecomment-4282041576
* https://discuss.python.org/t/pep-822-dedented-multiline-string-d-string/105519/130

@methane Would you like to retarget this for Python 3.16?


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4941.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->