### PR TITLE
PEP 838: Add reference implementations

### DIFF
--- a/peps/pep-0838.rst
+++ b/peps/pep-0838.rst
@@ -128,7 +128,12 @@ documentation for this field. The field is not user-facing.
 Reference Implementation
 ========================
 
-Reference implementations will be provided for uv, virtualenv, and CPython.
+Reference implementations are available for uv, virtualenv and CPython:
+
+- `uv <https://github.com/astral-sh/uv/pull/20569>`__
+- `virtualenv <https://github.com/pypa/virtualenv/pull/3193>`__
+- :mod:`venv` in :cpython-pr:`154378`
+- An optional CPython startup check in :cpython-pr:`154381`
 
 
 .. _pep838-appendix:


### PR DESCRIPTION
Reference implementations are available for uv, virtualenv and CPython.

<!--
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->

* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)
