### PR TITLE
PEP 838: Move to standards track

### DIFF
--- a/peps/pep-0838.rst
+++ b/peps/pep-0838.rst
@@ -2,11 +2,9 @@ PEP: 838
 Title: Adding python-version to pyvenv.cfg
 Author: Konstantin Schütze <konstin@mailbox.org>
 Sponsor: Alex Waygood <alex.waygood@gmail.com>
-PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: Pending
 Status: Draft
 Type: Standards Track
-Topic: Packaging
 Created: 15-Jul-2026
 Python-Version: 3.16
 Post-History: Pending


### PR DESCRIPTION
PEP 838 affects the stdlib `venv` module, so it goes into the standards track instead of the packaging track.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)
