### PR TITLE
Infra: Link breadcrumbs back to homepage not /pep-0000/

### DIFF
--- a/pep_sphinx_extensions/pep_theme/templates/page.html
+++ b/pep_sphinx_extensions/pep_theme/templates/page.html
@@ -37,7 +37,7 @@
             <h1 data-pagefind-ignore>Python Enhancement Proposals</h1>
             <ul class="breadcrumbs">
                 <li><a href="https://www.python.org/" title="The Python Programming Language">Python</a> &raquo; </li>
-                <li><a href="{{ pathto("pep-0000") }}">PEP Index</a> &raquo; </li>
+                <li><a href="{{ pathto('', resource=True) }}" title="Python Enhancement Proposals (PEPs)">PEP Index</a> &raquo; </li>
                 <li>{{ title.split("–")[0].strip() }}</li>
             </ul>
             <button id="colour-scheme-cycler" onClick="setColourScheme(nextColourScheme())">


### PR DESCRIPTION
<!--
This template is for an infra or meta change not belonging to another category.
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

Right now:

1. Go to https://peps.python.org/
2. Click on a PEP: https://peps.python.org/pep-0008/
3. In the breadcrumbs at the top: "Python » PEP Index » PEP 8", click "PEP Index"

Expected result:

* Taken back to https://peps.python.org/

Actual result:

* Taken to https://peps.python.org/pep-0000/

That `/pep-0000/` is confusing, let's go back to the usual `/` instead.