### PR TITLE
PEP 846: Docstrings for type aliases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -719,6 +719,7 @@ peps/pep-0841.rst  @corona10 @sobolevn
 peps/pep-0842.rst  @ZeroIntensity
 peps/pep-0843.rst  @ZeroIntensity
 peps/pep-0844.rst  @warsaw
+peps/pep-0846.rst  @JelleZijlstra @johnslavik
 # ...
 peps/pep-2026.rst  @hugovk
 # ...

--- a/peps/pep-0846.rst
+++ b/peps/pep-0846.rst
@@ -1,0 +1,375 @@
+PEP: 846
+Title: Docstrings for Type Aliases
+Author: Bartosz Sławecki <bartosz@ilikepython.com>
+Sponsor: Jelle Zijlstra <jelle.zijlstra@gmail.com>
+Discussions-To: Pending
+Status: Draft
+Type: Standards Track
+Topic: Typing
+Created: 06-Sep-2026
+Python-Version: 3.16
+Post-History: `06-Sep-2026 <https://discuss.python.org/t/docstrings-for-type-aliases/108901>`__
+
+
+Abstract
+========
+
+This PEP proposes preserving a string literal immediately following a
+:py:keyword:`type` statement as the resulting type alias object's ``__doc__``
+attribute. The documentation would be available through runtime introspection
+and displayed by :py:func:`help`.
+
+The proposal follows the placement already supported by source-based
+documentation tools. It also adds support for type aliases to
+:py:func:`ast.get_docstring`. The draft proposes an optional ``doc`` field on
+:py:class:`ast.TypeAlias`, while retaining the original string statement in
+the AST. The representation and its behavior under AST transformations remain
+open for discussion.
+
+
+Motivation
+==========
+
+A type alias can describe an API convention that needs documentation:
+
+.. code-block:: python
+
+    type Timeout = float | None
+    """
+    Maximum wait in seconds.
+
+    Use None to wait indefinitely, or zero to return immediately.
+    """
+
+Several tools already recognize documentation written this way.
+`Pyright supports docstrings following type statements <Pyright_>`_
+(since 2023), `Sphinx's autotype directive <Sphinx_>`_ documents aliases
+and their docstrings (since 2025), and `Pylint recognizes these strings
+as documentation <Pylint_>`_ (since 2023).
+
+Python currently discards this documentation during compilation. Calling
+:py:func:`help(Timeout) <help>` displays generic information about
+:py:class:`~typing.TypeAliasType`, as illustrated in
+`the original CPython issue <Issue_>`_. A tool that needs the alias's
+documentation must find and parse its source, which may be unavailable after
+installation or when the alias is passed in from another component.
+
+The :py:keyword:`type` statement introduced by :pep:`695` creates a dedicated
+runtime object. That object can carry its own documentation, as functions and
+classes do. Preserving the docstring would make it available from the imported
+alias alone, including when the alias is re-exported.
+
+Runtime documentation could also be consumed by third-party frameworks.
+Frameworks that already recognize :py:class:`~typing.TypeAliasType` (such as
+Pydantic) could choose to use ``__doc__`` as descriptive metadata. Such
+integrations would be up to those projects.
+
+
+Specification
+=============
+
+Docstring Placement
+-------------------
+
+If the next statement after a :py:keyword:`type` statement in the same suite is
+an expression statement consisting of a string literal, that string is the
+alias's docstring.
+
+.. code-block:: python
+
+    type Timeout = float | None
+    """Maximum wait in seconds."""
+
+    type OtherTimeout = float | None
+    default_timeout = 30
+    """This is not OtherTimeout's docstring."""
+
+The rule applies wherever a :py:keyword:`type` statement is allowed, including
+inside functions, classes, and control-flow suites. The string must be in the
+same suite as the alias; a string in a nested or enclosing suite does not
+qualify. Generic aliases follow the same rule:
+
+.. code-block:: python
+
+    type ListOrSet[T] = list[T] | set[T]
+    """A collection whose order and duplicate handling depend on its type."""
+
+The literal forms accepted as docstrings are the same as for functions
+and classes. Adjacent string literals combined by the parser qualify.
+Bytes literals, f-strings, t-strings, and expressions such as
+``"first" + "second"`` do not qualify, even if compilation could reduce
+an expression to a constant string.
+
+Only the first following string statement supplies ``__doc__``.
+Additional docstrings, as described in :pep:`257`, are not concatenated
+or assigned to the alias.
+
+
+Runtime Behavior
+----------------
+
+The alias stores its docstring in ``__doc__``. An undocumented alias has
+``__doc__`` equal to ``None``. Accessing this attribute does not evaluate
+the alias's value.
+
+Compilation applies the same docstring whitespace processing as it does for
+function and class docstrings. In CPython, this uses ``_PyCompile_CleanDoc``,
+which expands tabs and cleans indentation while retaining surrounding blank
+lines. :py:func:`inspect.cleandoc` also removes surrounding blank lines and is
+used by inspection tools rather than compilation.
+
+The attribute can be assigned to after creation. Deleting it resets it to
+``None``. The :py:class:`~typing.TypeAliasType` constructor does not gain a
+docstring parameter; programmatically created aliases can be documented by
+assignment:
+
+.. code-block:: python
+
+    from typing import TypeAliasType
+
+    Timeout = TypeAliasType("Timeout", float | None)
+    Timeout.__doc__ = "Maximum wait in seconds."
+
+This proposal does not change the meaning of an alias to a type checker,
+or how its value is evaluated.
+
+
+Optimization
+------------
+
+Optimization level 2, selected by :option:`-OO` or
+:py:func:`compile(..., optimize=2) <compile>`, strips alias docstrings as it
+strips function and class docstrings. The resulting alias has ``__doc__`` equal
+to ``None``. Optimization levels 0 and 1 retain the docstring.
+
+Removing the primary docstring must not cause an additional string to become
+the alias's docstring. This also applies when an AST returned with docstrings
+stripped is compiled again at a lower optimization level. Assignments to
+``__doc__`` remain ordinary runtime assignments and are not stripped by
+:option:`-OO`.
+
+
+AST Support
+-----------
+
+The draft adds an optional string field, ``doc``, at the end of
+:py:class:`ast.TypeAlias`. Its fields are therefore ``name``, ``type_params``,
+``value``, and ``doc``. An omitted ``doc`` defaults to ``None``.
+
+When docstrings are retained, :py:func:`ast.parse` populates this field with
+the original string, before compilation's whitespace processing. The following
+``Expr(Constant(...))`` statement remains in its original position:
+
+.. code-block:: pycon
+
+    >>> import ast
+    >>> tree = ast.parse(
+    ...     'type Timeout = float | None\n"Maximum wait in seconds."'
+    ... )
+    >>> tree.body[0].doc
+    'Maximum wait in seconds.'
+    >>> tree.body[1].value.value
+    'Maximum wait in seconds.'
+
+:py:func:`ast.get_docstring` accepts :py:class:`~ast.TypeAlias` nodes. As with
+the node kinds it already supports, its default behavior cleans the docstring
+using :py:func:`inspect.cleandoc`. Passing ``clean=False`` returns the
+original string. An undocumented alias returns ``None``.
+
+Both :py:func:`ast.dump` and AST :py:func:`repr` display the documentation in
+the ``doc`` field and in the original string statement. The field receives no
+special redaction. The default :py:func:`ast.dump` omits ``doc`` when its value
+is ``None``, following the existing treatment of optional fields.
+
+Under optimization level 2, preprocessing clears the field and removes
+the primary string statement. It also prevents an additional string
+from being treated as a new docstring during subsequent compilation.
+
+In the reference implementation, a non-``None`` ``doc`` field takes precedence
+during compilation. If it is ``None``, preprocessing looks for a following
+string statement. :py:func:`ast.unparse` continues to emit the original
+statement and ignores ``doc``; it does not insert or rewrite statements to
+match that field. Consequently, editing only one copy can change the result of
+compiling the AST compared with compiling its unparsed source. The choice of
+representation and the policy for such edits are discussed under `Open Issues`_.
+
+
+Standard Library Support
+------------------------
+
+:py:mod:`pydoc`, including :py:func:`help`, will recognize type aliases and
+display their own documentation. Aliases will also be distinguished from other
+data members in module documentation. This applies to both text and HTML
+output.
+
+The reference implementation displays a declaration followed by the
+docstring. For the opening example, the documentation begins with:
+
+.. code-block:: text
+
+    Help on type alias Timeout in module mymodule:
+
+    type Timeout = float | None
+        Maximum wait in seconds.
+
+        Use None to wait indefinitely, or zero to return immediately.
+
+It follows this with a short "Lazy value access" section describing
+:py:attr:`~typing.TypeAliasType.__value__` and
+:py:meth:`~typing.TypeAliasType.evaluate_value`, and a pointer to
+:py:func:`help(typing.TypeAliasType) <help>` for the full interface.
+
+This PEP does not add automatic discovery of type alias docstrings to
+:py:mod:`doctest`. As noted in
+`the discussion of doctest support <ScopeDiscussion_>`_, that would require a
+separate change to its discovery rules.
+
+
+Rationale
+=========
+
+Placing the string after the declaration follows the convention already used by
+tools for type aliases and described for attribute docstrings in :pep:`257`.
+Applying this convention to :py:keyword:`type` statements was
+`recommended in the earlier discussion <PlacementDiscussion_>`_. Existing
+documented aliases would gain runtime documentation without requiring their
+authors to rewrite them.
+
+Unlike a function or class docstring, an alias docstring is a separate
+statement following the declaration. This requires readers to recognize
+an association between neighboring statements. The existing convention
+is the reason for choosing that placement; the dedicated alias object
+provides somewhere to store the documentation. These address different
+parts of the design.
+
+A new AST field lets :py:func:`ast.get_docstring` retrieve documentation from
+an alias node without requiring access to its containing suite. Retaining the
+original statement preserves the structure used by existing tools that already
+find docstrings there. The cost is duplicated information, which AST
+transformations may need to keep consistent.
+
+Preserving the documentation and rendering an alias declaration are separate
+operations. Documentation remains useful to callers that only read ``__doc__``
+or :py:func:`ast.get_docstring`, regardless of the final rendering policy
+chosen for :py:mod:`pydoc`.
+
+
+Backwards Compatibility
+=======================
+
+This PEP has no known backwards compatibility issues.
+
+
+Security Implications
+=====================
+
+This PEP has no known security implications.
+
+
+How to Teach This
+=================
+
+The reference documentation for the :py:keyword:`type` statement should show a
+docstring immediately after the declaration, then demonstrate ``Alias.__doc__``
+and :py:func:`help(Alias) <help>`. The :py:class:`typing.TypeAliasType`
+documentation should describe the new attribute and how to assign it for
+aliases created with the constructor.
+
+Users already familiar with source-based alias documentation can keep writing
+the same strings. The relevant boundary is that this runtime behavior applies
+to :py:keyword:`type` statements. Ordinary assignments, including older
+:py:data:`~typing.TypeAlias` annotations, do not gain it.
+
+Documentation for :py:class:`ast.TypeAlias` and :py:func:`ast.get_docstring`
+should explain the field, cleaning behavior, and the retained string statement.
+Guidance for authors of AST transformations depends on the resolution of the
+representation question below.
+
+
+Reference Implementation
+========================
+
+A CPython prototype is available in two commits:
+
+* `Compiler, runtime, and AST support <Compiler_>`_.
+* `pydoc support <Pydoc_>`_.
+
+AST preprocessing associates the string with the alias before code
+generation and before an AST is returned to Python code. It handles
+both ordinary bodies and nested statement sequences. Code generation
+consumes the populated field and passes the processed string to the
+runtime object; it does not modify the AST to find documentation.
+
+The :py:mod:`pydoc` implementation requests the alias expression in string
+format. This evaluation can trigger lazy imports. If it raises an
+:py:exc:`Exception`, it tries to recover the
+original expression from the source without evaluating it. If source recovery
+also fails, the declaration contains a placeholder with :py:func:`repr` of the
+original exception, and rendering continues with the docstring. A full
+traceback is not included. Failures to render type parameter bounds,
+constraints, or defaults cause that part of the declaration to be omitted.
+
+The prototype includes tests for docstrings in nested suites, generic
+aliases, additional strings, optimization, AST access and round trips,
+assignment and deletion of ``__doc__``, and text and HTML rendering,
+including rendering failures.
+
+
+Open Issues
+===========
+
+AST Representation and Transformations
+--------------------------------------
+
+The optional string field makes alias documentation directly accessible,
+but the field and following statement can disagree. The reference
+implementation's precedence rules are described under `AST Support`_.
+Before acceptance, this PEP needs to settle whether those rules should
+become part of the specification or whether a different representation
+would better support AST transformations.
+
+One alternative is for ``doc`` to refer to the original
+:py:class:`~ast.Constant` node. In-place edits would then be shared, but
+visitors would reach that node through two references, and replacing one
+reference could still make them diverge. Sharing a node would also require care
+when converting between Python AST objects and the compiler's internal
+representation.
+
+Another alternative is a private attribute exposed through
+:py:func:`ast.get_docstring`. This would avoid adding a public field, but
+would still need rules for updating or invalidating the stored documentation
+when the surrounding statements change.
+
+
+Acknowledgements
+================
+
+Thanks to Jelle Zijlstra for reviewing the proposal and agreeing to sponsor the PEP,
+and to the participants in `the initial discussion on Discourse <Discussion_>`_.
+
+Thanks to Peter Bierma and Jakub Romańczuk for convincing me to pursue the idea.
+
+Change History
+==============
+
+* `06-Sep-2026 <https://discuss.python.org/t/docstrings-for-type-aliases/108901>`__:
+  Initial proposal and first PEP draft.
+
+
+Copyright
+=========
+
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.
+
+
+.. _Pyright: https://discuss.python.org/t/docstrings-for-new-type-aliases-as-defined-in-pep-695/39816/5
+.. _PlacementDiscussion: https://discuss.python.org/t/docstrings-for-new-type-aliases-as-defined-in-pep-695/39816/3
+.. _Discussion: https://discuss.python.org/t/runtime-docstrings-for-type-aliases/108901
+.. _ScopeDiscussion: https://discuss.python.org/t/runtime-docstrings-for-type-aliases/108901/9
+.. _MetadataDiscussion: https://discuss.python.org/t/runtime-docstrings-for-type-aliases/108901/10
+.. _Sphinx: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#automatically-document-type-aliases
+.. _Pylint: https://pylint.readthedocs.io/en/latest/whatsnew/3/3.0/index.html#what-s-new-in-pylint-3-0-3
+.. _Issue: https://github.com/python/cpython/issues/156925
+.. _Compiler: https://github.com/johnslavik/cpython/commit/38779c761d9eaf19f195ed972e5986c0df384953
+.. _Pydoc: https://github.com/johnslavik/cpython/commit/e4910eeb0ca147f92e3b20262de13d0fb1bf3d97

