### PR TITLE
PEP 790: 3.15.0 beta 3 released on 2026-06-23

### DIFF
--- a/peps/pep-0790.rst
+++ b/peps/pep-0790.rst
@@ -47,10 +47,10 @@ Actual:
 - 3.15.0 beta 1: Thursday, 2026-05-07
   (No new features beyond this point.)
 - 3.15.0 beta 2: Tuesday, 2026-06-02
+- 3.15.0 beta 3: Tuesday, 2026-06-23
 
 Expected:
 
-- 3.15.0 beta 3: Tuesday, 2026-06-23
 - 3.15.0 beta 4: Saturday, 2026-07-18
 - 3.15.0 candidate 1: Tuesday, 2026-08-04
 - 3.15.0 candidate 2: Tuesday, 2026-09-01

--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3617,7 +3617,7 @@ date = 2026-06-02
 
 [[release."3.15"]]
 stage = "3.15.0 beta 3"
-state = "expected"
+state = "actual"
 date = 2026-06-23
 
 [[release."3.15"]]


### PR DESCRIPTION
https://discuss.python.org/t/python-3-15-0-beta-3-is-here/107866