### PR TITLE
PEP 11: Add `riscv64-unknown-linux-gnu` to Tier 3

### DIFF
--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -135,6 +135,7 @@ powerpc64le-unknown-linux-gnu    glibc, clang                Victor Stinner
 
                                  glibc, gcc                  Victor Stinner
 riscv64-unknown-linux-gnu        glibc, clang                Stan Ulbrych, Emma Smith
+
                                  glibc, gcc                  Stan Ulbrych, Emma Smith
 s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
 wasm32-unknown-emscripten        emcc                        Russell Keith-Magee

--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -134,6 +134,7 @@ aarch64-unknown-linux-gnu        64-bit Raspberry Pi OS, gcc Savannah Ostrowski,
 powerpc64le-unknown-linux-gnu    glibc, clang                Victor Stinner
 
                                  glibc, gcc                  Victor Stinner
+riscv64-unknown-linux-gnu        glibc, clang                Stan Ulbrych, Emma Smith
 s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
 wasm32-unknown-emscripten        emcc                        Russell Keith-Magee
 x86_64-linux-android                                         Russell Keith-Magee, Petr Viktorin

--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -134,7 +134,8 @@ aarch64-unknown-linux-gnu        64-bit Raspberry Pi OS, gcc Savannah Ostrowski,
 powerpc64le-unknown-linux-gnu    glibc, clang                Victor Stinner
 
                                  glibc, gcc                  Victor Stinner
-riscv64-unknown-linux-gnu        glibc, clang, gcc           Stan Ulbrych, Emma Smith
+riscv64-unknown-linux-gnu        glibc, clang                Stan Ulbrych, Emma Smith
+                                 glibc, gcc                  Stan Ulbrych, Emma Smith
 s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
 wasm32-unknown-emscripten        emcc                        Russell Keith-Magee
 x86_64-linux-android                                         Russell Keith-Magee, Petr Viktorin

--- a/peps/pep-0011.rst
+++ b/peps/pep-0011.rst
@@ -134,7 +134,7 @@ aarch64-unknown-linux-gnu        64-bit Raspberry Pi OS, gcc Savannah Ostrowski,
 powerpc64le-unknown-linux-gnu    glibc, clang                Victor Stinner
 
                                  glibc, gcc                  Victor Stinner
-riscv64-unknown-linux-gnu        glibc, clang                Stan Ulbrych, Emma Smith
+riscv64-unknown-linux-gnu        glibc, clang, gcc           Stan Ulbrych, Emma Smith
 s390x-unknown-linux-gnu          glibc, gcc                  Victor Stinner
 wasm32-unknown-emscripten        emcc                        Russell Keith-Magee
 x86_64-linux-android                                         Russell Keith-Magee, Petr Viktorin


### PR DESCRIPTION
It was accepted by the Steering Council in https://github.com/python/steering-council/issues/360.
<!--
This template is for an infra or meta change not belonging to another category.
**Please** read our Contributing Guidelines (CONTRIBUTING.rst)
to make sure this repo is the right place for your proposed change. Thanks!
-->
