### PR TITLE
PEP 828: Mark as Accepted

### DIFF
--- a/peps/pep-0828.rst
+++ b/peps/pep-0828.rst
@@ -3,12 +3,13 @@ Title: Supporting 'yield from' in asynchronous generators
 Author: Peter Bierma <peter@python.org>
 PEP-Delegate: Yury Selivanov <yury@vercel.com>
 Discussions-To: https://discuss.python.org/t/106459
-Status: Draft
+Status: Accepted
 Type: Standards Track
 Created: 07-Mar-2026
 Python-Version: 3.16
 Post-History: `07-Mar-2026 <https://discuss.python.org/t/106430>`__,
               `09-Mar-2026 <https://discuss.python.org/t/106459>`__
+Resolution: `03-Aug-2026 <https://discuss.python.org/t/106459/74>`__
 
 
 Abstract


### PR DESCRIPTION
* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [x] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [x] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date
