### PR TITLE
PEP 748: tlslib - context & socket

### DIFF
--- a/peps/pep-0748.rst
+++ b/peps/pep-0748.rst
@@ -390,7 +390,7 @@ The ``ServerContext`` protocol class has the following class definition:
             ...
 
         @abstractmethod
-        def create_buffer(self, server_hostname: str) -> TLSBuffer:
+        def create_buffer(self) -> TLSBuffer:
             """Creates a TLSBuffer that acts as an in-memory channel,
             and contains information about the TLS exchange
             (cipher, negotiated_protocol, negotiated_tls_version, etc.)."""

--- a/peps/pep-0748.rst
+++ b/peps/pep-0748.rst
@@ -422,7 +422,7 @@ need to implement the following:
 
 * ``recv`` and ``send``
 * ``accept`` (server-side)
-* ``close``
+* ``shutdown`` and ``close``
 * ``getsockname``
 * ``getpeername``
 
@@ -437,6 +437,12 @@ connection, such as:
 The following code describes these functions in more detail:
 
 .. code-block:: python
+
+    class TLSShutdownMode(enum.IntEnum):
+        SHUT_RD = 0
+        SHUT_WR = 1
+        SHUT_RDWR = 2
+
 
     class TLSSocket(Protocol):
         """This class implements a socket.socket-like object that creates an OS
@@ -464,15 +470,41 @@ The following code describes these functions in more detail:
             ...
 
         @abstractmethod
-        def close(self, force: bool = False) -> None:
-            """Shuts down the connection and mark the socket closed.
-            If force is True, this method should send the close_notify alert and shut down
-            the socket without waiting for the other side.
-            If force is False, this method should send the close_notify alert and raise
-            the WantReadError exception until a corresponding close_notify alert has been
-            received from the other side.
-            In either case, this method should return WantWriteError if sending the
-            close_notify alert currently fails."""
+        def shutdown(self, how: TLSShutdownMode) -> None:
+            """
+            Shutdown TLS and the underlying socket.
+
+            * ``SHUT_RD`` (``0``) unilateraly close the receiving-side: discard
+              present and future unread messages.
+            * ``SHUT_WR`` (``1``) gracefully close the sending-side: send a
+              closing alert and prevent sending more messages.
+            * ``SHUT_RDWR`` (``2``): both ``SHUT_WR`` and ``SHUT_RD``.
+
+            .. danger::
+
+                Both ``shutdown(SHUT_RD)`` and ``shutdown(SHUT_RDWR)`` pose a
+                risk of data loss: they are unsafe unless the connection is
+                otherwise known to be over or when truncation is not an issue.
+
+                In TLS 1.2, the same risk applies also to ``shutdown(SHUT_WR)``.
+            """
+            ...
+
+        @abstractmethod
+        def close(self) -> None:
+            """
+            Close the underlying socket, but only when it is safe to do so.
+
+            When the sending-side of the connection is still open, it gracefully
+            closes the TLS sending-side before closing the socket, raising
+            ``WantWriteError`` when it fails.
+
+            When the receiving-side of the connection is still open, it always
+            raises ``WantReadError`` as there's a risk of data loss / truncation
+            attack. The user must first either: (safe) ``recv`` until the peer
+            closes its sending-side of the connection, or (unsafe) take the risk
+            and unilateraly ``shutdown`` the receiving-side of the connection.
+            """
             ...
 
         @abstractmethod

--- a/peps/pep-0748.rst
+++ b/peps/pep-0748.rst
@@ -351,7 +351,15 @@ The ``ClientContext`` protocol class has the following class definition:
             ...
 
         @abstractmethod
-        def connect(self, address: tuple[str | None, int]) -> TLSSocket:
+        def create_connection(
+            self,
+            address: tuple[str | None, bytes | str | int | None],
+            timeout: float | None = ...,
+            source_address: _Address | None = None,
+            *,
+            all_errors: bool = False,
+            sever_hostname: str | None = None,
+        ) -> TLSSocket:
             """Creates a TLSSocket that behaves like a socket.socket, and
             contains information about the TLS exchange
             (cipher, negotiated_protocol, negotiated_tls_version, etc.).
@@ -382,9 +390,18 @@ The ``ServerContext`` protocol class has the following class definition:
             ...
 
         @abstractmethod
