### PR TITLE
PEP 790: 3.15.0 beta 2 released on 2026-06-02

### DIFF
--- a/peps/pep-0790.rst
+++ b/peps/pep-0790.rst
@@ -46,10 +46,10 @@ Actual:
 - 3.15.0 alpha 8: Tuesday, 2026-04-07
 - 3.15.0 beta 1: Thursday, 2026-05-07
   (No new features beyond this point.)
+- 3.15.0 beta 2: Tuesday, 2026-06-02
 
 Expected:
 
-- 3.15.0 beta 2: Tuesday, 2026-06-02
 - 3.15.0 beta 3: Tuesday, 2026-06-23
 - 3.15.0 beta 4: Saturday, 2026-07-18
 - 3.15.0 candidate 1: Tuesday, 2026-08-04

--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3612,7 +3612,7 @@ date = 2026-05-07
 
 [[release."3.15"]]
 stage = "3.15.0 beta 2"
-state = "expected"
+state = "actual"
 date = 2026-06-02
 
 [[release."3.15"]]


### PR DESCRIPTION
https://discuss.python.org/t/python-3-15-0-beta-2-is-here/107610