### PR TITLE
PEP 1, 12 and template: update style

### DIFF
--- a/peps/pep-0001.rst
+++ b/peps/pep-0001.rst
@@ -107,7 +107,7 @@ PEP editors
 -----------
 
 The PEP editors are individuals responsible for managing the administrative
-and editorial aspects of the PEP workflow (e.g. assigning PEP numbers and
+and editorial aspects of the PEP workflow (for example, assigning PEP numbers and
 changing their status).  See `PEP editor responsibilities & workflow`_ for
 details.
 
@@ -163,7 +163,7 @@ Submitting a PEP
 Following the above initial discussion, the workflow varies based on whether
 any of the PEP's co-authors are core developers. If one or more of the PEP's
 co-authors are core developers, they are responsible for following the process
-outlined below. Otherwise (i.e. none of the co-authors are core developers),
+outlined below. Otherwise (when none of the co-authors are core developers),
 then the PEP author(s) will need to find a sponsor for the PEP.
 
 Ideally, a core developer sponsor is identified, but non-core sponsors may also
@@ -210,7 +210,7 @@ The standard PEP workflow is:
   * It is sound and complete.  The ideas must make technical sense.  The
     editors do not consider whether they seem likely to be accepted.
   * The title accurately describes the content.
-  * The PEP's language (spelling, grammar, sentence structure, etc.)
+  * The PEP's language (spelling, grammar, sentence structure, and so on).
     and code style (examples should match :pep:`7` & :pep:`8`) should be
     correct and conformant.  The PEP text will be automatically checked for
     correct reStructuredText formatting when the pull request is submitted.
@@ -331,7 +331,7 @@ responsibility of the Steering Council, which is formally initiated by
 opening a `Steering Council issue`_ once the authors (and sponsor, if any)
 determine the PEP is ready for final review and resolution.
 
-To expedite the process in selected cases (e.g. when a change is clearly
+To expedite the process in selected cases (for example, when a change is clearly
 beneficial and ready to be accepted, but the PEP hasn't been formally submitted
 for review yet), the Steering Council may also initiate a PEP review, first
 notifying the PEP author(s) and giving them a chance to make revisions.
@@ -367,7 +367,7 @@ The Steering Council will generally approve such self-nominations by default,
 but may choose to decline them.
 Possible reasons for the Steering Council declining a
 self-nomination as PEP-Delegate include, but are not limited to, perceptions of
-a potential conflict of interest (e.g. working for the same organisation as the
+a potential conflict of interest (for example, working for the same organisation as the
 PEP submitter), or simply considering another potential PEP-Delegate to be
 more appropriate. If core developers (or other community members) have concerns
 regarding the suitability of a PEP-Delegate for any given PEP, they may ask
@@ -420,7 +420,7 @@ PEPs may still be Rejected or Withdrawn *even after the related changes have
 been included in a Python release*.
 
 Wherever possible, it is considered preferable to reduce the scope of a proposal
-to avoid the need to rely on the "Provisional" status (e.g. by deferring some
+to avoid the need to rely on the "Provisional" status (for example, by deferring some
 features to later PEPs), as this status can lead to version compatibility
 challenges in the wider Python ecosystem. :pep:`411` provides additional details
 on potential use cases for the Provisional status.
@@ -461,7 +461,7 @@ deprecation process (which may require a new PEP providing the rationale for
 the deprecation).
 
 Some Informational and Process PEPs may also have a status of "Active"
-if they are never meant to be completed.  E.g. :pep:`1` (this PEP).
+if they are never meant to be completed.  For example: :pep:`1` (this PEP).
 
 
 PEP maintenance
@@ -496,7 +496,7 @@ Each PEP should have the following parts/sections:
 1. Preamble -- :rfc:`2822` style headers containing meta-data about the
    PEP, including the PEP number, a short descriptive title (limited
    to a maximum of 44 characters), the names, and optionally the
-   contact info for each author, etc.
+   contact info for each author, and so on.
 
 2. Abstract -- a short (~200 word) description of the technical issue
    being addressed.
@@ -518,7 +518,7 @@ Each PEP should have the following parts/sections:
 5. Rationale -- The rationale fleshes out the specification by
    describing why particular design decisions were made.  It should
    describe alternate designs that were considered and related work,
-   e.g. how the feature is supported in other languages.
+   for example, how the feature is supported in other languages.
 
    The rationale should provide evidence of consensus within the
    community and discuss important objections or concerns raised

--- a/peps/pep-0001.rst
+++ b/peps/pep-0001.rst
@@ -30,7 +30,7 @@ commands for retrieving older revisions, and can also be browsed
 `on GitHub <https://github.com/python/peps>`__.
 
 
-PEP Audience
+PEP audience
 ============
 
 The typical primary audience for PEPs are the core developers of the CPython
@@ -43,7 +43,7 @@ to manage complex design coordination problems that require collaboration across
 multiple projects.
 
 
-PEP Types
+PEP types
 =========
 
 There are three kinds of PEP:
@@ -73,7 +73,7 @@ There are three kinds of PEP:
    Any meta-PEP is also considered a Process PEP.
 
 
-PEP Workflow
+PEP workflow
 ============
 
 Python's Steering Council
@@ -85,7 +85,7 @@ in :pep:`13`, in their role as the final authorities on whether or not PEPs
 will be accepted or rejected.
 
 
-Python's Core Developers
+Python's core developers
 ------------------------
 
 There are several references in this PEP to "core developers". This refers to
@@ -103,12 +103,12 @@ Council's design authority derives from their election by the currently active
 core developers. Now, PEP-Delegate is used in place of BDFL-Delegate.
 
 
-PEP Editors
+PEP editors
 -----------
 
 The PEP editors are individuals responsible for managing the administrative
 and editorial aspects of the PEP workflow (e.g. assigning PEP numbers and
-changing their status).  See `PEP Editor Responsibilities & Workflow`_ for
+changing their status).  See `PEP editor responsibilities & workflow`_ for
 details.
 
 PEP editorship is by invitation of the current editors, and they can be
@@ -193,7 +193,7 @@ The standard PEP workflow is:
 
 * In the "Type:" header field, enter "Standards Track",
   "Informational", or "Process" as appropriate, and for the "Status:"
-  field enter "Draft".  For full details, see `PEP Header Preamble`_.
+  field enter "Draft".  For full details, see `PEP header preamble`_.
 
 * Update `.github/CODEOWNERS`_ such that any co-author(s) or sponsors
   with write access to the `PEP repository`_ are listed for your new file.
@@ -240,7 +240,7 @@ during the approval phase, and are the final arbiter of a draft's PEP-ability.
 Developers with write access to the `PEP repository`_ may claim PEP
 numbers directly by creating and committing a new PEP. When doing so, the
 developer must handle the tasks that would normally be taken care of by the
-PEP editors (see `PEP Editor Responsibilities & Workflow`_). This includes
+PEP editors (see `PEP editor responsibilities & workflow`_). This includes
 ensuring the initial version meets the expected standards for submitting a
 PEP.  Alternately, even developers should submit PEPs via pull request.
 When doing so, you are generally expected to handle the process yourself;
@@ -321,7 +321,7 @@ are a critical part of what the Steering Council or PEP-Delegate will
 consider when reviewing the PEP.
 
 
-PEP Review & Resolution
+PEP review & resolution
 -----------------------
 
 Once the authors have completed a PEP, they may request a review for
@@ -464,7 +464,7 @@ Some Informational and Process PEPs may also have a status of "Active"
 if they are never meant to be completed.  E.g. :pep:`1` (this PEP).
 
 
-PEP Maintenance
+PEP maintenance
 ---------------
 
 In general, PEPs are no longer substantially modified after they have reached
@@ -524,18 +524,18 @@ Each PEP should have the following parts/sections:
    community and discuss important objections or concerns raised
    during discussion.
 
-6. Backwards Compatibility -- All PEPs that introduce backwards
+6. Backwards compatibility -- All PEPs that introduce backwards
    incompatibilities must include a section describing these
    incompatibilities and their severity.  The PEP must explain how the
    author proposes to deal with these incompatibilities.  PEP
    submissions without a sufficient backwards compatibility treatise
    may be rejected outright.
 
-7. Security Implications -- If there are security concerns in relation
+7. Security implications -- If there are security concerns in relation
    to the PEP, those concerns should be explicitly written out to make
    sure reviewers of the PEP are aware of them.
 
-8. How to Teach This -- For a PEP that adds new functionality or changes
+8. How to teach this -- For a PEP that adds new functionality or changes
    language behavior, it is helpful to include a section on how to
    teach users, new and experienced, how to apply the PEP to their
    work.
@@ -544,7 +544,7 @@ Each PEP should have the following parts/sections:
    changes that would help users adopt a new feature or migrate their
    code to use a language change.
 
-9. Reference Implementation -- The reference implementation must be
+9. Reference implementation -- The reference implementation must be
    completed before any PEP is given status "Final", but it need not
    be completed before the PEP is accepted.  While there is merit
    to the approach of reaching consensus on the specification and
@@ -556,7 +556,7 @@ Each PEP should have the following parts/sections:
    appropriate for either the Python language reference or the
    standard library reference.
 
-10. Rejected Ideas -- Throughout the discussion of a PEP, various ideas
+10. Rejected ideas -- Throughout the discussion of a PEP, various ideas
     will be proposed which are not accepted. Those rejected ideas should
     be recorded along with the reasoning as to why they were rejected.
     This both helps record the thought process behind the final version
@@ -567,7 +567,7 @@ Each PEP should have the following parts/sections:
     Rationale section that is focused specifically on why certain ideas
     were not ultimately pursued.
 
-11. Open Issues -- While a PEP is in draft, ideas can come up which
+11. Open issues -- While a PEP is in draft, ideas can come up which
     warrant further discussion. Those ideas should be recorded so people
     know that they are being thought about but do not have a concrete
     resolution. This helps make sure all issues required for the PEP to be
@@ -581,10 +581,10 @@ Each PEP should have the following parts/sections:
 13. Footnotes -- A collection of footnotes cited in the PEP, and
     a place to list non-inline hyperlink targets.
 
-Change History -- A summary of major changes the PEP has undergone, based on
+14. Change history -- A summary of major changes the PEP has undergone, based on
     discussions and feedback. Think of this as a "changelog" or "release notes"
     for the PEP.  In general, whenever you update the ``Post-History`` header
-    for major changes, add a new bullet item in newest-first (i.e. reverse
+    for major changes, add a new bullet item in newest-first (that is, reverse
     chronological) order, using the same ``DD-MMM-YYYY`` format, with
     sub-bullets summarizing the changes. You can consider linking this to the
     same link as the ``Post-History`` link.  This isn't mandatory, so it's left
@@ -596,7 +596,7 @@ Change History -- A summary of major changes the PEP has undergone, based on
     public domain and CC0-1.0-Universal_ (see this PEP for an example).
 
 
-PEP Formats and Templates
+PEP formats and templates
 =========================
 
 PEPs are UTF-8 encoded text files using the reStructuredText_ format.
@@ -610,7 +610,7 @@ The PEP text files are automatically
 for easier `online reading <https://peps.python.org/>`__.
 
 
-PEP Header Preamble
+PEP header preamble
 ===================
 
 Each PEP must begin with an :rfc:`2822` style header preamble.  The headers
@@ -673,7 +673,7 @@ reject a PEP.
 *Note: The Resolution header is required for Standards Track PEPs
 only.  It contains a URL that should point to an email message or
 other web resource where the pronouncement about
-(i.e. approval or rejection of) the PEP is made.*
+(approval or rejection of) the PEP is made.*
 
 The Discussions-To header provides the URL to the current
 canonical discussion thread for the PEP.
@@ -691,7 +691,7 @@ The Created header records the date that the PEP was assigned a
 number, while Post-History is used to record the dates of and corresponding
 URLs to the Discussions-To threads for the PEP, with the former as the
 linked text, and the latter as the link target.
-Both sets of dates should be in ``dd-mmm-yyyy`` format, e.g. ``14-Aug-2001``.
+Both sets of dates should be in ``dd-mmm-yyyy`` format, for example, ``14-Aug-2001``.
 
 Standards Track PEPs will typically have a Python-Version header which
 indicates the version of Python that the feature will be released with.
@@ -711,20 +711,20 @@ Replaces header containing the number of the PEP that it rendered
 obsolete.
 
 
-Auxiliary Files
+Auxiliary files
 ===============
 
 PEPs may include auxiliary files such as diagrams.  Such files should be
 named ``pep-XXXX-Y.ext``, where "XXXX" is the PEP number, "Y" is a
 serial number (starting at 1), and "ext" is replaced by the actual
-file extension (e.g. "png").
+file extension (for example, "png").
 
 Alternatively, all support files may be placed in a subdirectory called
 ``pep-XXXX``, where "XXXX" is the PEP number. When using a subdirectory, there
 are no constraints on the names used in files.
 
 
-Changing Existing PEPs
+Changing existing PEPs
 ======================
 
 Draft PEPs are freely open for discussion and proposed modification, at the
@@ -741,7 +741,7 @@ See the `Contributing Guide`_ for additional details, and when in doubt,
 please check first with the PEP author and/or a PEP editor.
 
 
-Transferring PEP Ownership
+Transferring PEP ownership
 ==========================
 
 It occasionally becomes necessary to transfer ownership of PEPs to a
@@ -750,7 +750,7 @@ a co-author of the transferred PEP, but that's really up to the
 original author.  A good reason to transfer ownership is because the
 original author no longer has the time or interest in updating it or
 following through with the PEP process, or has fallen off the face of
-the 'net (i.e. is unreachable or not responding to email).  A bad
+the 'net (for example, is unreachable or not responding to email).  A bad
 reason to transfer ownership is because the author doesn't agree with the
 direction of the PEP.  One aim of the PEP process is to try to build
 consensus around a PEP, but if that's not possible, an author can always
@@ -765,7 +765,7 @@ doesn't respond in a timely manner, the PEP editors will make a
 unilateral decision (it's not like such decisions can't be reversed :).
 
 
-PEP Editor Responsibilities & Workflow
+PEP editor responsibilities & workflow
 ======================================
 
 A PEP editor must be added to the ``@python/pep-editors`` group on GitHub and
@@ -788,13 +788,13 @@ For each new PEP that comes in an editor does the following:
 
 * The title should accurately describe the content.
 
-* The file name extension is correct (i.e. ``.rst``).
+* The file name extension is ``.rst``.
 
 * Ensure that everyone listed as a sponsor or co-author of the PEP who has write
   access to the `PEP repository`_ is added to `.github/CODEOWNERS`_.
 
-* Skim the PEP for obvious defects in language (spelling, grammar,
-  sentence structure, etc.), and code style (examples should conform to
+* Skim the PEP for obvious defects in language (such as spelling, grammar,
+  sentence structure), and code style (examples should conform to
   :pep:`7` & :pep:`8`).  Editors may correct problems themselves, but are
   not required to do so (reStructuredText syntax is checked by the repo's CI).
 
@@ -825,7 +825,7 @@ Once the PEP is ready for the repository, a PEP editor will:
 * Merge the new (or updated) PEP.
 
 * Inform the author of the next steps (open a discussion thread and
-  update the PEP with it, post an announcement, etc).
+  update the PEP with it, post an announcement, and so on).
 
 Updates to existing PEPs should be submitted as a `GitHub pull request`_.
 
@@ -887,7 +887,7 @@ Footnotes
 .. _Contributing Guide: https://github.com/python/peps/blob/main/CONTRIBUTING.rst
 
 
-Change History
+Change history
 ==============
 
 * 2026-02-02

--- a/peps/pep-0001.rst
+++ b/peps/pep-0001.rst
@@ -210,8 +210,8 @@ The standard PEP workflow is:
   * It is sound and complete.  The ideas must make technical sense.  The
     editors do not consider whether they seem likely to be accepted.
   * The title accurately describes the content.
-  * The PEP's language (spelling, grammar, sentence structure, and so on).
-    and code style (examples should match :pep:`7` & :pep:`8`) should be
+  * The PEP's language (spelling, grammar, sentence structure, and so on)
+    and code style (examples should match :pep:`7` and :pep:`8`) should be
     correct and conformant.  The PEP text will be automatically checked for
     correct reStructuredText formatting when the pull request is submitted.
     PEPs with invalid reST markup will not be approved.
@@ -795,7 +795,7 @@ For each new PEP that comes in an editor does the following:
 
 * Skim the PEP for obvious defects in language (such as spelling, grammar,
   sentence structure), and code style (examples should conform to
-  :pep:`7` & :pep:`8`).  Editors may correct problems themselves, but are
+  :pep:`7` and :pep:`8`).  Editors may correct problems themselves, but are
   not required to do so (reStructuredText syntax is checked by the repo's CI).
 
 * If a project is portrayed as benefiting from or supporting the PEP, make sure
@@ -835,7 +835,7 @@ for changes, and correct any structure, grammar, spelling, or
 markup mistakes they see.
 
 PEP editors don't pass judgment on PEPs.  They merely do the
-administrative & editorial part (which is generally a low volume task).
+administrative and editorial part (which is generally a low volume task).
 
 Resources:
 

--- a/peps/pep-0012.rst
+++ b/peps/pep-0012.rst
@@ -45,7 +45,7 @@ submission won't get automatically rejected because of form.
 Rationale
 =========
 
-ReStructuredText provides PEP authors with useful functionality and
+reStructuredText provides PEP authors with useful functionality and
 expressivity, while maintaining easy readability in the source text.
 The processed HTML form makes the functionality accessible to readers:
 live hyperlinks, styled text, tables, images, and automatic tables of
@@ -188,7 +188,7 @@ your PEP):
   Resolution:
 
 
-ReStructuredText PEP formatting requirements
+reStructuredText PEP formatting requirements
 ============================================
 
 The following is a PEP-specific summary of reStructuredText syntax.
@@ -779,7 +779,7 @@ and the extensions added by `Sphinx <https://www.sphinx-doc.org/>`_.
 
 A number of resources are available to learn more about them:
 
-* `Sphinx ReStructuredText Primer
+* `Sphinx reStructuredText Primer
   <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_,
   a gentle but fairly detailed introduction.
 

--- a/peps/pep-0012.rst
+++ b/peps/pep-0012.rst
@@ -52,7 +52,7 @@ live hyperlinks, styled text, tables, images, and automatic tables of
 contents, among other advantages.
 
 
-How to Use This Template
+How to use this template
 ========================
 
 To use this template you must first decide whether your PEP is going
@@ -153,7 +153,7 @@ directions below.
   replacing all this gobbledygook with your own text. Be sure to
   adhere to the format guidelines below, specifically on the
   prohibition of tab characters and the indentation requirements.
-  See "Suggested Sections" below for a template of sections to include.
+  See "Suggested sections" below for a template of sections to include.
 
 - Update your Footnotes section, listing any footnotes and
   non-inline link targets referenced by the text.
@@ -188,7 +188,7 @@ your PEP):
   Resolution:
 
 
-ReStructuredText PEP Formatting Requirements
+ReStructuredText PEP formatting requirements
 ============================================
 
 The following is a PEP-specific summary of reStructuredText syntax.
@@ -206,7 +206,7 @@ excepting URLs and similar circumstances.
 Tab characters must never appear in the document at all.
 
 
-Section Headings
+Section headings
 ----------------
 
 PEP headings must begin in column zero and the initial letter of each
@@ -219,13 +219,13 @@ characters minimum).  First-level section titles are underlined with
 and third-level section titles with "'" (single quotes or
 apostrophes).  For example::
 
-    First-Level Title
+    First-level title
     =================
 
-    Second-Level Title
+    Second-level title
     ------------------
 
-    Third-Level Title
+    Third-level title
     '''''''''''''''''
 
 If there are more than three levels of sections in your PEP, you may
@@ -233,20 +233,20 @@ insert overline/underline-adorned titles for the first and second
 levels as follows::
 
     ============================
-    First-Level Title (optional)
+    First-level title (optional)
     ============================
 
     -----------------------------
-    Second-Level Title (optional)
+    Second-level title (optional)
     -----------------------------
 
-    Third-Level Title
+    Third-level title
     =================
 
-    Fourth-Level Title
+    Fourth-level title
     ------------------
 
-    Fifth-Level Title
+    Fifth-level title
     '''''''''''''''''
 
 You shouldn't have more than five levels of sections in your PEP.  If
@@ -270,7 +270,7 @@ Paragraphs are not indented unless they are part of an indented
 construct (such as a block quote or a list item).
 
 
-Inline Markup
+Inline markup
 -------------
 
 Portions of text within paragraphs and other text blocks may be
@@ -284,7 +284,7 @@ styled.  For example::
     so they're safe for any kind of code snippets.
 
 
-Block Quotes
+Block quotes
 ------------
 
 Block quotes consist of indented body elements.  For example::
@@ -300,7 +300,7 @@ Block quotes may be nested inside other body elements.  Use 4 spaces
 per indent level.
 
 
-Literal Blocks
+Literal blocks
 --------------
 
 ..
@@ -520,7 +520,7 @@ If you think of the underscore as a right-pointing arrow, it points
 *away* from the reference and *toward* the target.
 
 
-Internal and PEP/RFC Links
+Internal and PEP/RFC links
 --------------------------
 
 The same mechanism as hyperlinks can be used for internal references.
@@ -637,7 +637,7 @@ visible in the processed document.  For example:
         Ensure the date is accurate.
 
 
-Escaping Mechanism
+Escaping mechanism
 ------------------
 
 reStructuredText uses backslashes ("``\``") to override the special
@@ -672,7 +672,7 @@ you would write the following::
     :ref:`type expression <typing:type-expression>`
 
 
-Canonical Documentation
+Canonical documentation
 -----------------------
 
 As :pep:`PEP 1 describes <1#pep-maintenance>`,
@@ -740,7 +740,7 @@ would render as:
         Also, see the :ref:`Data Persistence docs <persistence>` for other examples.
 
 
-Habits to Avoid
+Habits to avoid
 ===============
 
 Many programmers who are familiar with TeX often write quotation marks
@@ -758,7 +758,7 @@ above), use double-backquotes::
     ``literal text: in here, anything goes!``
 
 
-Suggested Sections
+Suggested sections
 ==================
 
 Various sections are found to be common across PEPs and are outlined in
@@ -801,7 +801,7 @@ resources don't address, ping ``@python/pep-editors`` on GitHub, open an
 or reach out to a PEP editor directly.
 
 
-Change History
+Change history
 ==============
 
 * `22-Feb-2026 <https://discuss.python.org/t/small-but-useful-change-to-pep-1-12/106250>`_

--- a/peps/pep-0012.rst
+++ b/peps/pep-0012.rst
@@ -85,7 +85,7 @@ directions below.
   header with the name of the core developer sponsoring your PEP.
 
 - Add the direct URL of the PEP's canonical discussion thread
-  (on e.g. Python-Dev, Discourse, etc) under the Discussions-To header.
+  (for example, on Python-Dev, Discourse) under the Discussions-To header.
   If the thread will be created after the PEP is submitted as an official
   draft, it is okay to just put "Pending" initially, but remember to
   update the PEP with the URL as soon as the PEP is successfully merged
@@ -107,12 +107,12 @@ directions below.
 
 - Change the Created header to today's date.  Be sure to follow the
   format carefully: it must be in ``DD-MMM-YYYY`` format, where the
-  ``MMM`` is the three-letter English month abbreviation, i.e. one of Jan,
+  ``MMM`` is the three-letter English month abbreviation: one of Jan,
   Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec.
 
 - For Standards Track PEPs, after the Created header, add a
   Python-Version header and set the value to the next planned version
-  of Python, i.e. the one your new feature will hopefully make its
+  of Python, that is, the one your new feature will hopefully make its
   first appearance in.  Do not use an alpha or beta release
   designation here.  Thus, if the last version of Python was 2.2 alpha
   1 and you're hoping to get your new feature into Python 2.2, set the
@@ -133,7 +133,7 @@ directions below.
   with commas in between each posting.
 
   If you posted threads for your PEP on August 14, 2001 and September 3, 2001,
-  the Post-History header would look like, e.g.:
+  the Post-History header would look like, for example:
 
   .. code-block:: email
 
@@ -146,7 +146,7 @@ directions below.
 - Add a Replaces header if your PEP obsoletes an earlier PEP.  The
   value of this header is the number of the PEP that your new PEP is
   replacing.  Only add this header if the older PEP is in "final"
-  form, i.e. is either Accepted, Final, or Rejected.  You aren't
+  form: either Accepted, Final, or Rejected.  You aren't
   replacing an older open PEP if you're submitting a competing idea.
 
 - Now write your Abstract, Rationale, and other content for your PEP,
@@ -340,7 +340,7 @@ of the appropriate `Pygments lexer <https://pygments.org/docs/lexers/>`_
 
     .. code-block:: rst
 
-        An example of the ``rst`` lexer (i.e. *reStructuredText*).
+        An example of the ``rst`` lexer (that is: *reStructuredText*).
 
 For PEPs that predominantly contain literal blocks of a specific language,
 use the ``.. highlight:: language`` directive with the appropriate ``language``
@@ -398,7 +398,7 @@ suffix ("1)", "2)").  For example::
     1. As with bullet list items, the left edge of paragraphs must
        align.
 
-    2. Each list item may contain multiple paragraphs, sublists, etc.
+    2. Each list item may contain multiple paragraphs, sublists, and so on.
 
        This is the second paragraph of the second list item.
 

--- a/peps/pep-0012/pep-NNNN.rst
+++ b/peps/pep-0012/pep-NNNN.rst
@@ -40,37 +40,37 @@ Rationale
 [Describe why particular design decisions were made.]
 
 
-Backwards Compatibility
+Backwards compatibility
 =======================
 
 [Describe potential impact and severity on pre-existing code.]
 
 
-Security Implications
+Security implications
 =====================
 
 [How could a malicious user take advantage of this new feature?]
 
 
-How to Teach This
+How to teach this
 =================
 
 [How to teach users, new and experienced, how to apply the PEP to their work.]
 
 
-Reference Implementation
+Reference implementation
 ========================
 
 [Link to any existing implementation and details about its state, e.g. proof-of-concept.]
 
 
-Rejected Ideas
+Rejected ideas
 ==============
 
 [Why certain ideas that were brought while discussing this PEP were not ultimately pursued.]
 
 
-Open Issues
+Open issues
 ===========
 
 [Any points that are still being decided/discussed.]
@@ -88,7 +88,7 @@ Footnotes
 [A collection of footnotes cited in the PEP, and a place to list non-inline hyperlink targets.]
 
 
-Change History
+Change history
 ==============
 
 [A summary of major changes the PEP has undergone.  Whenever you update the

--- a/peps/pep-0012/pep-NNNN.rst
+++ b/peps/pep-0012/pep-NNNN.rst
@@ -61,7 +61,7 @@ How to teach this
 Reference implementation
 ========================
 
-[Link to any existing implementation and details about its state, e.g. proof-of-concept.]
+[Link to any existing implementation and details about its state, for example, proof-of-concept.]
 
 
 Rejected ideas
@@ -92,7 +92,7 @@ Change history
 ==============
 
 [A summary of major changes the PEP has undergone.  Whenever you update the
-``Post-History``, add a new bullet item in newest-first (i.e. reverse
+``Post-History``, add a new bullet item in newest-first (that is, reverse
 chronological) order, using the same ``DD-MMM-YYYY`` format, with sub-bullets
 summarizing the changes.  You can use the same link for the date bullet as you
 do in the ``Post-History`` addition.]


### PR DESCRIPTION
We usually don't review PEPs to the same level as the main docs following our [style guide](https://devguide.python.org/documentation/style-guide/), as each PEP is more of a standalone document compared to the docs' editorial whole; and also not to delay publishing and discussing PEPs: authoring and shepherding a PEP is a big task as it is.

However, let's update PEP 1, 12 and especially the template to set an example.