### PR TITLE
Infra: drop Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.10"
         - "3.11"
         - "3.12"
         - "3.13"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,8 +53,7 @@ repos:
       - id: black
         name: "Format with Black"
         args:
-          - '--target-version=py39'
-          - '--target-version=py310'
+          - '--target-version=py311'
         files: '^(peps/conf\.py|pep_sphinx_extensions/tests/.*)$'
 
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,5 @@
 output-format = "full"
-target-version = "py310"
+target-version = "py311"
 
 [lint]
 ignore = [

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox>=4.2
 env_list =
-    py{315, 314, 313, 312, 311, 310}
+    py{315, 314, 313, 312, 311}
 no_package = true
 
 [testenv]


### PR DESCRIPTION
Python 3.10 support is blocking the work on #4926. Drop discussed with and approved by Hugo [here](https://github.com/python/peps/pull/4926#issuecomment-5092537932).