### PR TITLE
PEP 827: Switch ParamKind to be a proper enum

### DIFF
--- a/peps/pep-0827.rst
+++ b/peps/pep-0827.rst
@@ -379,29 +379,32 @@ We introduce a ``Param`` type that contains all the information about a function
     class Param[
         N: str | None,
         T,
-        K: ParamKind = Literal["positional_or_keyword"],
+        K: ParamKind = Literal[ParamKind.POSITIONAL_OR_KEYWORD],
         D = typing.Never,
     ]:
         pass
 
-    ParamKind = typing.Literal[
-        "*", "**", "keyword", "positional", "positional_or_keyword"
-    ]
+    class ParamKind(enum.IntEnum):
+        POSITIONAL_ONLY = 0
+        POSITIONAL_OR_KEYWORD = 1
+        VAR_POSITIONAL = 2
+        KEYWORD_ONLY = 3
+        VAR_KEYWORD = 4
 
-    type PosParam[T] = Param[None, T, Literal["positional"]]
-    type PosDefaultParam[T] = Param[None, T, Literal["positional"], T]
-    type DefaultParam[N: str, T] = Param[N, T, Literal["positional_or_keyword"], T]
-    type NamedParam[N: str, T] = Param[N, T, Literal["keyword"]]
-    type NamedDefaultParam[N: str, T] = Param[N, T, Literal["keyword"], T]
-    type ArgsParam[T] = Param[None, T, Literal["*"]]
-    type KwargsParam[T] = Param[None, T, Literal["**"]]
+    type PosParam[T] = Param[None, T, Literal[ParamKind.POSITIONAL_ONLY]]
+    type PosDefaultParam[T] = Param[None, T, Literal[ParamKind.POSITIONAL_ONLY], T]
+    type DefaultParam[N: str, T] = Param[N, T, Literal[ParamKind.POSITIONAL_OR_KEYWORD], T]
+    type NamedParam[N: str, T] = Param[N, T, Literal[ParamKind.KEYWORD_ONLY]]
+    type NamedDefaultParam[N: str, T] = Param[N, T, Literal[ParamKind.KEYWORD_ONLY], T]
+    type ArgsParam[T] = Param[None, T, Literal[ParamKind.VAR_POSITIONAL]]
+    type KwargsParam[T] = Param[None, T, Literal[ParamKind.VAR_KEYWORD]]
 
 
 The argument ``K``, of type ``ParamKind``, represents the parameter
 kind of the parameter, and defaults to the ordinary
-``Literal["positional_or_keyword"]``. It is an error to create
-``Callable`` with a ``Param`` containing multiple kinds unioned
-together.
+``Literal[ParamKind.POSITIONAL_OR_KEYWORD]``. ``ParamKind`` mirrors
+``inspect._ParameterKind``. It is an error to create ``Callable``
+with a ``Param`` containing multiple kinds unioned together.
 
 The argument ``D`` carries the type of the parameter's default, if one
 exists, and is ``Never`` otherwise. When the default value is a
@@ -438,13 +441,13 @@ as::
 
     Callable[
         Params[
-            Param[Literal["a"], int, Literal["positional"]],
+            Param[Literal["a"], int, Literal[ParamKind.POSITIONAL_ONLY]],
             Param[Literal["b"], int],
-            Param[Literal["c"], int, Literal["positional_or_keyword"], Literal[0]],
-            Param[None, int, Literal["*"]],
-            Param[Literal["d"], int, Literal["keyword"]],
-            Param[Literal["e"], int, Literal["keyword"], Literal[0]],
-            Param[None, int, Literal["**"]],
+            Param[Literal["c"], int, Literal[ParamKind.POSITIONAL_OR_KEYWORD], Literal[0]],
+            Param[None, int, Literal[ParamKind.VAR_POSITIONAL]],
+            Param[Literal["d"], int, Literal[ParamKind.KEYWORD_ONLY]],
+            Param[Literal["e"], int, Literal[ParamKind.KEYWORD_ONLY], Literal[0]],
+            Param[None, int, Literal[ParamKind.VAR_KEYWORD]],
         ],
         int,
     ]
@@ -1124,7 +1127,7 @@ based on iterating over all attributes.
                         p.name,
                         p.type,
                         # All arguments are keyword-only
-                        Literal["keyword"],
+                        Literal[ParamKind.KEYWORD_ONLY],
                         # GetDefault is Never when there's no default, so use it
                         # directly as D.
                         GetDefault[p.init],
@@ -1902,11 +1905,6 @@ Open Issues
   configurable in the ``TypedDict`` serving as the bound somehow? If
   ``readonly`` had been added as a parameter to ``TypedDict`` we would
   use that, but it wasn't.
-
-* :ref:`Extended Callables <pep827-extended-callables-prereq>`: Currently the
-  qualifiers are short strings for code brevity, but an alternate approach
-  would be to mirror ``inspect.Signature`` more directly, and have an enum
-  with names like ``ParamKind.POSITIONAL_OR_KEYWORD``. Would that be better?
 
 * :ref:`Members <pep827-members>`: Should ``Members`` return all
   methods, even those without annotations? We excluded them out of the


### PR DESCRIPTION
* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)