--- a/peps/pep-0846.rst
+++ b/peps/pep-0846.rst
@@ -117,8 +117,7 @@ the alias's value.
 Compilation applies the same docstring whitespace processing as it does for
 function and class docstrings. In CPython, this uses ``_PyCompile_CleanDoc``,
 which expands tabs and cleans indentation while retaining surrounding blank
-lines. :py:func:`inspect.cleandoc` also removes surrounding blank lines and is
-used by inspection tools rather than compilation.
+lines. :py:func:`inspect.cleandoc` also removes surrounding blank lines.
 
 The attribute can be assigned to after creation. Deleting it resets it to
 ``None``. The :py:class:`~typing.TypeAliasType` constructor does not gain a

--- a/peps/pep-0846.rst
+++ b/peps/pep-0846.rst
@@ -16,21 +16,25 @@ Abstract
 
 This PEP proposes preserving a string literal immediately following a
 :py:keyword:`type` statement as the resulting type alias object's ``__doc__``
-attribute. The documentation would be available through runtime introspection
-and displayed by :py:func:`help`.
-
-The proposal follows the placement already supported by source-based
-documentation tools. It also adds support for type aliases to
-:py:func:`ast.get_docstring`. The draft proposes an optional ``doc`` field on
-:py:class:`ast.TypeAlias`, while retaining the original string statement in
-the AST. The representation and its behavior under AST transformations remain
-open for discussion.
+attribute, exposing that documentation through :py:mod:`ast`, and displaying
+it through :py:mod:`pydoc` and :py:func:`help`. It follows the placement already
+supported by source-based documentation tools. The proposed AST support adds
+an optional ``doc`` field to :py:class:`ast.TypeAlias` and extends
+:py:func:`ast.get_docstring` to accept alias nodes, while retaining the
+original string statement. The AST representation and its behavior under
+transformations remain open for discussion.
 
 
 Motivation
 ==========
 