-        def connect(self, address: tuple[str | None, int]) -> TLSSocket:
-            """Creates a TLSSocket that behaves like a socket.socket, and
-            contains information about the TLS exchange
+        def create_server(
+            self,
+            address: _Address,
+            *,
+            family: int = socket.AF_INET,
+            backlog: int | None = None,
+            reuse_port: bool = False,
+            dualstack_ipv6: bool = False,
+        ) -> TLSSocket:
+            """Creates a listening socket with an accept() function that returns
+            a TLSSocket that behaves like a socket.socket, and contains
+            information about the TLS exchange
             (cipher, negotiated_protocol, negotiated_tls_version, etc.).
             """
             ...
@@ -404,7 +421,7 @@ specification of the ``TLSSocket`` protocol class. Specifically, implementations
 need to implement the following:
 
 * ``recv`` and ``send``
-* ``listen`` and ``accept``
+* ``accept`` (server-side)
 * ``close``
 * ``getsockname``
 * ``getpeername``
@@ -456,13 +473,6 @@ The following code describes these functions in more detail:
             received from the other side.
             In either case, this method should return WantWriteError if sending the
             close_notify alert currently fails."""
-            ...
-
-        @abstractmethod
-        def listen(self, backlog: int) -> None:
-            """Enable a server to accept connections. If backlog is specified, it
-            specifies the number of unaccepted connections that the system will allow
-            before refusing new connections."""
             ...
 
         @abstractmethod

--- a/peps/pep-0748.rst
+++ b/peps/pep-0748.rst
@@ -365,7 +365,36 @@ The ``ClientContext`` protocol class has the following class definition:
             (cipher, negotiated_protocol, negotiated_tls_version, etc.)."""
             ...
 
-The ``ServerContext`` is similar, taking a ``TLSServerConfiguration`` instead.
+The ``ServerContext`` protocol class has the following class definition:
+
+.. code-block:: python
+
+    class ServerContext(Protocol):
+        @abstractmethod
+        def __init__(self, configuration: TLSServerConfiguration) -> None:
+            """Create a new server context object from a given TLS server configuration."""
+            ...
+
+        @property
+        @abstractmethod
+        def configuration(self) -> TLSServerConfiguration:
+            """Returns the TLS server configuration that was used to create the server context."""
+            ...
+
+        @abstractmethod
+        def connect(self, address: tuple[str | None, int]) -> TLSSocket:
+            """Creates a TLSSocket that behaves like a socket.socket, and
+            contains information about the TLS exchange
+            (cipher, negotiated_protocol, negotiated_tls_version, etc.).
+            """
+            ...
+
+        @abstractmethod
+        def create_buffer(self, server_hostname: str) -> TLSBuffer:
+            """Creates a TLSBuffer that acts as an in-memory channel,
+            and contains information about the TLS exchange
+            (cipher, negotiated_protocol, negotiated_tls_version, etc.)."""
+            ...
 
 Socket
 ~~~~~~


### PR DESCRIPTION
### [PEP 748: create_connection and create_server instead of connect](https://github.com/python/peps/commit/785c0c4e0b4b78d4869c933cd28cce6a7273a349)

Prior discussions at:
* https://github.com/trailofbits/tlslib.py/pull/68
* https://github.com/trailofbits/tlslib.py/pull/75

That commit is the solution to my struggle binding an Ipv6 localhost address when I first tested tlslib. At the time the library was always binding the socket using `family=AF_INET`. The solution we implemented in tlslib is to perform a DNS request on the user-provided address to determine the family to use (`family=AF_INET6` in my case).

I'm still unhappy with this API server-side. "connect" is the wrong verb, it should be "bind". It is not obvious if other sockets are supported (e.g. Unix Domain Socket).

`create_connection` and `create_server` make so much more sense to me, at least as long as we don't have a `wrap_socket` function.

### [PEP 748: shutdown(show: 0|1|2) instead of close(force: bool)](https://github.com/python/peps/commit/3d40e2fe33caab5986a6a52c30d8c0126da157c5)

Prior discussions:
* https://discuss.python.org/t/pre-pep-discussion-revival-of-pep-543-a-unified-tls-api-for-python/51263/72 (Close Notify part)
* https://discuss.python.org/t/pre-pep-discussion-revival-of-pep-543-a-unified-tls-api-for-python/51263/76
* https://discuss.python.org/t/pre-pep-discussion-revival-of-pep-543-a-unified-tls-api-for-python/51263/79

Work in progress in siotls:
* https://codeberg.org/drlazor8/siotls/pulls/26

The messages I wrote on the forum explain the problems I have with `close(force: bool)`, which mainly boils down to "it feels too TLS 1.2-ish". I spent many days exploring ideas to have a clean API to terminate the TLS connection a way that is safe in both TLS 1.2 (synchronous termination) and TLS 1.3 (asynchronous and IMO better). Reusing `socket`'s `shutdown` terminology feels right to me. It works well for TLS 1.3 and is fine for TLS 1.2.

There are other things in the current Buffer & Socket spec that I find are leaking openssl's API, and that I expect won't work very well with other TLS libraries (including my own) but I'm not ready at this time to make new proposals.