### PR TITLE
PEP 811: Mark as 'Active'

### DIFF
--- a/peps/pep-0811.rst
+++ b/peps/pep-0811.rst
@@ -3,7 +3,7 @@ Title: Defining Python Security Response Team membership and responsibilities
 Author: Seth Michael Larson <seth@python.org>
 Sponsor: Gregory P. Smith <greg@krypto.org>
 Discussions-To: https://discuss.python.org/t/104606
-Status: Accepted
+Status: Active
 Type: Process
 Topic: Governance
 Created: 22-Oct-2025


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

This is technically more suitable for this PEP, per [PEP 1](https://peps.python.org/pep-0001/):

> Process PEPs may also have a status of “Active” if they are never meant to be completed. E.g. [PEP 1](https://peps.python.org/pep-0001/) (this PEP).

Another option is marking it as 'Final,' and noting the page in the devguide as the up-to-date spec. I wasn't quite sure which is best, what do you think @sethmlarson?