### PR TITLE
PEP 797: Mark as Rejected

### DIFF
--- a/peps/pep-0797.rst
+++ b/peps/pep-0797.rst
@@ -2,12 +2,13 @@ PEP: 797
 Title: Shared Object Proxies
 Author: Peter Bierma <peter@python.org>
 Discussions-To: https://discuss.python.org/t/105709
-Status: Draft
+Status: Rejected
 Type: Standards Track
 Created: 08-Aug-2025
 Python-Version: 3.16
 Post-History: `01-Jul-2025 <https://discuss.python.org/t/97306>`__,
               `13-Jan-2026 <https://discuss.python.org/t/105709>`__,
+Resolution: `08-Jul-2026 <https://discuss.python.org/t/105709/35>`__
 
 
 Abstract


### PR DESCRIPTION
* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [x] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date
