### PR TITLE
PEP 833: add some qualifying language

### DIFF
--- a/peps/pep-0833.rst
+++ b/peps/pep-0833.rst
@@ -130,6 +130,12 @@ the following versioning marker:
 
    <meta name="pypi:repository-version" content="1.4">
 
+This specification _deliberately_ uses **SHOULD NOT** rather than
+**MUST NOT** when describing the prohibition on future updates to the HTML
+representation. Future PEPs _may_ update the HTML representation,
+but this specification discourages doing so without a specific and compelling
+reason (beyond the desire to make symmetric changes to both representations).
+
 Future Considerations
 =====================
 


### PR DESCRIPTION
This qualifies the PEP's specification a bit more, making it clear that **SHOULD NOT** was an intentional cap (versus **MUST NOT**) on changes to the HTML representation.

Per DPO: https://discuss.python.org/t/pep-833-freezing-the-html-simple-repository-api/107051/30



<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4944.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->