### PR TITLE
PEP 835: Update Discussions-To and Post-History with official thread

### DIFF
--- a/peps/pep-0835.rst
+++ b/peps/pep-0835.rst
@@ -2,13 +2,14 @@ PEP: 835
 Title: Shorthand syntax for Annotated type metadata
 Author: Till Varoquaux <till.varoquaux@gmail.com>
 Sponsor: Ivan Levkivskyi <levkivskyi@gmail.com>
-Discussions-To: https://discuss.python.org/t/106888
+Discussions-To: https://discuss.python.org/t/pep-835-shorthand-syntax-for-annotated-type-metadata/107795
 Status: Draft
 Type: Standards Track
 Topic: Typing
 Created: 12-Jun-2026
 Python-Version: 3.16
-Post-History: `19-Apr-2026 <https://discuss.python.org/t/shorthand-syntax-for-annotated-type-metadata/106888>`__
+Post-History: `19-Apr-2026 <https://discuss.python.org/t/shorthand-syntax-for-annotated-type-metadata/106888>`__,
+              `18-Jun-2026 <https://discuss.python.org/t/pep-835-shorthand-syntax-for-annotated-type-metadata/107795>`__
 
 Abstract
 ========

--- a/peps/pep-0835.rst
+++ b/peps/pep-0835.rst
@@ -9,7 +9,7 @@ Topic: Typing
 Created: 12-Jun-2026
 Python-Version: 3.16
 Post-History: `19-Apr-2026 <https://discuss.python.org/t/shorthand-syntax-for-annotated-type-metadata/106888>`__,
-              `18-Jun-2026 <https://discuss.python.org/t/pep-835-shorthand-syntax-for-annotated-type-metadata/107795>`__
+              `18-Jun-2026 <https://discuss.python.org/t/pep-835-shorthand-syntax-for-annotated-type-metadata/107795>`__,
 
 Abstract
 ========


### PR DESCRIPTION
This is a minor follow-up to the initial draft merged in #4995.

The official Discourse thread for PEP 835 has now been published. This PR updates `peps/pep-0835.rst` with the new metadata:
* Updates `Discussions-To:` to point to the new thread.
* Appends the new posting date (18-Jun-2026) and link to the `Post-History:` header.