### PR TITLE
PEP 748: tlslib - configuration

### DIFF
--- a/peps/pep-0748.rst
+++ b/peps/pep-0748.rst
@@ -1072,7 +1072,7 @@ The definitions of the errors are below:
 
 
     class ConfigurationError(TLSError):
-        """An special exception that implementations can use when the provided
+        """A special exception that implementations can use when the provided
         configuration uses features not supported by that implementation."""
 
 

--- a/peps/pep-0748.rst
+++ b/peps/pep-0748.rst
@@ -276,7 +276,7 @@ The ``TLSClientConfiguration`` class would be defined by the following code:
             inner_protocols: Sequence[NextProtocol | bytes] | None = None,
             lowest_supported_version: TLSVersion | None = None,
             highest_supported_version: TLSVersion | None = None,
-            trust_store: TrustStore | None = None,
+            trust_store: TrustStore = TrustStore.system(),
         ) -> None:
             if inner_protocols is None:
                 inner_protocols = []
@@ -309,8 +309,12 @@ The ``TLSClientConfiguration`` class would be defined by the following code:
             return self._highest_supported_version
 
         @property
-        def trust_store(self) -> TrustStore | None:
+        def trust_store(self) -> TrustStore:
             return self._trust_store
+
+A ``trust_store`` is mandatory and is used to validate the server certificates.
+It uses the system's trust store by default. Insecure connections are only
+possible via the :ref:`insecure` module.
 
 Server Configuration
 ^^^^^^^^^^^^^^^^^^^^
@@ -372,6 +376,9 @@ The ``TLSServerConfiguration`` class would be defined by the following code:
         def trust_store(self) -> TrustStore | None:
             return self._trust_store
 
+A ``trust_store`` is optional. Setting one enables client authentication and
+uses the trust store to validate the client certificates. Leaving it ``None``
+disables client authentication.
 
 Context
 ~~~~~~~
@@ -1502,6 +1509,8 @@ a trust store:
 Note that this function only needs to verify that supported constructors were
 used for the certificates, private keys, and trust store. It does not need to
 parse or retrieve the objects to validate them further.
+
+.. _insecure:
 
 Insecure Usage
 --------------

--- a/peps/pep-0748.rst
+++ b/peps/pep-0748.rst
@@ -316,6 +316,11 @@ A ``trust_store`` is mandatory and is used to validate the server certificates.
 It uses the system's trust store by default. Insecure connections are only
 possible via the :ref:`insecure` module.
 
+When ``certificate_chain`` is set, it is a single signing chain comprising a
+leaf client certificate including its corresponding private key and optionally a
+list of intermediate certificates. These certificates will be offered to the
+server during the handshake if required.
+
 Server Configuration
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -335,7 +340,7 @@ The ``TLSServerConfiguration`` class would be defined by the following code:
 
         def __init__(
             self,
-            certificate_chain: Sequence[SigningChain] | None = None,
+            certificate_chain: Sequence[SigningChain],
             ciphers: Sequence[CipherSuite] | None = None,
             inner_protocols: Sequence[NextProtocol | bytes] | None = None,
             lowest_supported_version: TLSVersion | None = None,
@@ -353,7 +358,7 @@ The ``TLSServerConfiguration`` class would be defined by the following code:
             self._trust_store = trust_store
 
         @property
-        def certificate_chain(self) -> Sequence[SigningChain] | None:
+        def certificate_chain(self) -> Sequence[SigningChain]:
             return self._certificate_chain
 
         @property
@@ -375,6 +380,14 @@ The ``TLSServerConfiguration`` class would be defined by the following code:
         @property
         def trust_store(self) -> TrustStore | None:
             return self._trust_store
+
+Server authentication is mandatory, so the configuration must include
+at least one signing chain comprising a leaf server certificate including
+its corresponding private key and optionally a list of intermediate
+certificates. It is possible to set more than a single signing chain to
+support multiple virtual hosts. Implementations should raise ``ValueError``
+when no signing chain is provided. Insecure connections with server
+authentication disabled are only possible via the :ref:`insecure` module.
 
 A ``trust_store`` is optional. Setting one enables client authentication and
 uses the trust store to validate the client certificates. Leaving it ``None``

--- a/peps/pep-0748.rst
+++ b/peps/pep-0748.rst
@@ -252,6 +252,9 @@ backwards-compatibility purposes, new fields are only appended to these objects.
 Existing fields will never be removed, renamed, or reordered. They are split
 between client and server to minimize API confusion.
 
+Client Configuration
+^^^^^^^^^^^^^^^^^^^^
+
 The ``TLSClientConfiguration`` class would be defined by the following code:
 
 .. code-block:: python
@@ -309,8 +312,66 @@ The ``TLSClientConfiguration`` class would be defined by the following code:
         def trust_store(self) -> TrustStore | None:
             return self._trust_store
 
-The ``TLSServerConfiguration`` object is similar to the client one, except that
-it takes a ``Sequence[SigningChain]`` as the ``certificate_chain`` parameter.
+Server Configuration
+^^^^^^^^^^^^^^^^^^^^
+
+The ``TLSServerConfiguration`` class would be defined by the following code:
+
+.. code-block:: python
+
+    class TLSServerConfiguration:
+        __slots__ = (
+            "_certificate_chain",
+            "_ciphers",
+            "_inner_protocols",
+            "_lowest_supported_version",
+            "_highest_supported_version",
+            "_trust_store",
+        )
+
+        def __init__(
+            self,
+            certificate_chain: Sequence[SigningChain] | None = None,
+            ciphers: Sequence[CipherSuite] | None = None,
+            inner_protocols: Sequence[NextProtocol | bytes] | None = None,
+            lowest_supported_version: TLSVersion | None = None,
+            highest_supported_version: TLSVersion | None = None,
+            trust_store: TrustStore | None = None,
+        ) -> None:
+            if inner_protocols is None:
+                inner_protocols = []
+
+            self._certificate_chain = certificate_chain
+            self._ciphers = ciphers
+            self._inner_protocols = inner_protocols
+            self._lowest_supported_version = lowest_supported_version
+            self._highest_supported_version = highest_supported_version
+            self._trust_store = trust_store
+
+        @property
+        def certificate_chain(self) -> Sequence[SigningChain] | None:
+            return self._certificate_chain
+
+        @property
+        def ciphers(self) -> Sequence[CipherSuite | int] | None:
+            return self._ciphers
+
+        @property
+        def inner_protocols(self) -> Sequence[NextProtocol | bytes]:
+            return self._inner_protocols
+
+        @property
+        def lowest_supported_version(self) -> TLSVersion | None:
+            return self._lowest_supported_version
+
+        @property
+        def highest_supported_version(self) -> TLSVersion | None:
+            return self._highest_supported_version
+
+        @property
+        def trust_store(self) -> TrustStore | None:
+            return self._trust_store
+
 
 Context
 ~~~~~~~

--- a/peps/pep-0748.rst
+++ b/peps/pep-0748.rst
@@ -1073,7 +1073,9 @@ The definitions of the errors are below:
 
     class ConfigurationError(TLSError):
         """A special exception that implementations can use when the provided
