### PR TITLE
PEP 12: Document where to find available intersphinx mappings

### DIFF
--- a/peps/pep-0012.rst
+++ b/peps/pep-0012.rst
@@ -660,10 +660,13 @@ You can use
 `Intersphinx references
 <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_
 to other Sphinx sites,
-such as the `Python documentation <https://docs.python.org/>`_
+such as the `Python documentation <https://docs.python.org/>`_,
 `packaging.python.org <https://packaging.python.org/>`_,
 and `typing.python.org <https://typing.python.org/>`_,
 to easily cross-reference pages, sections and Python/C objects.
+
+The available intersphinx mappings are defined in ``peps/conf.py``.
+Refer to that file for the current list of supported mappings.
 
 For example,
 to create a link pointing to a section of the typing docs,


### PR DESCRIPTION
## Summary

PEP 12 explains how to use Intersphinx references, but it does not indicate where authors can find the available intersphinx mappings.

This change adds a short note directing readers to `peps/conf.py`, which contains the current list of supported intersphinx mappings. This avoids duplicating the mappings in PEP 12 while making them easier to discover.

Closes gh-4610.

## Changes

- Add a note in the Intersphinx section of PEP 12 pointing readers to `peps/conf.py`.
- Fix a missing comma in the list of example documentation sites.

## Testing

- Built the documentation locally using:

```bash
python build.py
```

The build completed successfully with no new warnings or errors.