### PR TITLE
PEP 825: Mark as provisionally accepted

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -13,11 +13,22 @@ Author: Jonathan Dekhtiar <jonathan@dekhtiar.com>,
         Andy R. Terrel <andy.terrel@gmail.com>
 PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
 Discussions-To: https://discuss.python.org/t/pep-825-wheel-variants-package-format-split-from-pep-817/106196
-Status: Draft
+Status: Provisional
 Type: Standards Track
 Topic: Packaging
 Created: 17-Feb-2026
 Post-History: `17-Feb-2026 <https://discuss.python.org/t/pep-825-wheel-variants-package-format-split-from-pep-817/106196>`__
+Resolution: https://discuss.python.org/t/pep-825-wheel-variants-package-format-split-from-pep-817/106196/232
+
+
+Provisional Acceptance
+======================
+
+This PEP has been **provisionally accepted**. This PEP is part of an
+extended series of PEPs covering the whole wheel variant feature. Once
+the full suite of PEPs has been accepted, the acceptance will become
+final.
+
 
 Abstract
 ========


### PR DESCRIPTION
<!--
You can help complete the following checklist yourself if you like
by ticking any boxes you're sure about, like this: [x]

If you're unsure about anything, just leave it blank and we'll take a look.
-->

* [x] SC/PEP Delegate has formally accepted/rejected the PEP and posted to the ``Discussions-To`` thread
* [x] Pull request title in appropriate format (``PEP 123: Mark as Accepted``)
* [ ] ``Status`` changed to ``Accepted``/``Rejected``
* [x] ``Resolution`` field points directly to SC/PEP Delegate official acceptance/rejected post, including the date (e.g. `` `01-Jan-2000 <https://discuss.python.org/t/12345/100>`__ ``)
* [x] Acceptance/rejection notice added, if the SC/PEP delegate had major conditions or comments
* [x] ``Discussions-To``, ``Post-History`` and ``Python-Version`` up to date
