### PR TITLE
PEP 830: Target Python 3.16

### DIFF
--- a/peps/pep-0830.rst
+++ b/peps/pep-0830.rst
@@ -5,7 +5,7 @@ Discussions-To: https://discuss.python.org/t/106942
 Status: Draft
 Type: Standards Track
 Created: 15-Mar-2026
-Python-Version: 3.15
+Python-Version: 3.16
 Post-History: `12-Apr-2026 <https://discuss.python.org/t/106942>`__,
               `18-Apr-2026 <https://discuss.python.org/t/pep-830-add-timestamps-to-exceptions-and-tracebacks/106942/27>`__
 


### PR DESCRIPTION
Re: 
* https://github.com/python/steering-council/issues/348#issuecomment-4392555169
* https://discuss.python.org/t/pep-830-add-timestamps-to-exceptions-and-tracebacks/106942/29

@gpshead Would you like to retarget 3.16?
