### PR TITLE
Fix typo in PEP pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/Add a new PEP.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Add a new PEP.md
@@ -41,6 +41,6 @@ If your PEP is not Standards Track, remove the corresponding section.
     * [ ] Acknowledgements
     * [ ] Footnotes
     * [ ] Change History
-* [ ] ``Python-Version`` set to valid (pre-beta) future Python version, if relevant
+* [ pathum25] ``Python-Version`` set to valid (pre-beta) future Python version, if relevant
 * [ ] Any project stated in the PEP as supporting/endorsing/benefiting from the PEP formally confirmed such
 * [ ] Right before or after initial merging, [PEP discussion thread](https://peps.python.org/pep-0001/#discussing-a-pep) created and linked to in ``Discussions-To`` and ``Post-History``


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

* [ ] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [ ] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [ ] ``Status`` changed to ``Accepted``/``Rejected``
* [ ] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [ ] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [ ] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date
