### PR TITLE
PEP 11: promote aarch64-pc-windows-msvc to Tier 2

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -107,7 +107,7 @@ Tier 2
 Target Triple                 Notes                      Contacts
 ============================= ========================== ========
 aarch64-unknown-linux-gnu     glibc, clang               Victor Stinner, Gregory P. Smith
-aarch64-pc-windows-msvc                                  Steve Dower, Diego Russo
+aarch64-pc-windows-msvc                                  Steve Dower, Diego Russo, Chris Eibl
 wasm32-unknown-wasip1         WASI SDK, Wasmtime         Brett Cannon, Michael Droettboom, Savannah Ostrowski
 x86_64-apple-darwin           macOS, clang               Sam Gross, Barry Warsaw, Ronald Oussoren
 x86_64-unknown-linux-gnu      glibc, clang               Victor Stinner, Gregory P. Smith

--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -107,6 +107,7 @@ Tier 2
 Target Triple                 Notes                      Contacts
 ============================= ========================== ========
 aarch64-unknown-linux-gnu     glibc, clang               Victor Stinner, Gregory P. Smith
+aarch64-pc-windows-msvc                                  Steve Dower, Diego Russo
 wasm32-unknown-wasip1         WASI SDK, Wasmtime         Brett Cannon, Michael Droettboom, Savannah Ostrowski
 x86_64-apple-darwin           macOS, clang               Sam Gross, Barry Warsaw, Ronald Oussoren
 x86_64-unknown-linux-gnu      glibc, clang               Victor Stinner, Gregory P. Smith
@@ -126,7 +127,6 @@ Tier 3
 Target Triple                    Notes                       Contacts
 ================================ =========================== ========
 aarch64-linux-android                                        Russell Keith-Magee, Petr Viktorin
-aarch64-pc-windows-msvc                                      Steve Dower
 arm64-apple-ios                  iOS on device               Russell Keith-Magee, Ned Deily
 arm64-apple-ios-simulator        iOS on M1 macOS simulator   Russell Keith-Magee, Ned Deily
 armv7l-unknown-linux-gnueabihf   32-bit Raspberry Pi OS, gcc Gregory P. Smith


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

This is following the discussion https://discuss.python.org/t/python-on-windows-arm64/104524/

* Change is either:
    * [ ] To a Draft PEP
    * [X] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [X] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)
