### PR TITLE
PEP 621: Update `requires-python` link to intended `core-metadata` section

### DIFF
--- a/peps/pep-0621.rst
+++ b/peps/pep-0621.rst
@@ -219,7 +219,7 @@ error for unsupported content-types.
 '''''''''''''''''''
 - Format: string
 - `Core metadata`_: ``Requires-Python``
-  (`link <https://packaging.python.org/specifications/core-metadata/#summary>`__)
+  (`link <https://packaging.python.org/specifications/core-metadata/#requires-python>`__)
 - Synonyms
 
   - Flit_: ``requires-python``


### PR DESCRIPTION
Closes: https://github.com/python/peps/issues/5033

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)