### PR TITLE
Infra: repin pygments from commit hash to version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
 # Requirements for building PEPs with Sphinx
 
-# Sphinx requires >= 2.17. JSON5 support added in 2.19
-# Temporary archive install, pending release of Pygments > 2.20.0
-# https://github.com/pygments/pygments/discussions/3145
-pygments @ git+https://github.com/pygments/pygments@2cad2642058441b59782a6a18f03c98c42d081f1
+# Sphinx requires >= 2.17. JSON5 support added in 2.19, `lazy` highlight added in 2.21 
+pygments >= 2.21
 
 # Sphinx 6.1.0 broke copying images in parallel builds; fixed in 6.1.2
 # See https://github.com/sphinx-doc/sphinx/pull/11100

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for building PEPs with Sphinx
 
-# Sphinx requires >= 2.17. JSON5 support added in 2.19, `lazy` highlight added in 2.21 
+# Sphinx requires >= 2.17. JSON5 support added in 2.19, `lazy` highlight added in 2.21
 pygments >= 2.21
 
 # Sphinx 6.1.0 broke copying images in parallel builds; fixed in 6.1.2


### PR DESCRIPTION
Pygments has released v2.21, which includes changes for CPython 3.15. We can go back to using standard version range notation.