### PR TITLE
PEP 835: Fix Discourse link

### DIFF
--- a/peps/pep-0835.rst
+++ b/peps/pep-0835.rst
@@ -2,14 +2,14 @@ PEP: 835
 Title: Shorthand syntax for Annotated type metadata
 Author: Till Varoquaux <till.varoquaux@gmail.com>
 Sponsor: Ivan Levkivskyi <levkivskyi@gmail.com>
-Discussions-To: https://discuss.python.org/t/pep-835-shorthand-syntax-for-annotated-type-metadata/107795
+Discussions-To: https://discuss.python.org/t/pep-835-shorthand-syntax-for-annotated-type-metadata/107814
 Status: Draft
 Type: Standards Track
 Topic: Typing
 Created: 12-Jun-2026
 Python-Version: 3.16
 Post-History: `19-Apr-2026 <https://discuss.python.org/t/shorthand-syntax-for-annotated-type-metadata/106888>`__,
-              `18-Jun-2026 <https://discuss.python.org/t/pep-835-shorthand-syntax-for-annotated-type-metadata/107795>`__,
+              `18-Jun-2026 <https://discuss.python.org/t/pep-835-shorthand-syntax-for-annotated-type-metadata/107814>`__,
 
 Abstract
 ========


### PR DESCRIPTION
Re: https://discuss.python.org/t/pep-835-shorthand-syntax-for-annotated-type-metadata/107814/19

cc @till-varoquaux 