### PR TITLE
PEP 799: Mark as Final

### DIFF
--- a/peps/pep-0799.rst
+++ b/peps/pep-0799.rst
@@ -3,12 +3,14 @@ Title: A dedicated ``profiling`` package for organizing Python profiling tools
 Author: Pablo Galindo Salgado <pablogsal@python.org>,
         László Kiss Kollár <kiss.kollar.laszlo@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-799-a-dedicated-profilers-package-for-organizing-python-profiling-tool/100898
-Status: Accepted
+Status: Final
 Type: Standards Track
 Created: 21-Jul-2025
 Python-Version: 3.15
 Post-History: `01-Aug-2025 <https://discuss.python.org/t/pep-799-a-dedicated-profilers-package-for-organizing-python-profiling-tool/100898>`__
 Resolution: `21-Aug-2025 <https://discuss.python.org/t/pep-799-a-dedicated-profilers-package-for-organizing-python-profiling-tool/100898/21>`__
+
+.. canonical-doc:: :external+py3.15:mod:`profiling`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

The umbrella issue (https://github.com/python/cpython/issues/138122) still has one sub-issue open (https://github.com/python/cpython/issues/142927) for improving Tachyon UX, but we can already mark PEP as final.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4942.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->