### PR TITLE
PEP 808: Mark as Accepted

### DIFF
--- a/peps/pep-0808.rst
+++ b/peps/pep-0808.rst
@@ -5,12 +5,13 @@ Author: Henry Schreiner <henryschreineriii@gmail.com>,
 Sponsor: Filipe Laíns <lains@python.org>
 PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/104883
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Topic: Packaging
 Created: 19-Sep-2025
 Post-History: `17-Apr-2025 <https://discuss.python.org/t/88608>`__,
               `14-Nov-2025 <https://discuss.python.org/t/104883>`__
+Resolution: `19-May-2026 <https://discuss.python.org/t/104883/39>`__
 
 
 Abstract


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [ ] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date
