### PR TITLE
PEP 827: Minor fixes and cleanups

### DIFF
--- a/peps/pep-0827.rst
+++ b/peps/pep-0827.rst
@@ -613,8 +613,7 @@ Boolean operators
   Technically this relation is "consistency" in the typing spec, not
   equivalence.
 
-* ``Bool[T]``: Returns ``Literal[True]`` if ``T`` is also
-  ``Literal[True]`` or a union containing it.
+* ``Bool[T]``: Returns ``Literal[True]`` if ``T`` is also ``Literal[True]``.
   Equivalent to ``IsAssignable[T, Literal[True]] and not IsAssignable[T, Never]``.
 
   This is useful for invoking "helper aliases" that return a boolean
@@ -640,7 +639,7 @@ Basic operators
   fail in a runtime evaluator of types.)
 
   Special forms require special handling: the arguments list of a
-  ``Callable`` will be packed in a tuple and a ``...`` will be treated
+  ``Callable`` will be packed in a ``Params`` and a ``...`` will be treated
   as ``*args: Any`` and ``**kwargs: Any``, represented with the new
   ``Param`` types.
 
@@ -855,8 +854,11 @@ Many of the builtin operations are "lifted" over ``Union``.
 
 For example::
 
-    Concat[Literal['a'] | Literal['b'], Literal['c'] | Literal['d']] = (
-        Literal['ac'] | Literal['ad'] | Literal['bc'] | Literal['bd']
+    Slice[tuple[A, B, C], Literal[0] | Literal[1], Literal[2] | Literal[3]] = (
+        tuple[A, B]
+        | tuple[A, B, C]
+        | tuple[B]
+        | tuple[B, C]
     )
 
 
@@ -1326,7 +1328,7 @@ unbound type variables and let them be generalized::
     type Foo = NewProtocol[
         Member[
             Literal["process"],
-            Callable[[T], set[T] if IsAssignable[T, int] else T]
+            Callable[[T], T if IsAssignable[T, list] else list[T]]
         ]
     ]
 
@@ -1340,6 +1342,18 @@ in a lambda, we can delay evaluation in both of these cases.  (The
 functions with explicit generic annotations. For old-style generics,
 we'll probably have to try to evaluate it and then raise an error when
 we encounter a variable.)
+
+With our real syntax, this look likes::
+
+    type Foo = NewProtocol[
+        Member[
+            Literal["process"],
+            GenericCallable[
+                tuple[T],
+                lambda T: Callable[[T], T if IsAssignable[T, list] else list[T]],
+            ],
+        ]
+    ]
 
 The reason we suggest restricting the use of ``GenericCallable`` to
 the type argument of ``Member`` is because impredicative


### PR DESCRIPTION
 * Fix description of ``Bool[T]`` to match the definition
 * Update commentary about ``GetArg`` special forms to match change from #4866
 * Update lifting example to use an operator that is still in the spec
 * Make the ``GenericCallable`` rationale example more self-consistent
 * Have an example of ``GenericCallable``

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)
