### PR TITLE
PEP 745: Add 3.14.5rc1 release

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -68,10 +68,10 @@ Actual:
 - 3.14.2: Friday, 2025-12-05
 - 3.14.3: Tuesday, 2026-02-03
 - 3.14.4: Tuesday, 2026-04-07
+- 3.14.5 candidate 1: Monday, 2026-05-04
 
 Expected:
 
-- 3.14.5 candidate 1: Monday, 2026-05-04
 - 3.14.5: Friday, 2026-05-08
 - 3.14.6: Tuesday, 2026-06-09
 - 3.14.7: Tuesday, 2026-08-04

--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -71,7 +71,7 @@ Actual:
 
 Expected:
 
-- 3.14.5 candidate 1: Saturday, 2026-05-02
+- 3.14.5 candidate 1: Monday, 2026-05-04
 - 3.14.5: Friday, 2026-05-08
 - 3.14.6: Tuesday, 2026-06-09
 - 3.14.7: Tuesday, 2026-08-04

--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3500,7 +3500,7 @@ date = 2026-04-07
 [[release."3.14"]]
 stage = "3.14.5 candidate 1"
 state = "expected"
-date = 2026-05-02
+date = 2026-05-04
 
 [[release."3.14"]]
 stage = "3.14.5"

--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3499,7 +3499,7 @@ date = 2026-04-07
 
 [[release."3.14"]]
 stage = "3.14.5 candidate 1"
-state = "expected"
+state = "actual"
 date = 2026-05-04
 
 [[release."3.14"]]


### PR DESCRIPTION
https://blog.python.org/2026/05/python-3145rc1/