### PR TITLE
PEP 847: update links

### DIFF
--- a/peps/pep-0847.rst
+++ b/peps/pep-0847.rst
@@ -5,12 +5,13 @@ Author: Luis Gonzalez <lgonzalez@sonatype.com>,
         Zsolt Dollenstein <zsol.zsol@gmail.com>
 Sponsor: Donald Stufft <donald@stufft.io>
 PEP-Delegate: Donald Stufft <donald@stufft.io>
-Discussions-To: https://discuss.python.org/t/pre-pep-discussion-rfc-9457-error-responses-for-package-registries/105453
+Discussions-To: https://discuss.python.org/t/pep-847-problem-details-for-the-simple-repository-api/108996
 Status: Draft
 Type: Standards Track
 Topic: Packaging
 Created: 06-Aug-2026
-Post-History: `29-Dec-2025 <https://discuss.python.org/t/pre-pep-discussion-rfc-9457-error-responses-for-package-registries/105453>`__
+Post-History: `29-Dec-2025 <https://discuss.python.org/t/pre-pep-discussion-rfc-9457-error-responses-for-package-registries/105453>`__,
+              `10-Sep-2026 <https://discuss.python.org/t/pep-847-problem-details-for-the-simple-repository-api/108996>`__
 
 Abstract
 ========


### PR DESCRIPTION
Now that https://discuss.python.org/t/pep-847-problem-details-for-the-simple-repository-api/108996 is open 🙂 