### PR TITLE
PEP 810: Mark as Final

### DIFF
--- a/peps/pep-0810.rst
+++ b/peps/pep-0810.rst
@@ -8,7 +8,7 @@ Author: Pablo Galindo Salgado <pablogsal@python.org>,
         Noah Kim <noahbkim@gmail.com>,
         Tim Stumbaugh <me@tjstum.com>
 Discussions-To: https://discuss.python.org/t/104131
-Status: Accepted
+Status: Final
 Type: Standards Track
 Created: 02-Oct-2025
 Python-Version: 3.15
@@ -16,6 +16,7 @@ Post-History:
   `03-Oct-2025 <https://discuss.python.org/t/104131>`__,
 Resolution: `03-Nov-2025 <https://discuss.python.org/t/pep-810-explicit-lazy-imports/104131/466>`__
 
+.. canonical-doc:: :external+py3.15:ref:`lazy-imports`
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [ ] PEP matches the final implementation
* [ ] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)

And ready to close the implementation issue? https://github.com/python/cpython/issues/142349

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4943.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->