### PR TITLE
PEP 790: 3.15.0 beta 4 released on 2026-07-18

### DIFF
--- a/peps/pep-0790.rst
+++ b/peps/pep-0790.rst
@@ -48,10 +48,10 @@ Actual:
   (No new features beyond this point.)
 - 3.15.0 beta 2: Tuesday, 2026-06-02
 - 3.15.0 beta 3: Tuesday, 2026-06-23
+- 3.15.0 beta 4: Saturday, 2026-07-18
 
 Expected:
 
-- 3.15.0 beta 4: Saturday, 2026-07-18
 - 3.15.0 candidate 1: Tuesday, 2026-08-04
 - 3.15.0 candidate 2: Tuesday, 2026-09-01
 - 3.15.0 final: Thursday, 2026-10-01

--- a/release_management/python-releases.toml
+++ b/release_management/python-releases.toml
@@ -3622,7 +3622,7 @@ date = 2026-06-23
 
 [[release."3.15"]]
 stage = "3.15.0 beta 4"
-state = "expected"
+state = "actual"
 date = 2026-07-18
 
 [[release."3.15"]]


### PR DESCRIPTION
Hello from the EuroPython sprints!

<img width="2218" height="1664" alt="image" src="https://github.com/user-attachments/assets/c9711f62-3fd7-44b2-b648-496b121fba74" />
