### PR TITLE
PEP 825: address further feedback from DPO

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -355,6 +355,10 @@ available on the package index for the package version in question. It
 MUST be consistent with the `variant metadata`_ of the individual
 wheels, as specified in `metadata consistency`_.
 
+If clients find variant wheels with labels that are not listed in the
+index-level metadata file, they MAY either elect to ignore these wheels
+or to fetch variant metadata from them directly.
+
 This file SHOULD NOT be considered immutable and MAY be updated in a
 backward compatible way at any point (e.g. when adding a new variant).
 
@@ -863,8 +867,9 @@ behavior would be to:
    the non-variant wheels instead.
 6. Map the variant labels into sets of variant properties using the
    combined variant metadata. If any of the labels present in wheel
-   filenames are missing from it, assume that the respective wheels are
-   incompatible.
+   filenames are missing from it, either assume that the respective
+   wheels are incompatible or read their metadata directly from wheels,
+   as indicated in step 5.
 7. Obtain the ordered lists of compatible variant properties. The
    mechanism for this will be specified in a subsequent PEP.
 8. Filter and order variants based on the lists of compatible
@@ -1550,6 +1555,8 @@ Change History
   - Strengthened the index rules to require that the irrelevant optional
     attributes are not published by the index, and that they are ignored
     by tools.
+  - Added a suggestion for dealing with missing variants in index-level
+    metadata file.
 
 - 10-Aug-2026
 

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -366,6 +366,11 @@ Variant indexes MAY elect to either auto-generate the file from the
 uploaded variant wheels or allow the user to manually generate it
 themselves and upload it to the index.
 
+The same ``{name}-{version}-variants.json`` file can also be published
+alongside variant wheels in other (tool-specific) collections of wheels.
+An example of this would be a directory referenced by the commonly used
+``--find-links`` option.
+
 The ``foo-1.2.3-variants.json`` corresponding to the package with two
 wheel variants, one of them listed in the previous example, would look
 like:
@@ -1557,6 +1562,8 @@ Change History
     by tools.
   - Added a suggestion for dealing with missing variants in index-level
     metadata file.
+  - Indicated that the index-level metadata file can also be used in
+    non-standard sources of wheels.
 
 - 10-Aug-2026
 

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -218,7 +218,9 @@ will be promoted to version ``1.0.0``.
 If a backwards incompatible change is done to the specification,
 the major version number MUST be incremented, and the remaining version
 components MUST be zeroed. Tools MUST reject metadata with a major
-version number that they do not support.
+version number that they do not support. The specification update
+introducing such a change can provide further backwards compatibility
+and transition considerations.
 
 If a backwards compatible change is done to the specification, the minor
 version number MUST be incremented, and the patch number MUST be zeroed.

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -346,9 +346,8 @@ It should follow the rules for files in the
 :ref:`packaging:simple-repository-api`, except that the optional
 metadata attributes served by the index (such as ``core-metadata``,
 ``dist-info-metadata``, ``requires-python`` or ``yanked``) are not
-meaningful for that file. Indexes MAY publish or skip these attributes,
-as long as the values do not prevent correct operation. Tools MAY either
-use or ignore these values.
+meaningful for that file. Indexes MUST skip these attributes, and tools
+MUST ignore them.
 
 This file uses the same structure as `variant metadata`_, except that
 the ``variants`` object is index-scoped and it MUST list all variants
@@ -1179,11 +1178,9 @@ The index support aims to account for three scenarios:
 
 2. An index implementation that has more complete wheel support but does
    not wish to implement full variant wheel support immediately. The
-   index needs only to permit the user to upload said JSON file. To
-   account for minimalistic implementation, the specification permits
-   the index to treat said file similarly to a wheel, including
-   publishing attributes such as ``yanked``, as long as their values do
-   not prevent clients from working.
+   index needs to permit the user to upload said JSON file and it needs
+   to account for it in the wheel listings, but it does not need to
+   process variant metadata directly.
 
 3. An index implementation that implements complete wheel variant
    support. Such an index will parse uploaded variant wheels, and
@@ -1547,6 +1544,12 @@ and Zanie Blue.
 
 Change History
 ==============
+
+- 19-Aug-2026
+
+  - Strengthened the index rules to require that the irrelevant optional
+    attributes are not published by the index, and that they are ignored
+    by tools.
 
 - 10-Aug-2026
 


### PR DESCRIPTION
* Change is either:
    * [x] To a Draft PEP
    * [ ] To an Accepted or Final PEP, with Steering Council approval
    * [ ] To fix an editorial issue (markup, typo, link, header, etc)
* [x] PR title prefixed with PEP number (e.g. ``PEP 123: Summary of changes``)

Key changes (from Change History):

- Strengthened the index rules to require that the irrelevant optional
  attributes are not published by the index, and that they are ignored
  by tools.
- Added a suggestion for dealing with missing variants in index-level
  metadata file.
- Indicated that the index-level metadata file can also be used in
  non-standard sources of wheels.