### PR TITLE
PEP 745: Add 3.14.5rc1 and early 3.14.5

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -71,15 +71,17 @@ Actual:
 
 Expected:
 
-- 3.14.5: Tuesday, 2026-06-09
-- 3.14.6: Tuesday, 2026-08-04
-- 3.14.7: Tuesday, 2026-10-06
-- 3.14.8: Tuesday, 2026-12-01
-- 3.14.9: Tuesday, 2027-02-02
-- 3.14.10: Tuesday, 2027-04-06
-- 3.14.11: Tuesday, 2027-06-01
-- 3.14.12: Tuesday, 2027-08-03
-- 3.14.13: Tuesday, 2027-10-05
+- 3.14.5 candidate 1: Saturday, 2026-05-02
+- 3.14.5: Friday, 2026-05-08
+- 3.14.6: Tuesday, 2026-06-09
+- 3.14.7: Tuesday, 2026-08-04
+- 3.14.8: Tuesday, 2026-10-06
+- 3.14.9: Tuesday, 2026-12-01
+- 3.14.10: Tuesday, 2027-02-02
+- 3.14.11: Tuesday, 2027-04-06
+- 3.14.12: Tuesday, 2027-06-01
+- 3.14.13: Tuesday, 2027-08-03
+- 3.14.14: Tuesday, 2027-10-05
   (Final regular bugfix release with binary installers)
 
 .. release schedule: ends

--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3498,47 +3498,57 @@ state = "actual"
 date = 2026-04-07
 
 [[release."3.14"]]
+stage = "3.14.5 candidate 1"
+state = "expected"
+date = 2026-05-02
+
+[[release."3.14"]]
 stage = "3.14.5"
 state = "expected"
-date = 2026-06-09
+date = 2026-05-08
 
 [[release."3.14"]]
 stage = "3.14.6"
 state = "expected"
-date = 2026-08-04
+date = 2026-06-09
 
 [[release."3.14"]]
 stage = "3.14.7"
 state = "expected"
-date = 2026-10-06
+date = 2026-08-04
 
 [[release."3.14"]]
 stage = "3.14.8"
 state = "expected"
-date = 2026-12-01
+date = 2026-10-06
 
 [[release."3.14"]]
 stage = "3.14.9"
 state = "expected"
-date = 2027-02-02
+date = 2026-12-01
 
 [[release."3.14"]]
 stage = "3.14.10"
 state = "expected"
-date = 2027-04-06
+date = 2027-02-02
 
 [[release."3.14"]]
 stage = "3.14.11"
 state = "expected"
-date = 2027-06-01
+date = 2027-04-06
 
 [[release."3.14"]]
 stage = "3.14.12"
 state = "expected"
-date = 2027-08-03
+date = 2027-06-01
 
 [[release."3.14"]]
 stage = "3.14.13"
+state = "expected"
+date = 2027-08-03
+
+[[release."3.14"]]
+stage = "3.14.14"
 state = "expected"
 date = 2027-10-05
 


### PR DESCRIPTION
Re: https://discuss.python.org/t/reverting-the-incremental-gc-in-python-3-14-and-3-15/107014/45

* Add 3.14.5rc1 for tomorrow
* Move 3.14.5 final earlier, to Friday
* Bump patch versions for the rest, keeping original dates