### PR TITLE
PEP 797, 828: Defer to 3.16

### DIFF
--- a/peps/pep-0797.rst
+++ b/peps/pep-0797.rst
@@ -5,7 +5,7 @@ Discussions-To: https://discuss.python.org/t/105709
 Status: Draft
 Type: Standards Track
 Created: 08-Aug-2025
-Python-Version: 3.15
+Python-Version: 3.16
 Post-History: `01-Jul-2025 <https://discuss.python.org/t/97306>`__,
               `13-Jan-2026 <https://discuss.python.org/t/105709>`__,
 

--- a/peps/pep-0828.rst
+++ b/peps/pep-0828.rst
@@ -5,7 +5,7 @@ Discussions-To: https://discuss.python.org/t/106459
 Status: Draft
 Type: Standards Track
 Created: 07-Mar-2026
-Python-Version: 3.15
+Python-Version: 3.16
 Post-History: `07-Mar-2026 <https://discuss.python.org/t/106430>`__,
               `09-Mar-2026 <https://discuss.python.org/t/106459>`__
 


### PR DESCRIPTION
* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)