### PR TITLE
PEP 828: gold plate AsAsyncIterator and AsAsyncGenerator

### DIFF
--- a/peps/pep-0828.rst
+++ b/peps/pep-0828.rst
@@ -396,6 +396,8 @@ async one before calling ``async yield from``.
         async def __anext__(self):
             try:
                 return self._wrapped.__next__()
+            except StopAsyncIteration as e:
+                raise RuntimeError("async generator raised StopAsyncIteration") from e
             except StopIteration as e:
                 raise StopAsyncIteration(e.value) from e
 
@@ -404,17 +406,24 @@ async one before calling ``async yield from``.
         async def asend(self, value):
             try:
                 return self._wrapped.send(value)
+            except StopAsyncIteration as e:
+                raise RuntimeError("async generator raised StopAsyncIteration") from e
             except StopIteration as e:
                 raise StopAsyncIteration(e.value) from e
 
         async def athrow(self, exc):
             try:
                 return self._wrapped.throw(exc)
+            except StopAsyncIteration as e:
+                raise RuntimeError("async generator raised StopAsyncIteration") from e
             except StopIteration as e:
                 raise StopAsyncIteration(e.value) from e
 
         async def aclose(self):
-            return self._wrapped.close()
+            try:
+                return self._wrapped.close()
+            except StopAsyncIteration as e:
+                raise RuntimeError("async generator raised StopAsyncIteration") from e
 
 
     async def agen():


### PR DESCRIPTION
when writing the wrapper objects I forgot to handle a synchronous generator raising StopAsyncIteration