### PR TITLE
PEP 837: Renumber to 840

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -711,7 +711,7 @@ peps/pep-0832.rst  @brettcannon
 peps/pep-0833.rst  @dstufft
 peps/pep-0835.rst  @ilevkivskyi
 peps/pep-0836.rst  @savannahostrowski @Fidget-Spinner @brandtbucher
-peps/pep-0837.rst  @jeremyhylton
+peps/pep-0840.rst  @jeremyhylton
 # ...
 peps/pep-2026.rst  @hugovk
 # ...

--- a/peps/pep-0840.rst
+++ b/peps/pep-0840.rst
@@ -1,4 +1,4 @@
-PEP: 837
+PEP: 840
 Title: Name Resolution in Class Namespaces
 Author: Jeremy Hylton <jeremy@python.org>
 Status: Draft


### PR DESCRIPTION
837-839 are all open PRs. The next available is 840, let's switch this one to that.

For next time, see [hugovk.dev/next-pep-number/](https://hugovk.dev/next-pep-number/) or:

```console
❯ uvx pepotron next
Next available PEP: 840
```
