### PR TITLE
Update PEP link format in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Canonical links
 
 The canonical form of PEP links are zero-padded, such as
 ``https://peps.python.org/pep-0008/``.
-
+https://pathum25//
 Shortcut redirects are also available.
 For example, ``https://peps.python.org/8`` redirects to the canonical link.
 


### PR DESCRIPTION
Fix the PEP link format in the README.

<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about something, just leave it blank and we'll take a look.
-->

* [x] Final implementation has been merged (including tests and docs)
* [x] PEP matches the final implementation
* [x] Any substantial changes since the accepted version approved by the SC/PEP delegate
* [x] Pull request title in appropriate format (``PEP 123: Mark as Final``)
* [x] ``Status`` changed to ``Final`` (and ``Python-Version`` is correct)
* [x] Canonical docs/spec linked with a ``canonical-doc`` directive
      (or ``canonical-pypa-spec`` for packaging PEPs,
       or ``canonical-typing-spec`` for typing PEPs)
