### PR TITLE
PEP 101: document +dev suffix for untagged builds (PEP 440 compliance)

### DIFF
--- a/peps/pep-0101.rst
+++ b/peps/pep-0101.rst
@@ -469,7 +469,7 @@ the main repo.
   do some post-merge cleanup.  Check the top-level ``README.rst``
   and ``include/patchlevel.h`` files to ensure they now reflect
   the desired post-release values for on-going development.
-  The patchlevel should be the release tag with a ``+``.
+  The patchlevel should be the release tag with a ``+dev``.
   Also, if you cherry-picked changes from the standard release
   branch into the release engineering branch for this release,
   you will now need to manually remove each blurb entry from


### PR DESCRIPTION
Related to https://github.com/python/cpython/issues/99968 

Needs https://github.com/python/release-tools/pull/394