### PR TITLE
PEP 11: Update link to contacts for third-party ports in the Devguide

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -165,16 +165,16 @@ Unsupported code that *does* cause a maintenance burden, or obstructs
 general improvements, may be rejected or removed from the code base
 without a deprecation process.
 Core team members that do this intentionally are encouraged to notify people
-listed in the `Platforms experts list`_ in the CPython contributor's guide,
+listed in the `Ports and contacts list`_ in the CPython contributor's guide,
 to review any submitted fixes (if unobtrusive), and to consider adding
 configuration or extension capabilities necessary for workarounds.
 
 People interested in unsupported platforms may add themselves to the
-`Platforms experts list`_ to request that they be notified on issues
+`Ports and contacts list`_ to request that they be notified on issues
 related to "their" platform.
 There is, however, no formal guarantee that they *will* be notified.
 
-.. _Platforms experts list: https://devguide.python.org/core-team/experts/#platforms
+.. _Ports and contacts list: https://devguide.python.org/developer-workflow/porting/#ports-and-contacts
 
 Platforms not listed in this PEP may also be supported by the wider Python
 community in other ways. If your desired platform is not listed above,

--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -165,7 +165,7 @@ Unsupported code that *does* cause a maintenance burden, or obstructs
 general improvements, may be rejected or removed from the code base
 without a deprecation process.
 Core team members that do this intentionally are encouraged to notify people
-listed in the `Ports and contacts list`_ in the CPython contributor's guide,
+listed in the `Ports and contacts list`_ in the Python developer's guide,
 to review any submitted fixes (if unobtrusive), and to consider adding
 configuration or extension capabilities necessary for workarounds.
 


### PR DESCRIPTION
This was moved in https://github.com/python/devguide/pull/1839
