### PR TITLE
PEP 752: Fix Sphinx reference error

### DIFF
--- a/peps/pep-0752.rst
+++ b/peps/pep-0752.rst
@@ -222,7 +222,7 @@ changes so that consumers of the API are able to determine whether the
 repository supports this PEP.
 
 The following API changes would allow installers to offer users extra
-`security policies <security-implications_>`_.
+`security policies <pep752-security-implications_>`_.
 
 .. _project-detail:
 


### PR DESCRIPTION
https://github.com/python/peps/pull/4527 and https://github.com/python/peps/pull/5008 passed each other in flight, causing a Sphinx error after they both landed.

https://github.com/python/peps/actions/runs/28398022089/job/84141773937