### PR TITLE
PEP 694, 752: Use unique labels to fix warning

### DIFF
--- a/peps/pep-0694.rst
+++ b/peps/pep-0694.rst
@@ -1525,7 +1525,7 @@ A suggested approach:
    compatibility.
 
 
-.. _security-implications:
+.. _pep694-security-implications:
 
 Security Implications
 =====================
@@ -1715,7 +1715,7 @@ Change History
   * Add non-normative :ref:`Recommendations for Client Implementers <client-recommendations>` section
     with suggested UX patterns for tools like twine, uv, and GitHub Actions.
   * Add FAQ entries explaining why project name and version are required at session creation.
-  * Add a :ref:`security-implications` section.
+  * Add a :ref:`pep694-security-implications` section.
   * Specify that attempting to replace an in-progress file upload returns a ``409 Conflict``.
   * Specify that uploading a file matching one already published for an existing release returns a
     ``409 Conflict``, since published artifacts are immutable.

--- a/peps/pep-0752.rst
+++ b/peps/pep-0752.rst
@@ -361,7 +361,7 @@ chosen to signal a shared purpose with a prefix like `typeshed has done`__.
 
 __ https://github.com/python/typeshed/issues/2491#issuecomment-578456045
 
-.. _security-implications:
+.. _pep752-security-implications:
 
 Security Implications
 =====================


### PR DESCRIPTION
Fixes:

```
peps/pep-0694.rst:1531: WARNING: duplicate label security-implications, other instance in peps/pep-0752.rst
```
