### PR TITLE
PEP 833: Mark as Final

### DIFF
--- a/peps/pep-0833.rst
+++ b/peps/pep-0833.rst
@@ -4,13 +4,16 @@ Author: William Woodruff <william@yossarian.net>
 Sponsor: Donald Stufft <donald@stufft.io>
 PEP-Delegate: Donald Stufft <donald@stufft.io>
 Discussions-To: https://discuss.python.org/t/pep-833-freezing-the-html-simple-repository-api/107051
-Status: Accepted
+Status: Final
 Type: Standards Track
 Topic: Packaging
 Created: 21-Apr-2026
 Post-History: `13-Apr-2026 <https://discuss.python.org/t/106959>`__,
               `21-Apr-2026 <https://discuss.python.org/t/107051>`__,
 Resolution: `20-May-2026 <https://discuss.python.org/t/107051/34>`__
+
+.. canonical-pypa-spec:: :ref:`packaging:simple-repository-api`
+
 
 Abstract
 ========


### PR DESCRIPTION
Following https://github.com/pypa/packaging.python.org/pull/2066, PEP 833 is now in the Final state 🙂 