### PR TITLE
PEP 788: Mark as Accepted

### DIFF
--- a/peps/pep-0788.rst
+++ b/peps/pep-0788.rst
@@ -3,7 +3,7 @@ Title: Protecting the C API from Interpreter Finalization
 Author: Peter Bierma <peter@python.org>
 Sponsor: Victor Stinner <vstinner@python.org>
 Discussions-To: https://discuss.python.org/t/104150
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Created: 23-Apr-2025
 Python-Version: 3.15
@@ -11,6 +11,7 @@ Post-History: `10-Mar-2025 <https://discuss.python.org/t/83959>`__,
               `27-Apr-2025 <https://discuss.python.org/t/89863>`__,
               `28-May-2025 <https://discuss.python.org/t/93653>`__,
               `03-Oct-2025 <https://discuss.python.org/t/104150>`__
+Resolution: `28-Apr-2026 <https://discuss.python.org/t/104150/44>`__
 
 
 Abstract


### PR DESCRIPTION
* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [x] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--4945.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->