### PR TITLE
PEP 800: mark as Final

### DIFF
--- a/peps/pep-0800.rst
+++ b/peps/pep-0800.rst
@@ -2,7 +2,7 @@ PEP: 800
 Title: Disjoint bases in the type system
 Author: Jelle Zijlstra <jelle.zijlstra@gmail.com>
 Discussions-To: https://discuss.python.org/t/99910/
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Typing
 Created: 21-Jul-2025
@@ -10,6 +10,9 @@ Python-Version: 3.15
 Post-History: `18-Jul-2025 <https://discuss.python.org/t/solid-bases-for-detecting-incompatible-base-classes/99280>`__,
               `23-Jul-2025 <https://discuss.python.org/t/99910>`__,
 Resolution: `15-Apr-2026 <https://discuss.python.org/t/pep-800-solid-bases-in-the-type-system/99910/41>`__
+
+.. canonical-typing-spec:: :ref:`typing:disjoint-base` and
+                           :external+py3.15:func:`@typing.disjoint_base <typing.disjoint_base>`
 
 
 Abstract


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [x] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)
