### PR TITLE
PEP 694: fix unreferenced footnote

### DIFF
--- a/peps/pep-0694.rst
+++ b/peps/pep-0694.rst
@@ -1799,11 +1799,6 @@ as experience is gained operating Upload 2.0.
 .. [#fn-action] Obsolete ``:action`` values ``submit``, ``submit_pkg_info``, and ``doc_upload`` are
                 no longer supported
 
-
-.. [#fn-metadata] This would be fine if used as a pre-check, but the parallel metadata should be
-                  validated against the actual ``METADATA`` or similar files within the
-                  distribution.
-
 .. [#fn-hash] Specifically any hash algorithm name that `can be passed to
               <https://docs.python.org/3/library/hashlib.html#hashlib.new>`_ ``hashlib.new()`` and
               which does not require additional parameters.


### PR DESCRIPTION
<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [ ] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [x] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)


Ref: #4087 

I have decided to remove the unreferenced footnote. Given the content, it didn't make sense to leave it as a bare reference.