### PR TITLE
PEP 790: Move 3.15 b1 to Thursday 2026-05-07

### DIFF
--- a/peps/pep-0790.rst
+++ b/peps/pep-0790.rst
@@ -47,7 +47,7 @@ Actual:
 
 Expected:
 
-- 3.15.0 beta 1: Tuesday, 2026-05-05
+- 3.15.0 beta 1: Thursday, 2026-05-07
   (No new features beyond this point.)
 - 3.15.0 beta 2: Tuesday, 2026-06-02
 - 3.15.0 beta 3: Tuesday, 2026-06-23

--- a/peps/pep-0826.rst
+++ b/peps/pep-0826.rst
@@ -35,7 +35,7 @@ release cadence between feature versions, as defined by :pep:`602`.
 
 Expected:
 
-- 3.16 development begins: Tuesday, 2026-05-05
+- 3.16 development begins: Thursday, 2026-05-07
 - 3.16.0 alpha 1: Tuesday, 2026-10-13
 - 3.16.0 alpha 2: Tuesday, 2026-11-10
 - 3.16.0 alpha 3: Tuesday, 2026-12-15

--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3560,7 +3560,7 @@ status = "feature"
 branch =  "main"
 release-manager = "Hugo van Kemenade"
 start-of-development = 2025-05-07
-feature-freeze = 2026-05-05
+feature-freeze = 2026-05-07
 first-release = 2026-10-01
 end-of-bugfix = 2028-10-01
 end-of-life = 2031-10-01
@@ -3608,7 +3608,7 @@ date = 2026-04-07
 [[release."3.15"]]
 stage = "3.15.0 beta 1"
 state = "expected"
-date = 2026-05-05
+date = 2026-05-07
 
 [[release."3.15"]]
 stage = "3.15.0 beta 2"
@@ -3647,7 +3647,7 @@ pep = 826
 status = "planned"
 branch = ""
 release-manager = "Savannah Ostrowski"
-start-of-development = 2026-05-05
+start-of-development = 2026-05-07
 feature-freeze = 2027-05-04
 first-release = 2027-10-06
 end-of-bugfix = 2029-10-06


### PR DESCRIPTION
https://discuss.python.org/t/python-3-15-0-beta-1-is-near/107193

And 3.15 feature freeze == 3.16 start of development, so update PEP 826 as well.