-A type alias can describe an API convention that needs documentation:
+Several widely used development tools already recognize docstrings following
+type alias declarations. `Pyright supports docstrings following type
+statements <Pyright_>`_ (since 2023), `Sphinx's autotype directive <Sphinx_>`_
+documents aliases and their docstrings (since 2025), and `Pylint recognizes
+these strings as documentation <Pylint_>`_ (since 2023).
+
+For example, an alias can explain how callers should interpret its values:
 
 .. code-block:: python
 
@@ -41,14 +45,7 @@ A type alias can describe an API convention that needs documentation:
     Use None to wait indefinitely, or zero to return immediately.
     """
 
-Several tools already recognize documentation written this way.
-`Pyright supports docstrings following type statements <Pyright_>`_
-(since 2023), `Sphinx's autotype directive <Sphinx_>`_ documents aliases
-and their docstrings (since 2025), and `Pylint recognizes these strings
-as documentation <Pylint_>`_ (since 2023).
-
-Python currently discards this documentation during compilation. Calling
-:py:func:`help(Timeout) <help>` displays generic information about
+Calling :py:func:`help(Timeout) <help>` displays generic information about
 :py:class:`~typing.TypeAliasType`, as illustrated in
 `the original CPython issue <Issue_>`_. A tool that needs the alias's
 documentation must find and parse its source, which may be unavailable after
@@ -70,6 +67,12 @@ Specification
 
 Docstring Placement
 -------------------
+
+:pep:`257` defines the convention of placing attribute docstrings immediately
+after assignments and calls strings following another docstring "additional
+docstrings". This PEP applies that placement convention to
+:py:keyword:`type` statements and makes the first following docstring
+available at runtime.
 
 If the next statement after a :py:keyword:`type` statement in the same suite is
 an expression statement consisting of a string literal, that string is the
@@ -101,8 +104,7 @@ Bytes literals, f-strings, t-strings, and expressions such as
 an expression to a constant string.
 
 Only the first following string statement supplies ``__doc__``.
-Additional docstrings, as described in :pep:`257`, are not concatenated
-or assigned to the alias.
+Additional docstrings are not concatenated or assigned to the alias.
 
 
 Runtime Behavior
@@ -140,13 +142,29 @@ Optimization
 Optimization level 2, selected by :option:`-OO` or
 :py:func:`compile(..., optimize=2) <compile>`, strips alias docstrings as it
 strips function and class docstrings. The resulting alias has ``__doc__`` equal
-to ``None``. Optimization levels 0 and 1 retain the docstring.
+to ``None``. In the AST, preprocessing clears the ``doc`` field of
+:py:class:`ast.TypeAlias` and removes the primary string statement.
+Optimization levels 0 and 1 retain the docstring.
 
 Removing the primary docstring must not cause an additional string to become
 the alias's docstring. This also applies when an AST returned with docstrings
-stripped is compiled again at a lower optimization level. Assignments to
-``__doc__`` remain ordinary runtime assignments and are not stripped by
-:option:`-OO`.
+stripped is compiled again at a lower optimization level. If removing the
+primary string leaves another string literal immediately after the alias,
+preprocessing wraps that literal's :py:class:`ast.Constant` node in an
+:py:class:`ast.JoinedStr` node with the constant as its only value. The
+surrounding :py:class:`ast.Expr` statement remains in place. This preserves
+the string's value but prevents it from qualifying as a docstring, including
+when the AST is compiled again.
+
+This follows `CPython's existing docstring preprocessing
+<DocstringPreprocessing_>`_, which uses the same wrapper to prevent a string
+exposed by docstring removal or produced by constant folding from becoming
+a module, function, or class docstring. The same protection applies to
+non-docstring expressions following a type alias that fold to string
+constants.
+
+Assignments to ``__doc__`` remain ordinary runtime assignments and are not
+stripped by :option:`-OO`.
 
 
 AST Support
@@ -173,25 +191,23 @@ the original string, before compilation's whitespace processing. The following
 
 :py:func:`ast.get_docstring` accepts :py:class:`~ast.TypeAlias` nodes. As with
 the node kinds it already supports, its default behavior cleans the docstring
-using :py:func:`inspect.cleandoc`. Passing ``clean=False`` returns the
-original string. An undocumented alias returns ``None``.
+using :py:func:`inspect.cleandoc`. With ``clean=False``, the function returns
+the original string. It returns ``None`` for an undocumented alias.
 
 Both :py:func:`ast.dump` and AST :py:func:`repr` display the documentation in
 the ``doc`` field and in the original string statement. The field receives no
 special redaction. The default :py:func:`ast.dump` omits ``doc`` when its value
 is ``None``, following the existing treatment of optional fields.
 
-Under optimization level 2, preprocessing clears the field and removes
-the primary string statement. It also prevents an additional string
-from being treated as a new docstring during subsequent compilation.
+The reference implementation compiles an alias using its ``doc`` field. When
+the field is ``None``, preprocessing fills it from a qualifying string
+statement immediately after the alias, if one exists.
 
-In the reference implementation, a non-``None`` ``doc`` field takes precedence
-during compilation. If it is ``None``, preprocessing looks for a following
-string statement. :py:func:`ast.unparse` continues to emit the original
-statement and ignores ``doc``; it does not insert or rewrite statements to
-match that field. Consequently, editing only one copy can change the result of
-compiling the AST compared with compiling its unparsed source. The choice of
-representation and the policy for such edits are discussed under `Open Issues`_.
+:py:func:`ast.unparse` uses the following statement and ignores ``doc``.
+If an AST transformation changes only the field or only the statement,
+compiling the AST and compiling its unparsed source can produce different
+docstrings. How to handle such edits remains an `open issue
+<AST Representation and Transformations_>`_.
 
 
 Standard Library Support
@@ -202,8 +218,7 @@ display their own documentation. Aliases will also be distinguished from other
 data members in module documentation. This applies to both text and HTML
 output.
 
-The reference implementation displays a declaration followed by the
-docstring. For the opening example, the documentation begins with:
+For the opening example, the reference implementation displays:
 
 .. code-block:: text
 
@@ -214,10 +229,15 @@ docstring. For the opening example, the documentation begins with:
 
         Use None to wait indefinitely, or zero to return immediately.
 
-It follows this with a short "Lazy value access" section describing
-:py:attr:`~typing.TypeAliasType.__value__` and
-:py:meth:`~typing.TypeAliasType.evaluate_value`, and a pointer to
-:py:func:`help(typing.TypeAliasType) <help>` for the full interface.
+        Lazy value access:
+
+        __value__
+            Lazily evaluated value of the type alias.
+
+        evaluate_value
+            Evaluation function for __value__.
+
+        See help(typing.TypeAliasType) for the full type alias interface.
 
 This PEP does not add automatic discovery of type alias docstrings to
 :py:mod:`doctest`. As noted in
@@ -247,12 +267,6 @@ an alias node without requiring access to its containing suite. Retaining the
 original statement preserves the structure used by existing tools that already
 find docstrings there. The cost is duplicated information, which AST
 transformations may need to keep consistent.
-
-Preserving the documentation and rendering an alias declaration are separate
-operations. Documentation remains useful to callers that only read ``__doc__``
-or :py:func:`ast.get_docstring`, regardless of the final rendering policy
-chosen for :py:mod:`pydoc`.
-
 
 Backwards Compatibility
 =======================
@@ -372,4 +386,5 @@ CC0-1.0-Universal license, whichever is more permissive.
 .. _Pylint: https://pylint.readthedocs.io/en/latest/whatsnew/3/3.0/index.html#what-s-new-in-pylint-3-0-3
 .. _Issue: https://github.com/python/cpython/issues/156925
 .. _Compiler: https://github.com/johnslavik/cpython/commit/38779c761d9eaf19f195ed972e5986c0df384953
+.. _DocstringPreprocessing: https://github.com/python/cpython/blob/ee521e8ac19ad012ebc4e1b3e71b369988a9b9f8/Python/ast_preprocess.c#L467-L494
 .. _Pydoc: https://github.com/johnslavik/cpython/commit/e4910eeb0ca147f92e3b20262de13d0fb1bf3d97

--- a/peps/pep-0846.rst
+++ b/peps/pep-0846.rst
@@ -77,6 +77,8 @@ available at runtime.
 If the next statement after a :py:keyword:`type` statement in the same suite is
 an expression statement consisting of a string literal, that string is the
 alias's docstring.
+Comments and blank lines may appear between the :py:keyword:`type` statement
+and its docstring.
 
 .. code-block:: python
 
@@ -120,16 +122,18 @@ which expands tabs and cleans indentation while retaining surrounding blank
 lines. :py:func:`inspect.cleandoc` also removes surrounding blank lines.
 
 The attribute can be assigned to after creation. Deleting it resets it to
-``None``. The :py:class:`~typing.TypeAliasType` constructor does not gain a
-docstring parameter; programmatically created aliases can be documented by
-assignment:
+``None``. The :py:class:`~typing.TypeAliasType` constructor gains a keyword-only
+``doc`` parameter, defaulting to ``None``, that initializes ``__doc__`` without
+whitespace processing. Programmatically created aliases can be documented
+during construction or by later assignment:
 
 .. code-block:: python
 
     from typing import TypeAliasType
 
-    Timeout = TypeAliasType("Timeout", float | None)
-    Timeout.__doc__ = "Maximum wait in seconds."
+    Timeout = TypeAliasType(
+        "Timeout", float | None, doc="Maximum wait in seconds."
+    )
 
 This proposal does not change the meaning of an alias to a type checker,
 or how its value is evaluated.
@@ -302,7 +306,7 @@ representation question below.
 Reference Implementation
 ========================
 
-A CPython prototype is available in two commits:
+A CPython prototype is available at these revisions:
 
 * `Compiler, runtime, and AST support <Compiler_>`_.
 * `pydoc support <Pydoc_>`_.
@@ -384,6 +388,6 @@ CC0-1.0-Universal license, whichever is more permissive.
 .. _Sphinx: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#automatically-document-type-aliases
 .. _Pylint: https://pylint.readthedocs.io/en/latest/whatsnew/3/3.0/index.html#what-s-new-in-pylint-3-0-3
 .. _Issue: https://github.com/python/cpython/issues/156925
-.. _Compiler: https://github.com/johnslavik/cpython/commit/38779c761d9eaf19f195ed972e5986c0df384953
+.. _Compiler: https://github.com/johnslavik/cpython/commit/a57746e5dc141e99a0016198a40abbf291bed00a
 .. _DocstringPreprocessing: https://github.com/python/cpython/blob/ee521e8ac19ad012ebc4e1b3e71b369988a9b9f8/Python/ast_preprocess.c#L467-L494
 .. _Pydoc: https://github.com/johnslavik/cpython/commit/e4910eeb0ca147f92e3b20262de13d0fb1bf3d97


### PR DESCRIPTION
<!--
You can use the following checklist when double-checking your PEP,
and you can help complete some of it yourself if you like
by ticking any boxes you're sure about, like this: [x]
If you're unsure about anything, just leave it blank and we'll take a look.

If your PEP is not Standards Track, remove the corresponding section.
-->

I've just started the work on the PEP, hence a draft PR to book the number.

<details>

<summary>PR template checkboxes</summary>

## Basic requirements (all PEP Types)

* [x] Read and followed [PEP 1](https://peps.python.org/1) & [PEP 12](https://peps.python.org/12)
* [x] File created from the [latest PEP template](https://github.com/python/peps/blob/main/peps/pep-0012/pep-NNNN.rst?plain=1)
* [x] PEP has next available number, & set in filename (``pep-NNNN.rst``), PR title (``PEP 123: <Title of PEP>``) and ``PEP`` header
    * Tip: find the next available number with [pepotron](https://github.com/hugovk/pepotron) — run ``uvx pepotron next`` (or ``pipx install pepotron`` then ``pep next``)
* [x] Title clearly, accurately and concisely describes the content in 79 characters or less
* [x] Core dev/PEP editor listed as ``Author`` or ``Sponsor``, and formally confirmed their approval
* [x] ``Author``, ``Status`` (``Draft``), ``Type`` and ``Created`` headers filled out correctly
* [x] ``PEP-Delegate``, ``Topic``, ``Requires`` and ``Replaces`` headers completed if appropriate
* [x] Required sections included
    * [x] Abstract (first section)
    * [x] Copyright (last section; exact wording from template required)
* [x] Code is well-formatted (PEP 7/PEP 8) and is in [code blocks, with the right lexer names](https://peps.python.org/pep-0012/#literal-blocks) if non-Python
* [x] PEP builds with no warnings, pre-commit checks pass and content displays as intended in the rendered HTML
* [x] Authors/sponsor added to ``.github/CODEOWNERS`` for the PEP


## Standards Track requirements

* [x] PEP topic [discussed in a suitable venue](https://peps.python.org/pep-0001/#start-with-an-idea-for-python) with general agreement that a PEP is appropriate
* [x] [Suggested sections](https://peps.python.org/pep-0012/#suggested-sections) included (unless not applicable)
    * [x] Motivation
    * [x] Specification
    * [x] Rationale
    * [x] Backwards Compatibility
    * [x] Security Implications
    * [x] How to Teach This
    * [x] Reference Implementation
    * [ ] Rejected Ideas
    * [x] Open Issues
    * [x] Acknowledgements
    * [x] Footnotes
    * [x] Change History
* [x] ``Python-Version`` set to valid (pre-beta) future Python version, if relevant
* [ ] Any project stated in the PEP as supporting/endorsing/benefiting from the PEP formally confirmed such
* [ ] Right before or after initial merging, [PEP discussion thread](https://peps.python.org/pep-0001/#discussing-a-pep) created and linked to in ``Discussions-To`` and ``Post-History``

</details>