### PR TITLE
PEP 719, 745: 3.13.14, 3.14.6 released on 2026-06-10

### DIFF
--- a/peps/pep-0719.rst
+++ b/peps/pep-0719.rst
@@ -77,10 +77,10 @@ Actual:
 - 3.13.11: Friday, 2025-12-05
 - 3.13.12: Tuesday, 2026-02-03
 - 3.13.13: Tuesday, 2026-04-07
+- 3.13.14: Wednesday, 2026-06-10
 
 Expected:
 
-- 3.13.14: Tuesday, 2026-06-09
 - 3.13.15: Tuesday, 2026-08-04
 - 3.13.16: Tuesday, 2026-10-06
   (Final regular bugfix release with binary installers)

--- a/peps/pep-0745.rst
+++ b/peps/pep-0745.rst
@@ -70,10 +70,10 @@ Actual:
 - 3.14.4: Tuesday, 2026-04-07
 - 3.14.5 candidate 1: Monday, 2026-05-04
 - 3.14.5: Sunday, 2026-05-10
+- 3.14.6: Wednesday, 2026-06-10
 
 Expected:
 
-- 3.14.6: Tuesday, 2026-06-09
 - 3.14.7: Tuesday, 2026-08-04
 - 3.14.8: Tuesday, 2026-10-06
 - 3.14.9: Tuesday, 2026-12-01

--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3376,8 +3376,8 @@ date = 2026-04-07
 
 [[release."3.13"]]
 stage = "3.13.14"
-state = "expected"
-date = 2026-06-09
+state = "actual"
+date = 2026-06-10
 
 [[release."3.13"]]
 stage = "3.13.15"
@@ -3509,8 +3509,8 @@ date = 2026-05-10
 
 [[release."3.14"]]
 stage = "3.14.6"
-state = "expected"
-date = 2026-06-09
+state = "actual"
+date = 2026-06-10
 
 [[release."3.14"]]
 stage = "3.14.7"


### PR DESCRIPTION
* https://www.python.org/downloads/release/python-3146/
* 3.13 coming soon