-        configuration uses features not supported by that implementation."""
+        configuration uses features not supported by that implementation. Do not
+        use this exception when the provided configuration is invalid, use
+        standard exceptions instead."""
 
 
 Certificates


### PR DESCRIPTION
First time contributor :tada:

A few suggestions to make the configuration a bit more explicit. I decided to leave most of the attributes undocumented as they are pretty explicit to me, and to instead only document the few attributes that are different from the client and the server.

### [PEP 748: ConfigurationError is only for unsupported features](https://github.com/python/peps/commit/b3229ec84b803a0b4240c1287b66eb3f9c33bf1e)

Discussed at https://github.com/trailofbits/tlslib.py/issues/72#issuecomment-3409443129

> ConfigurationError was intended for when specific implementations don't support certain behavior (e.g. adding a certificate by identifier). I think ValueError should be fine, probably raised when validating the configuration. *~Joop*

### [PEP 748: certificate_chain is mandatory server-side](https://github.com/python/peps/commit/ea0b73f34c78b034e0ace18b5d7738e5efc2d125)

Discussed at https://discuss.python.org/t/pre-pep-discussion-revival-of-pep-543-a-unified-tls-api-for-python/51263/75

> This makes sense to me. We can allow empty server certificates in the insecure module. *~Joop*

### [PEP 748: disambiguate config trust_store=None](https://github.com/python/peps/commit/6e61445101d6657d90de403ed722395b6d2ec4c7)

Discussed at https://discuss.python.org/t/pre-pep-discussion-revival-of-pep-543-a-unified-tls-api-for-python/51263/78

> I agree, this is better. *~Joop*