### PR TITLE
Infra: Pin Pygments to a development version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for building PEPs with Sphinx
 # Sphinx requires >= 2.17. JSON5 support added in 2.19
-Pygments >= 2.19
+pygments @ git+https://github.com/pygments/pygments@2cad2642058441b59782a6a18f03c98c42d081f1
 # Sphinx 6.1.0 broke copying images in parallel builds; fixed in 6.1.2
 # See https://github.com/sphinx-doc/sphinx/pull/11100
 Sphinx >= 5.1.1, != 6.1.0, != 6.1.1, < 8.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Requirements for building PEPs with Sphinx
 
 # Sphinx requires >= 2.17. JSON5 support added in 2.19
-# Temporary direct requirement, pending release of Pygments > 2.20.0
+# Temporary archive install, pending release of Pygments > 2.20.0
 # https://github.com/pygments/pygments/discussions/3145
 pygments @ git+https://github.com/pygments/pygments@2cad2642058441b59782a6a18f03c98c42d081f1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,10 @@
 # Requirements for building PEPs with Sphinx
+
 # Sphinx requires >= 2.17. JSON5 support added in 2.19
+# Temporary direct requirement, pending release of Pygments > 2.20.0
+# https://github.com/pygments/pygments/discussions/3145
 pygments @ git+https://github.com/pygments/pygments@2cad2642058441b59782a6a18f03c98c42d081f1
+
 # Sphinx 6.1.0 broke copying images in parallel builds; fixed in 6.1.2
 # See https://github.com/sphinx-doc/sphinx/pull/11100
 Sphinx >= 5.1.1, != 6.1.0, != 6.1.1, < 8.1.0


### PR DESCRIPTION
This allows the PEP 810 examples to be highlighted correctly. See also https://github.com/python/cpython/issues/153227.