### PR TITLE
Infra: Don't use raw HTML for masked email addresses

### DIFF
--- a/pep_sphinx_extensions/pep_processor/transforms/pep_zero.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_zero.py
@@ -18,7 +18,7 @@ class PEPZero(transforms.Transform):
         self.startnode.parent.remove(self.startnode)
 
 
-def _mask_email(ref: nodes.reference) -> nodes.reference:
+def _mask_email(ref: nodes.reference) -> nodes.reference | nodes.Text:
     """Mask the email address in `ref` and return a replacement node.
 
     `ref` is returned unchanged if it contains no email address.
@@ -31,4 +31,4 @@ def _mask_email(ref: nodes.reference) -> nodes.reference:
     """
     if not ref.get("refuri", "").startswith("mailto:"):
         return ref
-    return nodes.raw("", ref[0].replace("@", "&#32;&#97;t&#32;"), format="html")
+    return nodes.Text(ref[0].replace("@", " at "))

--- a/pep_sphinx_extensions/tests/pep_processor/transform/test_pep_zero.py
+++ b/pep_sphinx_extensions/tests/pep_processor/transform/test_pep_zero.py
@@ -11,7 +11,7 @@ from pep_sphinx_extensions.pep_processor.transforms import pep_zero
             nodes.reference(
                 "", text="user@example.com", refuri="mailto:user@example.com"
             ),
-            '<raw format="html" xml:space="preserve">user&#32;&#97;t&#32;example.com</raw>',
+            "user at example.com",
         ),
         (
             nodes.reference("", text="Introduction", refid="introduction"),


### PR DESCRIPTION
Fixes https://github.com/python/peps/issues/5096.