### PR TITLE
PEP 753: mark as Final

### DIFF
--- a/peps/pep-0753.rst
+++ b/peps/pep-0753.rst
@@ -5,7 +5,7 @@ Author: William Woodruff <william@yossarian.net>,
 Sponsor: Barry Warsaw <barry at python.org>
 PEP-Delegate: Paul Moore <p.f.moore at gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-753-uniform-urls-in-core-metadata/62792
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Packaging
 Created: 29-Aug-2024


### PR DESCRIPTION
This PEP has been final for a while, per its canonical PyPA spec (which has also been linked in the PEP for a while):

https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-project-urls

(This was my own fault, I probably forgot to update this.)

CC @facutuesca as co-editor