### PR TITLE
Infra: change `<article>` to `<main>`

### DIFF
--- a/pep_sphinx_extensions/pep_theme/static/mq.css
+++ b/pep_sphinx_extensions/pep_theme/static/mq.css
@@ -38,7 +38,7 @@
         padding: 0.5rem 1rem 0;
         width: 100%;
     }
-    section#pep-page-section > article,
+    section#pep-page-section > main,
     section#pep-page-section > footer#pep-page-footer {
         max-width: 37em;
         width: 74%;
@@ -65,7 +65,7 @@
   }
 }
 @media (min-width: 60em) {
-    section#pep-page-section > article,
+    section#pep-page-section > main,
     section#pep-page-section > footer#pep-page-footer {
         max-width: 56em;
         padding-left: 3.2%;
@@ -83,7 +83,7 @@
         font-size: 10pt;
         line-height: 1.67;
     }
-    *[role="main"] a[href]:after {
+    main a[href]:after {
         content: " (" attr(href) ")";
         font-size: .75rem;
     }
@@ -163,7 +163,7 @@
         display: none;
     }
 
-    section#pep-page-section > article,
+    section#pep-page-section > main,
     section#pep-page-section > footer#pep-page-footer {
         float: none;
         max-width: 100%;

--- a/pep_sphinx_extensions/pep_theme/static/style.css
+++ b/pep_sphinx_extensions/pep_theme/static/style.css
@@ -288,7 +288,7 @@ table.pep-zero-table tr td:nth-child(5) {
 }
 
 /* Numerical index */
-article:has(> section#numerical-index) {
+main:has(> section#numerical-index) {
     float: unset !important;
     width: 90% !important;
     max-width: 90% !important;

--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -53,14 +53,14 @@
         </div>
         {# Exclude noisy non-PEP pages from Pagefind indexing #}
         {%- if pagename.startswith(("404", "numerical", "pep-0000", "topic")) %}
-        <article>
+        <main>
         {%- else %}
-        <article data-pagefind-body>
+        <main data-pagefind-body>
         {%- endif %}
             {# Add pagefind meta for the title to improve search result display #}
             <span data-pagefind-meta="title:{{ title }}" data-pagefind-weight="10" class="visually-hidden">{{ title }}</span>
             {{ body }}
-        </article>
+        </main>
         {%- if not pagename.startswith(("404", "numerical")) %}
         <nav id="pep-sidebar">
             <pagefind-searchbox shortcut="/" style="font-family: inherit"></pagefind-searchbox>


### PR DESCRIPTION
Follow on from https://github.com/python/peps/pull/4977.

We still get "697 files changed · ± 697 modified" on the Read the Docs previews: https://github.com/python/peps/pull/4994#issuecomment-4670664344.

The [detection logic](https://docs.readthedocs.com/platform/stable/reference/main-content-detection.html#detection-logic) is:

> 1. **Elements with `role="main"` attribute:** This ARIA role is used by many static site generators and themes to indicate the main content area.
> 2. **The `<main>` HTML tag:** The semantic HTML5 element for main content.
> 3. **Parent of the first `<h1>` tag:** If no explicit main content markers are found, the system assumes all sections are siblings under a common parent, and uses the parent of the first heading as the main content container.
> 4. **The `<body>` tag:** As a last resort, if none of the above are found, the entire body is used.

Let's go for 2 and use `<main>` instead of `<article role="main">`:

Both have good semantics: there can be multiple `article`s in a page (we have just one), or a single `main`. But `main` is also a "landmark", which helps accessibility:

> The `<main>` element behaves like a [main landmark](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/main_role) role. [Landmarks](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Techniques#landmark_roles) can be used by assistive technology to quickly identify and navigate to large sections of the document. Prefer using the `<main>` element over declaring `role="main"`, unless there are [legacy browser support concerns](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/main#browser_compatibility).

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/main

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/article