### PR TITLE
PEP 745: 3.14.5 released on 2026-05-10

### DIFF
--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -69,10 +69,10 @@ Actual:
 - 3.14.3: Tuesday, 2026-02-03
 - 3.14.4: Tuesday, 2026-04-07
 - 3.14.5 candidate 1: Monday, 2026-05-04
+- 3.14.5: Sunday, 2026-05-10
 
 Expected:
 
-- 3.14.5: Sunday, 2026-05-10
 - 3.14.6: Tuesday, 2026-06-09
 - 3.14.7: Tuesday, 2026-08-04
 - 3.14.8: Tuesday, 2026-10-06

--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3504,7 +3504,7 @@ date = 2026-05-04
 
 [[release."3.14"]]
 stage = "3.14.5"
-state = "expected"
+state = "actual"
 date = 2026-05-10
 
 [[release."3.14"]]


### PR DESCRIPTION
* https://blog.python.org/2026/05/python-3145-is-out/
* https://www.python.org/downloads/release/python-3145/
